### PR TITLE
 Fix crash on close

### DIFF
--- a/src/toolbars/ToolManager.cpp
+++ b/src/toolbars/ToolManager.cpp
@@ -503,6 +503,7 @@ void ToolManager::Destroy()
          pair.second.reset();
 
       mIndicator.reset();
+      mMenuManagerSubscription.Reset();
    }
 }
 


### PR DESCRIPTION
Resolves: #6890

- During shutdown `ProjectHistory::Get(project).SetStateTo(...)` is called and adds an event to the event queue. 
- Then, most UI elements are destroyed, including the call to ToolManager::Destroy, yet the subscription is kept connected. 
- If the project is closed without saving, the progress bar is shown to display the checkpointing progress.
- In turn, this runs the event loop and causes the event to be dispatched
- As a result, ToolManager is trying to update the toolbar's UI after getting an event from UndoManager.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
