### PR TITLE
Change the order of startup windows

### DIFF
--- a/src/AudacityApp.cpp
+++ b/src/AudacityApp.cpp
@@ -1698,6 +1698,14 @@ bool AudacityApp::InitPart2()
       project = ProjectManager::New();
    }
 
+   // Update Manager may spawn a modal dialog, we need to hide the splash screen before that
+   bool splashFadeOut = !playingJournal;
+   HideSplashScreen(splashFadeOut);
+
+#if defined(HAVE_UPDATES_CHECK)
+   UpdateManager::Start(playingJournal);
+#endif
+
    if (!playingJournal && ProjectSettings::Get(*project).GetShowSplashScreen())
    {
       // This may do a check-for-updates at every start up.
@@ -1708,14 +1716,6 @@ bool AudacityApp::InitPart2()
       WhatsNewDialog::Show(*project);
 #endif
    }
-
-   // Update Manager may spawn a modal dialog, we need to hide the splash screen before that
-   bool splashFadeOut = !playingJournal;
-   HideSplashScreen(splashFadeOut);
-
-#if defined(HAVE_UPDATES_CHECK)
-   UpdateManager::Start(playingJournal);
-#endif
 
    Importer::Get().Initialize();
    ExportPluginRegistry::Get().Initialize();


### PR DESCRIPTION
Now "App updates & usage info" is shown first, and "What's new" second
<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
