### PR TITLE
UI-less Lv2 support

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,6 +2,7 @@
     "recommendations": [
         "ms-vscode.cmake-tools",
         "ms-vscode.cpptools",
-        "zachflower.uncrustify" // for code formatting
+        "zachflower.uncrustify", // for code formatting
+        "vadimcn.vscode-lldb", // provides a fast debugger (tried on Linux)
     ],
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,7 +1,7 @@
 {
     "configurations": [
         {
-            "name": "run audacity",
+            "name": "Launch",
             "type": "cppvsdbg",
             "request": "launch",
             "program": "${workspaceFolder}/build/Debug/install/bin/audacity.exe",
@@ -28,15 +28,47 @@
             "visualizerFile": "${workspaceFolder}/.vscode/qt6.natvis",
         },
         {
-            "name": "run audacity (Linux)",
-            "type": "cppdbg",
+            // Requires CodeLLDB extension
+            // Doesn't support visualizerFile but is much faster than cppvsdbg
+            "name": "Launch (Linux - lldb)",
+            "type": "lldb",
             "request": "launch",
             "program": "${workspaceFolder}/build/Debug/src/app/audacity",
             "preLaunchTask": "CMake: build",
+            "args": [
+                // "--register-audio-plugin",
+                // "https://wasted.audio/software/wstd_flangr"
+            ],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "name": "Launch (Linux - cppdbg)",
+            "type": "cppdbg",
+            "MIMode": "gdb",
+            "request": "launch",
+            "program": "${workspaceFolder}/build/Debug/src/app/audacity",
+            "preLaunchTask": "CMake: build",
+            "args": [
+                "--register-audio-plugin",
+                "https://wasted.audio/software/wstd_flangr"
+            ],
             "stopAtEntry": false,
             "cwd": "${workspaceFolder}/build/Debug/src/app",
             "visualizerFile": "${workspaceFolder}/.vscode/qt6.natvis",
             "showDisplayString": true
+        },
+        {
+            "name": "run audacity (MacOS)",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/build/Debug/src/app/audacity.app/Contents/MacOS/audacity",
+            "args": [],
+            "preLaunchTask": "CMake: install",
+            "stopAtEntry": false,
+            "cwd": "${fileDirname}",
+            "environment": [],
+            "externalConsole": false,
+            "MIMode": "lldb"
         }
     ]
 }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,7 +117,7 @@ option(AU_BUILD_EFFECTS_TESTS "Build effects tests" ON)
 option(AU_MODULE_EFFECTS_VST "Build audacity vst module" ON)
 set(AU_MODULE_VST_VST3_SDK_PATH "" CACHE PATH "[optional] Path to VST3_SDK. SDK version >= ${VST3_SDK_VERSION} required")
 
-option(AU_MODULE_EFFECTS_LV2 "Build audacity lv2 module" OFF)
+option(AU_MODULE_EFFECTS_LV2 "Build audacity lv2 module" ON)
 set(AU_MODULE_LV2_LV2SDK_PATH "" CACHE PATH "[optional] Path to lv2 SDK. lilv version >= 0.24.26 required")
 
 option(AU_USE_FFMPEG "Build mod-ffmpeg module" ON)

--- a/au3/libraries/lib-audio-unit/AudioUnitEffectsModule.cpp
+++ b/au3/libraries/lib-audio-unit/AudioUnitEffectsModule.cpp
@@ -184,7 +184,7 @@ void AudioUnitEffectsModule::AutoRegisterPlugins(PluginManagerInterface&)
 {
 }
 
-PluginPaths AudioUnitEffectsModule::FindModulePaths(PluginManagerInterface&)
+PluginPaths AudioUnitEffectsModule::FindModulePaths(PluginManagerInterface&) const
 {
     PluginPaths effects;
 

--- a/au3/libraries/lib-audio-unit/AudioUnitEffectsModule.h
+++ b/au3/libraries/lib-audio-unit/AudioUnitEffectsModule.h
@@ -56,7 +56,7 @@ public:
     FilePath InstallPath() override { return {}; }
 
     void AutoRegisterPlugins(PluginManagerInterface& pm) override;
-    PluginPaths FindModulePaths(PluginManagerInterface& pm) override;
+    PluginPaths FindModulePaths(PluginManagerInterface& pm) const override;
     unsigned DiscoverPluginsAtPath(
         const PluginPath& path, TranslatableString& errMsg, const RegistrationCallback& callback)
     override;

--- a/au3/libraries/lib-components/PluginProvider.h
+++ b/au3/libraries/lib-components/PluginProvider.h
@@ -146,7 +146,7 @@ public:
      @see GetFileExtensions DiscoverPluginsAtPath
      */
     virtual PluginPaths
-    FindModulePaths(PluginManagerInterface& pluginManager) = 0;
+    FindModulePaths(PluginManagerInterface& pluginManager) const = 0;
 
     //! Further expand a path reported by FindModulePaths
     /*!

--- a/au3/libraries/lib-effects/EffectManager.h
+++ b/au3/libraries/lib-effects/EffectManager.h
@@ -28,7 +28,7 @@ class wxString;
 typedef wxString PluginID;
 class Effect;
 class EffectPlugin;
-class EffectSettings;
+struct EffectSettings;
 class EffectInstance;
 
 struct EffectAndDefaultSettings {

--- a/au3/libraries/lib-effects/LoadEffects.cpp
+++ b/au3/libraries/lib-effects/LoadEffects.cpp
@@ -165,7 +165,7 @@ void BuiltinEffectsModule::AutoRegisterPlugins(PluginManagerInterface& pm)
     }
 }
 
-PluginPaths BuiltinEffectsModule::FindModulePaths(PluginManagerInterface&)
+PluginPaths BuiltinEffectsModule::FindModulePaths(PluginManagerInterface&) const
 {
     // Not really libraries
     PluginPaths names;

--- a/au3/libraries/lib-effects/LoadEffects.h
+++ b/au3/libraries/lib-effects/LoadEffects.h
@@ -64,7 +64,7 @@ public:
     FilePath InstallPath() override { return {}; }
 
     void AutoRegisterPlugins(PluginManagerInterface& pm) override;
-    PluginPaths FindModulePaths(PluginManagerInterface& pm) override;
+    PluginPaths FindModulePaths(PluginManagerInterface& pm) const override;
     unsigned DiscoverPluginsAtPath(
         const PluginPath& path, TranslatableString& errMsg, const RegistrationCallback& callback)
     override;

--- a/au3/libraries/lib-ladspa/LadspaEffectsModule.cpp
+++ b/au3/libraries/lib-ladspa/LadspaEffectsModule.cpp
@@ -177,7 +177,7 @@ void LadspaEffectsModule::AutoRegisterPlugins(PluginManagerInterface& pm)
     }
 }
 
-PluginPaths LadspaEffectsModule::FindModulePaths(PluginManagerInterface& pm)
+PluginPaths LadspaEffectsModule::FindModulePaths(PluginManagerInterface& pm) const
 {
     auto pathList = GetSearchPaths(pm);
     FilePaths files;
@@ -306,7 +306,7 @@ bool LadspaEffectsModule::CheckPluginExist(const PluginPath& path) const
     return wxFileName::FileExists(realPath);
 }
 
-FilePaths LadspaEffectsModule::GetSearchPaths(PluginManagerInterface& pluginManager)
+FilePaths LadspaEffectsModule::GetSearchPaths(PluginManagerInterface& pluginManager) const
 {
     FilePaths pathList;
     wxString pathVar;

--- a/au3/libraries/lib-ladspa/LadspaEffectsModule.h
+++ b/au3/libraries/lib-ladspa/LadspaEffectsModule.h
@@ -47,7 +47,7 @@ public:
     FilePath InstallPath() override;
 
     void AutoRegisterPlugins(PluginManagerInterface& pm) override;
-    PluginPaths FindModulePaths(PluginManagerInterface& pm) override;
+    PluginPaths FindModulePaths(PluginManagerInterface& pm) const override;
     unsigned DiscoverPluginsAtPath(
         const PluginPath& path, TranslatableString& errMsg, const RegistrationCallback& callback)
     override;
@@ -59,7 +59,7 @@ public:
 
     // LadspaEffectModule implementation
 
-    FilePaths GetSearchPaths(PluginManagerInterface& pluginManager);
+    FilePaths GetSearchPaths(PluginManagerInterface& pluginManager) const;
 };
 
 #endif

--- a/au3/libraries/lib-lv2/LV2Symbols.cpp
+++ b/au3/libraries/lib-lv2/LV2Symbols.cpp
@@ -46,6 +46,11 @@ URIDLIST
 
 bool InitializeGWorld()
 {
+    if (gWorld) {
+        // Already initialized.
+        return true;
+    }
+
     // Try to initialise Lilv, or return.
     uWorld.reset(lilv_world_new());
     if (!uWorld) {

--- a/au3/libraries/lib-lv2/LoadLV2.cpp
+++ b/au3/libraries/lib-lv2/LoadLV2.cpp
@@ -14,7 +14,6 @@ Functions that find and load all LV2 plugins on the system.
 
 *//*******************************************************************/
 #include "LV2Wrapper.h"
-#include "PluginHost.h"
 #include "PluginInterface.h"
 #if defined(USE_LV2)
 
@@ -116,12 +115,13 @@ bool LV2EffectsModule::Initialize()
     }
 
     wxGetEnv(wxT("LV2_PATH"), &mStartupPathVar);
+    return true;
+}
 
-    if (PluginHost::IsHostProcess()) {
-        //Plugin validation process does not call `AutoRegisterPlugins`
-        //Register plugins from `LV2_PATH` here
-        lilv_world_load_all(LV2Symbols::gWorld);
-    }
+bool LV2EffectsModule::InitializePluginRegistration()
+{
+    Initialize();
+    lilv_world_load_all(LV2Symbols::gWorld);
     return true;
 }
 

--- a/au3/libraries/lib-lv2/LoadLV2.cpp
+++ b/au3/libraries/lib-lv2/LoadLV2.cpp
@@ -220,7 +220,7 @@ void LV2EffectsModule::AutoRegisterPlugins(PluginManagerInterface& pluginManager
     lilv_world_load_all(LV2Symbols::gWorld);
 }
 
-PluginPaths LV2EffectsModule::FindModulePaths(PluginManagerInterface&)
+PluginPaths LV2EffectsModule::FindModulePaths(PluginManagerInterface&) const
 {
     // Retrieve data about all LV2 plugins
     const LilvPlugins* plugs = lilv_world_get_all_plugins(LV2Symbols::gWorld);

--- a/au3/libraries/lib-lv2/LoadLV2.h
+++ b/au3/libraries/lib-lv2/LoadLV2.h
@@ -56,7 +56,7 @@ public:
     FilePath InstallPath() override { return {}; }
 
     void AutoRegisterPlugins(PluginManagerInterface& pm) override;
-    PluginPaths FindModulePaths(PluginManagerInterface& pm) override;
+    PluginPaths FindModulePaths(PluginManagerInterface& pm) const override;
     unsigned DiscoverPluginsAtPath(
         const PluginPath& path, TranslatableString& errMsg, const RegistrationCallback& callback)
     override;

--- a/au3/libraries/lib-lv2/LoadLV2.h
+++ b/au3/libraries/lib-lv2/LoadLV2.h
@@ -37,6 +37,9 @@ public:
     LV2EffectsModule();
     virtual ~LV2EffectsModule();
 
+    //! Execute eitehr InitializePluginRegistration() or Initialize()
+    bool InitializePluginRegistration();
+
     // ComponentInterface implementation
 
     PluginPath GetPath() const override;
@@ -70,9 +73,9 @@ public:
 
     std::unique_ptr<Validator> MakeValidator() const override;
 
-private:
-
     static const LilvPlugin* GetPlugin(const PluginPath& path);
+
+private:
 
     //During initialization LV2 module will update LV2_PATH
     //environment variable, we need to preserve the its contents

--- a/au3/libraries/lib-nyquist-effects/LoadNyquist.cpp
+++ b/au3/libraries/lib-nyquist-effects/LoadNyquist.cpp
@@ -211,7 +211,7 @@ void NyquistEffectsModule::AutoRegisterPlugins(PluginManagerInterface& pm)
     }
 }
 
