### PR TITLE
Avoid division by zero on channel ratio calculation

### DIFF
--- a/src/projectscene/qml/Audacity/ProjectScene/clipsview/ChannelSplitter.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/clipsview/ChannelSplitter.qml
@@ -11,15 +11,7 @@ Item {
 
     opacity: 0.05
 
-    signal ratioChanged(double v)
-
-    QtObject {
-        id: prv
-
-        readonly property double minChannelHeight: 20
-        readonly property double minRatio: minChannelHeight / root.height
-        readonly property double maxRatio: (root.height - minChannelHeight) / root.height
-    }
+    signal positionChangeRequested(int y)
 
     Rectangle {
         id: splitter
@@ -43,26 +35,19 @@ Item {
         enabled: asymmetricStereoHeightsPossible
 
         onPositionChanged: {
-            let ratio = splitter.y / root.height
-            clampRatio(ratio)
+            root.positionChangeRequested(splitter.y)
         }
-    }
-
-    Component.onCompleted: {
-        root.heightChanged.connect(function() {
-            clampRatio(root.channelHeightRatio)
-        });
-    }
-
-    function clampRatio(ratio) {
-        let newRatio = Math.max(prv.minRatio, Math.min(prv.maxRatio, ratio));
-        root.ratioChanged(newRatio)
-        splitter.y = Math.round(newRatio * root.height - 1)
     }
 
     Binding {
         target: splitter
         property: "y"
-        value: Math.round(root.channelHeightRatio * root.height - 1)
+        value: {
+            if (root.height <= 0) {
+                return 0
+            }
+
+            return Math.round(root.channelHeightRatio * root.height)
+        }
     }
 }

--- a/src/projectscene/qml/Audacity/ProjectScene/clipsview/ClipItem.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/clipsview/ClipItem.qml
@@ -62,7 +62,7 @@ Rectangle {
 
     signal requestSelected()
     signal requestSelectionReset()
-    signal ratioChanged(double val)
+    signal splitterPositionChangeRequested(int position)
 
     signal pitchChangeRequested()
     signal pitchResetRequested()
@@ -681,8 +681,8 @@ Rectangle {
                 color: "#000000"
                 opacity: 0.10
 
-                onRatioChanged: function (ratio) {
-                    root.ratioChanged(ratio)
+                onPositionChangeRequested: function (position) {
+                    root.splitterPositionChangeRequested(position)
                 }
             }
 

--- a/src/projectscene/qml/Audacity/ProjectScene/clipsview/TrackClipsItem.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/clipsview/TrackClipsItem.qml
@@ -24,7 +24,6 @@ Item {
     property bool isMultiSelectionActive: false
     property bool isTrackAudible: true
     property bool isStereo: clipsModel.isStereo
-    property double channelHeightRatio: 0.5
     property bool moveActive: false
     property bool altPressed: false
     property bool ctrlPressed: false
@@ -93,6 +92,12 @@ Item {
         anchors.bottomMargin: sep.height
         z: 1
 
+        property double targetHeightRatio: 0.5
+        property double channelHeightRatio: 0.5
+        readonly property int minChannelHeight: 20
+        readonly property int yMinValue: Math.min(root.height / 2, minChannelHeight)
+        readonly property int yMaxValue: Math.max(root.height / 2, root.height - minChannelHeight);
+
         property bool isNearSample: false
         property bool multiSampleEdit: false
         property bool isBrush: false
@@ -123,6 +128,19 @@ Item {
                 }
             }
             return false
+        }
+
+        function updateChannelHeightRatio(position) {
+            const newY = Math.min(Math.max(position, yMinValue), yMaxValue)
+            channelHeightRatio = newY / height
+        }
+
+        function resetTargetHeightRatio() {
+            targetHeightRatio = channelHeightRatio
+        }
+
+        onHeightChanged: {
+            updateChannelHeightRatio(clipsContainer.targetHeightRatio * clipsContainer.height)
         }
 
         MouseArea {
@@ -272,7 +290,7 @@ Item {
                 leftVisibleMargin: clipItem.leftVisibleMargin
                 rightVisibleMargin: clipItem.rightVisibleMargin
                 collapsed: trackViewState.isTrackCollapsed
-                channelHeightRatio: root.channelHeightRatio
+                channelHeightRatio: clipsContainer.channelHeightRatio
                 showChannelSplitter: isStereo
 
                 navigation.name: Boolean(clipItem) ? clipItem.title + clipItem.index : ""
@@ -418,8 +436,9 @@ Item {
                     clipsModel.resetSelectedClip()
                 }
 
-                onRatioChanged: function (ratio) {
-                    root.channelHeightRatio = ratio
+                onSplitterPositionChangeRequested: function (position) {
+                    clipsContainer.updateChannelHeightRatio(position)
+                    clipsContainer.resetTargetHeightRatio()
                 }
 
                 onPitchChangeRequested: {
@@ -563,13 +582,14 @@ Item {
         anchors.topMargin: trackViewState.isTrackCollapsed ? 1 : 21
         anchors.bottomMargin: 3
 
-        channelHeightRatio: root.channelHeightRatio
+        channelHeightRatio: clipsContainer.channelHeightRatio
         color: "#FFFFFF"
         opacity: 0.05
         visible: isStereo
 
-        onRatioChanged: function(ratio) {
-            root.channelHeightRatio = ratio
+        onPositionChangeRequested: function(position) {
+            clipsContainer.updateChannelHeightRatio(position)
+            clipsContainer.resetTargetHeightRatio()
         }
     }
 


### PR DESCRIPTION
Resolves: #8780 #7666 

Avoid division by zero on channel ratio calculation

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:
- [x] Crash should not happen
- [x] The ratio should be preserved even if I minimize and then increase the height of the clip
- [ ] No regressions on the channel ratio (moving the spitter, changing height and so on)
