### PR TITLE
Improved priority ordering and renaming of selections

### DIFF
--- a/src/projectscene/view/clipsview/clipcontextmenumodel.cpp
+++ b/src/projectscene/view/clipsview/clipcontextmenumodel.cpp
@@ -37,15 +37,16 @@ void ClipContextMenuModel::load()
     auto colorItems = makeClipColourItems();
 
     MenuItemList items {
-        makeItemWithArg("clip-properties"),
-        makeItemWithArg("rename-clip"),
-        makeMenu(muse::TranslatableString("clip", "Clip color"), colorItems, "colorMenu"),
-        makeSeparator(),
         makeItemWithArg("copy"),
-        makeItemWithArg("duplicate"),
         makeItemWithArg("cut"),
+        makeItemWithArg("rename-clip"),
+        makeItemWithArg("clip-properties"),
         makeSeparator(),
+        makeMenu(muse::TranslatableString("clip", "Clip color"), colorItems, "colorMenu"),
         makeItemWithArg("split"),
+        makeItemWithArg("duplicate"),
+        makeSeparator(),
+        makeItemWithArg("clip-properties"),
         makeSeparator(),
         makeItemWithArg("clip-export"),
         makeSeparator(),

--- a/src/projectscene/view/clipsview/clipcontextmenumodel.cpp
+++ b/src/projectscene/view/clipsview/clipcontextmenumodel.cpp
@@ -149,9 +149,9 @@ void ClipContextMenuModel::updateColorMenu()
 MenuItemList ClipContextMenuModel::makeClipColourItems()
 {
     m_colorChangeActionCodeList.clear();
-    MenuItemList items;
+    MenuItemList items; 
     items <<
-        makeMenuItem("action://trackedit/clip/change-color-auto", muse::TranslatableString("clip", muse::String::fromStdString("Auto")));
+    makeMenuItem("action://trackedit/clip/change-color-auto", muse::TranslatableString("clip", muse::String::fromStdString("Default track colour")));
     m_colorChangeActionCodeList.push_back("action://trackedit/clip/change-color-auto");
 
     const auto& colors = projectSceneConfiguration()->clipColors();


### PR DESCRIPTION
Resolves: 
[#8195](https://github.com/audacity/audacity/issues/8195)
[#8203](https://github.com/audacity/audacity/issues/8203)

Improved the ordering priority of clip selections in the context menu and renamed selection actions for better clarity.  
This improves usability and aligns the naming with standard UX conventions.

<!-- "x" to fill the checkboxes -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [ ] If changes are extensive, then there is a sequence of easily reviewable commits
- [ ] Each commit's message describes its purpose and effects
- [ ] There are no behavior changes unnecessary for the stated purpose of the PR


