### PR TITLE
Use full prototypes for functions in libnyquist

### DIFF
--- a/au3/lib-src/libnyquist/nyquist/cmt/midifile.c
+++ b/au3/lib-src/libnyquist/nyquist/cmt/midifile.c
@@ -24,21 +24,14 @@
 
 #define MIDIFILE_ERROR -1
 
-#ifdef PROTOTYPES
-#define NOARGS void
-#else
-#define NOARGS
-#endif
-
 /* public stuff */
 extern int abort_flag;
 
 /* Functions to be called while processing the MIDI file. */
-void (*Mf_starttrack)(NOARGS) = 0;
-void (*Mf_endtrack)(NOARGS) = 0;
-int (*Mf_getc)(NOARGS) = 0;
-void (*Mf_eot)(NOARGS) = 0;
-#ifdef PROTOTYPES
+void (*Mf_starttrack)(void) = 0;
+void (*Mf_endtrack)(void) = 0;
+int (*Mf_getc)(void) = 0;
+void (*Mf_eot)(void) = 0;
 void (*Mf_error)(char *) = 0;
 void (*Mf_header)(int,int,int) = 0;
 void (*Mf_on)(int,int,int) = 0;
@@ -58,27 +51,6 @@ void (*Mf_tempo)(int) = 0;
 void (*Mf_keysig)(int,int) = 0;
 void (*Mf_sqspecific)(int,char*) = 0;
 void (*Mf_text)(int,int,char*) = 0;
-#else
-void (*Mf_error)() = 0;
-void (*Mf_header)() = 0;
-void (*Mf_on)() = 0;
-void (*Mf_off)() = 0;
-void (*Mf_pressure)() = 0;
-void (*Mf_controller)() = 0;
-void (*Mf_pitchbend)() = 0;
-void (*Mf_program)() = 0;
-void (*Mf_chanpressure)() = 0;
-void (*Mf_sysex)() = 0;
-void (*Mf_arbitrary)() = 0;
-void (*Mf_metamisc)() = 0;
-void (*Mf_seqnum)() = 0;
-void (*Mf_smpte)() = 0;
-void (*Mf_tempo)() = 0;
-void (*Mf_timesig)() = 0;
-void (*Mf_keysig)() = 0;
-void (*Mf_sqspecific)() = 0;
-void (*Mf_text)() = 0;
-#endif
 
 int Mf_nomerge = 0;             /* 1 => continue'ed system exclusives are */
                                 /* not collapsed. */
@@ -89,18 +61,16 @@ int Mf_skipinit = 0;            /* 1 if initial garbage should be skipped */
 
 static long Mf_toberead = 0L;
 
-static long readvarinum(NOARGS);
-static long read32bit(NOARGS);
-static int read16bit(NOARGS);
-static void msgenlarge(NOARGS);
-static char *msg(NOARGS);
-static int readheader(NOARGS);
-static void readtrack(NOARGS);
-static void sysex(NOARGS), msginit(NOARGS);
-static int egetc(NOARGS);
-static int msgleng(NOARGS);
-
-#ifdef PROTOTYPES
+static long readvarinum(void);
+static long read32bit(void);
+static int read16bit(void);
+static void msgenlarge(void);
+static char *msg(void);
+static int readheader(void);
+static void readtrack(void);
+static void sysex(void), msginit(void);
+static int egetc(void);
+static int msgleng(void);
 static int readmt(char*,int);
 static long to32bit(int,int,int,int);
 static int to16bit(int,int);
@@ -109,15 +79,6 @@ static void badbyte(int);
 static void metaevent(int);
 static void msgadd(int);
 static void chanmessage(int,int,int);
-#else
-static long to32bit();
-static int to16bit();
-static void mferror();
-static void badbyte();
-static void metaevent();
-static void msgadd();
-static void chanmessage();
-#endif
 
 static int midifile_error;
 


### PR DESCRIPTION
Resolves: #8726

gcc 15.1.0 made some breaking changes that caused code related to K&R to fail to compile. This PR drops support for K&R, which was suggested by maintainer @kryksyh in https://github.com/audacity/audacity/issues/8726#issuecomment-2930741352.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [ ] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
