### PR TITLE
8662 realtime effect categorization

### DIFF
--- a/src/appshell/qml/Preferences/internal/EffectOptionsSection.qml
+++ b/src/appshell/qml/Preferences/internal/EffectOptionsSection.qml
@@ -9,45 +9,49 @@ import Audacity.Preferences
 BaseSection {
     id: root
 
-    title: qsTrc("appshell/preferences", "Effect options")
+    title: qsTrc("appshell/preferences", "Effect menu organization")
     spacing: 16
 
     property var pluginPreferencesModel: null
 
-    property var effectOrganizationLabels: [
-        qsTrc("playback", "Group by category"),
-        qsTrc("playback", "Group by type"),
-    ]
+    RadioButtonGroup {
 
-    ComboBoxWithTitle {
-        title: qsTrc("appshell/preferences", "Effect menu organization")
-        columnWidth: root.columnWidth
+        width: parent.width
+        height: 50
 
-        currentIndex: pluginPreferencesModel.effectMenuOrganization
-        model: effectOrganizationLabels
+        spacing: root.rowSpacing
+        orientation: Qt.Vertical
 
-        navigation.name: "EffectMenuOrganizationBox"
-        navigation.panel: root.navigation
-        navigation.row: 0
+        Column {
+            width: parent.width
+            spacing: root.columnSpacing
 
-        onValueEdited: function(newIndex, newValue) {
-            pluginPreferencesModel.setEffectMenuOrganization(newIndex)
-        }
-    }
+            RoundedRadioButton {
 
-    ComboBoxWithTitle {
-        title: qsTrc("appshell/preferences", "Realtime effect organization")
-        columnWidth: root.columnWidth
+                checked: pluginPreferencesModel.effectMenuOrganization == 0
+                text: qsTrc("appshell/preferences", "Group effects")
 
-        currentIndex: pluginPreferencesModel.realtimeEffectOrganization
-        model: effectOrganizationLabels
+                navigation.name: "GroupEffects"
+                navigation.panel: root.navigation
+                navigation.row: 0
 
-        navigation.name: "RealtimeEffectOrganizationBox"
-        navigation.panel: root.navigation
-        navigation.row: 1
+                onToggled: {
+                    pluginPreferencesModel.setEffectMenuOrganization(0)
+                }
+            }
 
-        onValueEdited: function(newIndex, newValue) {
-            pluginPreferencesModel.setRealtimeEffectOrganization(newIndex)
+            RoundedRadioButton {
+                checked: pluginPreferencesModel.effectMenuOrganization == 1
+                text: qsTrc("appshell/preferences", "Display effects in one flat list")
+
+                navigation.name: "DoNotGroupEffects"
+                navigation.panel: root.navigation
+                navigation.row: 1
+
+                onToggled: {
+                    pluginPreferencesModel.setEffectMenuOrganization(1)
+                }
+            }
         }
     }
 }

--- a/src/appshell/view/appmenumodel.cpp
+++ b/src/appshell/view/appmenumodel.cpp
@@ -801,8 +801,10 @@ MenuItemList AppMenuModel::makeEffectsItems()
     const effects::utils::EffectFilter filter = [](const effects::EffectMeta& meta) {
         return meta.type != effects::EffectType::Processor;
     };
-    const muse::uicomponents::MenuItemList effectMenus = effects::utils::effectMenus(effectsConfiguration()->effectMenuOrganization(),
-                                                                                     effectsProvider()->effectMetaList(), filter,  *this);
+    const muse::uicomponents::MenuItemList effectMenus = effects::utils::destructiveEffectMenu(
+        effectsConfiguration()->effectMenuOrganization(),
+        effectsProvider()->effectMetaList(), filter,
+        *this);
     if (!effectMenus.empty()) {
         items << makeSeparator() << effectMenus;
     }
@@ -820,8 +822,10 @@ MenuItemList AppMenuModel::makeGeneratorItems()
     const effects::utils::EffectFilter filter = [](const effects::EffectMeta& meta) {
         return meta.type != effects::EffectType::Generator;
     };
-    const muse::uicomponents::MenuItemList effectMenus = effects::utils::effectMenus(effectsConfiguration()->effectMenuOrganization(),
-                                                                                     effectsProvider()->effectMetaList(), filter,  *this);
+    const muse::uicomponents::MenuItemList effectMenus = effects::utils::destructiveEffectMenu(
+        effectsConfiguration()->effectMenuOrganization(),
+        effectsProvider()->effectMetaList(), filter,
+        *this);
 
     items << effectMenus;
 

--- a/src/appshell/view/preferences/pluginpreferencesmodel.cpp
+++ b/src/appshell/view/preferences/pluginpreferencesmodel.cpp
@@ -14,9 +14,6 @@ void PluginPreferencesModel::init()
     effectsConfiguration()->effectMenuOrganizationChanged().onNotify(this, [this] {
         emit effectMenuOrganizationChanged();
     });
-    effectsConfiguration()->realtimeEffectOrganizationChanged().onNotify(this, [this] {
-        emit realtimeEffectOrganizationChanged();
-    });
 }
 
 au::effects::EffectMenuOrganization PluginPreferencesModel::effectMenuOrganization() const
@@ -31,20 +28,5 @@ void PluginPreferencesModel::setEffectMenuOrganization(effects::EffectMenuOrgani
     }
 
     effectsConfiguration()->setEffectMenuOrganization(organization);
-}
-
-au::effects::EffectMenuOrganization PluginPreferencesModel::realtimeEffectOrganization() const
-{
-    return effectsConfiguration()->realtimeEffectOrganization();
-}
-
-void PluginPreferencesModel::setRealtimeEffectOrganization(
-    effects::EffectMenuOrganization organization)
-{
-    if (realtimeEffectOrganization() == organization) {
-        return;
-    }
-
-    effectsConfiguration()->setRealtimeEffectOrganization(organization);
 }
 }