-PluginPaths NyquistEffectsModule::FindModulePaths(PluginManagerInterface& pm)
+PluginPaths NyquistEffectsModule::FindModulePaths(PluginManagerInterface& pm) const
 {
     auto pathList = NyquistBase::GetNyquistSearchPath();
     FilePaths files;

--- a/au3/libraries/lib-nyquist-effects/LoadNyquist.h
+++ b/au3/libraries/lib-nyquist-effects/LoadNyquist.h
@@ -42,7 +42,7 @@ public:
     FilePath InstallPath() override;
 
     void AutoRegisterPlugins(PluginManagerInterface& pm) override;
-    PluginPaths FindModulePaths(PluginManagerInterface& pm) override;
+    PluginPaths FindModulePaths(PluginManagerInterface& pm) const override;
     unsigned DiscoverPluginsAtPath(
         const PluginPath& path, TranslatableString& errMsg, const RegistrationCallback& callback)
     override;

--- a/au3/libraries/lib-vst/VSTEffectsModule.cpp
+++ b/au3/libraries/lib-vst/VSTEffectsModule.cpp
@@ -140,7 +140,7 @@ void VSTEffectsModule::AutoRegisterPlugins(PluginManagerInterface&)
 {
 }
 
-PluginPaths VSTEffectsModule::FindModulePaths(PluginManagerInterface& pm)
+PluginPaths VSTEffectsModule::FindModulePaths(PluginManagerInterface& pm) const
 {
     FilePaths pathList;
     FilePaths files;
@@ -155,7 +155,7 @@ PluginPaths VSTEffectsModule::FindModulePaths(PluginManagerInterface& pm)
         }
     }
 
-    const auto AddCustomPaths = [](PluginManagerInterface& pm, VSTEffectsModule& module, FilePaths& pathList)
+    const auto AddCustomPaths = [](PluginManagerInterface& pm, const VSTEffectsModule& module, FilePaths& pathList)
     {
         const auto customPaths = pm.ReadCustomPaths(module);
         std::copy(customPaths.begin(), customPaths.end(), std::back_inserter(pathList));

--- a/au3/libraries/lib-vst/VSTEffectsModule.h
+++ b/au3/libraries/lib-vst/VSTEffectsModule.h
@@ -48,7 +48,7 @@ public:
     FilePath InstallPath() override;
 
     void AutoRegisterPlugins(PluginManagerInterface& pm) override;
-    PluginPaths FindModulePaths(PluginManagerInterface& pm) override;
+    PluginPaths FindModulePaths(PluginManagerInterface& pm) const override;
     unsigned DiscoverPluginsAtPath(
         const PluginPath& path, TranslatableString& errMsg, const RegistrationCallback& callback)
     override;

--- a/au3/libraries/lib-vst3/VST3EffectsModule.cpp
+++ b/au3/libraries/lib-vst3/VST3EffectsModule.cpp
@@ -156,7 +156,7 @@ bool VST3EffectsModule::SupportsCustomModulePaths() const
 }
 
 PluginPaths
-VST3EffectsModule::FindModulePaths(PluginManagerInterface& pluginManager)
+VST3EffectsModule::FindModulePaths(PluginManagerInterface& pluginManager) const
 {
     //Note: The host recursively scans these folders at startup in this order (User/Global/Application).
     //https://developer.steinberg.help/display/VST/Plug-in+Locations

--- a/au3/libraries/lib-vst3/VST3EffectsModule.h
+++ b/au3/libraries/lib-vst3/VST3EffectsModule.h
@@ -60,7 +60,7 @@ public:
     FilePath InstallPath() override;
     void AutoRegisterPlugins(PluginManagerInterface& pluginManager) override;
     bool SupportsCustomModulePaths() const override;
-    PluginPaths FindModulePaths(PluginManagerInterface& pluginManager) override;
+    PluginPaths FindModulePaths(PluginManagerInterface& pluginManager) const override;
     unsigned DiscoverPluginsAtPath(const PluginPath& path, TranslatableString& errMsg, const RegistrationCallback& callback) override;
     bool CheckPluginExist(const PluginPath& path) const override;
     std::unique_ptr<ComponentInterface>

--- a/au3/src/commands/LoadCommands.cpp
+++ b/au3/src/commands/LoadCommands.cpp
@@ -156,7 +156,7 @@ void BuiltinCommandsModule::AutoRegisterPlugins(PluginManagerInterface& pm)
     }
 }
 
