### PR TITLE
Add a special case for OpenVINO plugins menu

### DIFF
--- a/libraries/lib-module-manager/PluginManager.h
+++ b/libraries/lib-module-manager/PluginManager.h
@@ -129,6 +129,8 @@ public:
    //! @{
    class MODULE_MANAGER_API Iterator {
    public:
+      using Filter = std::function<bool(const PluginDescriptor&)>;
+
       //! Iterates all, even disabled
       explicit Iterator(PluginManager &manager);
       //! Iterates only enabled and matching plugins, with family enabled too if an effect
@@ -137,6 +139,8 @@ public:
       );
       //! Iterates only enabled and matching effects, with family enabled too
       Iterator(PluginManager &manager, EffectType type);
+      //! Iterates only enabled plugins matching the filter predicate
+      Iterator(PluginManager &manager, Filter filter);
       bool operator != (int) const {
          return mIterator != mPm.mRegisteredPlugins.end();
       }
@@ -146,6 +150,7 @@ public:
       void Advance(bool incrementing);
       const PluginManager &mPm;
       PluginMap::iterator mIterator;
+      Filter mFilter { nullptr };
       EffectType mEffectType{ EffectTypeNone };
       int mPluginType{ PluginTypeNone };
    };
@@ -158,6 +163,7 @@ public:
    Range AllPlugins() { return { Iterator{ *this } }; }
    Range PluginsOfType(int type) { return { Iterator{ *this, type } }; }
    Range EffectsOfType(EffectType type) { return { Iterator{ *this, type } }; }
+   Range Plugins(Iterator::Filter filter) { return { Iterator{ *this, filter } }; }
    //! @}
 
    bool IsPluginEnabled(const PluginID & ID);


### PR DESCRIPTION
Add a special case for OpenVINO plugins to group them into a single place in /Effects

A part of: #8677

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
