### PR TITLE
Track focus state

### DIFF
--- a/src/effects/effects_base/internal/effectexecutionscenario.cpp
+++ b/src/effects/effects_base/internal/effectexecutionscenario.cpp
@@ -401,6 +401,7 @@ muse::Ret EffectExecutionScenario::performEffectOnEachSelectedClip(au3::Au3Proje
     for (const auto& clip : clipsToProcess) {
         selectionController()->setSelectedClips({ clip }, complete);
         selectionController()->setSelectedTracks({ clip.trackId }, complete);
+        selectionController()->setFocusedTrack(clip.trackId);
 
         WaveTrack* waveTrack = au3::DomAccessor::findWaveTrack(project, ::TrackId(clip.trackId));
         IF_ASSERT_FAILED(waveTrack) {

--- a/src/projectscene/projectscene.qrc
+++ b/src/projectscene/projectscene.qrc
@@ -25,7 +25,8 @@
         <file>qml/Audacity/ProjectScene/trackspanel/audio/VolumeTooltip.qml</file>
         <file>qml/Audacity/ProjectScene/toolbars/ProjectToolBar.qml</file>
         <file>qml/Audacity/ProjectScene/toolbars/UndoRedoToolBar.qml</file>
-        <file>qml/Audacity/ProjectScene/clipsview/PlayCursor.qml</file>
+        <file>qml/Audacity/ProjectScene/clipsview/PlayCursorLine.qml</file>
+        <file>qml/Audacity/ProjectScene/clipsview/PlayCursorHead.qml</file>
         <file>qml/Audacity/ProjectScene/clipsview/VerticalRulersPanel.qml</file>
         <file>qml/Audacity/ProjectScene/statusbar/SelectionStatus.qml</file>
         <file>qml/Audacity/ProjectScene/toolbars/PlaybackToolBar.qml</file>

--- a/src/projectscene/qml/Audacity/ProjectScene/clipsview/PlayCursorHead.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/clipsview/PlayCursorHead.qml
@@ -2,56 +2,19 @@ import QtQuick
 import Muse.Ui
 import Muse.UiComponents
 
-Rectangle {
 
-    id: root
+Item {
+    id: playCursorHead
 
-    property color borderColor: "#000000"
-    property int borderWidth: 1
     property bool timelinePressed: false
 
     signal setPlaybackPosition(real x)
     signal playCursorMousePositionChanged(real x)
 
-    Rectangle {
-        id: cursor
-
-        x: -width / 2
-        width: 3
-        height: root.height
-        color: "#ffffff"
-
-
-        // draw borders without top one
-        Rectangle {
-            id: leftBorder
-            color: borderColor
-            width: borderWidth
-            height: parent.height
-            anchors.left: parent.left
-        }
-        Rectangle {
-            id: rightBorder
-            color: borderColor
-            width: borderWidth
-            height: parent.height
-            anchors.right: parent.right
-        }
-        Rectangle {
-            id: bottomBorder
-            color: borderColor
-            width: root.width
-            height: borderWidth
-            anchors.bottom: parent.bottom
-        }
-    }
-
     StyledIconLabel {
         id: playheadIcon
 
         x: -(playheadIcon.width) / 2 - 0.5
-        y: -playheadIcon.height
-        z: 1
 
         iconCode: IconCode.PLAYHEAD_FILLED
 
@@ -76,13 +39,12 @@ Rectangle {
             cursorShape: pressed || timelinePressed ? Qt.ClosedHandCursor : Qt.OpenHandCursor
 
             onPositionChanged: function(e) {
-                var ix = mapToItem(root.parent, e.x, e.y).x
+                var ix = mapToItem(content, e.x, e.y).x
                 if (pressed) {
                     setPlaybackPosition(ix)
                 }
                 playCursorMousePositionChanged(ix)
             }
         }
-
     }
 }

--- a/src/projectscene/qml/Audacity/ProjectScene/clipsview/PlayCursorLine.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/clipsview/PlayCursorLine.qml
@@ -1,0 +1,45 @@
+import QtQuick
+import Muse.Ui
+import Muse.UiComponents
+
+Rectangle {
+
+    id: root
+
+    property color borderColor: "#000000"
+    property int borderWidth: 1
+    property bool timelinePressed: false
+
+    Rectangle {
+        id: cursor
+
+        x: -width / 2
+        width: 3
+        height: root.height
+        color: "#ffffff"
+
+
+        // draw borders without top one
+        Rectangle {
+            id: leftBorder
+            color: borderColor
+            width: borderWidth
+            height: parent.height
+            anchors.left: parent.left
+        }
+        Rectangle {
+            id: rightBorder
+            color: borderColor
+            width: borderWidth
+            height: parent.height
+            anchors.right: parent.right
+        }
+        Rectangle {
+            id: bottomBorder
+            color: borderColor
+            width: root.width
+            height: borderWidth
+            anchors.bottom: parent.bottom
+        }
+    }
+}

--- a/src/projectscene/qml/Audacity/ProjectScene/clipsview/TrackClipsItem.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/clipsview/TrackClipsItem.qml
@@ -20,6 +20,7 @@ Item {
 
     property bool isDataSelected: false
     property bool isTrackSelected: false
+    property bool isTrackFocused: false
     property bool isMultiSelectionActive: false
     property bool isTrackAudible: true
     property bool isStereo: clipsModel.isStereo
@@ -489,11 +490,26 @@ Item {
 
     Rectangle {
         id: selectedTrackHighlight
-        z: 0
+
         anchors.fill: parent
+        anchors.bottomMargin: sep.thickness
+        anchors.leftMargin: -canvas.anchors.leftMargin
+
+        color: "#FFFFFF"
+        opacity: 0.10
+
+        visible: root.isDataSelected || root.isTrackSelected
+    }
+
+    Rectangle {
+        id: defaultTrackHighlight
+
+        anchors.fill: parent
+        anchors.bottomMargin: sep.thickness
+        anchors.leftMargin: -canvas.anchors.leftMargin
+
         color: "#FFFFFF"
         opacity: 0.05
-        visible: root.isDataSelected || root.isTrackSelected
     }
 
     MouseArea {
@@ -548,10 +564,26 @@ Item {
         }
     }
 
+    Rectangle {
+        id: trackFocusState
+
+        anchors.fill: parent
+        anchors.leftMargin: -border.width - canvas.anchors.leftMargin
+        anchors.rightMargin: -border.width
+        anchors.topMargin: -border.width
+
+        visible: isTrackFocused
+
+        color: "transparent"
+
+        border.color: "#7EB1FF"
+        border.width: 2
+    }
+
     SeparatorLine {
         id: sep
-        color: "#FFFFFF"
-        opacity: 0.1
+
+        color: "transparent"
         anchors.bottom: parent.bottom
         thickness: 2
     }

--- a/src/projectscene/qml/Audacity/ProjectScene/clipsview/TracksClipsView.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/clipsview/TracksClipsView.qml
@@ -30,7 +30,7 @@ Rectangle {
 
     color: ui.theme.backgroundPrimaryColor
 
-    clip:true
+    clip: true
 
     TracksListClipsModel {
         id: tracksModel
@@ -127,84 +127,119 @@ Rectangle {
     }
 
     Rectangle {
-        id: timelineIndent
+        id: canvasIndent
+        anchors.top: timelineHeader.bottom
+        anchors.bottom: parent.bottom
+        height: timelineHeader.height
+        width: content.anchors.leftMargin
+        color: ui.theme.backgroundQuarternaryColor
+    }
+
+    Item {
+        id: timelineHeader
+
         anchors.top: parent.top
         anchors.left: parent.left
-        height: timeline.height
-        width: content.anchors.leftMargin
-        color: timeline.color
-
-        SeparatorLine {
-            id: topBorder
-            width: parent.width
-            anchors.bottom: parent.bottom
-            color: ui.theme.strokeColor
-        }
-    }
-
-    Rectangle {
-        id: canvasIndent
-        anchors.top: timelineIndent.bottom
-        anchors.bottom: parent.bottom
-        height: timeline.height
-        width: content.anchors.leftMargin
-        color: ui.theme.backgroundTertiaryColor
-    }
-
-    Timeline {
-        id: timeline
-
-        anchors.top: parent.top
-        anchors.left: timelineIndent.right
         anchors.right: parent.right
+        height: timeline.height
+        z: content.z + 1 // to prevent clips overlapping timeline ruler
 
         clip: true
 
-        height: 40
-
-        function updateCursorPosition(x, y) {
-            lineCursor.x = x
-            timeline.context.updateMousePositionTime(x)
-            tracksViewState.setMouseY(Math.max(0, Math.min(y, mainMouseArea.height)));
-        }
-
-        MouseArea {
-            id: timelineMouseArea
-            anchors.fill: parent
-            hoverEnabled: true
-
-            onPositionChanged: function(e) {
-                timeline.updateCursorPosition(e.x, e.y)
-            }
-
-            onClicked: function (e) {
-                if (!timeline.isMajorSection(e.y)) {
-                    playCursorController.seekToX(e.x, true /* triggerPlay */)
-                }
-            }
-        }
-
         Rectangle {
-            id: lineCursor
-
-            y: parent.top
-            height: timeline.height
-            width: 1
-
-            color: ui.theme.fontPrimaryColor
-        }
-
-        Rectangle {
-            id: timelineSelRect
-
-            x: timeline.context.singleClipSelected ? timeline.context.selectedClipStartPosition : timeline.context.selectionStartPosition
-            width: timeline.context.singleClipSelected ? timeline.context.selectedClipEndPosition - x : timeline.context.selectionEndPosition - x
+            id: timelineIndent
 
             anchors.top: parent.top
-            anchors.bottom: parent.bottom
+            anchors.left: parent.left
 
-            color: "#ABE7FF"
-            opacity: 0.3
+            height: timeline.height
+            width: content.anchors.leftMargin
+
+            color: timeline.color
+
+            SeparatorLine {
+                id: topBorder
+
+                anchors.bottom: parent.bottom
+
+                width: parent.width
+
+                color: ui.theme.strokeColor
+            }
+        }
+
+        Timeline {
+            id: timeline
+
+            anchors.top: parent.top
+            anchors.left: timelineIndent.right
+            anchors.right: parent.right
+
+            height: 40
+
+            function updateCursorPosition(x, y) {
+                lineCursor.x = x
+                timeline.context.updateMousePositionTime(x)
+                tracksViewState.setMouseY(Math.max(0, Math.min(y, mainMouseArea.height)));
+            }
+
+            MouseArea {
+                id: timelineMouseArea
+                anchors.fill: parent
+                hoverEnabled: true
+
+                onPositionChanged: function(e) {
+                    timeline.updateCursorPosition(e.x, e.y)
+                }
+
+                onClicked: function (e) {
+                    if (!timeline.isMajorSection(e.y)) {
+                        playCursorController.seekToX(e.x, true /* triggerPlay */)
+                    }
+                }
+            }
+
+            Rectangle {
+                id: lineCursor
+
+                y: parent.top
+                height: timeline.height
+                width: 1
+
+                color: ui.theme.fontPrimaryColor
+            }
+
+            Rectangle {
+                id: timelineSelRect
+
+                x: timeline.context.singleClipSelected ? timeline.context.selectedClipStartPosition : timeline.context.selectionStartPosition
+                width: timeline.context.singleClipSelected ? timeline.context.selectedClipEndPosition - x : timeline.context.selectionEndPosition - x
+
+                anchors.top: parent.top
+                anchors.bottom: parent.bottom
+
+                color: "#ABE7FF"
+                opacity: 0.3
+            }
+
+            PlayCursorHead {
+                id: head
+
+                anchors.top: parent.top
+                anchors.topMargin: 24
+
+                x: playCursorController.positionX
+
+                timelinePressed: timelineMouseArea.pressed
+
+                onSetPlaybackPosition: function(ix) {
+                    playCursorController.seekToX(ix)
+                }
+
+                onPlayCursorMousePositionChanged: function(ix) {
+                    timeline.updateCursorPosition(ix, -1)
+                }
+            }
         }
     }
 
@@ -230,7 +265,7 @@ Rectangle {
         id: content
         objectName: "clipsView"
         anchors.leftMargin: 12
-        anchors.top: timeline.bottom
+        anchors.top: timelineHeader.bottom
         anchors.bottom: parent.bottom
         anchors.left: parent.left
         anchors.right: parent.right
@@ -285,7 +320,7 @@ Rectangle {
                     if (tracksHovered) {
                         //! TODO AU4: handle context menu over empty track area
                     } else {
-                        canvasContextMenuLoader.show(Qt.point(e.x + timelineIndent.width, e.y + timeline.height), canvasContextMenuModel.items)
+                        canvasContextMenuLoader.show(Qt.point(e.x + timelineIndent.width, e.y + timelineHeader.height), canvasContextMenuModel.items)
                     }
                 }
             }
@@ -376,7 +411,7 @@ Rectangle {
                 id: tracksClipsView
 
                 anchors.fill: parent
-                clip: true
+                clip: false // do not clip so clip handles are visible
 
                 navigation.section: root.navigationSection
                 navigation.order: 3
@@ -404,6 +439,12 @@ Rectangle {
                 signal startAutoScroll()
                 signal stopAutoScroll()
 
+                header: Rectangle {
+                    height: 2
+                    width: parent.width
+                    color: "transparent"
+                }
+
                 footer: Item {
                     height: tracksViewState.tracksVerticalScrollPadding
                 }
@@ -430,6 +471,7 @@ Rectangle {
                     target: timeline.context
 
                     function onViewContentYChangeRequested(delta) {
+                        let headerHeight = tracksClipsView.headerItem ? tracksClipsView.headerItem.height : 0
                         let totalContentHeight = tracksModel.totalTracksHeight + tracksViewState.tracksVerticalScrollPadding
                         let canMove = totalContentHeight > tracksClipsView.height
                         if (!canMove) {
@@ -440,7 +482,7 @@ Rectangle {
 
                         let maxContentY = totalContentHeight - tracksClipsView.height
                         maxContentY = Math.max(maxContentY, tracksClipsView.contentY)
-                        contentYOffset = Math.max(Math.min(contentYOffset, maxContentY), 0)
+                        contentYOffset = Math.max(Math.min(contentYOffset, maxContentY), -headerHeight)
 
                         tracksClipsView.contentY = contentYOffset
                     }
@@ -458,6 +500,7 @@ Rectangle {
                     trackId: model.trackId
                     isDataSelected: model.isDataSelected
                     isTrackSelected: model.isTrackSelected
+                    isTrackFocused: model.isTrackFocused
                     isMultiSelectionActive: model.isMultiSelectionActive
                     isTrackAudible: model.isTrackAudible
                     moveActive: tracksClipsView.moveActive
@@ -506,7 +549,7 @@ Rectangle {
                     }
 
                     onRequestSelectionContextMenu: function(x, y) {
-                        selectionContextMenuLoader.show(Qt.point(x + canvasIndent.width, y + timeline.height), selectionContextMenuModel.items)
+                        selectionContextMenuLoader.show(Qt.point(x + canvasIndent.width, y + timelineHeader.height), selectionContextMenuModel.items)
                     }
 
                     onSelectionDraged: function(x1, x2, completed) {
@@ -628,21 +671,15 @@ Rectangle {
             width: timeline.context.selectionEndPosition - x
         }
 
-        PlayCursor {
+        PlayCursorLine {
             id: playCursor
+
             anchors.top: tracksClipsViewArea.top
             anchors.bottom: parent.bottom
+
             x: playCursorController.positionX
-            z: 2
+
             timelinePressed: timelineMouseArea.pressed
-
-            onSetPlaybackPosition: function(ix) {
-                playCursorController.seekToX(ix)
-            }
-
-            onPlayCursorMousePositionChanged: function(ix) {
-                timeline.updateCursorPosition(ix, -1)
-            }
         }
 
         Rectangle {
@@ -661,7 +698,7 @@ Rectangle {
         VerticalRulersPanel {
             id: verticalRulers
 
-            height: parent.height - timeline.height
+            height: parent.height - timelineHeader.height
             anchors.right: tracksClipsViewArea.right
             anchors.bottom: tracksClipsViewArea.bottom
 

--- a/src/projectscene/qml/Audacity/ProjectScene/trackspanel/TrackItem.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/trackspanel/TrackItem.qml
@@ -19,6 +19,7 @@ ListItemBlank {
     property var container: null
     property bool dragged: false
     property bool collapsed: height <= mapFromItem(trackControlsRow, 0, trackControlsRow.height + bottomSeparator.height).y
+    property bool isFocused: false
 
     signal interactionStarted()
     signal interactionEnded()
@@ -60,7 +61,6 @@ ListItemBlank {
     }
 
     height: trackViewState.trackHeight
-    clip: true
     opacity: dragged ? 0.5 : 1
 
     background.color: (root.isSelected || hoverHandler.hovered) ?
@@ -120,11 +120,13 @@ ListItemBlank {
 
         spacing: 0
 
-        TrackSelectionBar {
-            id: selectionBar
+        Rectangle {
+            id: spacer
 
-            isSelected: root.isSelected
-            isHovered: hoverHandler.hovered
+            color: "transparent"
+
+            Layout.fillHeight: true
+            Layout.preferredWidth: 9
         }
 
         ColumnLayout {
@@ -239,7 +241,9 @@ ListItemBlank {
             }
         }
 
-        SeparatorLine {}
+        SeparatorLine {
+            Layout.bottomMargin: 2 * bottomSeparator.thickness
+        }
 
         Row {
             id: volumePressureContainer
@@ -360,12 +364,48 @@ ListItemBlank {
         }
     }
 
+    Rectangle {
+        id: trackHeaderBorder
+
+        anchors.fill: parent
+        anchors.rightMargin: -radius
+        anchors.leftMargin: spacer.width
+        anchors.bottomMargin: bottomSeparator.thickness
+
+        color: "transparent"
+        border.width: 1
+        border.color: ui.theme.strokeColor
+
+        radius: 4
+    }
+
     SeparatorLine {
         id: bottomSeparator
 
         anchors.bottom: parent.bottom
 
+        color: "transparent"
+
         thickness: 2
+    }
+
+    Rectangle {
+        id: trackFocusState
+
+        anchors.fill: parent
+        anchors.leftMargin: spacer.width - border.width
+        anchors.rightMargin: -radius
+        anchors.topMargin: -border.width
+        anchors.bottomMargin: bottomSeparator.thickness - border.width
+
+        visible: root.isFocused
+
+        color: "transparent"
+
+        border.color: "#7EB1FF"
+        border.width: 2
+
+        radius: 6
     }
 
     Component {

--- a/src/projectscene/qml/Audacity/ProjectScene/trackspanel/TrackItem.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/trackspanel/TrackItem.qml
@@ -222,7 +222,6 @@ ListItemBlank {
             FlatButton {
                 Layout.fillWidth: true
                 Layout.preferredHeight: 24
-                Layout.margins: 4
 
                 opacity: root.height > root.mapFromItem(this, 0, height + bottomSeparator.height).y ? 1 : 0
                 visible: opacity !== 0

--- a/src/projectscene/qml/Audacity/ProjectScene/trackspanel/TracksPanel.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/trackspanel/TracksPanel.qml
@@ -34,6 +34,7 @@ Item {
     TracksViewStateModel {
         id: tracksViewState
         onTracksVericalYChanged: {
+            let headerHeight = view.header.height ? view.header.height : 0
             view.contentY = tracksViewState.tracksVericalY
         }
     }
@@ -169,6 +170,12 @@ Item {
 
                 model: tracksModel
 
+                header: Rectangle {
+                    height: 2
+                    width: parent.width
+                    color: "transparent"
+                }
+
                 footer: Item {
                     height: tracksViewState.tracksVerticalScrollPadding
                 }
@@ -178,6 +185,7 @@ Item {
                 delegate: TrackItem {
                     item: itemData
                     isSelected: Boolean(item) ? item.isSelected : false
+                    isFocused: Boolean(item) ? item.isFocused : false
                     container: view
 
                     navigation.name: Boolean(item) ? item.title + item.index : ""
@@ -228,12 +236,13 @@ Item {
                         acceptedDevices: PointerDevice.Mouse | PointerDevice.TouchPad
 
                         onWheel: function(wheelEvent) {
+                            let headerHeight = view.headerItem ? view.headerItem.height : 0
                             let delta = wheelEvent.pixelDelta.y !== 0 ? wheelEvent.pixelDelta.y : wheelEvent.angleDelta.y
                             let offset  = view.contentY - delta
 
                             let maxContentY = view.contentHeight - view.height
                             maxContentY = Math.max(maxContentY, view.contentY)
-                            offset = Math.max(Math.min(offset, maxContentY), 0)
+                            offset = Math.max(Math.min(offset, maxContentY), -headerHeight)
 
                             view.contentY = offset
                         }

--- a/src/projectscene/view/clipsview/clipslistmodel.cpp
+++ b/src/projectscene/view/clipsview/clipslistmodel.cpp
@@ -1035,6 +1035,7 @@ void ClipsListModel::selectClip(const ClipKey& key)
             }
         } else {
             selectionController()->setSelectedClips(trackeditInteraction()->clipsInGroup(clipGroupId), complete);
+            selectionController()->setFocusedTrack(key.key.trackId);
         }
     } else {
         if (modifiers.testFlag(Qt::ShiftModifier)) {

--- a/src/projectscene/view/clipsview/selectionviewcontroller.cpp
+++ b/src/projectscene/view/clipsview/selectionviewcontroller.cpp
@@ -50,6 +50,9 @@ void SelectionViewController::onPressed(double x, double y)
         tracks = selectionController()->determinateTracks(m_startPoint.y(), y);
     }
 
+    if (!tracks.empty()) {
+        selectionController()->setFocusedTrack(tracks.at(0));
+    }
     selectionController()->setSelectedTracks(tracks, true);
 
     if (modifiers.testFlag(Qt::ShiftModifier) || modifiers.testFlag(Qt::ControlModifier)) {
@@ -99,7 +102,7 @@ void SelectionViewController::onPositionChanged(double x, double y)
     } else {
         tracks = selectionController()->determinateTracks(m_startPoint.y(), y);
     }
-    selectionController()->setSelectedTracks(tracks, true);
+    selectionController()->setSelectedTracks(tracks, false);
 
     // time
     double x1 = m_startPoint.x();
@@ -160,8 +163,10 @@ void SelectionViewController::onReleased(double x, double y)
 
     setSelectionActive(true);
 
-    if (!tracks.empty()) {
-        selectionController()->setSelectedTracks(tracks);
+    if (m_startPoint.y() < y) {
+        selectionController()->setFocusedTrack(tracks.back());
+    } else {
+        selectionController()->setFocusedTrack(tracks.front());
     }
     selectionController()->setSelectedTracks(tracks, true);
 

--- a/src/projectscene/view/clipsview/trackslistclipsmodel.cpp
+++ b/src/projectscene/view/clipsview/trackslistclipsmodel.cpp
@@ -47,6 +47,18 @@ void TracksListClipsModel::load()
         emit dataChanged(beginIndex, lastIndex, { IsDataSelectedRole });
     });
 
+    selectionController()->focusedTrackChanged().onReceive(this, [this](const trackedit::TrackId& trackId) {
+        Q_UNUSED(trackId);
+        if (m_trackList.empty()) {
+            return;
+        }
+
+        QModelIndex beginIndex = index(0);
+        QModelIndex lastIndex = index(static_cast<int>(m_trackList.size()) - 1);
+
+        emit dataChanged(beginIndex, lastIndex, { IsTrackFocusedRole });
+    });
+
     selectionController()->clipsSelected().onReceive(this, [this](const trackedit::ClipKeyList& clipKeys) {
         Q_UNUSED(clipKeys);
 
@@ -203,6 +215,9 @@ QVariant TracksListClipsModel::data(const QModelIndex& index, int role) const
     case IsTrackSelectedRole: {
         return muse::contains(selectionController()->selectedTracks(), track.id);
     }
+    case IsTrackFocusedRole: {
+        return selectionController()->focusedTrack() == track.id;
+    }
     case IsMultiSelectionActiveRole: {
         return selectionController()->selectedClips().size() > 1;
     }
@@ -233,6 +248,7 @@ QHash<int, QByteArray> TracksListClipsModel::roleNames() const
         { TrackIdRole, "trackId" },
         { IsDataSelectedRole, "isDataSelected" },
         { IsTrackSelectedRole, "isTrackSelected" },
+        { IsTrackFocusedRole, "isTrackFocused" },
         { IsMultiSelectionActiveRole, "isMultiSelectionActive" },
         { IsTrackAudibleRole, "isTrackAudible" },
     };

--- a/src/projectscene/view/clipsview/trackslistclipsmodel.h
+++ b/src/projectscene/view/clipsview/trackslistclipsmodel.h
@@ -63,6 +63,7 @@ private:
         TrackIdRole,
         IsDataSelectedRole,
         IsTrackSelectedRole,
+        IsTrackFocusedRole,
         IsMultiSelectionActiveRole,
         IsTrackAudibleRole,
     };

--- a/src/projectscene/view/timeline/gridlines.cpp
+++ b/src/projectscene/view/timeline/gridlines.cpp
@@ -14,7 +14,7 @@ void GridLines::paint(QPainter* painter)
 {
     // set background
     QRectF rect = boundingRect();
-    QColor canvasColor = uiconfiguration()->currentTheme().values.value(muse::ui::BACKGROUND_TERTIARY_COLOR).toString();
+    QColor canvasColor = uiconfiguration()->currentTheme().values.value(muse::ui::BACKGROUND_QUARTERNARY_COLOR).toString();
     painter->fillRect(rect, canvasColor);
 
     // draw left border

--- a/src/projectscene/view/trackspanel/trackitem.cpp
+++ b/src/projectscene/view/trackspanel/trackitem.cpp
@@ -302,3 +302,18 @@ void TrackItem::setIsSelected(bool selected)
     m_isSelected = selected;
     emit isSelectedChanged();
 }
+
+bool TrackItem::isFocused() const
+{
+    return m_isFocused;
+}
+
+void TrackItem::setIsFocused(bool focused)
+{
+    if (m_isFocused == focused) {
+        return;
+    }
+
+    m_isFocused = focused;
+    emit isFocusedChanged();
+}

--- a/src/projectscene/view/trackspanel/trackitem.h
+++ b/src/projectscene/view/trackspanel/trackitem.h
@@ -37,6 +37,7 @@ class TrackItem : public QObject, public muse::async::Asyncable
     Q_PROPERTY(bool muted READ muted WRITE setMuted NOTIFY mutedChanged)
 
     Q_PROPERTY(bool isSelected READ isSelected NOTIFY isSelectedChanged)
+    Q_PROPERTY(bool isFocused READ isFocused NOTIFY isFocusedChanged)
 
     muse::Inject<playback::ITrackPlaybackControl> trackPlaybackControl;
     muse::Inject<trackedit::ITrackeditInteraction> trackeditInteraction;
@@ -80,6 +81,9 @@ public:
     bool isSelected() const;
     void setIsSelected(bool selected);
 
+    bool isFocused() const;
+    void setIsFocused(bool focused);
+
 public slots:
     void setTitle(QString title);
 
@@ -110,6 +114,7 @@ signals:
     void auxSendItemListChanged();
 
     void isSelectedChanged();
+    void isFocusedChanged();
 
 protected:
     void setAudioChannelVolumePressure(const trackedit::audioch_t chNum, const float newValue);
@@ -130,6 +135,7 @@ protected:
     bool m_outputResourceItemsLoading = false;
 
     bool m_isSelected = false;
+    bool m_isFocused = false;
 };
 }
 

--- a/src/projectscene/view/trackspanel/trackslistmodel.cpp
+++ b/src/projectscene/view/trackspanel/trackslistmodel.cpp
@@ -99,6 +99,12 @@ void TracksListModel::load()
 
     loadTracks(prj->trackList());
 
+    onFocusedTrack(selectionController()->focusedTrack());
+
+    selectionController()->focusedTrackChanged().onReceive(this, [this](trackedit::TrackId trackId) {
+        onFocusedTrack(trackId);
+    });
+
     emit isEmptyChanged();
     emit isAddingAvailableChanged(true);
 }
@@ -349,6 +355,7 @@ void TracksListModel::setItemsSelected(const QModelIndexList& indexes, bool sele
     if (selected) {
         // if selecting new tracks, add them to the existing selection
         alreadySelectedTracksIds.insert(alreadySelectedTracksIds.end(), idsToModify.begin(), idsToModify.end());
+        selectionController()->setFocusedTrack(idsToModify.back());
     } else {
         // if deselecting tracks, remove them from the existing selection
         alreadySelectedTracksIds.erase(
@@ -574,6 +581,14 @@ void TracksListModel::onSelectedTracks(const TrackIdList& trackIds)
     QSignalBlocker blocker(m_selectionModel);
     QItemSelectionModel* selectionModel = m_selectionModel;
     selectionModel->select(selection, QItemSelectionModel::ClearAndSelect);
+}
+
+void TracksListModel::onFocusedTrack(const trackedit::TrackId& trackId)
+{
+    for (int i = 0; i < m_trackList.size(); ++i) {
+        auto& track = m_trackList.at(i);
+        track->setIsFocused(track->trackId() == trackId);
+    }
 }
 
 void TracksListModel::onTracksChanged(const std::vector<au::trackedit::Track>& tracks)

--- a/src/projectscene/view/trackspanel/trackslistmodel.h
+++ b/src/projectscene/view/trackspanel/trackslistmodel.h
@@ -98,6 +98,7 @@ private:
 
     void onProjectChanged();
     void onSelectedTracks(const trackedit::TrackIdList& tracksIds);
+    void onFocusedTrack(const trackedit::TrackId& trackId);
     void onTracksChanged(const std::vector<trackedit::Track>& tracks);
     void onTrackAdded(const trackedit::Track& track);
     void onTrackRemoved(const trackedit::Track& track);

--- a/src/trackedit/internal/au3/au3interaction.cpp
+++ b/src/trackedit/internal/au3/au3interaction.cpp
@@ -1007,6 +1007,7 @@ muse::Ret Au3Interaction::paste(const std::vector<ITrackDataPtr>& data, secs_t b
     if (selectedTracks.empty()) {
         const TrackIdList tracksIdsToSelect = pasteIntoNewTracks(copiedData);
         selectionController()->setSelectedTracks(tracksIdsToSelect);
+        selectionController()->setFocusedTrack(tracksIdsToSelect.front());
         projectWasModified = true;
         return muse::make_ok();
     }
@@ -1105,6 +1106,7 @@ muse::Ret Au3Interaction::paste(const std::vector<ITrackDataPtr>& data, secs_t b
     }
 
     selectionController()->setSelectedTracks(dstTracksIds);
+    selectionController()->setFocusedTrack(dstTracksIds.front());
 
     return ok;
 }
@@ -1906,6 +1908,7 @@ void Au3Interaction::addWaveTrack(int numChannels)
     prj->notifyAboutTrackAdded(DomConverter::track(track));
 
     selectionController()->setSelectedTracks({ track->GetId() });
+    selectionController()->setFocusedTrack(track->GetId());
 }
 
 bool Au3Interaction::newLabelTrack()

--- a/src/trackedit/internal/au3/au3selectioncontroller.h
+++ b/src/trackedit/internal/au3/au3selectioncontroller.h
@@ -75,6 +75,10 @@ public:
 
     void resetTimeSelection() override;
 
+    trackedit::TrackId focusedTrack() const override;
+    void setFocusedTrack(TrackId trackId) override;
+    muse::async::Channel<trackedit::TrackId> focusedTrackChanged() const override;
+
 private:
     void addSelectedTrack(const trackedit::TrackId& trackId);
     void updateSelectionController();
@@ -113,5 +117,8 @@ private:
     Val<trackedit::secs_t> m_selectedEndTime;
 
     Val<trackedit::secs_t> m_selectionStartTime; // indicates where user started selection
+
+    // track focus state
+    Val<TrackId> m_focusedTrack;
 };
 }

--- a/src/trackedit/iselectioncontroller.h
+++ b/src/trackedit/iselectioncontroller.h
@@ -74,5 +74,10 @@ public:
     virtual bool isSelectionGrouped() const = 0;
 
     virtual void resetTimeSelection() = 0;
+
+    // track focus state
+    virtual TrackId focusedTrack() const = 0;
+    virtual void setFocusedTrack(TrackId trackId) = 0;
+    virtual muse::async::Channel<trackedit::TrackId> focusedTrackChanged() const = 0;
 };
 }

--- a/src/trackedit/tests/mocks/selectioncontrollermock.h
+++ b/src/trackedit/tests/mocks/selectioncontrollermock.h
@@ -54,5 +54,9 @@ public:
     MOCK_METHOD(bool, isSelectionGrouped, (), (const, override));
 
     MOCK_METHOD(void, resetTimeSelection, (), (override));
+
+    MOCK_METHOD(TrackId, focusedTrack, (), (const, override));
+    MOCK_METHOD(void, setFocusedTrack, (TrackId trackId), (override));
+    MOCK_METHOD(muse::async::Channel<trackedit::TrackId>, focusedTrackChanged, (), (const, override));
 };
 }


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/8627
Resolves: https://github.com/audacity/audacity/issues/7224 

Few notes:
I had to reorganize main clips view: previously the inner area (containing track/clips only) had clipping turned on. That caused clip handles to be invisible when clip was at 0.0 position (these were clipped). We didn't change that before because it was messing with play cursor (playhead was not visible).
I turned off clipping for inner clipsview, but turned on clipping for outer clipsview (meaning the clipsview, left side indent and timelineruler area). This allowed clip handles to be visible. To fix the playcursor head I separated the PlayCursorLine (it's in  inner clipsview) and PlayCursorHead (it's in timeline ruler header).

Anticipating questions about setting track focus state when setting a selection to avoid calling multiple calls of
`selectionController()->setSelectedTracks(tracks);    
selectionController()->setFocusedTrack(id);`
together.
Very often those two change together, but there are situations when they don't so they have to be separate calls.