-PluginPaths BuiltinCommandsModule::FindModulePaths(PluginManagerInterface&)
+PluginPaths BuiltinCommandsModule::FindModulePaths(PluginManagerInterface&) const
 {
     // Not really libraries
     PluginPaths names;

--- a/au3/src/commands/LoadCommands.h
+++ b/au3/src/commands/LoadCommands.h
@@ -64,7 +64,7 @@ public:
     FilePath InstallPath() override { return {}; }
 
     void AutoRegisterPlugins(PluginManagerInterface& pm) override;
-    PluginPaths FindModulePaths(PluginManagerInterface& pm) override;
+    PluginPaths FindModulePaths(PluginManagerInterface& pm) const override;
     unsigned DiscoverPluginsAtPath(
         const PluginPath& path, TranslatableString& errMsg, const RegistrationCallback& callback)
     override;

--- a/au3/src/effects/vamp/LoadVamp.cpp
+++ b/au3/src/effects/vamp/LoadVamp.cpp
@@ -124,7 +124,7 @@ void VampEffectsModule::AutoRegisterPlugins(PluginManagerInterface&)
 {
 }
 
-PluginPaths VampEffectsModule::FindModulePaths(PluginManagerInterface&)
+PluginPaths VampEffectsModule::FindModulePaths(PluginManagerInterface&) const
 {
     PluginPaths names;
 

--- a/au3/src/effects/vamp/LoadVamp.h
+++ b/au3/src/effects/vamp/LoadVamp.h
@@ -48,7 +48,7 @@ public:
     FilePath InstallPath() override { return {}; }
 
     void AutoRegisterPlugins(PluginManagerInterface& pm) override;
-    PluginPaths FindModulePaths(PluginManagerInterface& pm) override;
+    PluginPaths FindModulePaths(PluginManagerInterface& pm) const override;
     unsigned DiscoverPluginsAtPath(
         const PluginPath& path, TranslatableString& errMsg, const RegistrationCallback& callback)
     override;

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -87,6 +87,7 @@ set(LINK_LIB
     au3wrap
     context
     effects_vst
+    effects_lv2
     project
     projectscene
     audio
@@ -104,7 +105,6 @@ if (AU_MODULE_EFFECTS_VST)
 endif()
 
 if (AU_MODULE_EFFECTS_LV2)
-    list(APPEND LINK_LIB effects_lv2)
     add_definitions(-DAU_MODULE_EFFECTS_LV2)
 endif()
 

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -62,6 +62,8 @@
 #include "effects/builtin/builtineffectsmodule.h"
 #ifdef AU_MODULE_EFFECTS_LV2
 #include "effects/lv2/lv2effectsmodule.h"
+#else
+#include "stubs/lv2/lv2effectsstubmodule.h"
 #endif
 #ifdef AU_MODULE_EFFECTS_VST
 #include "effects/vst/vsteffectsmodule.h"
@@ -174,14 +176,9 @@ int main(int argc, char** argv)
 #ifdef MUSE_MODULE_AUTOBOT
     app.addModule(new muse::autobot::AutobotModule());
 #endif
-#ifdef AU_MODULE_EFFECTS_LV2
     app.addModule(new au::effects::Lv2EffectsModule());
-#endif
-#ifdef AU_MODULE_EFFECTS_VST
     app.addModule(new au::effects::VstEffectsModule());
-#else
-    app.addModule(new au::effects::VstEffectsStubModule());
-#endif
+
     if (!isPluginRegistration) {
         app.addModule(new au::context::ContextModule());
         app.addModule(new au::audio::AudioModule());

--- a/src/au3wrap/CMakeLists.txt
+++ b/src/au3wrap/CMakeLists.txt
@@ -584,6 +584,9 @@ if (AU_MODULE_EFFECTS_LV2)
         ${AU3_LIBRARIES}/lib-lv2/LV2Utils.h
         ${AU3_LIBRARIES}/lib-lv2/LV2Wrapper.cpp
         ${AU3_LIBRARIES}/lib-lv2/LV2Wrapper.h
+        ${AU3_LIBRARIES}/lib-lv2/zix/common.h
+        ${AU3_LIBRARIES}/lib-lv2/zix/ring.cpp
+        ${AU3_LIBRARIES}/lib-lv2/zix/ring.h
     )
 endif()
 

--- a/src/au3wrap/lv2sdk/CMakeLists.txt
+++ b/src/au3wrap/lv2sdk/CMakeLists.txt
@@ -172,6 +172,11 @@ set(MODULE_INCLUDE
 
 set(MODULE_DEF
     -D_GNU_SOURCE # for /zix/src/posix/filesystem_posix.c
+    -DSORD_STATIC
+    -DLILV_STATIC
+    -DSERD_STATIC
+    -DSRATOM_STATIC
+    -DZIX_STATIC
 )
 
 set(MODULE_USE_PCH OFF)

--- a/src/au3wrap/lv2sdk/CMakeLists.txt
+++ b/src/au3wrap/lv2sdk/CMakeLists.txt
@@ -8,180 +8,280 @@ message(STATUS "AU_MODULE_LV2_LV2SDK_PATH: ${AU_MODULE_LV2_LV2SDK_PATH}")
 if(AU_MODULE_LV2_LV2SDK_PATH)
     set(LV2SDK_PATH ${AU_MODULE_LV2_LV2SDK_PATH})
 else()
-
-    # If not set MUSE_MODULE_VST_LV2SDK_PATH
-    # download lv2sdk source
-
-    set(REMOTE_ROOT_URL https://raw.githubusercontent.com/musescore/muse_deps/main)
-    set(remote_url "${REMOTE_ROOT_URL}/lv2sdk/lv2sdk_0.24.26")
-    set(local_path ${PROJECT_BINARY_DIR}/_deps/lv2sdk)
-    if (NOT EXISTS ${local_path}/lv2sdk.cmake)
-        file(MAKE_DIRECTORY ${local_path})
-        file(DOWNLOAD ${remote_url}/lv2sdk.cmake ${local_path}/lv2sdk.cmake
-            HTTPHEADER "Cache-Control: no-cache"
-        )
-    endif()
-
-    include(${local_path}/lv2sdk.cmake)
-
-    # func from ${name}.cmake)
-    cmake_language(CALL lv2sdk_Populate ${remote_url} ${local_path} "source" "" "")
-
-    set(LV2SDK_PATH ${local_path})
-
+    set(LV2SDK_PATH ${CMAKE_SOURCE_DIR}/au3/lib-src/lv2)
 endif()
 
-include(GetPlatformInfo)
+message(STATUS "LV2SDK_PATH: ${LV2SDK_PATH}")
 
-# lv2
-set(LV2_PATH ${LV2SDK_PATH}/lv2)
 
-# lilv
-set(LILV_PATH ${LV2SDK_PATH}/lilv)
-set(LILV_SRC
-    ${LILV_PATH}/src/collections.c
-    ${LILV_PATH}/src/dylib.c
-    ${LILV_PATH}/src/dylib.h
-    ${LILV_PATH}/src/instance.c
-    ${LILV_PATH}/src/lib.c
-    ${LILV_PATH}/src/lilv_config.h
-    ${LILV_PATH}/src/lilv_internal.h
-    ${LILV_PATH}/src/node.c
-    ${LILV_PATH}/src/plugin.c
-    ${LILV_PATH}/src/pluginclass.c
-    ${LILV_PATH}/src/port.c
-    ${LILV_PATH}/src/query.c
-    ${LILV_PATH}/src/scalepoint.c
-    ${LILV_PATH}/src/state.c
-    ${LILV_PATH}/src/ui.c
-    ${LILV_PATH}/src/util.c
-    ${LILV_PATH}/src/world.c
-    )
-
-# serd
-set(SERD_PATH ${LV2SDK_PATH}/serd)
-set(SERD_SRC
-    ${SERD_PATH}/src/attributes.h
-    ${SERD_PATH}/src/base64.c
-    ${SERD_PATH}/src/base64.h
-    ${SERD_PATH}/src/byte_sink.h
-    ${SERD_PATH}/src/byte_source.c
-    ${SERD_PATH}/src/byte_source.h
-    ${SERD_PATH}/src/env.c
-    ${SERD_PATH}/src/n3.c
-    ${SERD_PATH}/src/node.c
-    ${SERD_PATH}/src/node.h
-    ${SERD_PATH}/src/reader.c
-    ${SERD_PATH}/src/reader.h
-    ${SERD_PATH}/src/serd_config.h
-    ${SERD_PATH}/src/serdi.c
-    ${SERD_PATH}/src/serd_internal.h
-    ${SERD_PATH}/src/stack.h
-    ${SERD_PATH}/src/string.c
-    ${SERD_PATH}/src/string_utils.h
-    ${SERD_PATH}/src/system.c
-    ${SERD_PATH}/src/system.h
-    ${SERD_PATH}/src/try.h
-    ${SERD_PATH}/src/uri.c
-    ${SERD_PATH}/src/uri_utils.h
-    ${SERD_PATH}/src/warnings.h
-    ${SERD_PATH}/src/writer.c
-)
-
-# sord
-set(SORD_PATH ${LV2SDK_PATH}/sord)
-set(SORD_SRC
-    ${SORD_PATH}/src/sord.c
-    ${SORD_PATH}/src/sord_config.h
-    ${SORD_PATH}/src/sordi.c
-    ${SORD_PATH}/src/sord_internal.h
-    ${SORD_PATH}/src/sordmm_test.cpp
-    ${SORD_PATH}/src/sord_validate.c
-    ${SORD_PATH}/src/syntax.c
-)
-
-# zix
-set(ZIX_PATH ${LV2SDK_PATH}/zix)
-set(ZIX_SRC
-    ${ZIX_PATH}/src/allocator.c
-    ${ZIX_PATH}/src/btree.c
-    ${ZIX_PATH}/src/bump_allocator.c
-    ${ZIX_PATH}/src/digest.c
-    ${ZIX_PATH}/src/errno_status.c
-    ${ZIX_PATH}/src/errno_status.h
-    ${ZIX_PATH}/src/filesystem.c
-    ${ZIX_PATH}/src/hash.c
-    ${ZIX_PATH}/src/index_range.h
-    ${ZIX_PATH}/src/path.c
-    ${ZIX_PATH}/src/path_iter.h
-    ${ZIX_PATH}/src/ring.c
-    ${ZIX_PATH}/src/status.c
-    ${ZIX_PATH}/src/string_view.c
-    ${ZIX_PATH}/src/system.c
-    ${ZIX_PATH}/src/system.h
-    ${ZIX_PATH}/src/tree.c
-    ${ZIX_PATH}/src/zix_config.h
-)
+set(_PRVDIR ${CMAKE_CURRENT_BINARY_DIR}/private)
+set(_PUBDIR ${CMAKE_CURRENT_BINARY_DIR}/public)
+set(_DEST ${CMAKE_CURRENT_BINARY_DIR}/lib)
+set(_INTDIR ${CMAKE_CURRENT_BINARY_DIR})
+set(_LIBDIR ${CMAKE_INSTALL_LIBDIR} )
 
 if (OS_IS_WIN)
-    set(ZIX_SRC ${ZIX_SRC}
-        ${ZIX_PATH}/src/win32/environment_win32.c
-        ${ZIX_PATH}/src/win32/filesystem_win32.c
-        ${ZIX_PATH}/src/win32/sem_win32.c
-        ${ZIX_PATH}/src/win32/system_win32.c
-        ${ZIX_PATH}/src/win32/thread_win32.c
-        ${ZIX_PATH}/src/win32/win32_util.c
-        ${ZIX_PATH}/src/win32/win32_util.h
-        )
-elseif(OS_IS_LIN)
-    set(ZIX_SRC ${ZIX_SRC}
-        ${ZIX_PATH}/src/posix/environment_posix.c
-        ${ZIX_PATH}/src/posix/filesystem_posix.c
-        ${ZIX_PATH}/src/posix/sem_posix.c
-        ${ZIX_PATH}/src/posix/system_posix.c
-        ${ZIX_PATH}/src/posix/thread_posix.c
-        )
+   set(_PKGLIB "")
 elseif(OS_IS_MAC)
-    set(ZIX_SRC ${ZIX_SRC}
-        ${ZIX_PATH}/src/darwin/sem_darwin.c
-        )
+   set(_PKGLIB audacity.app/Contents/${_APPDIR}/Frameworks)
+else()
+   set(_PKGLIB ${_LIBDIR}/audacity)
 endif()
 
-# sratom
-set(SRATOM_PATH ${LV2SDK_PATH}/sratom)
-set(SRATOM_SRC
-    ${SRATOM_PATH}/src/sratom.c
+set( SOURCES
+   PRIVATE
+
+      # lilv
+
+      ${LV2SDK_PATH}/lilv/lilv/lilv.h
+      ${LV2SDK_PATH}/lilv/src/collections.c
+      ${LV2SDK_PATH}/lilv/src/instance.c
+      ${LV2SDK_PATH}/lilv/src/lib.c
+      ${LV2SDK_PATH}/lilv/src/lilv_internal.h
+      ${LV2SDK_PATH}/lilv/src/node.c
+      ${LV2SDK_PATH}/lilv/src/plugin.c
+      ${LV2SDK_PATH}/lilv/src/pluginclass.c
+      ${LV2SDK_PATH}/lilv/src/port.c
+      ${LV2SDK_PATH}/lilv/src/query.c
+      ${LV2SDK_PATH}/lilv/src/scalepoint.c
+      ${LV2SDK_PATH}/lilv/src/state.c
+      ${LV2SDK_PATH}/lilv/src/ui.c
+      ${LV2SDK_PATH}/lilv/src/util.c
+      ${LV2SDK_PATH}/lilv/src/world.c
+      ${LV2SDK_PATH}/lilv/src/zix/common.h
+      ${LV2SDK_PATH}/lilv/src/zix/tree.c
+      ${LV2SDK_PATH}/lilv/src/zix/tree.h
+      ${LV2SDK_PATH}/lilv/utils/bench.h
+      ${LV2SDK_PATH}/lilv/utils/uri_table.h
+
+      # serd
+
+      ${LV2SDK_PATH}/serd/serd/serd.h
+      ${LV2SDK_PATH}/serd/src/byte_source.c
+      ${LV2SDK_PATH}/serd/src/env.c
+      ${LV2SDK_PATH}/serd/src/n3.c
+      ${LV2SDK_PATH}/serd/src/node.c
+      ${LV2SDK_PATH}/serd/src/reader.c
+      ${LV2SDK_PATH}/serd/src/reader.h
+      ${LV2SDK_PATH}/serd/src/serd_internal.h
+      ${LV2SDK_PATH}/serd/src/string.c
+      ${LV2SDK_PATH}/serd/src/uri.c
+      ${LV2SDK_PATH}/serd/src/writer.c
+      
+      # sord
+
+      ${LV2SDK_PATH}/sord/sord/sord.h
+      ${LV2SDK_PATH}/sord/src/sord.c
+      ${LV2SDK_PATH}/sord/src/sord_internal.h
+      ${LV2SDK_PATH}/sord/src/syntax.c
+      ${LV2SDK_PATH}/sord/src/zix/btree.c
+      ${LV2SDK_PATH}/sord/src/zix/btree.h
+      ${LV2SDK_PATH}/sord/src/zix/common.h
+      ${LV2SDK_PATH}/sord/src/zix/digest.c
+      ${LV2SDK_PATH}/sord/src/zix/digest.h
+      ${LV2SDK_PATH}/sord/src/zix/hash.c
+      ${LV2SDK_PATH}/sord/src/zix/hash.h
+
+      # sratom
+
+      ${LV2SDK_PATH}/sratom/sratom/sratom.h
+      ${LV2SDK_PATH}/sratom/src/sratom.c
+
+      # suil
+
+      ${LV2SDK_PATH}/suil/src/host.c
+      ${LV2SDK_PATH}/suil/src/instance.c
+      ${LV2SDK_PATH}/suil/src/suil_internal.h
+      ${LV2SDK_PATH}/suil/suil/suil.h
 )
 
-set(MODULE_SRC
-    ${LILV_SRC}
-    ${SERD_SRC}
-    ${SORD_SRC}
-    ${ZIX_SRC}
-    ${SRATOM_SRC}
-    )
-
-set(MODULE_INCLUDE
-    ${LV2_PATH}/include
-    ${LILV_PATH}/include
-    ${SERD_PATH}/include
-    ${SORD_PATH}/include
-    ${ZIX_PATH}/include
-    ${SRATOM_PATH}/include
-    )
-
-set(MODULE_DEF
-    -D_GNU_SOURCE # for /zix/src/posix/filesystem_posix.c
-    -DSORD_STATIC
-    -DLILV_STATIC
-    -DSERD_STATIC
-    -DSRATOM_STATIC
-    -DZIX_STATIC
+set( INCLUDES
+   PRIVATE
+      ${_PRVDIR}
+      ${LV2SDK_PATH}/lilv/src
+      ${LV2SDK_PATH}/lilv/src/zix
+      ${LV2SDK_PATH}/serd/src
+      ${LV2SDK_PATH}/sord/src
+      ${LV2SDK_PATH}/sord/src/zix
+      ${LV2SDK_PATH}/sratom/src
+      ${LV2SDK_PATH}/suil/src
+   PUBLIC
+      ${_PUBDIR}
+      ${LV2SDK_PATH}/lv2
+      ${LV2SDK_PATH}/lilv
+      ${LV2SDK_PATH}/serd
+      ${LV2SDK_PATH}/sord
+      ${LV2SDK_PATH}/sratom
+      ${LV2SDK_PATH}/suil
 )
 
+set( DEFINES
+   PRIVATE
+      SUIL_INTERNAL
+)
+
+set( HEADERS
+
+   # lv2
+
+   ${LV2SDK_PATH}/lv2/lv2/atom/atom.h
+   ${LV2SDK_PATH}/lv2/lv2/atom/forge.h
+   ${LV2SDK_PATH}/lv2/lv2/atom/util.h
+   ${LV2SDK_PATH}/lv2/lv2/buf-size/buf-size.h
+   ${LV2SDK_PATH}/lv2/lv2/core/attributes.h
+   ${LV2SDK_PATH}/lv2/lv2/core/lv2.h
+   ${LV2SDK_PATH}/lv2/lv2/core/lv2_util.h
+   ${LV2SDK_PATH}/lv2/lv2/data-access/data-access.h
+   ${LV2SDK_PATH}/lv2/lv2/dynmanifest/dynmanifest.h
+   ${LV2SDK_PATH}/lv2/lv2/event/event-helpers.h
+   ${LV2SDK_PATH}/lv2/lv2/event/event.h
+   ${LV2SDK_PATH}/lv2/lv2/instance-access/instance-access.h
+   ${LV2SDK_PATH}/lv2/lv2/log/log.h
+   ${LV2SDK_PATH}/lv2/lv2/log/logger.h
+   ${LV2SDK_PATH}/lv2/lv2/midi/midi.h
+   ${LV2SDK_PATH}/lv2/lv2/morph/morph.h
+   ${LV2SDK_PATH}/lv2/lv2/options/options.h
+   ${LV2SDK_PATH}/lv2/lv2/parameters/parameters.h
+   ${LV2SDK_PATH}/lv2/lv2/patch/patch.h
+   ${LV2SDK_PATH}/lv2/lv2/port-groups/port-groups.h
+   ${LV2SDK_PATH}/lv2/lv2/port-props/port-props.h
+   ${LV2SDK_PATH}/lv2/lv2/presets/presets.h
+   ${LV2SDK_PATH}/lv2/lv2/resize-port/resize-port.h
+   ${LV2SDK_PATH}/lv2/lv2/state/state.h
+   ${LV2SDK_PATH}/lv2/lv2/time/time.h
+   ${LV2SDK_PATH}/lv2/lv2/ui/ui.h
+   ${LV2SDK_PATH}/lv2/lv2/units/units.h
+   ${LV2SDK_PATH}/lv2/lv2/uri-map/uri-map.h
+   ${LV2SDK_PATH}/lv2/lv2/urid/urid.h
+   ${LV2SDK_PATH}/lv2/lv2/worker/worker.h
+)
+
+set( src ${LV2SDK_PATH}/lv2 )
+set( dst ${_PUBDIR} )
+set( ns ${dst}/lv2/lv2plug.in/ns )
+set( stamp ${_INTDIR}/.stamp.lv2 )
+
+# Simulate the older directory structure (trailing "/" is important)
+file( MAKE_DIRECTORY ${ns} )
+file( COPY ${src}/lv2/core/lv2.h DESTINATION ${dst} )
+file( COPY ${src}/lv2/ DESTINATION ${ns}/ext )
+file( COPY ${src}/lv2/ DESTINATION ${ns}/extensions )
+file( COPY ${src}/lv2/core/ DESTINATION  ${ns}/lv2core )
+
+set( LILV_VERSION 0.24.4 )
+set( SERD_VERSION 0.30.2 )
+set( SORD_VERSION 0.16.4 )
+set( SRATOM_VERSION 0.6.4 )
+set( SUIL_VERSION 0.10.6 )
+
+set( HAVE_LV2 1 )
+set( HAVE_SERD 1 )
+set( HAVE_SORD 1 )
+set( HAVE_SRATOM 1 )
+
+if( OS_IS_WIN )
+   set( LILV_PATH_SEP ";" )
+   set( LILV_DIR_SEP "\\\\" )
+   set( LILV_DEFAULT_LV2_PATH "%APPDATA%\\\\LV2;%COMMONPROGRAMFILES%\\\\LV2" )
+
+   set( SUIL_MODULE_DIR "" )
+   set( SUIL_DIR_SEP "" )
+   set( SUIL_GTK2_LIB_NAME "libgtk-x11-2.0.so.0" )
+   set( SUIL_GTK3_LIB_NAME "libgtk-x11-3.0.so.0" )
+   set( SUIL_MODULE_PREFIX "" )
+   set( SUIL_MODULE_EXT ".dll" )
+elseif( OS_IS_MAC )
+   set( LILV_PATH_SEP ":" )
+   set( LILV_DIR_SEP "/" )
+   set( LILV_DEFAULT_LV2_PATH "~/Library/Audio/Plug-Ins/LV2:~/.lv2:/usr/local/lib/lv2:/usr/lib/lv2:/Library/Audio/Plug-Ins/LV2" )
+
+   set( SUIL_MODULE_DIR "" )
+   set( SUIL_DIR_SEP "" )
+   set( SUIL_GTK2_LIB_NAME "libgtk-x11-2.0.so.0" )
+   set( SUIL_GTK3_LIB_NAME "libgtk-x11-3.0.so.0" )
+   set( SUIL_MODULE_PREFIX "lib" )
+   set( SUIL_MODULE_EXT ".dylib" )
+elseif( OS_IS_LIN )
+   set( LILV_PATH_SEP ":" )
+   set( LILV_DIR_SEP "/" )
+   set( LILV_DEFAULT_LV2_PATH "~/.lv2:/usr/lib/lv2:/usr/local/lib/lv2" )
+
+   set( SUIL_MODULE_DIR "" )
+   set( SUIL_DIR_SEP "" )
+   set( SUIL_GTK2_LIB_NAME "libgtk-x11-2.0.so.0" )
+   set( SUIL_GTK3_LIB_NAME "libgtk-x11-3.0.so.0" )
+   set( SUIL_MODULE_PREFIX "lib" )
+   set( SUIL_MODULE_EXT ".so" )
+endif()
+
+configure_file( lilv_config.h.in "${_PRVDIR}/lilv_config.h" )
+configure_file( serd_config.h.in "${_PRVDIR}/serd_config.h" )
+configure_file( sord_config.h.in "${_PRVDIR}/sord_config.h" )
+configure_file( sratom_config.h.in "${_PRVDIR}/sratom_config.h" )
+configure_file( suil_config.h.in "${_PRVDIR}/suil_config.h" )
+
+set(MODULE_SRC ${SOURCES} ${HEADERS})
+set(MODULE_DEF ${DEFINES})
+set(MODULE_INCLUDE ${INCLUDES})
 set(MODULE_USE_PCH OFF)
 set(MODULE_USE_UNITY OFF)
 
 setup_module()
 
 target_no_warning(${MODULE} -w)
+
+if (OS_IS_LIN)
+   pkg_check_modules( X11 IMPORTED_TARGET "x11" )
+   pkg_check_modules( GTK2 IMPORTED_TARGET "gtk+-2.0" )
+   pkg_check_modules( GTK3 IMPORTED_TARGET "gtk+-3.0" )
+   pkg_check_modules( GTK2X11 IMPORTED_TARGET "gtk+-x11-2.0" )
+   pkg_check_modules( GTK3X11 IMPORTED_TARGET "gtk+-x11-3.0" )
+   pkg_check_modules( QT4 IMPORTED_TARGET "QtGui >= 4.4.0" )
+   pkg_check_modules( QT5 IMPORTED_TARGET "Qt5Widgets >= 5.1.0" )
+
+   macro( bld name packages define sources )
+      set( libs )
+      set( missing )
+      set( lib ${SUIL_MODULE_PREFIX}${name} )
+      foreach( pkg ${packages} )
+         if( NOT "${${pkg}_FOUND}" )
+            set( missing ON )
+            break()
+         endif()
+
+         list( APPEND libs
+            PRIVATE
+               PkgConfig::${pkg}
+         )
+      endforeach()
+
+      if( NOT missing )
+         list( APPEND DEFINES
+            PRIVATE
+               ${define}
+         )
+
+         add_library( ${lib} MODULE ${sources} )
+         add_dependencies( ${MODULE} ${lib} )
+
+         set_target_properties( ${lib}
+            PROPERTIES
+               LIBRARY_OUTPUT_DIRECTORY ${_DEST}/${_PKGLIB}
+               PREFIX ""
+         )
+
+         target_compile_definitions( ${lib} PRIVATE SUIL_SHARED ${DEFINES} )
+         target_include_directories( ${lib} PRIVATE ${INCLUDES} )
+         target_link_libraries( ${lib} PRIVATE ${libs} )
+      endif()
+   endmacro()
+
+   bld( "suil_x11"
+        "X11"
+        "SUIL_WITH_X11"
+        "${LV2SDK_PATH}/suil/src/x11.c" )
+   bld( "suil_x11_in_gtk2"
+        "X11;GTK2X11"
+        "SUIL_WITH_X11_IN_GTK2"
+        "${LV2SDK_PATH}/suil/src/x11_in_gtk2.c" )
+endif()

--- a/src/au3wrap/lv2sdk/lilv_config.h.in
+++ b/src/au3wrap/lv2sdk/lilv_config.h.in
@@ -1,0 +1,24 @@
+/* WARNING! All changes made to this file will be lost! */
+
+#ifndef W_LILV_CONFIG_H_WAF
+#define W_LILV_CONFIG_H_WAF
+
+#cmakedefine LILV_CXX 1
+#define PYTHONDIR "@PYTHONDIR@"
+#define PYTHONARCHDIR "@PYTHONARCHDIR@"
+#define LILV_VERSION "@LILV_VERSION@"
+#cmakedefine HAVE_LV2 1
+#cmakedefine HAVE_SERD 1
+#cmakedefine HAVE_SORD 1
+#cmakedefine HAVE_SRATOM 1
+#cmakedefine HAVE_SNDFILE 1
+#cmakedefine HAVE_LSTAT 1
+#cmakedefine HAVE_FLOCK 1
+#cmakedefine HAVE_FILENO 1
+#cmakedefine HAVE_CLOCK_GETTIME 1
+#cmakedefine HAVE_LIBDL 1
+#define LILV_PATH_SEP "@LILV_PATH_SEP@"
+#define LILV_DIR_SEP "@LILV_DIR_SEP@"
+#define LILV_DEFAULT_LV2_PATH "@LILV_DEFAULT_LV2_PATH@"
+
+#endif /* W_LILV_CONFIG_H_WAF */

--- a/src/au3wrap/lv2sdk/serd_config.h.in
+++ b/src/au3wrap/lv2sdk/serd_config.h.in
@@ -1,0 +1,12 @@
+/* WARNING! All changes made to this file will be lost! */
+
+#ifndef W_SERD_CONFIG_H_WAF
+#define W_SERD_CONFIG_H_WAF
+
+#cmakedefine HAVE_GCOV 1
+#define SERD_VERSION "@SERD_VERSION@"
+#cmakedefine HAVE_FILENO 1
+#cmakedefine HAVE_POSIX_FADVISE 1
+#cmakedefine HAVE_POSIX_MEMALIGN 1
+
+#endif /* W_SERD_CONFIG_H_WAF */

--- a/src/au3wrap/lv2sdk/sord_config.h.in
+++ b/src/au3wrap/lv2sdk/sord_config.h.in
@@ -1,0 +1,11 @@
+/* WARNING! All changes made to this file will be lost! */
+
+#ifndef W_SORD_CONFIG_H_WAF
+#define W_SORD_CONFIG_H_WAF
+
+#cmakedefine HAVE_GCOV 1
+#define SORD_VERSION "@SORD_VERSION@"
+#cmakedefine HAVE_SERD 1
+#cmakedefine HAVE_PCRE 1
+
+#endif /* W_SORD_CONFIG_H_WAF */

--- a/src/au3wrap/lv2sdk/sratom_config.h.in
+++ b/src/au3wrap/lv2sdk/sratom_config.h.in
@@ -1,0 +1,11 @@
+/* WARNING! All changes made to this file will be lost! */
+
+#ifndef W_SRATOM_CONFIG_H_WAF
+#define W_SRATOM_CONFIG_H_WAF
+
+#cmakedefine HAVE_LV2 1
+#cmakedefine HAVE_SERD 1
+#cmakedefine HAVE_SORD 1
+#define SRATOM_VERSION "@SRATOM_VERSION@"
+
+#endif /* W_SRATOM_CONFIG_H_WAF */

--- a/src/au3wrap/lv2sdk/suil_config.h.in
+++ b/src/au3wrap/lv2sdk/suil_config.h.in
@@ -1,0 +1,34 @@
+/* WARNING! All changes made to this file will be lost! */
+
+#ifndef W_SUIL_CONFIG_H_WAF
+#define W_SUIL_CONFIG_H_WAF
+
+#define SUIL_VERSION "@SUIL_VERSION@"
+#cmakedefine HAVE_LV2 1
+#cmakedefine HAVE_X11 1
+#cmakedefine HAVE_GTK2 1
+#cmakedefine HAVE_GTK2_X11 1
+#cmakedefine HAVE_GTK3 1
+#cmakedefine HAVE_GTK3_X11 1
+#cmakedefine HAVE_QT4 1
+#cmakedefine HAVE_QT5 1
+#cmakedefine HAVE_QMACCOCOAVIEWCONTAINER 1
+#cmakedefine HAVE_LIBDL 1
+#define SUIL_MODULE_DIR "@SUIL_MODULE_DIR@"
+#define SUIL_DIR_SEP "@SUIL_DIR_SEP@"
+#define SUIL_GTK2_LIB_NAME "@SUIL_GTK2_LIB_NAME@"
+#define SUIL_GTK3_LIB_NAME "@SUIL_GTK3_LIB_NAME@"
+#define SUIL_MODULE_PREFIX "@SUIL_MODULE_PREFIX@"
+#define SUIL_MODULE_EXT "@SUIL_MODULE_EXT@"
+#cmakedefine SUIL_WITH_QT4_IN_GTK2 1
+#cmakedefine SUIL_WITH_GTK2_IN_QT4 1
+#cmakedefine SUIL_WITH_GTK2_IN_QT5 1
+#cmakedefine SUIL_WITH_QT5_IN_GTK2 1
+#cmakedefine SUIL_WITH_X11_IN_GTK2 1
+#cmakedefine SUIL_WITH_X11_IN_GTK3 1
+#cmakedefine SUIL_WITH_QT5_IN_GTK3 1
+#cmakedefine SUIL_WITH_X11_IN_QT4 1
+#cmakedefine SUIL_WITH_X11_IN_QT5 1
+#cmakedefine SUIL_WITH_X11 1
+
+#endif /* W_SUIL_CONFIG_H_WAF */

--- a/src/effects/builtin/internal/builtinviewlauncher.cpp
+++ b/src/effects/builtin/internal/builtinviewlauncher.cpp
@@ -16,7 +16,7 @@ muse::Ret BuiltinViewLauncher::showEffect(const EffectInstanceId& instanceId) co
 {
     muse::UriQuery uri(muse::String(EFFECT_VIEWER_URI).toStdString());
     uri.addParam("instanceId", muse::Val(instanceId));
-    uri.addParam("isVst", muse::Val(false));
+    uri.addParam("effectFamily", muse::Val(EffectFamily::Builtin));
     return interactive()->openSync(uri).ret;
 }
 

--- a/src/effects/effects_base/CMakeLists.txt
+++ b/src/effects/effects_base/CMakeLists.txt
@@ -28,6 +28,8 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/ieffectviewlaunchregister.h
 
     # internal
+    ${CMAKE_CURRENT_LIST_DIR}/internal/abstractaudiopluginmetareader.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/internal/abstractaudiopluginmetareader.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/abstractviewlauncher.cpp
     ${CMAKE_CURRENT_LIST_DIR}/internal/abstractviewlauncher.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/effectconfigsettings.cpp
@@ -40,6 +42,8 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/internal/effectsuiactions.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/effectsprovider.cpp
     ${CMAKE_CURRENT_LIST_DIR}/internal/effectsprovider.h
+    ${CMAKE_CURRENT_LIST_DIR}/internal/effectsrepositoryhelper.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/internal/effectsrepositoryhelper.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/effectinstancesregister.cpp
     ${CMAKE_CURRENT_LIST_DIR}/internal/effectinstancesregister.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/effectexecutionscenario.cpp

--- a/src/effects/effects_base/effectsmodule.cpp
+++ b/src/effects/effects_base/effectsmodule.cpp
@@ -75,6 +75,7 @@ void EffectsModule::registerUiTypes()
 {
     qmlRegisterType<EffectViewLoader>("Audacity.Effects", 1, 0, "EffectViewLoader");
     qmlRegisterType<RealtimeEffectViewerDialogModel>("Audacity.Effects", 1, 0, "RealtimeEffectViewerDialogModel");
+    qmlRegisterUncreatableType<EffectFamilies>("Audacity.Effects", 1, 0, "EffectFamily", "Not creatable from QML");
 }
 
 void EffectsModule::onInit(const muse::IApplication::RunMode&)

--- a/src/effects/effects_base/effectstypes.h
+++ b/src/effects/effects_base/effectstypes.h
@@ -48,11 +48,20 @@ enum class EffectMenuOrganization {
     Flat = 1,
 };
 
-enum class EffectFamily {
-    Unknown = -1,
-    Builtin,
-    VST3,
+class EffectFamilies
+{
+    Q_GADGET
+public:
+    enum class EffectFamily {
+        Unknown = -1,
+        Builtin,
+        VST3,
+        LV2,
+    };
+    Q_ENUM(EffectFamily)
 };
+
+using EffectFamily = EffectFamilies::EffectFamily;
 
 enum class EffectType {
     Unknown = -1,
@@ -84,7 +93,7 @@ constexpr const char16_t* EFFECT_OPEN_ACTION = u"action://effects/open?effectId=
 constexpr const char16_t* REALTIME_EFFECT_ADD_ACTION = u"action://effects/realtime-add?effectId=%1";
 constexpr const char16_t* REALTIME_EFFECT_REPLACE_ACTION = u"action://effects/realtime-replace?effectId=%1";
 
-constexpr const char16_t* EFFECT_VIEWER_URI = u"audacity://effects/effect_viewer?instanceId=%1&isVst=%2";
+constexpr const char16_t* EFFECT_VIEWER_URI = u"audacity://effects/effect_viewer?instanceId=%1&effectFamily=%2";
 
 inline muse::actions::ActionQuery makeEffectAction(const char16_t* action, const EffectId id)
 {

--- a/src/effects/effects_base/effectsutils.cpp
+++ b/src/effects/effects_base/effectsutils.cpp
@@ -79,14 +79,30 @@ MenuItemList makeDestructiveBuiltinEffectSubmenu(const EffectMetaList& effects, 
     return items;
 }
 
+namespace {
+constexpr const char* effectFamiliyString(EffectFamily family)
+{
+    switch (family) {
+    case EffectFamily::Builtin: return "Audacity";
+    case EffectFamily::VST3: return "VST3";
+    case EffectFamily::LV2: return "LV2";
+    default:
+        assert(false);
+        return "Unknown";
+    }
+}
+} // namespace
+
 MenuItemList makeNonBuiltinEffectSubmenus(const EffectMetaList& effects, IEffectMenuItemFactory& effectMenu)
 {
     std::map<CiString /*family*/, std::map<CiString /*publisher*/, std::map<CiString /*title*/, EffectMetaSet> > > families;
 
     for (const EffectMeta& meta : effects) {
-        if (meta.family == EffectFamily::VST3) {
-            families[CiString{ muse::String{ "VST3" } }][CiString{ meta.vendor }][CiString{ meta.title }].insert(&meta);
+        if (meta.family == EffectFamily::Builtin) {
+            // Built-in effects are handled separately
+            continue;
         }
+        families[CiString{ muse::String{ effectFamiliyString(meta.family) } }][CiString{ meta.vendor }][CiString{ meta.title }].insert(&meta);
     }
 
     MenuItemList items;

--- a/src/effects/effects_base/internal/abstractaudiopluginmetareader.cpp
+++ b/src/effects/effects_base/internal/abstractaudiopluginmetareader.cpp
@@ -1,0 +1,123 @@
+#include "abstractaudiopluginmetareader.h"
+
+#include "libraries/lib-components/PluginProvider.h"
+#include "libraries/lib-strings/TranslatableString.h"
+#include "libraries/lib-module-manager/PluginManager.h"
+#include "libraries/lib-module-manager/ModuleManager.h"
+
+#include "au3wrap/internal/wxtypes_convert.h"
+
+#include "log.h"
+
+namespace au::effects {
+AbstractAudioPluginMetaReader::AbstractAudioPluginMetaReader(PluginProvider& provider)
+    : m_pluginProvider{provider}
+{
+}
+
+AbstractAudioPluginMetaReader::~AbstractAudioPluginMetaReader()
+{
+    IF_ASSERT_FAILED(m_terminated) {
+        LOGW() << "Better call deinit() on module deinit";
+        m_pluginProvider.Terminate();
+    }
+}
+
+void AbstractAudioPluginMetaReader::init(const muse::IApplication::RunMode& mode)
+{
+    doInit(mode);
+    m_initialized = true;
+}
+
+void AbstractAudioPluginMetaReader::doInit(const muse::IApplication::RunMode&)
+{
+    m_pluginProvider.Initialize();
+}
+
+void AbstractAudioPluginMetaReader::deinit()
+{
+    m_pluginProvider.Terminate();
+    m_terminated = true;
+}
+
+muse::RetVal<muse::audio::AudioResourceMetaList> AbstractAudioPluginMetaReader::readMeta(const muse::io::path_t& pluginPath) const
+{
+    IF_ASSERT_FAILED(m_initialized && !m_terminated) {
+        return make_ret(muse::Ret::Code::InternalError);
+    }
+
+    std::vector<PluginDescriptor> descriptors;
+
+    wxString wxPluginPath = au3::wxFromString(pluginPath.toString());
+    muse::String errorStr;
+    bool ok = true;
+    try
+    {
+        TranslatableString errorMessage{};
+        auto validator = m_pluginProvider.MakeValidator();
+        auto numPlugins = m_pluginProvider.DiscoverPluginsAtPath(
+            wxPluginPath, errorMessage, [&](PluginProvider* provider, ComponentInterface* ident) -> const PluginID&
+        {
+            //Workaround: use DefaultRegistrationCallback to create all descriptors for us
+            //and then put a copy into result
+            auto& id = PluginManager::DefaultRegistrationCallback(provider, ident);
+            if (const auto ptr = PluginManager::Get().GetPlugin(id)) {
+                auto desc = *ptr;
+                try
+                {
+                    if (validator) {
+                        validator->Validate(*ident);
+                    }
+                }
+                catch (...)
+                {
+                    desc.SetEnabled(false);
+                    desc.SetValid(false);
+                }
+                descriptors.emplace_back(std::move(desc));
+            }
+            return id;
+        });
+        if (!errorMessage.empty()) {
+            ok = false;
+            errorStr = au3::wxToString(errorMessage.Debug());
+        } else if (numPlugins == 0) {
+            ok = false;
+            errorStr = "no plugins found";
+        }
+    }
+    catch (...)
+    {
+        ok = false;
+        errorStr = "unknown error";
+    }
+
+    if (!ok) {
+        LOGE() << "error: " << errorStr;
+        return make_ret(muse::Ret::Code::InternalError); //! todo
+    }
+
+    muse::audio::AudioResourceMetaList metaList;
+    for (const PluginDescriptor& desc : descriptors) {
+        //! NOTE At the moment AU only supports Fx and Fx|Generator,
+        //! see VST3EffectBase::GetType
+        muse::String type;
+        if (desc.GetEffectType() == EffectType::EffectTypeProcess || desc.GetEffectType() == EffectType::EffectTypeGenerate) {
+            type = u"Fx";
+        } else {
+            type = u"None";
+        }
+
+        muse::audio::AudioResourceMeta meta;
+        meta.id = desc.GetID();
+        meta.type = metaType();
+        meta.attributes.emplace(muse::audio::CATEGORIES_ATTRIBUTE, type);
+        meta.vendor = desc.GetVendor();
+        meta.hasNativeEditorSupport = true;
+
+        metaList.emplace_back(std::move(meta));
+    }
+
+    return muse::RetVal<muse::audio::AudioResourceMetaList>::make_ok(metaList);
+}
+}

--- a/src/effects/effects_base/internal/abstractaudiopluginmetareader.h
+++ b/src/effects/effects_base/internal/abstractaudiopluginmetareader.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "audioplugins/iaudiopluginmetareader.h"
+#include "global/iapplication.h"
+
+class PluginProvider;
+
+namespace au::effects {
+class AbstractAudioPluginMetaReader : public muse::audioplugins::IAudioPluginMetaReader
+{
+public:
+    AbstractAudioPluginMetaReader(PluginProvider&);
+    ~AbstractAudioPluginMetaReader() override;
+
+    void init(const muse::IApplication::RunMode& mode);
+    void deinit();
+
+private:
+    virtual void doInit(const muse::IApplication::RunMode& mode);
+    muse::RetVal<muse::audio::AudioResourceMetaList> readMeta(const muse::io::path_t& pluginPath) const override;
+
+    PluginProvider& m_pluginProvider;
+    bool m_initialized = false;
+    bool m_terminated = false;
+};
+}

--- a/src/effects/effects_base/internal/effectexecutionscenario.cpp
+++ b/src/effects/effects_base/internal/effectexecutionscenario.cpp
@@ -245,7 +245,6 @@ muse::Ret EffectExecutionScenario::doPerformEffect(au3::Au3Project& project, con
             if (ret) {
                 effect->SaveUserPreset(CurrentSettingsGroup(), *settings);
             } else {
-                LOGE() << "failed show effect: " << effectId << ", ret: " << ret.toString();
                 return ret;
             }
         }

--- a/src/effects/effects_base/internal/effectsprovider.h
+++ b/src/effects/effects_base/internal/effectsprovider.h
@@ -9,6 +9,7 @@
 #include "context/iglobalcontext.h"
 #include "playback/iplayback.h"
 #include "effects/builtin/ibuiltineffectsrepository.h"
+#include "effects/lv2/ilv2effectsrepository.h"
 #include "effects/vst/ivsteffectsrepository.h"
 #include "effects/nyquist/inyquisteffectsrepository.h"
 #include "../ieffectsconfiguration.h"
@@ -24,6 +25,7 @@ class EffectsProvider : public IEffectsProvider, public muse::async::Asyncable
     muse::Inject<au::context::IGlobalContext> globalContext;
     muse::Inject<IEffectsConfiguration> configuration;
     muse::Inject<IBuiltinEffectsRepository> builtinEffectsRepository;
+    muse::Inject<ILv2EffectsRepository> lv2EffectsRepository;
     muse::Inject<IVstEffectsRepository> vstEffectsRepository;
     muse::Inject<INyquistEffectsRepository> nyquistEffectsRepository;
     muse::Inject<muse::IInteractive> interactive;
@@ -59,6 +61,7 @@ private:
 
     bool isVstSupported() const;
     bool isNyquistSupported() const;
+    bool isLv2Supported() const;
 
     muse::Ret doEffectPreview(EffectBase& effect, EffectSettings& settings);
 

--- a/src/effects/effects_base/internal/effectsrepositoryhelper.cpp
+++ b/src/effects/effects_base/internal/effectsrepositoryhelper.cpp
@@ -1,0 +1,118 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+#include "effectsrepositoryhelper.h"
+
+#include "libraries/lib-components/PluginProvider.h"
+#include "libraries/lib-strings/TranslatableString.h"
+#include "libraries/lib-module-manager/PluginManager.h"
+#include "libraries/lib-module-manager/ModuleManager.h"
+
+#include "au3wrap/internal/wxtypes_convert.h"
+#include "log.h"
+
+namespace au::effects {
+constexpr EffectFamily toEffectFamily(muse::audio::AudioResourceType type)
+{
+    switch (type) {
+    case muse::audio::AudioResourceType::VstPlugin:
+        return EffectFamily::VST3;
+    case muse::audio::AudioResourceType::Lv2Plugin:
+        return EffectFamily::LV2;
+    case muse::audio::AudioResourceType::FluidSoundfont:
+    case muse::audio::AudioResourceType::MusePlugin:
+    case muse::audio::AudioResourceType::MuseSamplerSoundPack:
+        return EffectFamily::Unknown;
+    default:
+        assert(false && "Unknown AudioResourceType");
+        return EffectFamily::Unknown;
+    }
+}
+
+EffectsRepositoryHelper::EffectsRepositoryHelper(PluginProvider& provider, muse::audio::AudioResourceType resourceType,
+                                                 GetTitleFunc getTitle)
+    : m_pluginProvider{provider}, m_resourceType{resourceType}, m_getTitle{std::move(getTitle)}
+{
+    IF_ASSERT_FAILED(toEffectFamily(resourceType) != EffectFamily::Unknown) {
+        LOGE() << "Invalid AudioResourceType for EffectsRepositoryHelper: " << static_cast<int>(resourceType);
+    }
+}
+
+EffectMetaList EffectsRepositoryHelper::effectMetaList() const
+{
+    using namespace muse::audioplugins;
+    using namespace muse::audio;
+
+    EffectMetaList effects;
+
+    const std::vector<AudioPluginInfo> allEffects = knownPlugins()->pluginInfoList();
+
+    for (const AudioPluginInfo& info : allEffects) {
+        if (!(info.type == AudioPluginType::Fx && info.meta.type == m_resourceType)) {
+            continue;
+        }
+
+        EffectMeta meta;
+        meta.id = muse::String(info.meta.id.c_str());
+        meta.family = toEffectFamily(m_resourceType);
+        meta.title = m_getTitle ? m_getTitle(info.path) : muse::io::completeBasename(info.path).toString();
+        meta.isRealtimeCapable = true;
+        meta.vendor = muse::String::fromStdString(info.meta.vendor);
+        meta.type = EffectType::Processor;
+        meta.path = info.path;
+
+        effects.push_back(std::move(meta));
+    }
+
+    return effects;
+}
+
+bool EffectsRepositoryHelper::ensurePluginIsLoaded(const EffectId& effectId) const
+{
+    if (PluginManager::Get().IsPluginLoaded(au3::wxFromString(effectId))) {
+        return true;
+    }
+
+    const auto plugins = knownPlugins()->pluginInfoList();
+    const auto it = std::find_if(plugins.begin(), plugins.end(), [&](const muse::audioplugins::AudioPluginInfo& info) {
+        return info.meta.id == effectId.toStdString();
+    });
+    if (it == plugins.end()) {
+        LOGE() << "plugin not in registry: " << effectId;
+        return false;
+    }
+    if (!it->enabled) {
+        LOGW() << "plugin disabled: " << effectId;
+        return false;
+    }
+    if (it->meta.type != m_resourceType) {
+        LOGE() << "Effect families don't match: expected " << static_cast<int>(m_resourceType)
+               << ", got " << static_cast<int>(it->meta.type);
+        return false;
+    }
+    const auto& path = it->path;
+
+    PluginID pluginId;
+    TranslatableString errorMessage{};
+    int numPlugins = m_pluginProvider.DiscoverPluginsAtPath(
+        au3::wxFromString(path.toString()), errorMessage,
+        [&](PluginProvider* provider, ComponentInterface* ident) -> const PluginID&
+    {
+        pluginId = PluginManager::DefaultRegistrationCallback(provider, ident);
+        return pluginId;
+    });
+
+    if (numPlugins == 0) {
+        LOGE() << "not found plugin: " << path;
+        return false;
+    }
+
+    const auto ptr = PluginManager::Get().GetPlugin(pluginId);
+    if (!ptr) {
+        LOGE() << "failed register plugin: " << au3::wxToStdSting(pluginId) << ", path: " << path;
+        return false;
+    }
+
+    return true;
+}
+}

--- a/src/effects/effects_base/internal/effectsrepositoryhelper.h
+++ b/src/effects/effects_base/internal/effectsrepositoryhelper.h
@@ -1,0 +1,34 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+#pragma once
+
+#include "effects/effects_base/effectstypes.h"
+#include "audioplugins/iknownaudiopluginsregister.h"
+#include "modularity/ioc.h"
+#include "global/io/path.h"
+
+class PluginProvider;
+
+namespace au::effects {
+class EffectsRepositoryHelper final : public muse::Injectable
+{
+public:
+    muse::Inject<muse::audioplugins::IKnownAudioPluginsRegister> knownPlugins;
+
+public:
+    using GetTitleFunc = std::function<muse::String (const muse::io::path_t&)>;
+
+    EffectsRepositoryHelper(PluginProvider&, muse::audio::AudioResourceType, GetTitleFunc getTitle = nullptr);
+
+    virtual ~EffectsRepositoryHelper() = default;
+
+    EffectMetaList effectMetaList() const;
+    bool ensurePluginIsLoaded(const EffectId& effectId) const;
+
+private:
+    PluginProvider& m_pluginProvider;
+    const muse::audio::AudioResourceType m_resourceType;
+    const GetTitleFunc m_getTitle;
+};
+} // namespace au::effects

--- a/src/effects/effects_base/qml/Audacity/Effects/RealtimeEffectViewerDialog.qml
+++ b/src/effects/effects_base/qml/Audacity/Effects/RealtimeEffectViewerDialog.qml
@@ -8,6 +8,7 @@ import Muse.Ui
 import Muse.UiComponents
 
 import Audacity.Effects
+import Audacity.Lv2
 import Audacity.Vst
 
 EffectStyledDialogView {
@@ -27,13 +28,25 @@ EffectStyledDialogView {
 
     QtObject {
         id: prv
-        property int padding: viewerModel.isVst3() ? 4 : 16
+        property int padding: viewerModel.effectFamily == EffectFamily.Builtin ? 16 : 4
         property alias viewItem: viewLoader.item
     }
 
     Component.onCompleted: {
         viewerModel.load()
-        viewLoader.sourceComponent = viewerModel.isVst3() ? vstViewerComponent : builtinViewerComponent
+        switch (viewerModel.effectFamily) {
+            case EffectFamily.Builtin:
+                viewLoader.sourceComponent = builtinViewerComponent
+                break
+            case EffectFamily.LV2:
+                viewLoader.sourceComponent = lv2ViewerComponent
+                break
+            case EffectFamily.VST3:
+                viewLoader.sourceComponent = vstViewerComponent
+                break
+            default:
+                viewLoader.sourceComponent = null
+        }
     }
 
     RealtimeEffectViewerDialogModel {
@@ -65,6 +78,15 @@ EffectStyledDialogView {
                 id: view
                 instanceId: root.instanceId
             }
+        }
+    }
+
+
+    Component {
+        id: lv2ViewerComponent
+        Lv2Viewer {
+            id: view
+            instanceId: root.instanceId
         }
     }
 

--- a/src/effects/effects_base/view/realtimeeffectviewerdialogmodel.h
+++ b/src/effects/effects_base/view/realtimeeffectviewerdialogmodel.h
@@ -30,6 +30,7 @@ class RealtimeEffectViewerDialogModel : public QObject, public muse::Injectable,
     Q_PROPERTY(
         muse::ui::NavigationPanel
         * navigationPanel READ prop_navigationPanel WRITE prop_setNavigationPanel NOTIFY navigationPanelChanged);
+    Q_PROPERTY(EffectFamily effectFamily READ prop_effectFamily NOTIFY effectFamilyChanged);
 
     muse::Inject<IEffectInstancesRegister> instancesRegister;
     muse::Inject<IEffectsProvider> effectsProvider;
@@ -39,7 +40,6 @@ class RealtimeEffectViewerDialogModel : public QObject, public muse::Injectable,
 
 public:
     Q_INVOKABLE void load();
-    Q_INVOKABLE bool isVst3() const;
 
     RealtimeEffectViewerDialogModel(QObject* parent = nullptr);
     ~RealtimeEffectViewerDialogModel() override;
@@ -60,6 +60,8 @@ public:
     muse::ui::NavigationPanel* prop_navigationPanel() const;
     void prop_setNavigationPanel(muse::ui::NavigationPanel* navigationPanel);
 
+    EffectFamily prop_effectFamily() const;
+
 signals:
     void trackNameChanged();
     void titleChanged();
@@ -67,6 +69,7 @@ signals:
     void isMasterEffectChanged();
     void dialogViewChanged();
     void navigationPanelChanged();
+    void effectFamilyChanged();
 
 private:
     void subscribe();
@@ -75,7 +78,6 @@ private:
     bool eventFilter(QObject* obj, QEvent* event) override;
 
     RealtimeEffectStatePtr m_effectState;
-    bool m_isVst3 = false;
     muse::uicomponents::DialogView* m_dialogView = nullptr;
     muse::ui::NavigationPanel* m_navigationPanel = nullptr;
 };

--- a/src/effects/lv2/CMakeLists.txt
+++ b/src/effects/lv2/CMakeLists.txt
@@ -3,16 +3,26 @@
 #
 declare_module(effects_lv2)
 
-#set(MODULE_QRC lv2.qrc)
+set(MODULE_QRC lv2.qrc)
 
 set(MODULE_QML_IMPORT ${CMAKE_CURRENT_LIST_DIR}/qml )
 
 set(MODULE_SRC
+    ${CMAKE_CURRENT_LIST_DIR}/ilv2effectsrepository.h
     ${CMAKE_CURRENT_LIST_DIR}/lv2effectsmodule.cpp
     ${CMAKE_CURRENT_LIST_DIR}/lv2effectsmodule.h
 
+    ${CMAKE_CURRENT_LIST_DIR}/internal/lv2effectsrepository.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/internal/lv2effectsrepository.h
+    ${CMAKE_CURRENT_LIST_DIR}/internal/lv2pluginmetareader.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/internal/lv2pluginmetareader.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/lv2pluginsscanner.cpp
     ${CMAKE_CURRENT_LIST_DIR}/internal/lv2pluginsscanner.h
+    ${CMAKE_CURRENT_LIST_DIR}/internal/lv2viewlauncher.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/internal/lv2viewlauncher.h
+
+    ${CMAKE_CURRENT_LIST_DIR}/view/lv2viewloader.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/view/lv2viewloader.h
 )
 
 # AU3

--- a/src/effects/lv2/ilv2effectsrepository.h
+++ b/src/effects/lv2/ilv2effectsrepository.h
@@ -1,0 +1,20 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+#pragma once
+
+#include "modularity/imoduleinterface.h"
+
+#include "effects/effects_base/effectstypes.h"
+
+namespace au::effects {
+class ILv2EffectsRepository : MODULE_EXPORT_INTERFACE
+{
+    INTERFACE_ID(ILv2EffectsRepository)
+public:
+    virtual ~ILv2EffectsRepository() = default;
+
+    virtual EffectMetaList effectMetaList() const = 0;
+    virtual bool ensurePluginIsLoaded(const EffectId&) const = 0;
+};
+}

--- a/src/effects/lv2/internal/lv2effectsrepository.cpp
+++ b/src/effects/lv2/internal/lv2effectsrepository.cpp
@@ -1,0 +1,41 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+#include "lv2effectsrepository.h"
+
+#include "au3wrap/internal/wxtypes_convert.h"
+#include "log.h"
+
+#include "libraries/lib-lv2/LoadLV2.h"
+#include "libraries/lib-components/PluginProvider.h"
+#include "libraries/lib-strings/TranslatableString.h"
+#include "libraries/lib-module-manager/PluginManager.h"
+#include "libraries/lib-module-manager/ModuleManager.h"
+#include "libraries/lib-effects/EffectManager.h"
+
+#include <lilv/lilv.h>
+
+namespace au::effects {
+namespace {
+muse::String effectTitle(const muse::io::path_t& path)
+{
+    const LilvPlugin* plugin = ::LV2EffectsModule::GetPlugin(path.c_str());
+    return muse::String { lilv_node_as_string(lilv_plugin_get_name(plugin)) };
+}
+}
+
+Lv2EffectsRepository::Lv2EffectsRepository()
+    : m_helper{m_module, muse::audio::AudioResourceType::Lv2Plugin, effectTitle}
+{
+}
+
+EffectMetaList Lv2EffectsRepository::effectMetaList() const
+{
+    return m_helper.effectMetaList();
+}
+
+bool Lv2EffectsRepository::ensurePluginIsLoaded(const EffectId& effectId) const
+{
+    return m_helper.ensurePluginIsLoaded(effectId);
+}
+}

--- a/src/effects/lv2/internal/lv2effectsrepository.h
+++ b/src/effects/lv2/internal/lv2effectsrepository.h
@@ -1,0 +1,24 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+#pragma once
+
+#include "../ilv2effectsrepository.h"
+#include "effects/effects_base/internal/effectsrepositoryhelper.h"
+#include "modularity/ioc.h"
+#include "libraries/lib-lv2/LoadLV2.h"
+
+namespace au::effects {
+class Lv2EffectsRepository final : public ILv2EffectsRepository
+{
+public:
+    Lv2EffectsRepository();
+
+    EffectMetaList effectMetaList() const override;
+    bool ensurePluginIsLoaded(const EffectId& effectId) const override;
+
+private:
+    LV2EffectsModule m_module;
+    EffectsRepositoryHelper m_helper;
+};
+}

--- a/src/effects/lv2/internal/lv2pluginmetareader.cpp
+++ b/src/effects/lv2/internal/lv2pluginmetareader.cpp
@@ -1,0 +1,35 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+#include "lv2pluginmetareader.h"
+#include "libraries/lib-module-manager/PluginManager.h"
+#include "libraries/lib-module-manager/PluginManager.h"
+#include "libraries/lib-strings/TranslatableString.h"
+
+namespace au::effects {
+Lv2PluginMetaReader::Lv2PluginMetaReader()
+    : AbstractAudioPluginMetaReader{m_module} {}
+
+muse::audio::AudioResourceType Lv2PluginMetaReader::metaType() const
+{
+    return muse::audio::AudioResourceType::Lv2Plugin;
+}
+
+void Lv2PluginMetaReader::doInit(const muse::IApplication::RunMode& mode)
+{
+    if (mode == muse::IApplication::RunMode::AudioPluginRegistration) {
+        m_module.InitializePluginRegistration();
+    } else {
+        m_module.Initialize();
+    }
+}
+
+bool Lv2PluginMetaReader::canReadMeta(const muse::io::path_t& path) const
+{
+    const wxString wxPluginPath{ path.toStdString() };
+    const std::vector<wxString> paths = m_module.FindModulePaths(PluginManager::Get());
+    return std::any_of(paths.begin(), paths.end(), [&](const wxString& modulePath) {
+        return wxPluginPath == modulePath;
+    });
+}
+}

--- a/src/effects/lv2/internal/lv2pluginmetareader.h
+++ b/src/effects/lv2/internal/lv2pluginmetareader.h
@@ -1,20 +1,21 @@
 /*
-* Audacity: A Digital Audio Editor
-*/
+ * Audacity: A Digital Audio Editor
+ */
 #pragma once
 
 #include "effects/effects_base/internal/abstractaudiopluginmetareader.h"
-#include "libraries/lib-vst3/VST3EffectsModule.h"
+#include "libraries/lib-lv2/LoadLV2.h"
 
 namespace au::effects {
-class Vst3PluginsMetaReader : public AbstractAudioPluginMetaReader
+class Lv2PluginMetaReader final : public AbstractAudioPluginMetaReader
 {
 public:
-    Vst3PluginsMetaReader();
+    Lv2PluginMetaReader();
     muse::audio::AudioResourceType metaType() const override;
     bool canReadMeta(const muse::io::path_t& pluginPath) const override;
 
 private:
-    VST3EffectsModule m_module;
+    void doInit(const muse::IApplication::RunMode& mode) override;
+    LV2EffectsModule m_module;
 };
 }

--- a/src/effects/lv2/internal/lv2viewlauncher.cpp
+++ b/src/effects/lv2/internal/lv2viewlauncher.cpp
@@ -1,0 +1,25 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+#include "lv2viewlauncher.h"
+
+#include "libraries/lib-components/EffectInterface.h"
+#include "libraries/lib-realtime-effects/RealtimeEffectState.h"
+
+#include "au3wrap/internal/wxtypes_convert.h"
+#include "log.h"
+
+using namespace au::effects;
+
+muse::Ret Lv2ViewLauncher::showEffect(const EffectInstanceId& instanceId) const
+{
+    muse::UriQuery uri(muse::String(EFFECT_VIEWER_URI).toStdString());
+    uri.addParam("instanceId", muse::Val(instanceId));
+    uri.addParam("effectFamily", muse::Val(EffectFamily::LV2));
+    return interactive()->openSync(uri).ret;
+}
+
+void Lv2ViewLauncher::showRealtimeEffect(const RealtimeEffectStatePtr& state) const
+{
+    doShowRealtimeEffect(state);
+}

--- a/src/effects/lv2/internal/lv2viewlauncher.h
+++ b/src/effects/lv2/internal/lv2viewlauncher.h
@@ -1,16 +1,18 @@
 /*
-* Audacity: A Digital Audio Editor
-*/
+ * Audacity: A Digital Audio Editor
+ */
 #pragma once
 
 #include "effects/effects_base/internal/abstractviewlauncher.h"
 
+#include "global/modularity/ioc.h"
+#include "effects/effects_base/ieffectinstancesregister.h"
+#include "global/iinteractive.h"
+
 namespace au::effects {
-class BuiltinViewLauncher final : public AbstractViewLauncher
+class Lv2ViewLauncher final : public AbstractViewLauncher
 {
 public:
-    BuiltinViewLauncher() = default;
-
     muse::Ret showEffect(const EffectInstanceId& instanceId) const override;
     void showRealtimeEffect(const RealtimeEffectStatePtr& state) const override;
 };

--- a/src/effects/lv2/lv2.qrc
+++ b/src/effects/lv2/lv2.qrc
@@ -1,0 +1,6 @@
+<RCC>
+    <qresource prefix="/">
+        <file>qml/Audacity/Lv2/qmldir</file>
+        <file>qml/Audacity/Lv2/Lv2Viewer.qml</file>
+    </qresource>
+</RCC>

--- a/src/effects/lv2/lv2effectsmodule.h
+++ b/src/effects/lv2/lv2effectsmodule.h
@@ -9,9 +9,13 @@
 #include "modularity/imodulesetup.h"
 
 namespace au::effects {
+class Lv2PluginMetaReader;
+
 class Lv2EffectsModule : public muse::modularity::IModuleSetup
 {
 public:
+    Lv2EffectsModule();
+
     std::string moduleName() const override;
     void registerExports() override;
     void resolveImports() override;
@@ -21,5 +25,6 @@ public:
     void onDeinit() override;
 
 private:
+    const std::shared_ptr<Lv2PluginMetaReader> m_metaReader;
 };
 }

--- a/src/effects/lv2/qml/Audacity/Lv2/Lv2Viewer.qml
+++ b/src/effects/lv2/qml/Audacity/Lv2/Lv2Viewer.qml
@@ -1,0 +1,48 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+import QtQuick
+
+import Audacity.Lv2
+
+Rectangle {
+
+    id: root
+
+    property string instanceId: ""
+
+    property string title: builder.contentItem ? builder.contentItem.title : ""
+    property bool isApplyAllowed: builder.contentItem ? builder.contentItem.isApplyAllowed : false
+
+    signal closeRequested()
+
+    color: ui.theme.backgroundPrimaryColor
+
+    implicitWidth: builder.contentItem ? builder.contentItem.implicitWidth : 450
+    implicitHeight: builder.contentItem ? builder.contentItem.implicitHeight : 200
+
+    width: implicitWidth
+    height: implicitHeight
+
+    Component.onCompleted: {
+        builder.load(root.instanceId, root)
+    }
+
+    function manage(parent) {
+        if (builder.contentItem) {
+            builder.contentItem.manage(parent)
+        }
+    }
+
+    function preview() {
+        if (builder.contentItem) {
+            builder.contentItem.preview()
+        }
+    }
+
+    Lv2ViewLoader {
+        id: builder
+
+        onCloseRequested: root.closeRequested()
+    }
+}

--- a/src/effects/lv2/qml/Audacity/Lv2/qmldir
+++ b/src/effects/lv2/qml/Audacity/Lv2/qmldir
@@ -1,0 +1,2 @@
+module Audacity.Lv2
+Lv2Viewer 1.0 Lv2Viewer.qml

--- a/src/effects/lv2/view/lv2viewloader.cpp
+++ b/src/effects/lv2/view/lv2viewloader.cpp
@@ -1,0 +1,38 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+#include "lv2viewloader.h"
+#include "effects/effects_base/effectstypes.h"
+
+#include <QQmlEngine>
+
+#include "au3wrap/internal/wxtypes_convert.h"
+#include "global/types/number.h"
+#include "libraries/lib-effects/EffectManager.h"
+#include "libraries/lib-effects/Effect.h"
+
+#include "log.h"
+
+namespace au::effects {
+Lv2ViewLoader::Lv2ViewLoader(QObject* parent)
+    : QObject(parent)
+{}
+
+Lv2ViewLoader::~Lv2ViewLoader()
+{
+    if (m_contentItem) {
+        m_contentItem->deleteLater();
+        m_contentItem = nullptr;
+    }
+}
+
+void Lv2ViewLoader::load(const QString& /* instanceId */, QObject* /* itemParent */)
+{
+    LOGW() << "not implemented";
+}
+
+QQuickItem* Lv2ViewLoader::contentItem() const
+{
+    return m_contentItem;
+}
+}

--- a/src/effects/lv2/view/lv2viewloader.h
+++ b/src/effects/lv2/view/lv2viewloader.h
@@ -1,0 +1,31 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+#pragma once
+
+#include <QObject>
+#include <QQuickItem>
+
+namespace au::effects {
+class Lv2ViewLoader : public QObject
+{
+    Q_OBJECT
+
+    Q_PROPERTY(QQuickItem * contentItem READ contentItem NOTIFY contentItemChanged FINAL)
+
+public:
+    Lv2ViewLoader(QObject* parent = nullptr);
+    ~Lv2ViewLoader() override;
+
+    QQuickItem* contentItem() const;
+
+    Q_INVOKABLE void load(const QString& instanceId, QObject* itemParent);
+
+signals:
+    void contentItemChanged();
+    void closeRequested();
+
+private:
+    QQuickItem* m_contentItem = nullptr;
+};
+}

--- a/src/effects/vst/internal/vst3pluginsmetareader.cpp
+++ b/src/effects/vst/internal/vst3pluginsmetareader.cpp
@@ -4,106 +4,20 @@
 
 #include "vst3pluginsmetareader.h"
 
-#include "libraries/lib-components/PluginProvider.h"
-#include "libraries/lib-strings/TranslatableString.h"
-#include "libraries/lib-module-manager/PluginManager.h"
-#include "libraries/lib-module-manager/ModuleManager.h"
-#include "libraries/lib-vst3/VST3EffectsModule.h"
-
-#include "au3wrap/internal/wxtypes_convert.h"
-
-#include "log.h"
-
 using namespace au::effects;
 using namespace muse;
-using namespace muse::audio;
 
-muse::audio::AudioResourceType Vst3PluginsMetaReader::metaType() const
+Vst3PluginsMetaReader::Vst3PluginsMetaReader()
+    : AbstractAudioPluginMetaReader{m_module}
 {
-    return muse::audio::AudioResourceType::VstPlugin;
 }
 
-bool Vst3PluginsMetaReader::canReadMeta(const io::path_t&) const
+bool Vst3PluginsMetaReader::canReadMeta(const io::path_t& pluginPath) const
 {
-    return true;
+    return io::suffix(pluginPath) == "vst3";
 }
 
-RetVal<AudioResourceMetaList> Vst3PluginsMetaReader::readMeta(const io::path_t& pluginPath) const
+audio::AudioResourceType Vst3PluginsMetaReader::metaType() const
 {
-    std::vector<PluginDescriptor> descriptors;
-
-    wxString wxPluginPath = au3::wxFromString(pluginPath.toString());
-    bool error = false;
-    String errorStr;
-
-    VST3EffectsModule vst3Module;
-
-    try
-    {
-        TranslatableString errorMessage{};
-        auto validator = vst3Module.MakeValidator();
-        auto numPlugins = vst3Module.DiscoverPluginsAtPath(
-            wxPluginPath, errorMessage, [&](PluginProvider* provider, ComponentInterface* ident) -> const PluginID&
-        {
-            //Workaround: use DefaultRegistrationCallback to create all descriptors for us
-            //and then put a copy into result
-            auto& id = PluginManager::DefaultRegistrationCallback(provider, ident);
-            if (const auto ptr = PluginManager::Get().GetPlugin(id)) {
-                auto desc = *ptr;
-                try
-                {
-                    if (validator) {
-                        validator->Validate(*ident);
-                    }
-                }
-                catch (...)
-                {
-                    desc.SetEnabled(false);
-                    desc.SetValid(false);
-                }
-                descriptors.emplace_back(std::move(desc));
-            }
-            return id;
-        });
-        if (!errorMessage.empty()) {
-            error = true;
-            errorStr = au3::wxToString(errorMessage.Debug());
-        } else if (numPlugins == 0) {
-            error = true;
-            errorStr = "no plugins found";
-        }
-    }
-    catch (...)
-    {
-        error = true;
-        errorStr = "unknown error";
-    }
-
-    if (error) {
-        LOGE() << "error: " << errorStr;
-        return make_ret(Ret::Code::InternalError); //! todo
-    }
-
-    AudioResourceMetaList metaList;
-    for (const PluginDescriptor& desc : descriptors) {
-        //! NOTE At the moment AU only supports Fx and Fx|Generator,
-        //! see VST3EffectBase::GetType
-        muse::String type;
-        if (desc.GetEffectType() == EffectType::EffectTypeProcess || desc.GetEffectType() == EffectType::EffectTypeGenerate) {
-            type = u"Fx";
-        } else {
-            type = u"None";
-        }
-
-        muse::audio::AudioResourceMeta meta;
-        meta.id = desc.GetID();
-        meta.type = muse::audio::AudioResourceType::VstPlugin;
-        meta.attributes.emplace(muse::audio::CATEGORIES_ATTRIBUTE, type);
-        meta.vendor = desc.GetVendor();
-        meta.hasNativeEditorSupport = true;
-
-        metaList.emplace_back(std::move(meta));
-    }
-
-    return RetVal<AudioResourceMetaList>::make_ok(metaList);
+    return audio::AudioResourceType::VstPlugin;
 }

--- a/src/effects/vst/internal/vst3viewlauncher.cpp
+++ b/src/effects/vst/internal/vst3viewlauncher.cpp
@@ -47,10 +47,11 @@ muse::Ret Vst3ViewLauncher::showEffect(const EffectInstanceId& instanceId) const
         return muse::make_ret(muse::Ret::Code::InternalError);
     }
 
-    constexpr auto isVst = true;
-    muse::Ret ret = interactive()->openSync(muse::String(EFFECT_VIEWER_URI)
-                                            .arg(size_t(museVstInstance->id())).arg(isVst).toStdString()
-                                            ).ret;
+    muse::UriQuery uri(muse::String(EFFECT_VIEWER_URI).toStdString());
+    uri.addParam("instanceId", muse::Val(instanceId));
+    uri.addParam("effectFamily", muse::Val(EffectFamily::VST3));
+
+    muse::Ret ret = interactive()->openSync(uri).ret;
 
     return ret;
 }

--- a/src/effects/vst/internal/vst3viewlauncher.h
+++ b/src/effects/vst/internal/vst3viewlauncher.h
@@ -14,7 +14,7 @@
 #include "vst/ivstinstancesregister.h"
 
 namespace au::effects {
-class Vst3ViewLauncher : public AbstractViewLauncher
+class Vst3ViewLauncher final : public AbstractViewLauncher
 {
     muse::Inject<muse::vst::IVstInstancesRegister> museInstancesRegister;
 

--- a/src/effects/vst/internal/vsteffectsrepository.cpp
+++ b/src/effects/vst/internal/vsteffectsrepository.cpp
@@ -3,93 +3,19 @@
 */
 #include "vsteffectsrepository.h"
 
-#include "libraries/lib-components/PluginProvider.h"
-#include "libraries/lib-strings/TranslatableString.h"
-#include "libraries/lib-module-manager/PluginManager.h"
-#include "libraries/lib-module-manager/ModuleManager.h"
-#include "libraries/lib-vst3/VST3EffectsModule.h"
-
-#include "au3wrap/internal/wxtypes_convert.h"
-
-#include "log.h"
-
 using namespace au::effects;
+
+VstEffectsRepository::VstEffectsRepository()
+    : m_helper{m_module, muse::audio::AudioResourceType::VstPlugin}
+{
+}
 
 EffectMetaList VstEffectsRepository::effectMetaList() const
 {
-    using namespace muse::audioplugins;
-    using namespace muse::audio;
-
-    EffectMetaList effects;
-
-    const std::vector<AudioPluginInfo> allEffects = knownPlugins()->pluginInfoList();
-
-    for (const AudioPluginInfo& info : allEffects) {
-        if (!(info.type == AudioPluginType::Fx && info.meta.type == AudioResourceType::VstPlugin)) {
-            continue;
-        }
-
-        EffectMeta meta;
-        meta.id = muse::String(info.meta.id.c_str());
-        meta.family = EffectFamily::VST3;
-        meta.title = muse::io::completeBasename(info.path).toString();
-        meta.isRealtimeCapable = true;
-        meta.vendor = muse::String::fromStdString(info.meta.vendor);
-        meta.type = EffectType::Processor;
-        meta.path = info.path;
-
-        effects.push_back(std::move(meta));
-    }
-
-    return effects;
+    return m_helper.effectMetaList();
 }
 
 bool VstEffectsRepository::ensurePluginIsLoaded(const EffectId& effectId) const
 {
-    if (PluginManager::Get().IsPluginLoaded(au3::wxFromString(effectId))) {
-        return true;
-    }
-
-    VST3EffectsModule vst3Module;
-
-    const auto plugins = knownPlugins()->pluginInfoList();
-    const auto it = std::find_if(plugins.begin(), plugins.end(), [&](const muse::audioplugins::AudioPluginInfo& info) {
-        return info.meta.id == effectId.toStdString();
-    });
-    if (it == plugins.end()) {
-        LOGE() << "plugin not in registry: " << effectId;
-        return false;
-    }
-    if (!it->enabled) {
-        LOGW() << "plugin disabled: " << effectId;
-        return false;
-    }
-    if (it->meta.type != muse::audio::AudioResourceType::VstPlugin) {
-        LOGE() << "not a VST plugin: " << effectId;
-        return false;
-    }
-    const auto& path = it->path;
-
-    PluginID pluginId;
-    TranslatableString errorMessage{};
-    int numPlugins = vst3Module.DiscoverPluginsAtPath(
-        au3::wxFromString(path.toString()), errorMessage,
-        [&](PluginProvider* provider, ComponentInterface* ident) -> const PluginID&
-    {
-        pluginId = PluginManager::DefaultRegistrationCallback(provider, ident);
-        return pluginId;
-    });
-
-    if (numPlugins == 0) {
-        LOGE() << "not found plugin: " << path;
-        return false;
-    }
-
-    const auto ptr = PluginManager::Get().GetPlugin(pluginId);
-    if (!ptr) {
-        LOGE() << "failed register plugin: " << au3::wxToStdSting(pluginId) << ", path: " << path;
-        return false;
-    }
-
-    return true;
+    return m_helper.ensurePluginIsLoaded(effectId);
 }

--- a/src/effects/vst/internal/vsteffectsrepository.h
+++ b/src/effects/vst/internal/vsteffectsrepository.h
@@ -4,19 +4,21 @@
 #pragma once
 
 #include "../ivsteffectsrepository.h"
-
+#include "effects/effects_base/internal/effectsrepositoryhelper.h"
 #include "modularity/ioc.h"
-#include "audioplugins/iknownaudiopluginsregister.h"
+#include "libraries/lib-vst3/VST3EffectsModule.h"
 
 namespace au::effects {
-class VstEffectsRepository : public IVstEffectsRepository
+class VstEffectsRepository final : public IVstEffectsRepository
 {
-    muse::Inject<muse::audioplugins::IKnownAudioPluginsRegister> knownPlugins;
-
 public:
-    VstEffectsRepository() = default;
+    VstEffectsRepository();
 
     EffectMetaList effectMetaList() const override;
     bool ensurePluginIsLoaded(const EffectId&) const override;
+
+private:
+    VST3EffectsModule m_module;
+    EffectsRepositoryHelper m_helper;
 };
 }

--- a/src/effects/vst/vsteffectsmodule.cpp
+++ b/src/effects/vst/vsteffectsmodule.cpp
@@ -30,6 +30,11 @@ static void vst_init_qrc()
     Q_INIT_RESOURCE(vst);
 }
 
+VstEffectsModule::VstEffectsModule()
+    : m_vstMetaReader(std::make_shared<Vst3PluginsMetaReader>())
+{
+}
+
 std::string VstEffectsModule::moduleName() const
 {
     return "effects_vst";
@@ -56,7 +61,7 @@ void VstEffectsModule::resolveImports()
 
     auto metaReaderRegister = ioc()->resolve<muse::audioplugins::IAudioPluginMetaReaderRegister>(moduleName());
     if (metaReaderRegister) {
-        metaReaderRegister->registerReader(std::make_shared<Vst3PluginsMetaReader>());
+        metaReaderRegister->registerReader(m_vstMetaReader);
     }
 
     auto lr = ioc()->resolve<IEffectViewLaunchRegister>(moduleName());
@@ -76,12 +81,14 @@ void VstEffectsModule::registerUiTypes()
     qmlRegisterType<VstViewModel>("Audacity.Vst", 1, 0, "VstViewModel");
 }
 
-void VstEffectsModule::onInit(const muse::IApplication::RunMode&)
+void VstEffectsModule::onInit(const muse::IApplication::RunMode& runMode)
 {
     m_museVstModulesRepository->init();
+    m_vstMetaReader->init(runMode);
 }
 
 void VstEffectsModule::onDeinit()
 {
     m_museVstModulesRepository->deinit();
+    m_vstMetaReader->deinit();
 }

--- a/src/effects/vst/vsteffectsmodule.h
+++ b/src/effects/vst/vsteffectsmodule.h
@@ -11,9 +11,12 @@
 namespace au::effects {
 class VstEffectsRepository;
 class MuseVstModulesRepository;
+class Vst3PluginsMetaReader;
 class VstEffectsModule : public muse::modularity::IModuleSetup
 {
 public:
+    VstEffectsModule();
+
     std::string moduleName() const override;
     void registerExports() override;
     void resolveImports() override;
@@ -24,6 +27,7 @@ public:
 
 private:
 
+    const std::shared_ptr<Vst3PluginsMetaReader> m_vstMetaReader;
     std::shared_ptr<VstEffectsRepository> m_vstEffectsRepository;
     std::shared_ptr<MuseVstModulesRepository> m_museVstModulesRepository;
 };

--- a/src/stubs/CMakeLists.txt
+++ b/src/stubs/CMakeLists.txt
@@ -1,3 +1,6 @@
 if (NOT AU_MODULE_EFFECTS_VST)
     add_subdirectory(vst)
 endif()
+if (NOT AU_MODULE_EFFECTS_LV2)
+    add_subdirectory(lv2)
+endif()

--- a/src/stubs/lv2/CMakeLists.txt
+++ b/src/stubs/lv2/CMakeLists.txt
@@ -1,0 +1,11 @@
+declare_module(effects_lv2)
+
+set(MODULE_QRC lv2.qrc)
+set(MODULE_QML_IMPORT ${CMAKE_CURRENT_LIST_DIR}/qml )
+set(MODULE_IS_STUB ON)
+set(MODULE_SRC
+    ${CMAKE_CURRENT_LIST_DIR}/lv2effectsstubmodule.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/lv2effectsstubmodule.h
+)
+
+setup_module()

--- a/src/stubs/lv2/lv2.qrc
+++ b/src/stubs/lv2/lv2.qrc
@@ -1,0 +1,6 @@
+<RCC>
+    <qresource prefix="/">
+        <file>qml/Audacity/Lv2/qmldir</file>
+        <file>qml/Audacity/Lv2/Lv2ViewerStub.qml</file>
+    </qresource>
+</RCC>

--- a/src/stubs/lv2/lv2effectsstubmodule.cpp
+++ b/src/stubs/lv2/lv2effectsstubmodule.cpp
@@ -1,0 +1,21 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+#include "lv2effectsstubmodule.h"
+
+static void lv2_init_qrc()
+{
+    Q_INIT_RESOURCE(lv2);
+}
+
+namespace au::effects {
+std::string Lv2EffectsModule::moduleName() const
+{
+    return "effects_lv2_stub";
+}
+
+void Lv2EffectsModule::registerResources()
+{
+    lv2_init_qrc();
+}
+}

--- a/src/stubs/lv2/lv2effectsstubmodule.h
+++ b/src/stubs/lv2/lv2effectsstubmodule.h
@@ -6,10 +6,10 @@
 #include "modularity/imodulesetup.h"
 
 namespace au::effects {
-class VstEffectsModule : public muse::modularity::IModuleSetup
+class Lv2EffectsModule : public muse::modularity::IModuleSetup
 {
 public:
-    VstEffectsModule() = default;
+    Lv2EffectsModule() = default;
 
     std::string moduleName() const override;
     void registerResources() override;

--- a/src/stubs/lv2/qml/Audacity/Lv2/Lv2ViewerStub.qml
+++ b/src/stubs/lv2/qml/Audacity/Lv2/Lv2ViewerStub.qml
@@ -1,0 +1,8 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+import QtQuick 2.15
+
+Item {
+    property string instanceId
+}

--- a/src/stubs/lv2/qml/Audacity/Lv2/qmldir
+++ b/src/stubs/lv2/qml/Audacity/Lv2/qmldir
@@ -1,0 +1,2 @@
+module Audacity.Lv2
+Lv2Viewer 1.0 Lv2ViewerStub.qml

--- a/src/stubs/vst/vsteffectsstubmodule.cpp
+++ b/src/stubs/vst/vsteffectsstubmodule.cpp
@@ -1,7 +1,7 @@
 /*
  * Audacity: A Digital Audio Editor
  */
-#include "vsteffectsstubmodule.h"
+#include "vsteffectsmodule.h"
 
 static void vst_init_qrc()
 {
@@ -9,12 +9,12 @@ static void vst_init_qrc()
 }
 
 namespace au::effects {
-std::string VstEffectsStubModule::moduleName() const
+std::string VstEffectsModule::moduleName() const
 {
     return "effects_vst_stub";
 }
 
-void VstEffectsStubModule::registerResources()
+void VstEffectsModule::registerResources()
 {
     vst_init_qrc();
 }


### PR DESCRIPTION
Resolves: #8302

This PR provides UI-less support for LV2 on Linux and MacOS (*), namely
* plugins are discovered and made available in the effect menus,
* they can be applied destructively or in real time
* UI-less: the viewers will be empty, so they can only be used with default values for now

(*) On Windows, at the time of writing, the DSP binary doesn't get found. This might be a difficult problem or not, but Windows support is not a priority at all anyway. That we have MacOS support is already going to be helpful for development.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

### QA
This PR involved some refactoring of our effect-related code. Please prioritize that
- [x] the existing effect capabilities not having regressed on any platform.

Where LV2 is concerned, please test the following, exclusively on Linux (non-Linux support being there more for developer convenience) :
- [x] Can be applied destructively
- [x] When added to a track, processes the audio and can be bypassed like other effect families (please ignore that the dialog is empty)
- [x] Cancel / Preview / Apply of the destructive dialogs already work (although the UI not being apparent)
