### PR TITLE
Use GetEffectsDialog for all "Get more effects" menus and buttons

### DIFF
--- a/modules/sharing/mod-cloud-audiocom/CMakeLists.txt
+++ b/modules/sharing/mod-cloud-audiocom/CMakeLists.txt
@@ -93,7 +93,6 @@ list(APPEND LIBRARIES
       lib-menus-interface
       lib-shuttlegui-interface
       lib-wx-wrappers-interface
-      mod-musehub-ui-interface # Get Effects dialog
       Audacity # Toolbars live here
 )
 

--- a/modules/sharing/mod-cloud-audiocom/ui/ShareAudioToolbar.cpp
+++ b/modules/sharing/mod-cloud-audiocom/ui/ShareAudioToolbar.cpp
@@ -9,6 +9,7 @@
 
 **********************************************************************/
 #include "ShareAudioToolbar.h"
+#include "menus/GetEffectsHelper.h"
 
 #include <wx/sizer.h>
 #include <wx/stattext.h>
@@ -28,7 +29,7 @@
 #include "ProjectWindow.h"
 #include "Theme.h"
 
-#include "GetEffectsDialog.h"
+#include "menus/GetEffectsHelper.h"
 #include "dialogs/ShareAudioDialog.h"
 #include "toolbars/ToolManager.h"
 #include "widgets/AButton.h"
@@ -214,11 +215,10 @@ void ShareAudioToolbar::MakeGetEffectsButton()
    mGetEffectsButton = MakeButton(ID_GET_EFFECTS_BUTTON, XO("Get Effects"), theTheme.Image(bmpPlug));
 
    mGetEffectsButton->Bind(wxEVT_BUTTON, [this](auto) {
-      musehub::GetEffectsDialog dlg(&ProjectWindow::Get(mProject));
-      dlg.ShowModal();
+      GetEffectsHelper::Get().GetEffects();
 
-         mGetEffectsButton->PopUp();
-      });
+      mGetEffectsButton->PopUp();
+   });
 
 }
 void ShareAudioToolbar::ArrangeButtons()

--- a/modules/sharing/mod-musehub-ui/CMakeLists.txt
+++ b/modules/sharing/mod-musehub-ui/CMakeLists.txt
@@ -13,6 +13,7 @@ set( SOURCES
 list(APPEND LIBRARIES
    lib-wx-wrappers-interface
    lib-musehub-interface
+   Audacity
 )
 
 audacity_module( ${TARGET} "${SOURCES}" "${LIBRARIES}" "" "" )

--- a/modules/sharing/mod-musehub-ui/GetEffectsDialog.cpp
+++ b/modules/sharing/mod-musehub-ui/GetEffectsDialog.cpp
@@ -24,9 +24,11 @@
 #include "NetworkManager.h"
 #include "Request.h"
 
-#include "RoundedStaticBitmap.h"
+#include "AppEvents.h"
 #include "BasicUI.h"
+#include "menus/GetEffectsHelper.h"
 #include "Theme.h"
+#include "RoundedStaticBitmap.h"
 #include "AllThemeResources.h"
 #include "GradientButton.h"
 #include "WindowAccessible.h"
@@ -361,5 +363,29 @@ void GetEffectsDialog::AddEffectsPage(const std::string& group, const std::vecto
    page->SetAutoLayout(true);
    m_treebook->AddPage(page, group.data());
 }
+
+
+class GetEffectsHandler
+{
+
+public:
+   GetEffectsHandler() {
+      AppEvents::OnAppInitialized([this] {
+         mSubscription = GetEffectsHelper::Get().Subscribe(
+            [this](const auto&) -> bool {
+               GetEffectsDialog dialog(wxTheApp->GetTopWindow());
+               dialog.ShowModal();
+               return true;
+            }, GetEffectsHandlerType::Custom
+         );
+      });
+   }
+
+private:
+   Observer::Subscription mSubscription;
+
+};
+
+static GetEffectsHandler sEventHandler;
 
 }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -561,6 +561,7 @@ set( SOURCES
       menus/EditMenus.cpp
       menus/ExtraMenus.cpp
       menus/FileMenus.cpp
+      menus/GetEffectsHelper.cpp
       menus/HelpMenus.cpp
       menus/LabelMenus.cpp
       menus/MenuHelper.cpp

--- a/src/PluginRegistrationDialog.cpp
+++ b/src/PluginRegistrationDialog.cpp
@@ -21,6 +21,7 @@
 #include "PluginStartupRegistration.h"
 #include "ProgressDialog.h"
 #include "ShuttleGui.h"
+#include "menus/GetEffectsHelper.h"
 
 #include <set>
 #include <wx/setup.h> // for wxUSE_* macros
@@ -344,7 +345,7 @@ void PluginRegistrationDialog::OnRescan(wxCommandEvent& WXUNUSED(evt))
 
 void PluginRegistrationDialog::OnGetMoreEffects(wxCommandEvent& WXUNUSED(evt))
 {
-   OpenInDefaultBrowser("https://www.audacityteam.org/mh-pluginmanager");
+   GetEffectsHelper::Get().GetEffects();
 }
 
 void PluginRegistrationDialog::OnOK(wxCommandEvent & WXUNUSED(evt))

--- a/src/RealtimeEffectPanel.cpp
+++ b/src/RealtimeEffectPanel.cpp
@@ -48,6 +48,7 @@
 #include "ListNavigationPanel.h"
 #include "MovableControl.h"
 #include "menus/MenuHelper.h"
+#include "menus/GetEffectsHelper.h"
 #include "prefs/EffectsPrefs.h"
 
 #if wxUSE_ACCESSIBILITY
@@ -154,7 +155,7 @@ namespace
             if(commandId == wxID_REMOVE)
                return wxString {};
             if(commandId == wxID_MORE)
-               OpenInDefaultBrowser("https://www.audacityteam.org/mh-rtepanel");
+               GetEffectsHelper::Get().GetEffects();
             else
                return visitor.GetPluginID(commandId).GET();
          }

