### PR TITLE
Welcome dialog: remove top and bottom of grey band from the tab order.

### DIFF
--- a/src/WhatsNewDialog.cpp
+++ b/src/WhatsNewDialog.cpp
@@ -307,6 +307,16 @@ private:
 };
 }
 
+class NotFocusableWindow : public wxWindow
+{
+public:
+   NotFocusableWindow(wxWindow* parent, wxWindowID id)
+      : wxWindow(parent, id)
+   {}
+
+   bool AcceptsFocus() const override { return false; }
+};
+
 BEGIN_EVENT_TABLE(WhatsNewDialog, wxDialogWrapper)
    EVT_BUTTON(WhatsNewID_WatchReleaseVideo, WhatsNewDialog::OnWatchReleaseVideo)
    EVT_BUTTON(WhatsNewID_GoToMuseHub, WhatsNewDialog::OnGoToMuseHub)
@@ -403,7 +413,7 @@ void WhatsNewDialog::Populate(ShuttleGui& S)
    }
    S.EndVerticalLay();
 
-   const auto line = safenew wxWindow(S.GetParent(), wxID_ANY);
+   const auto line = safenew NotFocusableWindow(S.GetParent(), wxID_ANY);
    line->SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_BTNSHADOW));
    line->SetSize(-1, 1);
 
@@ -437,7 +447,7 @@ void WhatsNewDialog::Populate(ShuttleGui& S)
    }
    S.EndHorizontalLay();
 
-   const auto bottomLine = safenew wxWindow(S.GetParent(), wxID_ANY);
+   const auto bottomLine = safenew NotFocusableWindow(S.GetParent(), wxID_ANY);
    bottomLine->SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_BTNSHADOW));
    bottomLine->SetSize(-1, 1);
    S


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/8797
Note that this only fixes the second part of the above issue - the first part has already been fixed.

Problem: The top and bottom boundaries of the grey band are in the tab order. They obviously shouldn't be.

Fix: Introduce a simple class which overrides AcceptsFocus() returning false;

- [ x] I signed [CLA](https://www.audacityteam.org/cla/)
- [ x] The title of the pull request describes an issue it addresses
- [x ] If changes are extensive, then there is a sequence of easily reviewable commits
- [x ] Each commit's message describes its purpose and effects
- [x ] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x ] Each commit compiles and runs on my machine without known undesirable changes of behavior