--- a/src/appshell/view/preferences/pluginpreferencesmodel.h
+++ b/src/appshell/view/preferences/pluginpreferencesmodel.h
@@ -16,8 +16,6 @@ class PluginPreferencesModel : public QObject, public muse::async::Asyncable
     Q_OBJECT
 
     Q_PROPERTY(effects::EffectMenuOrganization effectMenuOrganization READ effectMenuOrganization NOTIFY effectMenuOrganizationChanged)
-    Q_PROPERTY(
-        effects::EffectMenuOrganization realtimeEffectOrganization READ realtimeEffectOrganization NOTIFY realtimeEffectOrganizationChanged)
 
     muse::Inject<effects::IEffectsConfiguration> effectsConfiguration;
 
@@ -27,13 +25,9 @@ public:
     effects::EffectMenuOrganization effectMenuOrganization() const;
     Q_INVOKABLE void setEffectMenuOrganization(effects::EffectMenuOrganization);
 
-    effects::EffectMenuOrganization realtimeEffectOrganization() const;
-    Q_INVOKABLE void setRealtimeEffectOrganization(effects::EffectMenuOrganization);
-
     Q_INVOKABLE void init();
 
 signals:
     void effectMenuOrganizationChanged();
-    void realtimeEffectOrganizationChanged();
 };
 }

--- a/src/effects/effects_base/effectstypes.h
+++ b/src/effects/effects_base/effectstypes.h
@@ -44,8 +44,8 @@ using TrackId = long;
 using EffectChainLinkIndex = int;
 
 enum class EffectMenuOrganization {
-    ByCategory = 0,
-    ByType = 1,
+    Grouped = 0,
+    Flat = 1,
 };
 
 enum class EffectFamily {

--- a/src/effects/effects_base/effectsutils.h
+++ b/src/effects/effects_base/effectsutils.h
@@ -10,6 +10,8 @@
 namespace au::effects::utils {
 using EffectFilter = std::function<bool (const EffectMeta&)>;
 
-muse::uicomponents::MenuItemList effectMenus(EffectMenuOrganization organization, EffectMetaList metaList, const EffectFilter& filter,
-                                             IEffectMenuItemFactory& effectMenu);
+muse::uicomponents::MenuItemList destructiveEffectMenu(EffectMenuOrganization organization, EffectMetaList metaList,
+                                                       const EffectFilter& filter, IEffectMenuItemFactory& effectMenu);
+muse::uicomponents::MenuItemList realtimeEffectMenu(EffectMenuOrganization organization, EffectMetaList metaList,
+                                                    const EffectFilter& filter, IEffectMenuItemFactory& effectMenu);
 }

--- a/src/effects/effects_base/ieffectsconfiguration.h
+++ b/src/effects/effects_base/ieffectsconfiguration.h
@@ -22,9 +22,5 @@ public:
     virtual EffectMenuOrganization effectMenuOrganization() const = 0;
     virtual void setEffectMenuOrganization(EffectMenuOrganization) = 0;
     virtual muse::async::Notification effectMenuOrganizationChanged() const = 0;
-
-    virtual EffectMenuOrganization realtimeEffectOrganization() const = 0;
-    virtual void setRealtimeEffectOrganization(EffectMenuOrganization) = 0;
-    virtual muse::async::Notification realtimeEffectOrganizationChanged() const = 0;
 };
 }

--- a/src/effects/effects_base/internal/effectsconfiguration.cpp
+++ b/src/effects/effects_base/internal/effectsconfiguration.cpp
@@ -10,7 +10,6 @@ using namespace au::effects;
 static const std::string moduleName("effects");
 static const muse::Settings::Key APPLY_EFFECT_TO_ALL_AUDIO(moduleName, "effects/applyEffectToAllAudio");
 static const muse::Settings::Key EFFECT_MENU_ORGANIZATION(moduleName, "effects/effectMenuOrganization");
-static const muse::Settings::Key REALTIME_EFFECT_ORGANIZATION(moduleName, "effects/realtimeEffectOrganization");
 
 void EffectsConfiguration::init()
 {
@@ -19,14 +18,9 @@ void EffectsConfiguration::init()
         m_applyEffectToAllAudioChanged.notify();
     });
 