--- a/src/menus/GetEffectsHelper.cpp
+++ b/src/menus/GetEffectsHelper.cpp
@@ -1,0 +1,54 @@
+/**********************************************************************
+Audacity: A Digital Audio Editor
+**********************************************************************/
+
+#include "GetEffectsHelper.h"
+
+#include "AppEvents.h"
+#include "BasicUI.h"
+
+
+static const wxString GetEffectsDefaultUrl = "https://www.audacityteam.org/mh-effectmenu";
+
+GetEffectsHelper& GetEffectsHelper::Get()
+{
+   static GetEffectsHelper instance;
+   return instance;
+}
+
+void GetEffectsHelper::GetEffects()
+{
+   Publish({});
+}
+
+Observer::Subscription GetEffectsHelper::Subscribe(Callback callback, GetEffectsHandlerType handlerType)
+{
+   // If the custom handler is already set, do not allow overriding it
+   if (mHandlerType == GetEffectsHandlerType::Custom)
+   {
+      return {};
+   }
+   mHandlerType = handlerType;
+   return Publisher::Subscribe(callback);
+}
+
+// Default handler for the "Get Effects" action when no other handler is registered.
+class DefaultGetEffectsHandler final
+{
+public:
+   DefaultGetEffectsHandler() {
+      AppEvents::OnAppInitialized([this] {
+         mSubscription = GetEffectsHelper::Get().Subscribe(
+            [this](const auto&) -> bool {
+               BasicUI::OpenInDefaultBrowser(GetEffectsDefaultUrl);
+               return true;
+            });
+      });
+   }
+
+private:
+   Observer::Subscription mSubscription;
+
+};
+
+static DefaultGetEffectsHandler sDefaultGetEffectsHandler;

--- a/src/menus/GetEffectsHelper.h
+++ b/src/menus/GetEffectsHelper.h
@@ -1,0 +1,28 @@
+/**********************************************************************
+Audacity: A Digital Audio Editor
+**********************************************************************/
+
+#pragma once
+
+#include "Observer.h"
+
+enum class GetEffectsHandlerType
+{
+   Default, // Default handler that opens the default browser to the "Get Effects" URL
+   Custom   // Custom handler that overrides the default behavior
+};
+
+class AUDACITY_DLL_API GetEffectsHelper final : public Observer::Publisher<Observer::Message, false>
+{
+private:
+   GetEffectsHelper() = default;
+
+public:
+   static GetEffectsHelper &Get();
+   Observer::Subscription Subscribe(Callback callback, GetEffectsHandlerType handlerType = GetEffectsHandlerType::Default);
+   void GetEffects();
+
+private:
+   GetEffectsHandlerType mHandlerType = GetEffectsHandlerType::Default;
+
+};

--- a/src/menus/MenuHelper.cpp
+++ b/src/menus/MenuHelper.cpp
@@ -126,7 +126,9 @@ CommandFlag FixBatchFlags(CommandFlag batchflags, const PluginDescriptor* plug)
    if ( plug->GetSymbol().Msgid() == XO( "Noise Reduction" ) )
       return ( batchflags | NoiseReductionTimeSelectedFlag() ) & ~TimeSelectedFlag();
    // For OpenVINO Music Generation so that it could be used when no audio is selected
-   if ( plug->GetSymbol().Msgid() == XO( "OpenVINO Music Generation" ) )
+   // Note: do not use translatable string here, because
+   // translations are not synchronized yet with OpenVINO project
+   if ( plug->GetSymbol().Internal() == "OpenVINO Music Generation" )
       return AudioIONotBusyFlag();
    return batchflags;
 }

--- a/src/menus/PluginMenus.cpp
+++ b/src/menus/PluginMenus.cpp
@@ -15,6 +15,7 @@
 #include "EffectManager.h"
 #include "HelpSystem.h"
 #include "Journal.h"
+#include "GetEffectsHelper.h"
 #include "MenuHelper.h"
 #include "PluginManager.h"
 #include "Prefs.h"
@@ -364,15 +365,7 @@ auto EffectMenu()
          , Command(
             wxT("GetMoreEffects"), XXO("Get more effects..."),
             [](const CommandContext&) {
-               OpenInDefaultBrowser("https://www.audacityteam.org/mh-effectmenu");
-            },
-            AlwaysEnabledFlag)
-#endif
-#if defined(__WXMSW__)
-         , Command(
-            wxT("GetAIEffects"), XXO("Get AI effects..."),
-            [](const CommandContext&) {
-               OpenInDefaultBrowser("https://audacityteam.org/download/openvino");
+               GetEffectsHelper::Get().GetEffects();
             },
             AlwaysEnabledFlag)
 #endif


### PR DESCRIPTION
Use GetEffectsDialog for all "Get more effects" menus and buttons

Remove "Get AI effects" as it will be available on "Get Effects"

**QA: Please check,** that all menus\buttons in
* Realime Effects -> Add effect -> Get more effects
* Main menu -> Effects -> Get more effects
* Plugin manager -> Get more effects
* Main toolbar -> Get Effects

work, and open "Get Effects" dialog on macOS and Windows, or a web page on Linux.

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
