### PR TITLE
Space is reserved for playback toggle

### DIFF
--- a/src/context/internal/uicontextresolver.cpp
+++ b/src/context/internal/uicontextresolver.cpp
@@ -35,6 +35,7 @@ static const Uri PROJECT_PAGE_URI("audacity://project");
 //! but we don't have that yet, so binding it to
 //! area that's being focused when opening a project
 static const QString PROJECT_NAVIGATION_PANEL("MainToolBar");
+static const QString PLAYBACK_TOOLBAR_NAVIGATION_PANEL("PlaybackToolBar");
 
 void UiContextResolver::init()
 {
@@ -114,7 +115,7 @@ UiContext UiContextResolver::currentUiContext() const
         if (activePanel) {
             if (activePanel->name() == PROJECT_NAVIGATION_PANEL) {
                 return context::UiCtxProjectFocused;
-            } else if (activePanel->name() != "ToolBarView") {
+            } else if (activePanel->name() != PLAYBACK_TOOLBAR_NAVIGATION_PANEL) {
                 return context::UiCtxProjectPlayback;
             }
         }

--- a/src/context/internal/uicontextresolver.cpp
+++ b/src/context/internal/uicontextresolver.cpp
@@ -35,7 +35,6 @@ static const Uri PROJECT_PAGE_URI("audacity://project");
 //! but we don't have that yet, so binding it to
 //! area that's being focused when opening a project
 static const QString PROJECT_NAVIGATION_PANEL("MainToolBar");
-static const QString PLAYBACK_TOOLBAR_NAVIGATION_PANEL("PlaybackToolBar");
 
 void UiContextResolver::init()
 {
@@ -115,7 +114,7 @@ UiContext UiContextResolver::currentUiContext() const
         if (activePanel) {
             if (activePanel->name() == PROJECT_NAVIGATION_PANEL) {
                 return context::UiCtxProjectFocused;
-            } else if (activePanel->name() != PLAYBACK_TOOLBAR_NAVIGATION_PANEL) {
+            } else {
                 return context::UiCtxProjectPlayback;
             }
         }

--- a/src/context/internal/uicontextresolver.cpp
+++ b/src/context/internal/uicontextresolver.cpp
@@ -114,6 +114,8 @@ UiContext UiContextResolver::currentUiContext() const
         if (activePanel) {
             if (activePanel->name() == PROJECT_NAVIGATION_PANEL) {
                 return context::UiCtxProjectFocused;
+            } else if (activePanel->name() != "ToolBarView") {
+                return context::UiCtxProjectPlayback;
             }
         }
 
@@ -129,8 +131,14 @@ bool UiContextResolver::match(const ui::UiContext& currentCtx, const ui::UiConte
         return true;
     }
 
-    //! NOTE If the current context is `UiCtxProjectFocused`, then we allow `UiCtxProjectOpened` too
-    if (currentCtx == context::UiCtxProjectFocused && actCtx == context::UiCtxProjectOpened) {
+    //! NOTE If the current context is `UiCtxProjectFocused` or `UiCtxProjectPlayback`, then we allow `UiCtxProjectOpened` too
+    if ((currentCtx == context::UiCtxProjectFocused || currentCtx == context::UiCtxProjectPlayback)
+        && actCtx == context::UiCtxProjectOpened) {
+        return true;
+    }
+
+    //! NOTE If the current context is `UiCtxProjectPlayback`, then we allow `UiCtxProjectFocused` too
+    if (currentCtx == context::UiCtxProjectFocused && actCtx == context::UiCtxProjectPlayback) {
         return true;
     }
 
@@ -165,6 +173,8 @@ bool UiContextResolver::isShortcutContextAllowed(const std::string& scContext) c
 
     if (CTX_PROJECT_OPENED == scContext) {
         return matchWithCurrent(context::UiCtxProjectOpened);
+    } else if (CTX_PROJECT_PLAYBACK == scContext) {
+        return matchWithCurrent(context::UiCtxProjectPlayback);
     } else if (CTX_PROJECT_FOCUSED == scContext) {
         return matchWithCurrent(context::UiCtxProjectFocused);
     } else if (CTX_NOT_PROJECT_FOCUSED == scContext) {

--- a/src/context/shortcutcontext.h
+++ b/src/context/shortcutcontext.h
@@ -32,6 +32,7 @@ namespace au::context {
 // common shortcuts (re declared for convenience)
 static const std::string CTX_ANY = muse::shortcuts::CTX_ANY;
 static const std::string CTX_PROJECT_OPENED = muse::shortcuts::CTX_PROJECT_OPENED;
+static const std::string CTX_PROJECT_PLAYBACK = "project-playback";
 static const std::string CTX_PROJECT_FOCUSED = muse::shortcuts::CTX_PROJECT_FOCUSED;
 
 //! NOTE special context for navigation shortcuts because the notation has its own navigation system
@@ -48,6 +49,7 @@ public:
 
             CTX_PROJECT_OPENED,
             CTX_NOT_PROJECT_FOCUSED,
+            CTX_PROJECT_PLAYBACK,
             CTX_PROJECT_FOCUSED,
         };
 

--- a/src/context/uicontext.h
+++ b/src/context/uicontext.h
@@ -36,6 +36,7 @@ static constexpr muse::ui::UiContext UiCtxProjectOpened = "UiCtxProjectOpened";
 static constexpr muse::ui::UiContext UiCtxHomeOpened = "UiCtxHomeOpened";
 
 // project detail
+static constexpr muse::ui::UiContext UiCtxProjectPlayback = "UiCtxProjectPlayback";
 static constexpr muse::ui::UiContext UiCtxProjectFocused = "UiCtxProjectFocused";
 }
 

--- a/src/playback/internal/playbackuiactions.cpp
+++ b/src/playback/internal/playbackuiactions.cpp
@@ -29,14 +29,14 @@ static const ActionQuery CHANGE_INPUT_CHANNELS_QUERY("action://playback/change-i
 const UiActionList PlaybackUiActions::m_mainActions = {
     UiAction(PLAY_ACTION_CODE,
              au::context::UiCtxProjectOpened,
-             au::context::CTX_PROJECT_FOCUSED,
+             au::context::CTX_PROJECT_PLAYBACK,
              TranslatableString("action", "Play"),
              TranslatableString("action", "Play"),
              IconCode::Code::PLAY_FILL
              ),
     UiAction(PAUSE_ACTION_CODE,
              au::context::UiCtxProjectOpened,
-             au::context::CTX_PROJECT_FOCUSED,
+             au::context::CTX_PROJECT_PLAYBACK,
              TranslatableString("action", "Pause"),
              TranslatableString("action", "Pause"),
              IconCode::Code::PAUSE_FILL

--- a/src/projectscene/qml/Audacity/ProjectScene/toolbars/PlaybackToolBar.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/toolbars/PlaybackToolBar.qml
@@ -39,6 +39,9 @@ Item {
     StyledToolBarView {
         id: view
 
+        navigationPanel.name: "PlaybackToolBar"
+        navigationPanel.accessible.name: qsTrc("projectscene", "Playback toolbar")
+
         anchors.verticalCenter: parent.verticalCenter
 
         rowHeight: isMultiline ? 32 : 48


### PR DESCRIPTION
Resolves: #8751

#8751: Like in Audacity 3, the space bar is reserved for playback toggle in appropriate focus contexts.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:
- [x] Keyboard shortcut reassignment still works for play/pause, and if another key is assigned to this action, Space behaves like enter on UI elements (e.g. it toggles the power button of an effect)
