### PR TITLE
audacity-8699 fix: channelHeightRatio is handled inside ClipItem and ChannelSplitter so we default initialise for stereo case

### DIFF
--- a/src/projectscene/qml/Audacity/ProjectScene/clipsview/TrackClipsItem.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/clipsview/TrackClipsItem.qml
@@ -23,7 +23,7 @@ Item {
     property bool isMultiSelectionActive: false
     property bool isTrackAudible: true
     property bool isStereo: clipsModel.isStereo
-    property double channelHeightRatio: isStereo ? 0.5 : 1
+    property double channelHeightRatio: 0.5
     property bool moveActive: false
     property bool altPressed: false
     property bool ctrlPressed: false


### PR DESCRIPTION
Resolves: [this issue](https://github.com/audacity/audacity/issues/8699)

no more issues when dropping a mono track on a stereo track, undo is behaving as expected now

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior