### PR TITLE
Feat #479: Add Recording Notes Integration

### DIFF
--- a/src/appshell/qml/ProjectPage/ProjectPage.qml
+++ b/src/appshell/qml/ProjectPage/ProjectPage.qml
@@ -94,6 +94,14 @@ DockPage {
         return null
     }
 
+    function openNotepad() {
+        if (notepadPanel.visible) {
+            notepadPanel.close()
+        } else {
+            notepadPanel.open()
+        }
+    }
+
     onInited: {
         Qt.callLater(pageModel.init)
     }
@@ -227,6 +235,10 @@ DockPage {
                     relayout()
                 }
 
+                onOpenNotepad: {
+                    root.openNotepad()
+                }
+
                 navigationPanel.section: root.playbackToolBarKeyNavSec
                 navigationPanel.order: 1
 
@@ -344,6 +356,65 @@ DockPage {
             HistoryPanel {
                 navigationSection: historyPanel.navigationSection
                 navigationOrderStart: historyPanel.contentNavigationPanelOrderStart
+            }
+        },
+
+        DockPanel {
+            id: notepadPanel
+            readonly property int effectsSectionWidth: 240
+            property bool showEffectsSection: false
+            property int titleBarHeight: 39
+
+            signal newFile()
+            signal saveFile()
+            signal openFile()
+
+            title: qsTrc("appshell", "Notepad")
+
+            groupName: root.verticalPanelsGroup
+            location: Location.Right
+
+            visible: false
+
+            dropDestinations: root.verticalPanelDropDestinations
+
+            titleBar: TextEditorTitleBar {
+                id: teTitleBarItem
+                effectsSectionWidth: notepadPanel.effectsSectionWidth
+                showEffectsSection: notepadPanel.showEffectsSection
+                implicitHeight: notepadPanel.titleBarHeight
+
+                onOpenFile: {
+                    notepadPanel.openFile()
+                }
+
+                onSaveFile: {
+                    notepadPanel.saveFile()
+                }
+
+                onNewFile: {
+                    notepadPanel.newFile()
+                }
+            }
+
+            TextEditor {
+                id: te
+
+                Connections {
+                    target: notepadPanel
+
+                    function onOpenFile() {
+                        te.notepad.openFile()
+                    }
+
+                    function onSaveFile() {
+                        te.notepad.save()
+                    }
+
+                    function onNewFile() {
+                        te.notepad.newFile()
+                    }
+                }
             }
         }
     ]

--- a/src/projectscene/CMakeLists.txt
+++ b/src/projectscene/CMakeLists.txt
@@ -39,6 +39,8 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/view/common/tracksviewstatemodel.h
     ${CMAKE_CURRENT_LIST_DIR}/view/common/customcursor.cpp
     ${CMAKE_CURRENT_LIST_DIR}/view/common/customcursor.h
+    ${CMAKE_CURRENT_LIST_DIR}/view/common/notepad.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/view/common/notepad.h
 
     ${CMAKE_CURRENT_LIST_DIR}/view/trackspanel/addeffectmenumodel.cpp
     ${CMAKE_CURRENT_LIST_DIR}/view/trackspanel/addeffectmenumodel.h

--- a/src/projectscene/projectscene.qrc
+++ b/src/projectscene/projectscene.qrc
@@ -52,6 +52,9 @@
         <file>qml/Audacity/ProjectScene/clipsview/pitchandspeed/PitchSection.qml</file>
         <file>qml/Audacity/ProjectScene/clipsview/pitchandspeed/GeneralSection.qml</file>
         <file>qml/Audacity/ProjectScene/clipsview/pitchandspeed/SpeedSection.qml</file>
+        <file>qml/Audacity/ProjectScene/common/TextEditor.qml</file>
+        <file>qml/Audacity/ProjectScene/common/TextEditorTitleBar.qml</file>
+        <file>qml/Audacity/ProjectScene/common/TextEditorTitleBarBackground.qml</file>
         <file>qml/Audacity/ProjectScene/historypanel/HistoryPanel.qml</file>
         <file>qml/Audacity/ProjectScene/toolbars/WorkspacesToolBar.qml</file>
         <file>qml/Audacity/ProjectScene/toolbars/internal/DropdownWithTitle.qml</file>

--- a/src/projectscene/projectscenemodule.cpp
+++ b/src/projectscene/projectscenemodule.cpp
@@ -19,6 +19,7 @@
 
 #include "view/common/tracksviewstatemodel.h"
 #include "view/common/customcursor.h"
+#include "view/common/notepad.h"
 
 #include "view/toolbars/audiosetupcontextmenumodel.h"
 #include "view/toolbars/projecttoolbarmodel.h"
@@ -128,6 +129,7 @@ void ProjectSceneModule::registerUiTypes()
     // common
     qmlRegisterType<TracksViewStateModel>("Audacity.ProjectScene", 1, 0, "TracksViewStateModel");
     qmlRegisterType<CustomCursor>("Audacity.ProjectScene", 1, 0, "CustomCursor");
+    qmlRegisterType<Notepad>("Audacity.ProjectScene", 1, 0, "Notepad");
 
     // toolbars
     qmlRegisterType<ProjectToolBarModel>("Audacity.ProjectScene", 1, 0, "ProjectToolBarModel");

--- a/src/projectscene/qml/Audacity/ProjectScene/common/TextEditor.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/common/TextEditor.qml
@@ -1,0 +1,61 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+import Muse.Ui
+import Muse.UiComponents
+
+import Audacity.ProjectScene
+
+Item {
+    id: notepadWindow
+    width: 800
+    height: 600
+
+    property alias notepad: notepad
+
+    Notepad {
+        id: notepad
+
+        onFileChanged: {
+            textArea.currentText = this.text
+        }
+    }
+
+    ColumnLayout {
+        width: parent.width
+        height: parent.height
+
+        TextInputArea {
+            id: textArea
+
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+
+            onTextChanged: function (text) {
+                notepad.setText(text)
+            }
+        }
+
+        Text {
+            Layout.fillWidth: true
+            height: 40
+            topPadding: 0
+            rightPadding: 10
+            bottomPadding: 5
+
+            text: {
+                const lines = notepad.text.split('\n').length;
+                const numWords = notepad.text.trim().split(/\s+/).filter(w => w).length;
+                const numChars = notepad.text.length;
+                const fileName = notepad.file ? notepad.file.split('/').pop() : "Untitled";
+
+                `File: ${fileName} | Lines: ${lines} | Words: ${numWords} | Characters: ${numChars}`
+            }
+
+            font.family: "monospace"
+            color: ui.theme.fontPrimaryColor
+            horizontalAlignment: Text.AlignRight
+        }
+    }
+}

--- a/src/projectscene/qml/Audacity/ProjectScene/common/TextEditorTitleBar.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/common/TextEditorTitleBar.qml
@@ -1,0 +1,219 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+import Muse.Ui
+import Muse.UiComponents
+
+import "qrc:/kddockwidgets/private/quick/qml/" as KDDW
+
+KDDW.TitleBarBase {
+    id: root
+
+    property var navigationPanel
+    property var navigationOrder
+    property var contextMenuModel
+
+    property int effectsSectionWidth: 0
+    property bool showEffectsSection: false
+
+    signal newFile()
+    signal saveFile()
+    signal openFile()
+
+    anchors.fill: parent
+    heightWhenVisible: implicitHeight
+
+    Component.onCompleted: {
+        if (effectsSectionWidth == 0) {
+            console.warn("effectsSectionWidth is not set ; doing some guesswork")
+            effectsSectionWidth = 240
+        }
+    }
+
+    RowLayout {
+        id: rowLayout
+        anchors.fill: parent
+        spacing: 0
+
+        Rectangle {
+            id: effectsTitleBar
+            visible: root.showEffectsSection
+            color: ui.theme.backgroundPrimaryColor
+            property int padding: parent.height / 4
+            border.color: "transparent"
+            border.width: padding
+
+            Layout.preferredWidth: root.effectsSectionWidth
+            Layout.preferredHeight: root.implicitHeight
+
+            StyledTextLabel {
+                text: qsTrc("projectscene", "Realtime effects")
+                anchors.fill: parent
+                padding: effectsTitleBar.padding
+                horizontalAlignment: Text.AlignLeft
+                verticalAlignment: Text.AlignVCenter
+            }
+
+            MouseArea {
+                anchors.fill: parent
+            }
+
+            Rectangle {
+                color: effectsTitleBar.color
+                width: root.implicitHeight
+                height: root.implicitHeight
+                anchors.right: parent.right
+                FlatButton {
+                    transparent: true
+                    width: parent.width - 2 * effectsTitleBar.padding
+                    height: parent.height - 2 * effectsTitleBar.padding
+                    anchors.centerIn: parent
+                    normalColor: ui.theme.backgroundPrimaryColor
+                    hoverHitColor: ui.theme.buttonColor
+                    icon: IconCode.CLOSE_X_ROUNDED
+                    onClicked: {
+                        root.effectsSectionCloseButtonClicked()
+                    }
+                }
+            }
+        }
+
+        SeparatorLine { }
+
+        FlatButton {
+            id: gripButton
+
+            Layout.preferredHeight: root.implicitHeight
+            Layout.preferredWidth: 28
+            backgroundRadius: 0
+
+            visible: true
+            normalColor: ui.theme.backgroundSecondaryColor
+            hoverHitColor: ui.theme.buttonColor
+
+            mouseArea.objectName: root.objectName + "_gripButton"
+            mouseArea.cursorShape: Qt.SizeAllCursor
+            // do not accept buttons as FlatButton's mouseArea will override
+            // DockTitleBar mouseArea and panel will not be draggable
+            mouseArea.acceptedButtons: Qt.NoButton
+
+            transparent: false
+            contentItem: StyledIconLabel {
+                iconCode: IconCode.TOOLBAR_GRIP
+            }
+
+            backgroundItem: TextEditorTitleBarBackground {
+                mouseArea: gripButton.mouseArea
+                color: gripButton.normalColor
+                baseColor: gripButton.normalColor
+            }
+        }
+
+        SeparatorLine { }
+
+        FlatButton {
+            id: newFileBtn
+
+            width: (root.verticalPanelDefaultWidth - gripButton.width) / 3
+            Layout.fillWidth: true
+            Layout.preferredHeight: root.implicitHeight
+
+            accessible.name: qsTrc("projectscene", "New file")
+            backgroundRadius: 0
+            normalColor: ui.theme.backgroundSecondaryColor
+            hoverHitColor: ui.theme.buttonColor
+
+            text: qsTrc("projectscene", "New file")
+
+            //! TODO AU4
+            enabled: true //root.isAddingAvailable
+
+            icon: IconCode.NEW_FILE
+
+            orientation: Qt.Horizontal
+
+            backgroundItem: TextEditorTitleBarBackground {
+                mouseArea: newFileBtn.mouseArea
+                color: newFileBtn.normalColor
+                baseColor: newFileBtn.normalColor
+            }
+
+            onClicked: {
+                root.newFile()
+            }
+        }
+
+        SeparatorLine { }
+
+        FlatButton {
+            id: openBtn
+
+            width: (root.verticalPanelDefaultWidth - gripButton.width) / 3
+            Layout.fillWidth: true
+            Layout.preferredHeight: root.implicitHeight
+
+            accessible.name: qsTrc("projectscene", "Open notes")
+            backgroundRadius: 0
+            normalColor: ui.theme.backgroundSecondaryColor
+            hoverHitColor: ui.theme.buttonColor
+
+            text: qsTrc("projectscene", "Open notes")
+
+            //! TODO AU4
+            enabled: true //root.isAddingAvailable
+
+            icon: IconCode.OPEN_FILE
+
+            orientation: Qt.Horizontal
+
+            backgroundItem: TextEditorTitleBarBackground {
+                mouseArea: openBtn.mouseArea
+                color: openBtn.normalColor
+                baseColor: openBtn.normalColor
+            }
+
+            onClicked: {
+                root.openFile()
+            }
+        }
+
+        SeparatorLine { }
+
+        FlatButton {
+            id: saveBtn
+
+            width: (root.verticalPanelDefaultWidth - gripButton.width) / 3
+            Layout.fillWidth: true
+            Layout.preferredHeight: root.implicitHeight
+
+            accessible.name: qsTrc("projectscene", "Save notes")
+            backgroundRadius: 0
+            normalColor: ui.theme.backgroundSecondaryColor
+            hoverHitColor: ui.theme.buttonColor
+
+            text: qsTrc("projectscene", "Save notes")
+
+            //! TODO AU4
+            enabled: true //root.isAddingAvailable
+
+            icon: IconCode.SAVE
+
+            orientation: Qt.Horizontal
+
+            backgroundItem: TextEditorTitleBarBackground {
+                mouseArea: saveBtn.mouseArea
+                color: saveBtn.normalColor
+                baseColor: saveBtn.normalColor
+            }
+
+            onClicked: {
+                root.saveFile()
+            }
+        }
+    }
+
+    SeparatorLine {
+        anchors.top: rowLayout.bottom
+    }
+}

--- a/src/projectscene/qml/Audacity/ProjectScene/common/TextEditorTitleBarBackground.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/common/TextEditorTitleBarBackground.qml
@@ -1,0 +1,83 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * Audacity-CLA-applies
+ *
+ * Audacity
+ * A Digital Audio Editor
+ *
+ * Copyright (C) 2024 Audacity BVBA and others
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import QtQuick 2.15
+
+import Muse.Ui 1.0
+import Muse.UiComponents 1.0
+
+Rectangle {
+    id: root
+
+    property bool highlight: false
+    property var mouseArea: null
+    property color baseColor: "transparent"
+
+    color: baseColor
+
+    border.width: ui.theme.borderWidth
+    border.color: ui.theme.strokeColor
+
+    Rectangle {
+        id: topBackground
+
+        anchors.fill: parent
+        color: "transparent"
+    }
+
+    Rectangle {
+        id: focusBorder
+
+        anchors.fill: parent
+
+        visible: root.highlight
+
+        color: "transparent"
+
+        border.color: ui.theme.fontPrimaryColor
+        border.width: ui.theme.navCtrlBorderWidth
+        radius: Number(parent.radius) > 0 ? parent.radius : 0
+    }
+
+    states: [
+        State {
+            name: "PRESSED"
+            when: root.mouseArea.pressed
+
+            PropertyChanges {
+                target: topBackground
+                color: ui.theme.buttonColor
+                opacity: ui.theme.buttonOpacityHit
+            }
+        },
+
+        State {
+            name: "HOVERED"
+            when: root.mouseArea.containsMouse && !root.mouseArea.pressed
+
+            PropertyChanges {
+                target: topBackground
+                color: ui.theme.buttonColor
+                opacity: ui.theme.buttonOpacityHover
+            }
+        }
+    ]
+}

--- a/src/projectscene/qml/Audacity/ProjectScene/qmldir
+++ b/src/projectscene/qml/Audacity/ProjectScene/qmldir
@@ -12,6 +12,8 @@ TrackEffectsSection 1.0 trackspanel/TrackEffectsSection.qml
 TracksTitleBar 1.0 trackspanel/TracksTitleBar.qml
 TracksClipsView 1.0 clipsview/TracksClipsView.qml
 TracksPositionController 1.0 common/TracksPositionController.qml
+TextEditor 1.0 common/TextEditor.qml
+TextEditorTitleBar 1.0 common/TextEditorTitleBar.qml
 SelectionStatus 1.0 statusbar/SelectionStatus.qml
 Snap 1.0 toolbars/Snap.qml
 HistoryPanel 1.0 historypanel/HistoryPanel.qml

--- a/src/projectscene/qml/Audacity/ProjectScene/toolbars/PlaybackToolBar.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/toolbars/PlaybackToolBar.qml
@@ -22,6 +22,8 @@ Item {
 
     property alias navigationPanel: view.navigationPanel
 
+    signal openNotepad()
+
     width: {
         let contentWidth = view.width + prv.customizeButtonSpaceWidth
         return maximumWidth > 0 ? Math.max(contentWidth, maximumWidth) : contentWidth
@@ -250,6 +252,28 @@ Item {
                     itemData.handleMenuItem(itemId)
                 }
             }
+        }
+    }
+
+
+    FlatButton {
+        id: openNotepadButton
+
+        anchors.right: parent.right
+        anchors.rightMargin: 24 + customizeButton.width
+        anchors.bottom: parent.bottom
+        anchors.bottomMargin: 12
+
+        width: 28
+        height: width
+
+        icon: IconCode.PAGE
+        iconFont: ui.theme.toolbarIconsFont
+        toolTipTitle: qsTrc("projectscene", "Open Notepad")
+        toolTipDescription: qsTrc("projectscene", "Show/hide notepad")
+
+        onClicked: {
+            root.openNotepad()
         }
     }
 

