### PR TITLE
Avoid crash when no track is selected

### DIFF
--- a/src/projectscene/view/clipsview/selectionviewcontroller.cpp
+++ b/src/projectscene/view/clipsview/selectionviewcontroller.cpp
@@ -163,6 +163,12 @@ void SelectionViewController::onReleased(double x, double y)
         return;
     }
 
+    if (tracks.empty()) {
+        selectionController()->resetSelectedTracks();
+        setSelection(x1, x2, true);
+        return;
+    }
+
     setSelectionActive(true);
 
     if (m_startPoint.y() < y) {

--- a/src/projectscene/view/trackspanel/trackslistmodel.cpp
+++ b/src/projectscene/view/trackspanel/trackslistmodel.cpp
@@ -350,6 +350,10 @@ void TracksListModel::setItemsSelected(const QModelIndexList& indexes, bool sele
         }
     }
 
+    if (idsToModify.empty()) {
+        return;
+    }
+
     // keep selectionController in sync with muse::uicomponents::ItemMultiSelectionModel
     auto alreadySelectedTracksIds = selectionController()->selectedTracks();
     if (selected) {


### PR DESCRIPTION
Resolves: #8927 

Avoid crash when no track is selected

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
