### PR TITLE
Implement Wave Colour menu

### DIFF
--- a/au3/libraries/lib-wave-track-paint/waveform/WaveBitmapCache.cpp
+++ b/au3/libraries/lib-wave-track-paint/waveform/WaveBitmapCache.cpp
@@ -47,6 +47,13 @@ struct Triplet final
         b = color.GetBlue();
     }
 
+    void SetWaveColor(graphics::Color color)
+    {
+        r = color.GetRed();
+        g = color.GetGreen();
+        b = color.GetBlue();
+    }
+
     Triplet(const Triplet&) = default;
     Triplet(Triplet&&) = default;
     Triplet& operator=(const Triplet&) = default;

--- a/au3/libraries/lib-wave-track/WaveClip.cpp
+++ b/au3/libraries/lib-wave-track/WaveClip.cpp
@@ -292,6 +292,7 @@ WaveClip::WaveClip(
     mIsPlaceholder = orig.GetIsPlaceholder();
 
     mColor = orig.mColor;
+    mWaveColor = orig.mWaveColor;
 
     assert(NChannels() == (token.emptyCopy ? 0 : orig.NChannels()));
     assert(token.emptyCopy || CheckInvariants());
@@ -357,6 +358,7 @@ WaveClip::WaveClip(
     }
 
     mColor = orig.mColor;
+    mWaveColor = orig.mWaveColor;
 
     assert(NChannels() == orig.NChannels());
     assert(CheckInvariants());
@@ -1088,6 +1090,7 @@ static constexpr auto ClipTempo_attr = "clipTempo";
 static constexpr auto Name_attr = "name";
 static constexpr auto GroupId_attr = "groupId";
 static constexpr auto Color_attr = "color";
+static constexpr auto waveColor_attr = "wave_color";
 
 bool WaveClip::HandleXMLTag(const std::string_view& tag, const AttributesList& attrs)
 {
@@ -1160,6 +1163,10 @@ bool WaveClip::HandleXMLTag(const std::string_view& tag, const AttributesList& a
             } else if (attr == Color_attr) {
                 if (value.IsStringView()) {
                     SetColor(value.ToWString());
+                }
+            } else if (attr == waveColor_attr) {
+                if (value.IsStringView()) {
+                    SetWaveColor(value.ToWString());
                 }
             } else if (Attachments::FindIf(
                            [&](WaveClipListener& listener){
@@ -1242,6 +1249,7 @@ void WaveClip::WriteXML(size_t ii, XMLWriter& xmlFile) const
     xmlFile.WriteAttr(Name_attr, mName);
     xmlFile.WriteAttr(GroupId_attr, static_cast<long>(mGroupId));
     xmlFile.WriteAttr(Color_attr, mColor);
+    xmlFile.WriteAttr(Color_attr, mWaveColor);
     Attachments::ForEach([&](const WaveClipListener& listener){
         listener.WriteXMLAttributes(xmlFile);
     });
@@ -1913,9 +1921,19 @@ void WaveClip::SetColor(const wxString& color)
     mColor = color;
 }
 
+void WaveClip::SetWaveColor(const wxString& color)
+{
+    mWaveColor = color;
+}
+
 const wxString& WaveClip::GetColor() const
 {
     return mColor;
+}
+
+const wxString& WaveClip::GetWaveColor() const
+{
+    return mWaveColor;
 }
 
 sampleCount WaveClip::TimeToSamples(double time) const

--- a/au3/libraries/lib-wave-track/WaveClip.h
+++ b/au3/libraries/lib-wave-track/WaveClip.h
@@ -842,8 +842,10 @@ public:
     void SetGroupId(int64_t id);
 
     void SetColor(const wxString& color);
+    void SetWaveColor(const wxString& color);
     const wxString& GetColor() const;
-
+    const wxString& GetWaveColor() const;
+    
     // TimeToSamples and SamplesToTime take clip stretch ratio into account.
     // Use them to convert time / sample offsets.
     sampleCount TimeToSamples(double time) const override;
@@ -1060,6 +1062,7 @@ private:
     int64_t mGroupId = -1;
 
     wxString mColor;
+    wxString mWaveColor;
 };
 
 #endif

--- a/au3/src/commands/SetClipCommand.cpp
+++ b/au3/src/commands/SetClipCommand.cpp
@@ -61,6 +61,7 @@ bool SetClipCommand::VisitSettings(SettingsVisitorBase<Const>& S)
 {
     S.OptionalY(bHasContainsTime).Define(mContainsTime,   wxT("At"),         0.0, 0.0, 100000.0);
     S.OptionalN(bHasColour).DefineEnum(mColour,         wxT("Color"),      kColour0, kColourStrings, nColours);
+    S.OptionalN(bHasWaveColour).DefineEnum(mWaveColour,         wxT("WaveColor"),      kColour0, kColourStrings, nColours);
     // Allowing a negative start time is not a mistake.
     // It will be used in demonstrating time before zero.
     S.OptionalN(bHasT0).Define(mT0,             wxT("Start"),      0.0, -5.0, 1000000.0);
@@ -81,6 +82,8 @@ void SetClipCommand::PopulateOrExchange(ShuttleGui& S)
     {
         S.Optional(bHasContainsTime).TieNumericTextBox(XXO("At:"),            mContainsTime);
         S.Optional(bHasColour).TieChoice(XXO("Color:"),         mColour,
+                                         Msgids(kColourStrings, nColours));
+        S.Optional(bHasWaveColour).TieChoice(XXO("Wave Color:"), mWaveColour,
                                          Msgids(kColourStrings, nColours));
         S.Optional(bHasT0).TieNumericTextBox(XXO("Start:"),         mT0);
         S.Optional(bHasName).TieTextBox(XXO("Name:"),          mName);
@@ -105,6 +108,11 @@ bool SetClipCommand::Apply(const CommandContext& context)
                     if (bHasColour) {
                         for (const auto channel : interval->Channels()) {
                             WaveColorAttachment::Get(*channel).SetColorIndex(mColour);
+                        }
+                    }
+                    if (bHasWaveColour) {
+                        for (const auto channel : interval->Channels()) {
+                            WaveColorAttachment::Get(*channel).SetWaveColorIndex(mColour);
                         }
                     }
                     // No validation of overlap yet.  We assume the user is sensible!

--- a/au3/src/commands/SetTrackInfoCommand.cpp
+++ b/au3/src/commands/SetTrackInfoCommand.cpp
@@ -350,6 +350,10 @@ bool SetTrackVisualsCommand::ApplyInner(
         WaveformAppearance::Get(*wt).SetColorIndex(mColour);
     }
 
+    if (bHasWaveColour) {
+        WaveformAppearance::Get(wc).SetWaveColorIndex(mWaveColour);
+    }
+
     if (bHasHeight) {
         for (auto pChannel : t.Channels<WaveChannel>()) {
             ChannelView::Get(*pChannel).SetExpandedHeight(mHeight);

--- a/au3/src/tracks/playabletrack/wavetrack/ui/WaveformAppearance.cpp
+++ b/au3/src/tracks/playabletrack/wavetrack/ui/WaveformAppearance.cpp
@@ -60,6 +60,7 @@ void WaveformAppearance::Subscribe(const std::shared_ptr<WaveTrack>& pTrack)
                 case WaveTrackMessage::New:
                 case WaveTrackMessage::Deserialized:
                     WaveColorAttachment::Get(*message.pClip).SetColorIndex(mColorIndex);
+                    WaveColorAttachment::Get(*message.pClip).SetWaveColorIndex(mWaveColorIndex);
                 default:
                     break;
             }
@@ -111,6 +112,21 @@ void WaveformAppearance::SetColorIndex(int colorIndex)
         for (const auto& pChannel : pInterval->Channels()) {
             WaveColorAttachment::Get(*pChannel)
             .SetColorIndex(colorIndex);
+        }
+    }
+}
+
+void WaveformAppearance::SetWaveColorIndex(int colorIndex)
+{
+    mWaveColorIndex = colorIndex;
+    const auto pTrack = mwTrack.lock();
+    if (!pTrack) {
+        return;
+    }
+    for (const auto& pInterval : pTrack->Intervals()) {
+        for (const auto& pChannel : pInterval->Channels()) {
+            WaveColorAttachment::Get(*pChannel)
+            .SetWaveColorIndex(colorIndex);
         }
     }
 }
@@ -174,5 +190,14 @@ bool WaveColorAttachment::HandleXMLAttribute(const std::string_view& attr,
         SetColorIndex(longValue);
         return true;
     }
+
+    if (attr == WaveColorIndex_attr) {
+        if (!valueView.TryGet(longValue)) {
+            return false;
+        }
+        SetWaveColorIndex(longValue);
+        return true;
+    }
+    
     return false;
 }

--- a/au3/src/tracks/playabletrack/wavetrack/ui/WaveformAppearance.h
+++ b/au3/src/tracks/playabletrack/wavetrack/ui/WaveformAppearance.h
@@ -36,6 +36,7 @@ public:
 
     int GetColorIndex() const { return mColorIndex; }
     void SetColorIndex(int colorIndex);
+    void SetWaveColorIndex(int colorIndex);
 
 private:
     void Subscribe(const std::shared_ptr<WaveTrack>& pTrack);
@@ -68,6 +69,7 @@ struct WaveColorAttachment final : WaveClipListener
 
     int GetColorIndex() const { return mColorIndex; }
     void SetColorIndex(int colorIndex) { mColorIndex = colorIndex; }
+    void SetWaveColorIndex(int colorIndex) { mColorIndex = colorIndex; }
 
 private:
     int mColorIndex{};

--- a/au3/src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
+++ b/au3/src/tracks/playabletrack/wavetrack/ui/WaveformView.cpp
@@ -1135,6 +1135,7 @@ void WaveColorMenuTable::OnWaveColorChange(wxCommandEvent& event)
     AudacityProject* const project = &mpData->project;
 
     WaveformAppearance::Get(track).SetColorIndex(newWaveColor);
+    WaveformAppearance::Get(track).SetWaveColorIndex(newWaveColor);
 
     ProjectHistory::Get(*project)
     .PushState(XO("Changed '%s' to %s")

--- a/src/au3wrap/internal/domconverter.cpp
+++ b/src/au3wrap/internal/domconverter.cpp
@@ -45,6 +45,8 @@ au::trackedit::Clip DomConverter::clip(const Au3WaveTrack* waveTrack, const Au3W
     clip.endTime = au3clip->GetPlayEndTime();
     clip.color = (!wxToString(au3clip->GetColor()).isEmpty()) ? muse::draw::Color(au3clip->GetColor()) : TrackColor::Get(
         waveTrack).GetColor();
+    clip.wave_color = (!wxToString(au3clip->GetWaveColor()).isEmpty()) ? muse::draw::Color(au3clip->GetWaveColor())
+                                                                        : QColor(0,0,0);
     clip.groupId = au3clip->GetGroupId();
     clip.hasCustomColor = !wxToString(au3clip->GetColor()).isEmpty();
     clip.stereo = au3clip->NChannels() > 1;

--- a/src/projectscene/internal/projectsceneconfiguration.cpp
+++ b/src/projectscene/internal/projectsceneconfiguration.cpp
@@ -136,6 +136,23 @@ const std::vector<std::pair<std::string, std::string> >& ProjectSceneConfigurati
     return colors;
 }
 
+const std::vector<std::pair<std::string, std::string> >& ProjectSceneConfiguration::waveColors() const
+{
+    static std::vector<std::pair<std::string /*name*/, std::string /*color*/> > wave_colors = {
+        { "Blue", "#3576CC" },
+        { "Violet", "#6B63B8" },
+        { "Magenta", "#A05C99" },
+        { "Red", "#B24D4D" },
+        { "Orange", "#8B5C2A" },
+        { "Yellow", "#B8962A" },
+        { "Green", "#4C8B36" },
+        { "Turquoise", "#25806A" },
+        { "Cyan", "#2B7E8F" },
+    };
+
+    return wave_colors;
+}
+
 ClipStyles::Style ProjectSceneConfiguration::clipStyle() const
 {
     return muse::settings()->value(CLIP_STYLE).toEnum<ClipStyles::Style>();

--- a/src/projectscene/internal/projectsceneconfiguration.h
+++ b/src/projectscene/internal/projectsceneconfiguration.h
@@ -40,6 +40,7 @@ public:
     muse::async::Notification isEffectsPanelVisibleChanged() const override;
 
     const std::vector<std::pair<std::string, std::string> >& clipColors() const override;
+    const std::vector<std::pair<std::string, std::string> >& waveColors() const override;
 
     ClipStyles::Style clipStyle() const override;
     void setClipStyle(ClipStyles::Style style) override;

--- a/src/projectscene/internal/projectsceneuiactions.cpp
+++ b/src/projectscene/internal/projectsceneuiactions.cpp
@@ -149,6 +149,13 @@ static UiActionList STATIC_ACTIONS = {
              TranslatableString("action", "Follow track color"),
              Checkable::Yes
              ),
+    UiAction("action://trackedit/clip/change-wave-color-auto",
+             au::context::UiCtxAny,
+             au::context::CTX_ANY,
+             TranslatableString("action", "Follow track wave color"),
+             TranslatableString("action", "Follow track wave color"),
+             Checkable::Yes
+             ),
     UiAction("play-position-decrease",
              au::context::UiCtxProjectOpened,
              muse::shortcuts::CTX_PROJECT_OPENED,
@@ -178,8 +185,10 @@ ProjectSceneUiActions::ProjectSceneUiActions(std::shared_ptr<ProjectSceneActions
 void ProjectSceneUiActions::init()
 {
     const auto& colors = configuration()->clipColors();
+    const auto& wave_colors = configuration()->waveColors();
+
     m_actions.clear();
-    m_actions.reserve(2 * colors.size() + STATIC_ACTIONS.size());
+    m_actions.reserve(2 * colors.size() + 1 * wave_colors.size() + STATIC_ACTIONS.size());
 
     for (const auto& color : colors) {
         UiAction clipColorAction;
@@ -205,6 +214,20 @@ void ProjectSceneUiActions::init()
         trackColorAction.checkable = Checkable::Yes;
 
         m_actions.push_back(std::move(trackColorAction));
+    }
+
+    for (const auto& color : wave_colors) {
+        UiAction waveColorAction;
+        waveColorAction.code = muse::actions::ActionQuery(makeWaveColorChangeAction(color.second)).toString();
+        waveColorAction.uiCtx = context::UiCtxProjectOpened;
+        waveColorAction.scCtx = context::CTX_PROJECT_FOCUSED;
+        waveColorAction.description = muse::TranslatableString("action", "Change wave color");
+        waveColorAction.title = muse::TranslatableString("action", "Change wave color");
+        waveColorAction.iconCode = IconCode::Code::FRETBOARD_MARKER_CIRCLE_FILLED;
+        waveColorAction.iconColor = QString::fromStdString(color.second);
+        waveColorAction.checkable = Checkable::Yes;
+
+        m_actions.push_back(std::move(waveColorAction));
     }
 
     m_actions.insert(m_actions.end(), STATIC_ACTIONS.begin(), STATIC_ACTIONS.end());

--- a/src/projectscene/iprojectsceneconfiguration.h
+++ b/src/projectscene/iprojectsceneconfiguration.h
@@ -31,6 +31,7 @@ public:
     virtual muse::async::Notification isEffectsPanelVisibleChanged() const = 0;
 
     virtual const std::vector<std::pair<std::string, std::string> >& clipColors() const = 0;
+    virtual const std::vector<std::pair<std::string, std::string> >& waveColors() const = 0;
 
     virtual ClipStyles::Style clipStyle() const = 0;
     virtual void setClipStyle(ClipStyles::Style style) = 0;

--- a/src/projectscene/qml/Audacity/ProjectScene/clipsview/ClipItem.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/clipsview/ClipItem.qml
@@ -21,6 +21,7 @@ Rectangle {
     property alias channelHeightRatio: channelSplitter.channelHeightRatio
     property var canvas: null
     property color clipColor: "#677CE4"
+    property color waveColor: "#000000"
     property color normalHeaderColor: root.currentClipStyle == ClipStyle.COLORFUL ? root.clipColor : root.classicHeaderColor
     property color selectedHeaderColor: root.currentClipStyle == ClipStyle.COLORFUL ? ui.blendColors("#ffffff", root.clipColor, 0.3) : classicHeaderColor
     property color normalHeaderHoveredColor: root.currentClipStyle == ClipStyle.COLORFUL ? ui.blendColors("#ffffff", root.clipColor, 0.8) : classicHeaderHoveredColor
@@ -651,6 +652,7 @@ Rectangle {
             channelHeightRatio: showChannelSplitter ? root.channelHeightRatio : 1
 
             clipColor: root.clipColor
+            waveColor: root.waveColor
             clipSelected: root.clipSelected
             isIsolationMode: root.isIsolationMode
             multiSampleEdit: root.multiSampleEdit

--- a/src/projectscene/qml/Audacity/ProjectScene/clipsview/ClipItemSmall.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/clipsview/ClipItemSmall.qml
@@ -5,6 +5,8 @@ Rectangle {
     id: root
 
     property color clipColor: "#677CE4"
+    property color waveColor: "#000000"
+
     property bool collapsed: false
 
     //radius: 4

--- a/src/projectscene/qml/Audacity/ProjectScene/clipsview/TrackClipsItem.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/clipsview/TrackClipsItem.qml
@@ -228,11 +228,12 @@ Item {
         }
 
         Component {
-            id: clipSmallComp
+            id: clipSmallCompwave
 
             ClipItemSmall {
 
                 clipColor: clipItem.color
+                waveColor: clipItem.wave_color
                 collapsed: trackViewState.isTrackCollapsed
             }
         }
@@ -247,6 +248,7 @@ Item {
                 canvas: root.canvas
                 title: clipItem.title
                 clipColor: clipItem.color
+                waveColor: clipItem.wave_color
                 currentClipStyle: clipsModel.clipStyle
                 groupId: clipItem.groupId
                 clipKey: clipItem.key

--- a/src/projectscene/tests/mocks/projectsceneconfigurationmock.h
+++ b/src/projectscene/tests/mocks/projectsceneconfigurationmock.h
@@ -30,6 +30,8 @@ public:
     MOCK_METHOD(muse::async::Notification, isEffectsPanelVisibleChanged, (), (const, override));
 
     MOCK_METHOD((const std::vector<std::pair<std::string, std::string> >&), clipColors, (), (const, override));
+    
+    MOCK_METHOD((const std::vector<std::pair<std::string, std::string> >&), waveColors, (), (const, override));
 
     MOCK_METHOD(ClipStyles::Style, clipStyle, (), (const, override));
     MOCK_METHOD(void, setClipStyle, (ClipStyles::Style style), (override));

--- a/src/projectscene/types/projectscenetypes.h
+++ b/src/projectscene/types/projectscenetypes.h
@@ -175,6 +175,13 @@ inline muse::actions::ActionQuery makeClipColorChangeAction(const std::string& c
                                                                                 colorHex)));
 }
 
+constexpr const char16_t* WAVE_COLOR_CHANGE_ACTION = u"action://trackedit/clip/change-wave-color?wave_color=%1";
+inline muse::actions::ActionQuery makeWaveColorChangeAction(const std::string& wave_colorHex)
+{
+    return muse::actions::ActionQuery(muse::String(WAVE_COLOR_CHANGE_ACTION).arg(muse::String::fromStdString(
+                                                                                wave_colorHex)));
+}
+
 constexpr const char16_t* TRACK_COLOR_CHANGE_ACTION = u"action://trackedit/track/change-color?color=%1";
 inline muse::actions::ActionQuery makeTrackColorChangeAction(const std::string& colorHex)
 {

--- a/src/projectscene/view/clipsview/clipcontextmenumodel.h
+++ b/src/projectscene/view/clipsview/clipcontextmenumodel.h
@@ -37,10 +37,14 @@ private:
     void updateStretchEnabledState(muse::uicomponents::MenuItem& item);
 
     muse::uicomponents::MenuItemList makeClipColourItems();
+    muse::uicomponents::MenuItemList makeWaveColourItems();
     void updateColorCheckedState();
+    void updateWaveColorCheckedState();
     void updateColorMenu();
+    void updateWaveColorMenu();
 
     ClipKey m_clipKey;
     muse::actions::ActionCodeList m_colorChangeActionCodeList;
+    muse::actions::ActionCodeList m_wave_colorChangeActionCodeList;
 };
 }

--- a/src/projectscene/view/clipsview/cliplistitem.cpp
+++ b/src/projectscene/view/clipsview/cliplistitem.cpp
@@ -18,6 +18,7 @@ void ClipListItem::setClip(const trackedit::Clip& clip)
     emit pitchChanged();
     emit speedPercentageChanged();
     emit colorChanged();
+    emit wave_colorChanged();
     emit groupIdChanged();
     emit waveChanged();
 }
@@ -46,6 +47,11 @@ void ClipListItem::setTitle(const QString& newTitle)
 QColor ClipListItem::color() const
 {
     return m_clip.color.toQColor();
+}
+
+QColor ClipListItem::wave_color() const
+{
+    return m_clip.wave_color.toQColor();
 }
 
 int ClipListItem::groupId() const

--- a/src/projectscene/view/clipsview/cliplistitem.h
+++ b/src/projectscene/view/clipsview/cliplistitem.h
@@ -18,6 +18,7 @@ class ClipListItem : public QObject
     Q_PROPERTY(ClipKey key READ key CONSTANT)
     Q_PROPERTY(QString title READ title WRITE setTitle NOTIFY titleChanged FINAL)
     Q_PROPERTY(QColor color READ color NOTIFY colorChanged FINAL)
+    Q_PROPERTY(QColor wave_color READ wave_color NOTIFY wave_colorChanged FINAL)
     Q_PROPERTY(int groupId READ groupId NOTIFY groupIdChanged FINAL)
 
     Q_PROPERTY(double x READ x WRITE setX NOTIFY xChanged FINAL)
@@ -44,6 +45,8 @@ public:
     void setTitle(const QString& newTitle);
 
     QColor color() const;
+    
+    QColor wave_color() const;
 
     int groupId() const;
 
@@ -73,6 +76,7 @@ signals:
     void xChanged();
     void widthChanged();
     void colorChanged();
+    void wave_colorChanged();
     void groupIdChanged();
     void leftVisibleMarginChanged();
     void rightVisibleMarginChanged();

--- a/src/projectscene/view/clipsview/waveview.cpp
+++ b/src/projectscene/view/clipsview/waveview.cpp
@@ -16,7 +16,7 @@
 using namespace au::projectscene;
 
 static const QColor BACKGROUND_COLOR = QColor(255, 255, 255);
-static const QColor SAMPLES_BASE_COLOR = QColor(0, 0, 0);
+static const QColor SAMPLES_BASE_COLOR = QColor(0, 128, 255);// QColor(0, 0, 0);
 static const QColor SAMPLES_HIGHLIGHT_COLOR = QColor(255, 255, 255);
 static const QColor RMS_BASE_COLOR = QColor(255, 255, 255);
 static const QColor CENTER_LINE_COLOR = QColor(0, 0, 0);
@@ -24,7 +24,7 @@ static const QColor SAMPLE_HEAD_COLOR = QColor(0, 0, 0);
 static const QColor SAMPLE_STALK_COLOR = QColor(0, 0, 0);
 
 static const QColor CLASSIC_BACKGROUND_COLOR = QColor(241, 243, 254);
-static const QColor CLASSIC_SAMPLES_BASE_COLOR = QColor(100, 100, 204);
+static const QColor CLASSIC_SAMPLES_BASE_COLOR = QColor(0, 128, 255); //QColor(100, 100, 204);
 
 static const QColor CLASSIC_BACKGROUND_SELECTED_COLOR = QColor(175, 194, 238);
 static const QColor CLASSIC_SAMPLES_BASE_SELECTED_COLOR = QColor(68, 71, 195);
@@ -98,10 +98,9 @@ void WaveView::applyColorfulStyle(IWavePainter::Params& params,
     params.style.blankBrush = muse::draw::blendQColors(BACKGROUND_COLOR, clipColor, bgAlpha);
     params.style.normalBackground = muse::draw::blendQColors(BACKGROUND_COLOR, clipColor, normalBgAlpha);
     params.style.selectedBackground = transformColor(params.style.normalBackground);
-
-    params.style.samplePen = muse::draw::blendQColors(params.style.blankBrush, SAMPLES_BASE_COLOR, 0.8);
+    params.style.samplePen = muse::draw::blendQColors(params.style.blankBrush, m_waveColor, 0.8);
     params.style.selectedSamplePen = muse::draw::blendQColors(params.style.blankBrush,
-                                                              selected ? SAMPLES_HIGHLIGHT_COLOR : SAMPLES_BASE_COLOR,
+                                                              selected ? SAMPLES_HIGHLIGHT_COLOR : m_waveColor,
                                                               0.75);
     params.style.rmsPen = muse::draw::blendQColors(params.style.samplePen, RMS_BASE_COLOR, 0.1);
     params.style.centerLine = muse::draw::blendQColors(params.style.samplePen, CENTER_LINE_COLOR, 0.2);
@@ -126,7 +125,7 @@ void WaveView::applyClassicStyle(IWavePainter::Params& params, bool selected) co
     params.style.normalBackground = params.style.blankBrush;
     params.style.selectedBackground = selected ? transformColor(CLASSIC_BACKGROUND_SELECTED_COLOR) : CLASSIC_BACKGROUND_SELECTED_COLOR;
 
-    QColor baseSampleColor = selected ? CLASSIC_SAMPLES_BASE_SELECTED_COLOR : CLASSIC_SAMPLES_BASE_COLOR;
+    QColor baseSampleColor = selected ? CLASSIC_SAMPLES_BASE_SELECTED_COLOR : m_waveColor;
     params.style.samplePen = baseSampleColor;
     params.style.selectedSamplePen = CLASSIC_SAMPLES_BASE_SELECTED_COLOR;
     params.style.rmsPen = baseSampleColor;
@@ -194,6 +193,11 @@ QColor WaveView::clipColor() const
     return m_clipColor;
 }
 
+QColor WaveView::waveColor() const
+{
+    return m_waveColor;
+}
+
 void WaveView::setClipColor(const QColor& newClipColor)
 {
     if (m_clipColor == newClipColor) {
@@ -201,6 +205,19 @@ void WaveView::setClipColor(const QColor& newClipColor)
     }
     m_clipColor = newClipColor;
     emit clipColorChanged();
+
+    update();
+}
+
+void WaveView::setWaveColor(const QColor& newWaveColor)
+{
+    if (m_waveColor == newWaveColor) 
+    {
+        return;
+    }
+
+    m_waveColor = newWaveColor;
+    emit waveColorChanged();
 
     update();
 }

--- a/src/projectscene/view/clipsview/waveview.h
+++ b/src/projectscene/view/clipsview/waveview.h
@@ -21,6 +21,7 @@ class WaveView : public QQuickPaintedItem
     Q_PROPERTY(TimelineContext * context READ timelineContext WRITE setTimelineContext NOTIFY timelineContextChanged FINAL)
     Q_PROPERTY(ClipKey clipKey READ clipKey WRITE setClipKey NOTIFY clipKeyChanged FINAL)
     Q_PROPERTY(QColor clipColor READ clipColor WRITE setClipColor NOTIFY clipColorChanged FINAL)
+    Q_PROPERTY(QColor waveColor READ waveColor WRITE setWaveColor NOTIFY waveColorChanged FINAL)
     Q_PROPERTY(bool clipSelected READ clipSelected WRITE setClipSelected NOTIFY clipSelectedChanged FINAL)
     Q_PROPERTY(double channelHeightRatio READ channelHeightRatio WRITE setChannelHeightRatio NOTIFY channelHeightRatioChanged FINAL)
 
@@ -48,6 +49,8 @@ public:
     void setClipKey(const ClipKey& newClipKey);
     QColor clipColor() const;
     void setClipColor(const QColor& newClipColor);
+    QColor waveColor() const;
+    void setWaveColor(const QColor& newWaveColor);
     bool clipSelected() const;
     void setClipSelected(bool newClipSelected);
     ClipTime clipTime() const;
@@ -79,6 +82,7 @@ signals:
     void timelineContextChanged();
     void clipKeyChanged();
     void clipColorChanged();
+    void waveColorChanged();
     void clipTimeChanged();
     void clipSelectedChanged();
     void channelHeightRatioChanged();
@@ -99,6 +103,7 @@ private:
     TimelineContext* m_context = nullptr;
     ClipKey m_clipKey;
     QColor m_clipColor;
+    QColor m_waveColor;
     double m_clipLeft = 0;
     double m_channelHeightRatio = 0.5;
     bool m_clipSelected = false;

--- a/src/trackedit/dom/clip.h
+++ b/src/trackedit/dom/clip.h
@@ -18,6 +18,7 @@ struct Clip {
 
     muse::String title;
     muse::draw::Color color;
+    muse::draw::Color wave_color;// = QColor(0, 128, 255); // Default to blue
     int groupId = -1;
     double startTime = 0.0;
     double endTime = 0.0;
@@ -29,6 +30,7 @@ struct Clip {
 
     bool stretchToMatchTempo = false;
     bool hasCustomColor = false;
+    bool hasCustomWaveColor = false;
 
     inline bool isValid() const { return key.isValid(); }
 };

--- a/src/trackedit/internal/au3/au3interaction.cpp
+++ b/src/trackedit/internal/au3/au3interaction.cpp
@@ -877,6 +877,28 @@ bool Au3Interaction::changeClipColor(const ClipKey& clipKey, const std::string& 
     return true;
 }
 
+bool Au3Interaction::changeWaveColor(const ClipKey& clipKey, const std::string& newColor)
+{
+    WaveTrack* waveTrack = DomAccessor::findWaveTrack(projectRef(), ::TrackId(clipKey.trackId));
+    IF_ASSERT_FAILED(waveTrack) 
+    {
+        return false;
+    }
+
+    std::shared_ptr<WaveClip> clip = DomAccessor::findWaveClip(waveTrack, clipKey.clipId);
+    IF_ASSERT_FAILED(clip) 
+    {
+        return false;
+    }
+
+    clip->SetWaveColor(newColor);
+
+    trackedit::ITrackeditProjectPtr prj = globalContext()->currentTrackeditProject();
+    prj->notifyAboutClipChanged(DomConverter::clip(waveTrack, clip.get()));
+
+    return true;
+}
+
 bool Au3Interaction::changeTrackColor(const TrackId trackId, const std::string& color)
 {
     Au3WaveTrack* waveTrack = DomAccessor::findWaveTrack(projectRef(), ::TrackId(trackId));

--- a/src/trackedit/internal/au3/au3interaction.h
+++ b/src/trackedit/internal/au3/au3interaction.h
@@ -44,6 +44,7 @@ public:
     bool changeClipSpeed(const ClipKey& clipKey, double speed) override;
     bool resetClipSpeed(const ClipKey& clipKey) override;
     bool changeClipColor(const ClipKey& clipKey, const std::string& color) override;
+    bool changeWaveColor(const ClipKey& clipKey, const std::string& color) override;
     bool changeTrackColor(const TrackId trackId, const std::string& color) override;
     bool changeClipOptimizeForVoice(const ClipKey& clipKey, bool optimize) override;
     bool renderClipPitchAndSpeed(const ClipKey& clipKey) override;

--- a/src/trackedit/internal/trackeditactionscontroller.cpp
+++ b/src/trackedit/internal/trackeditactionscontroller.cpp
@@ -82,7 +82,9 @@ static const ActionCode GROUP_CLIPS_CODE("group-clips");
 static const ActionCode UNGROUP_CLIPS_CODE("ungroup-clips");
 
 static const ActionQuery AUTO_COLOR_QUERY("action://trackedit/clip/change-color-auto");
+static const ActionQuery AUTO_WAVE_COLOR_QUERY("action://trackedit/clip/change-wave-color-auto");
 static const ActionQuery CHANGE_COLOR_QUERY("action://trackedit/clip/change-color");
+static const ActionQuery CHANGE_WAVE_COLOR_QUERY("action://trackedit/clip/change-wave-color");
 static const ActionQuery TRACK_CHANGE_COLOR_QUERY("action://trackedit/track/change-color");
 
 // In principle, disabled are actions that modify the data involved in playback.
@@ -212,7 +214,9 @@ void TrackeditActionsController::init()
     dispatcher()->reg(this, UNGROUP_CLIPS_CODE, this, &TrackeditActionsController::ungroupClips);
 
     dispatcher()->reg(this, AUTO_COLOR_QUERY, this, &TrackeditActionsController::setClipColor);
+    dispatcher()->reg(this, AUTO_WAVE_COLOR_QUERY, this, &TrackeditActionsController::setWaveColor);
     dispatcher()->reg(this, CHANGE_COLOR_QUERY, this, &TrackeditActionsController::setClipColor);
+    dispatcher()->reg(this, CHANGE_WAVE_COLOR_QUERY, this, &TrackeditActionsController::setWaveColor);
 
     dispatcher()->reg(this, TRACK_CHANGE_COLOR_QUERY, this, &TrackeditActionsController::setTrackColor);
 
@@ -1184,6 +1188,25 @@ void TrackeditActionsController::setClipColor(const muse::actions::ActionQuery& 
 
     auto clipKey = selectionController()->selectedClips().front();
     trackeditInteraction()->changeClipColor(clipKey, newColor);
+    notifyActionCheckedChanged(q.toString());
+}
+
+void TrackeditActionsController::setWaveColor(const muse::actions::ActionQuery& q)
+{
+    if (!selectionController()->hasSelectedClips()) {
+        return;
+    }
+
+    std::string newWaveColor;
+    if (q.contains("wave_color")) {
+        newWaveColor = q.param("wave_color").toString();
+    } else {
+        newWaveColor = "";
+    }
+
+    auto clipKey = selectionController()->selectedClips().front();
+    trackeditInteraction()->changeWaveColor(clipKey, newWaveColor);
+
     notifyActionCheckedChanged(q.toString());
 }
 

--- a/src/trackedit/internal/trackeditactionscontroller.h
+++ b/src/trackedit/internal/trackeditactionscontroller.h
@@ -123,6 +123,7 @@ private:
     void ungroupClips();
 
     void setClipColor(const muse::actions::ActionQuery& q);
+    void setWaveColor(const muse::actions::ActionQuery& q);
     void setTrackColor(const muse::actions::ActionQuery& q);
 
     muse::async::Channel<muse::actions::ActionCode> m_actionEnabledChanged;

--- a/src/trackedit/internal/trackeditinteraction.cpp
+++ b/src/trackedit/internal/trackeditinteraction.cpp
@@ -71,6 +71,11 @@ bool TrackeditInteraction::changeClipColor(const ClipKey& clipKey, const std::st
     return m_interaction->changeClipColor(clipKey, color);
 }
 
+bool TrackeditInteraction::changeWaveColor(const ClipKey& clipKey, const std::string& wave_color)
+{
+    return m_interaction->changeWaveColor(clipKey, wave_color);
+}
+
 bool TrackeditInteraction::changeTrackColor(const TrackId trackId, const std::string& color)
 {
     return m_interaction->changeTrackColor(trackId, color);

--- a/src/trackedit/internal/trackeditinteraction.h
+++ b/src/trackedit/internal/trackeditinteraction.h
@@ -31,6 +31,7 @@ private:
     bool changeClipSpeed(const ClipKey& clipKey, double speed) override;
     bool resetClipSpeed(const ClipKey& clipKey) override;
     bool changeClipColor(const ClipKey& clipKey, const std::string& color) override;
+    bool changeWaveColor(const ClipKey& clipKey, const std::string& wave_color) override;
     bool changeTrackColor(const TrackId trackId, const std::string& color) override;
     bool changeClipOptimizeForVoice(const ClipKey& clipKey, bool optimize) override;
     bool renderClipPitchAndSpeed(const ClipKey& clipKey) override;

--- a/src/trackedit/internal/trackeditoperationcontroller.cpp
+++ b/src/trackedit/internal/trackeditoperationcontroller.cpp
@@ -109,6 +109,11 @@ bool TrackeditOperationController::changeClipColor(const ClipKey& clipKey, const
     return trackAndClipOperations()->changeClipColor(clipKey, color);
 }
 
+bool TrackeditOperationController::changeWaveColor(const ClipKey& clipKey, const std::string& wave_color)
+{
+    return trackAndClipOperations()->changeWaveColor(clipKey, wave_color);
+}
+
 bool TrackeditOperationController::changeTrackColor(const TrackId trackId, const std::string& color)
 {
     if (trackAndClipOperations()->changeTrackColor(trackId, color)) {

--- a/src/trackedit/internal/trackeditoperationcontroller.h
+++ b/src/trackedit/internal/trackeditoperationcontroller.h
@@ -40,6 +40,7 @@ public:
     bool changeClipSpeed(const ClipKey& clipKey, double speed) override;
     bool resetClipSpeed(const ClipKey& clipKey) override;
     bool changeClipColor(const ClipKey& clipKey, const std::string& color) override;
+    bool changeWaveColor(const ClipKey& clipKey, const std::string& wave_color) override;
     bool changeTrackColor(const TrackId trackId, const std::string& color) override;
     bool changeClipOptimizeForVoice(const ClipKey& clipKey, bool optimize) override;
     bool renderClipPitchAndSpeed(const ClipKey& clipKey) override;

--- a/src/trackedit/itrackandclipoperations.h
+++ b/src/trackedit/itrackandclipoperations.h
@@ -39,6 +39,7 @@ public:
     virtual bool changeClipSpeed(const ClipKey& clipKey, double speed) = 0;
     virtual bool resetClipSpeed(const ClipKey& clipKey) = 0;
     virtual bool changeClipColor(const ClipKey& clipKey, const std::string& color) = 0;
+    virtual bool changeWaveColor(const ClipKey& clipKey, const std::string& wave_color) = 0;
     virtual bool changeTrackColor(const TrackId trackId, const std::string& color) = 0;
     virtual bool changeClipOptimizeForVoice(const ClipKey& clipKey, bool optimize) = 0;
     virtual bool renderClipPitchAndSpeed(const ClipKey& clipKey) = 0;

--- a/src/trackedit/itrackeditinteraction.h
+++ b/src/trackedit/itrackeditinteraction.h
@@ -39,6 +39,7 @@ public:
     virtual bool changeClipSpeed(const ClipKey& clipKey, double speed) = 0;
     virtual bool resetClipSpeed(const ClipKey& clipKey) = 0;
     virtual bool changeClipColor(const ClipKey& clipKey, const std::string& color) = 0;
+    virtual bool changeWaveColor(const ClipKey& clipKey, const std::string& wave_color) = 0;
     virtual bool changeTrackColor(const TrackId trackId, const std::string& color) = 0;
     virtual bool changeClipOptimizeForVoice(const ClipKey& clipKey, bool optimize) = 0;
     virtual bool renderClipPitchAndSpeed(const ClipKey& clipKey) = 0;


### PR DESCRIPTION
This feature adds a Wave Colour menu similar to the existing Clip Colour menu, allowing users to change the color of waveforms in the UI. Users can right-click on a clip and select the Wave Colour option to choose a new color for the waveform, improving project organization and visual clarity.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [ ] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