--- a/src/projectscene/view/common/notepad.cpp
+++ b/src/projectscene/view/common/notepad.cpp
@@ -1,0 +1,109 @@
+/*
+* Audacity: A Digital Audio Editor
+*/
+#include "notepad.h"
+#include <QFileDialog>
+#include <QFile>
+#include <QTextStream>
+#include <QGuiApplication>
+#include <QClipboard>
+#include <QMessageBox>
+#include <QDebug>
+
+using namespace au::projectscene;
+
+Notepad::Notepad(QObject *parent)
+    : QObject(parent)
+{
+}
+
+Notepad::~Notepad()
+{
+}
+
+QString Notepad::text() const {
+    return currentText;
+}
+
+QString Notepad::file() const {
+    return currentFile;
+}
+
+void Notepad::newFile()
+{
+    setText("");
+    setFile("");
+    emit textChanged();
+}
+
+void Notepad::setText(const QString &text) {
+    if (currentText != text) {
+        currentText = text;
+        emit textChanged();
+    }
+}
+
+void Notepad::setFile(const QString &text) {
+    if (currentFile != text) {
+        currentFile = text;
+        emit fileChanged();
+    }
+}
+
+void Notepad::openFile()
+{
+    QString fileName = QFileDialog::getOpenFileName(
+        nullptr,
+        "Open File",
+        "",
+        "Text Files (*.txt);;All Files (*)"
+    );
+    if (fileName.isEmpty()) return;
+
+    QFile file(fileName);
+    if (!file.open(QIODevice::ReadOnly | QFile::Text)) {
+        qWarning() << "Cannot open file:" << file.errorString();
+        return;
+    }
+
+    setFile(fileName);
+    QTextStream in(&file);
+    setText(in.readAll());
+    file.close();
+
+    emit fileChanged();
+}
+
+void Notepad::saveAs()
+{
+    QString fileName = QFileDialog::getSaveFileName(
+        nullptr,
+        "Save As",
+        "",
+        "Text Files (*.txt);;All Files (*)"
+        );
+    if (fileName.isEmpty()) return;
+
+    if (!fileName.endsWith(".txt", Qt::CaseInsensitive))
+        fileName += ".txt";
+
+    currentFile = fileName;
+    save();
+}
+
+void Notepad::save() {
+    if (currentFile.isEmpty()) {
+        saveAs();
+        return;
+    }
+
+    QFile file(currentFile);
+    if (!file.open(QIODevice::WriteOnly | QFile::Text)) {
+        qWarning() << "Cannot save file:" << file.errorString();
+        return;
+    }
+
+    QTextStream out(&file);
+    out << currentText;  
+    file.close();
+}

--- a/src/projectscene/view/common/notepad.h
+++ b/src/projectscene/view/common/notepad.h
@@ -1,0 +1,39 @@
+/*
+* Audacity: A Digital Audio Editor
+*/
+#pragma once
+
+#include <QObject>
+#include <QString>
+
+namespace au::projectscene {
+class Notepad : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(QString text READ text WRITE setText NOTIFY textChanged FINAL)
+    Q_PROPERTY(QString file READ file WRITE setFile NOTIFY fileChanged FINAL)
+
+public:
+    explicit Notepad(QObject *parent = nullptr);
+    ~Notepad();
+
+    Q_INVOKABLE void newFile();
+    Q_INVOKABLE void openFile();
+    Q_INVOKABLE void saveAs();
+    Q_INVOKABLE void save();
+    Q_INVOKABLE void setText(const QString &text);
+    Q_INVOKABLE void setFile(const QString &text);
+
+    QString text() const;
+    QString file() const;
+    
+signals:
+    void fileChanged();
+    void textChanged();
+    void insertText(const QString &text);
+
+private:
+    QString currentFile;
+    QString currentText;  
+};
+}


### PR DESCRIPTION
Implements: #479

As described in the issue, this implementation introduces a basic notepad feature, allowing users to take recording notes directly within Audacity — avoiding the need to switch between multiple windows.

We believe this is a solid starting point, with potential for future enhancements, such as a “teleprompter” mode, bullet-point checklists for tracking progress, and more.

Here’s a short video demonstrating the new feature:

https://github.com/user-attachments/assets/6888dc72-0a04-41fc-84c5-fcaaa54e1cd9


- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
