### PR TITLE
7470 Fix crash when importing short audio

### DIFF
--- a/libraries/lib-music-information-retrieval/MusicInformationRetrieval.cpp
+++ b/libraries/lib-music-information-retrieval/MusicInformationRetrieval.cpp
@@ -137,9 +137,10 @@ std::optional<MusicalMeter> GetMusicalMeterFromSignal(
    if (audio.GetSampleRate() <= 0)
       return {};
    const auto duration = 1. * audio.GetNumSamples() / audio.GetSampleRate();
-   if (duration > 60)
+   if (duration > 60 || duration < 1)
       // A file longer than 1 minute is most likely not a loop, and processing
       // it would be costly.
+      // A file shorter than 1 second is too short to be a loop.
       return {};
    DecimatingMirAudioReader decimatedAudio { audio };
    return GetMeterUsingTatumQuantizationFit(

--- a/libraries/lib-music-information-retrieval/StftFrameProvider.cpp
+++ b/libraries/lib-music-information-retrieval/StftFrameProvider.cpp
@@ -21,7 +21,7 @@ namespace MIR
 {
 namespace
 {
-constexpr auto twoPi = 2 * 3.14159265358979323846;
+constexpr auto twoPi = 2 * M_PI;
 
 int GetFrameSize(int sampleRate)
 {
@@ -94,6 +94,8 @@ int StftFrameProvider::GetSampleRate() const
 
 double StftFrameProvider::GetFrameRate() const
 {
+   if (mHopSize <= 0)
+      return 0;
    return 1. * mAudio.GetSampleRate() / mHopSize;
 }
 


### PR DESCRIPTION
Resolves: #7470

Short audio files resulted in incorrect calculations during loop detection. Now files up to 1s are not loop-detected.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