-    muse::settings()->setDefaultValue(EFFECT_MENU_ORGANIZATION, muse::Val(EffectMenuOrganization::ByCategory));
+    muse::settings()->setDefaultValue(EFFECT_MENU_ORGANIZATION, muse::Val(EffectMenuOrganization::Grouped));
     muse::settings()->valueChanged(EFFECT_MENU_ORGANIZATION).onReceive(nullptr, [this](const muse::Val&) {
         m_effectMenuOrganizationChanged.notify();
-    });
-
-    muse::settings()->setDefaultValue(REALTIME_EFFECT_ORGANIZATION, muse::Val(EffectMenuOrganization::ByType));
-    muse::settings()->valueChanged(REALTIME_EFFECT_ORGANIZATION).onReceive(nullptr, [this](const muse::Val&) {
-        m_realtimeEffectOrganizationChanged.notify();
     });
 }
 
@@ -62,20 +56,4 @@ void EffectsConfiguration::setEffectMenuOrganization(EffectMenuOrganization orga
 muse::async::Notification EffectsConfiguration::effectMenuOrganizationChanged() const
 {
     return m_effectMenuOrganizationChanged;
-}
-
-EffectMenuOrganization EffectsConfiguration::realtimeEffectOrganization() const
-{
-    return static_cast<EffectMenuOrganization>(muse::settings()->value(REALTIME_EFFECT_ORGANIZATION).toInt());
-}
-
-void EffectsConfiguration::setRealtimeEffectOrganization(
-    EffectMenuOrganization organization)
-{
-    muse::settings()->setSharedValue(REALTIME_EFFECT_ORGANIZATION, muse::Val(static_cast<int>(organization)));
-}
-
-muse::async::Notification EffectsConfiguration::realtimeEffectOrganizationChanged() const
-{
-    return m_realtimeEffectOrganizationChanged;
 }

--- a/src/effects/effects_base/internal/effectsconfiguration.h
+++ b/src/effects/effects_base/internal/effectsconfiguration.h
@@ -26,13 +26,8 @@ public:
     void setEffectMenuOrganization(EffectMenuOrganization) override;
     muse::async::Notification effectMenuOrganizationChanged() const override;
 
-    EffectMenuOrganization realtimeEffectOrganization() const override;
-    void setRealtimeEffectOrganization(EffectMenuOrganization) override;
-    muse::async::Notification realtimeEffectOrganizationChanged() const override;
-
 private:
     muse::async::Notification m_applyEffectToAllAudioChanged;
     muse::async::Notification m_effectMenuOrganizationChanged;
-    muse::async::Notification m_realtimeEffectOrganizationChanged;
 };
 }

--- a/src/projectscene/view/trackspanel/addeffectmenumodel.cpp
+++ b/src/projectscene/view/trackspanel/addeffectmenumodel.cpp
@@ -21,8 +21,8 @@ void AddEffectMenuModel::doLoad()
 void AddEffectMenuModel::doPopulateMenu()
 {
     const MenuItemList items
-        = au::effects::utils::effectMenus(effectsConfiguration()->realtimeEffectOrganization(),
-                                          effectsProvider()->effectMetaList(), m_effectFilter, *this);
+        = au::effects::utils::realtimeEffectMenu(effectsConfiguration()->effectMenuOrganization(),
+                                                 effectsProvider()->effectMetaList(), m_effectFilter, *this);
     setItems(items);
 }
 

--- a/src/projectscene/view/trackspanel/realtimeeffectlistitemmenumodel.cpp
+++ b/src/projectscene/view/trackspanel/realtimeeffectlistitemmenumodel.cpp
@@ -34,8 +34,9 @@ void RealtimeEffectListItemMenuModel::doPopulateMenu()
 
     items << makeMenuItem("realtimeeffect-remove", muse::TranslatableString("projectscene", "No effect")) << makeSeparator();
 
-    const auto effectMenus = effects::utils::effectMenus(
-        effectsConfiguration()->realtimeEffectOrganization(), effectsProvider()->effectMetaList(), m_effectFilter, *this);
+    const auto effectMenus = effects::utils::realtimeEffectMenu(
+        effectsConfiguration()->effectMenuOrganization(),
+        effectsProvider()->effectMetaList(), m_effectFilter, *this);
     if (!effectMenus.empty()) {
         items << makeSeparator() << effectMenus;
     }

--- a/src/projectscene/view/trackspanel/realtimeeffectmenumodelbase.cpp
+++ b/src/projectscene/view/trackspanel/realtimeeffectmenumodelbase.cpp
@@ -17,7 +17,7 @@ void RealtimeEffectMenuModelBase::load()
 
     effectsProvider()->effectMetaListChanged().onNotify(this, [this] { doPopulateMenu(); });
 
-    effectsConfiguration()->realtimeEffectOrganizationChanged().onNotify(this, [this]{ doPopulateMenu(); });
+    effectsConfiguration()->effectMenuOrganizationChanged().onNotify(this, [this]{ doPopulateMenu(); });
 
     trackSelection()->selectedTrackIdChanged().onNotify(this, [this]
     {


### PR DESCRIPTION
Resolves: #8662

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
