### PR TITLE
Enable make stereo track and resample on track context menu

### DIFF
--- a/au3/libraries/lib-wave-track/WaveClip.cpp
+++ b/au3/libraries/lib-wave-track/WaveClip.cpp
@@ -1784,7 +1784,7 @@ PitchAndSpeedPreset WaveClip::GetPitchAndSpeedPreset() const
 }
 
 /*! @excsafety{Strong} */
-void WaveClip::Resample(int rate, BasicUI::ProgressDialog* progress)
+void WaveClip::Resample(int rate, const std::function<void(size_t)>& progressReport)
 {
     // This mutator does not require the strong invariant.
 
@@ -1861,18 +1861,11 @@ void WaveClip::Resample(int rate, BasicUI::ProgressDialog* progress)
         }
         if (results) {
             pos += results->first;
-        }
-
-        if (progress) {
-            auto updateResult = progress->Poll(
-                pos.as_long_long(),
-                numSamples.as_long_long()
-                );
-            error = (updateResult != BasicUI::ProgressResult::Success);
-            if (error) {
-                throw UserException{};
+            if (progressReport) {
+                progressReport(results->first);
             }
         }
+
     }
 
     if (error) {

--- a/au3/libraries/lib-wave-track/WaveClip.h
+++ b/au3/libraries/lib-wave-track/WaveClip.h
@@ -35,10 +35,6 @@ class SampleBlockFactory;
 using SampleBlockFactoryPtr = std::shared_ptr<SampleBlockFactory>;
 class Sequence;
 class wxFileNameWrapper;
-namespace BasicUI {
-class ProgressDialog;
-}
-
 class WaveClip;
 
 // Array of pointers that assume ownership
@@ -445,7 +441,7 @@ public:
 
     // Resample clip. This also will set the rate, but without changing
     // the length of the clip
-    void Resample(int rate, BasicUI::ProgressDialog* progress = nullptr);
+    void Resample(int rate, const std::function<void(size_t)>& progressReport = {});
 
     double GetSequenceStartTime() const noexcept;
     void SetSequenceStartTime(double startTime);

--- a/au3/libraries/lib-wave-track/WaveTrack.cpp
+++ b/au3/libraries/lib-wave-track/WaveTrack.cpp
@@ -3416,10 +3416,10 @@ void WaveTrack::ReplaceInterval(
 
 /*! @excsafety{Weak} -- Partial completion may leave clips at differing sample rates!
 */
-void WaveTrack::Resample(int rate, BasicUI::ProgressDialog* progress)
+void WaveTrack::Resample(int rate, const std::function<void(size_t)>& progressReport)
 {
     for (const auto& pClip : Intervals()) {
-        pClip->Resample(rate, progress);
+        pClip->Resample(rate, progressReport);
     }
     DoSetRate(rate);
 }

--- a/au3/libraries/lib-wave-track/WaveTrack.h
+++ b/au3/libraries/lib-wave-track/WaveTrack.h
@@ -671,7 +671,7 @@ public:
     bool MergeClips(int clipidx1, int clipidx2);
 
     // Resample track (i.e. all clips in the track)
-    void Resample(int rate, BasicUI::ProgressDialog* progress = NULL);
+    void Resample(int rate, const std::function<void(size_t)>& progressReport = {});
 
     //! Random-access assignment of a range of samples
     /*!

--- a/src/projectscene/internal/projectviewstate.cpp
+++ b/src/projectscene/internal/projectviewstate.cpp
@@ -360,6 +360,11 @@ muse::ValCh<bool> ProjectViewState::ctrlPressed() const
     return m_ctrlPressed;
 }
 
+int ProjectViewState::trackDefaultHeight() const
+{
+    return DEFAULT_HEIGHT;
+}
+
 bool ProjectViewState::eventFilter(QObject* watched, QEvent* event)
 {
     if (event->type() == QEvent::KeyPress) {

--- a/src/projectscene/internal/projectviewstate.h
+++ b/src/projectscene/internal/projectviewstate.h
@@ -78,6 +78,8 @@ public:
     muse::ValCh<bool> altPressed() const override;
     muse::ValCh<bool> ctrlPressed() const override;
 
+    int trackDefaultHeight() const override;
+
 private:
     struct TrackData {
         muse::ValCh<int> height;

--- a/src/projectscene/iprojectviewstate.h
+++ b/src/projectscene/iprojectviewstate.h
@@ -65,6 +65,8 @@ public:
 
     virtual muse::ValCh<bool> altPressed() const = 0;
     virtual muse::ValCh<bool> ctrlPressed() const = 0;
+
+    virtual int trackDefaultHeight() const = 0;
 };
 
 using IProjectViewStatePtr = std::shared_ptr<IProjectViewState>;

--- a/src/projectscene/view/trackspanel/trackcontextmenumodel.h
+++ b/src/projectscene/view/trackspanel/trackcontextmenumodel.h
@@ -8,6 +8,7 @@
 #include "iprojectsceneconfiguration.h"
 #include "context/iglobalcontext.h"
 #include "trackedit/iprojecthistory.h"
+#include "trackedit/iselectioncontroller.h"
 #include "playback/iaudiodevicesprovider.h"
 
 namespace au::projectscene {
@@ -18,6 +19,7 @@ class TrackContextMenuModel : public muse::uicomponents::AbstractMenuModel
     muse::Inject<projectscene::IProjectSceneConfiguration> projectSceneConfiguration;
     muse::Inject<trackedit::IProjectHistory> projectHistory;
     muse::Inject<playback::IAudioDevicesProvider> audioDevicesProvider;
+    muse::Inject<trackedit::ISelectionController> selectionController;
 
     Q_PROPERTY(trackedit::TrackId trackId READ trackId WRITE setTrackId NOTIFY trackIdChanged FINAL)
 
@@ -52,6 +54,7 @@ private:
     void updateColorCheckedState();
     void updateTrackFormatState();
     void updateTrackRateState();
+    void updateTrackMonoState();
 
     trackedit::TrackId m_trackId;
     muse::actions::ActionCodeList m_colorChangeActionCodeList;

--- a/src/trackedit/internal/au3/au3interaction.cpp
+++ b/src/trackedit/internal/au3/au3interaction.cpp
@@ -2785,10 +2785,6 @@ bool Au3Interaction::userIsOkWithDownmixing() const
 
 bool Au3Interaction::userIsOkCombineMonoToStereo() const
 {
-    if (!configuration()->askBeforeConvertingToMonoOrStereo()) {
-        return true;
-    }
-
     const std::string title = muse::trc("trackedit", "Combine mono tracks to stereo");
     const std::string body = muse::trc("trackedit",
                                        "The tracks you are attempting to merge to stereo contain clips at "

--- a/src/trackedit/internal/au3/au3interaction.cpp
+++ b/src/trackedit/internal/au3/au3interaction.cpp
@@ -2508,9 +2508,9 @@ bool Au3Interaction::splitStereoTracksToLRMono(const TrackIdList& tracksIds)
         }
 
         const auto viewState = globalContext()->currentProject()->viewState();
-        const int currentHeight = viewState->trackHeight(trackId).val;
-        viewState->setTrackHeight(unlinkedTracks[0]->GetId(), currentHeight / 2);
-        viewState->setTrackHeight(unlinkedTracks[1]->GetId(), currentHeight / 2);
+        const int newHeight = std::max(viewState->trackHeight(trackId).val / 2, viewState->trackDefaultHeight());
+        viewState->setTrackHeight(unlinkedTracks[0]->GetId(), newHeight);
+        viewState->setTrackHeight(unlinkedTracks[1]->GetId(), newHeight);
 
         moveTracksTo({ unlinkedTracks[0]->GetId(), unlinkedTracks[1]->GetId() }, trackPosition(trackId));
 
@@ -2551,9 +2551,9 @@ bool Au3Interaction::splitStereoTracksToCenterMono(const TrackIdList& tracksIds)
         }
 
         const auto viewState = globalContext()->currentProject()->viewState();
-        const int currentHeight = viewState->trackHeight(trackId).val;
-        viewState->setTrackHeight(unlinkedTracks[0]->GetId(), currentHeight / 2);
-        viewState->setTrackHeight(unlinkedTracks[1]->GetId(), currentHeight / 2);
+        const int newHeight = std::max(viewState->trackHeight(trackId).val / 2, viewState->trackDefaultHeight());
+        viewState->setTrackHeight(unlinkedTracks[0]->GetId(), newHeight);
+        viewState->setTrackHeight(unlinkedTracks[1]->GetId(), newHeight);
 
         moveTracksTo({ unlinkedTracks[0]->GetId(), unlinkedTracks[1]->GetId() }, trackPosition(trackId));
 
@@ -2670,13 +2670,16 @@ bool Au3Interaction::makeStereoTrack(const TrackId left, const TrackId right)
     const Track rightTrack = DomConverter::track(au3RightTrack);
 
     ITrackeditProjectPtr prj = globalContext()->currentTrackeditProject();
-    tracks.Insert(au3LeftTrack, mix, true);
+    tracks.Append(mix, true);
+    prj->notifyAboutTrackAdded(DomConverter::track(mix.get()));
+
+    moveTracksTo({ mix->GetId() }, trackPosition(left));
+
     tracks.Remove(*au3LeftTrack);
     tracks.Remove(*au3RightTrack);
 
     viewState->setTrackHeight(mix->GetId(), newTrackHeight);
 
-    prj->notifyAboutTrackAdded(DomConverter::track(mix.get()));
     prj->notifyAboutTrackRemoved(leftTrack);
     prj->notifyAboutTrackRemoved(rightTrack);
 

--- a/src/trackedit/internal/au3/au3interaction.h
+++ b/src/trackedit/internal/au3/au3interaction.h
@@ -103,6 +103,7 @@ public:
     bool splitStereoTracksToLRMono(const TrackIdList& tracksIds) override;
     bool splitStereoTracksToCenterMono(const TrackIdList& tracksIds) override;
     bool makeStereoTrack(const TrackId left, const TrackId right) override;
+    bool resampleTracks(const TrackIdList& tracksIds, int rate) override;
 
     muse::ProgressPtr progress() const override;
 

--- a/src/trackedit/internal/au3/au3interaction.h
+++ b/src/trackedit/internal/au3/au3interaction.h
@@ -102,6 +102,7 @@ public:
     bool swapStereoChannels(const TrackIdList& tracksIds) override;
     bool splitStereoTracksToLRMono(const TrackIdList& tracksIds) override;
     bool splitStereoTracksToCenterMono(const TrackIdList& tracksIds) override;
+    bool makeStereoTrack(const TrackId left, const TrackId right) override;
 
     muse::ProgressPtr progress() const override;
 
@@ -121,6 +122,8 @@ private:
     NeedsDownmixing moveSelectedClipsUpOrDown(int offset);
     bool clipTransferNeedsDownmixing(const std::vector<Au3TrackDataPtr>& srcTracks, const TrackIdList& dstTracks) const;
     bool userIsOkWithDownmixing() const;
+    bool userIsOkCombineMonoToStereo() const;
+    bool canMergeMonoTracksToStereo(const TrackId left, const TrackId right);
     muse::Ret canPasteTrackData(const TrackIdList& tracksIds, const std::vector<Au3TrackDataPtr>& clipsToPaste) const;
     muse::Ret makeRoomForClip(const trackedit::ClipKey& clipKey);
     muse::Ret makeRoomForClipsOnTracks(const std::vector<TrackId>& tracksIds, const std::vector<Au3TrackDataPtr>& trackData, secs_t begin);

--- a/src/trackedit/internal/trackeditactionscontroller.cpp
+++ b/src/trackedit/internal/trackeditactionscontroller.cpp
@@ -73,6 +73,7 @@ static const ActionCode TRACK_SWAP_CHANNELS("track-swap-channels");
 static const ActionCode TRACK_SPLIT_STEREO_TO_LR("track-split-stereo-to-lr");
 static const ActionCode TRACK_SPLIT_STEREO_TO_CENTER("track-split-stereo-to-center");
 static const ActionCode TRACK_CHANGE_RATE_CUSTOM("track-change-rate-custom");
+static const ActionCode TRACK_MAKE_STEREO("track-make-stereo");
 
 static const ActionCode TRIM_AUDIO_OUTSIDE_SELECTION("trim-audio-outside-selection");
 static const ActionCode SILENCE_AUDIO_SELECTION("silence-audio-selection");
@@ -141,6 +142,7 @@ static const std::vector<ActionCode> actionsDisabledDuringRecording {
     TRACK_SPLIT_STEREO_TO_LR,
     TRACK_SPLIT_STEREO_TO_CENTER,
     TRACK_CHANGE_RATE_CUSTOM,
+    TRACK_MAKE_STEREO,
     GROUP_CLIPS_CODE,
     UNGROUP_CLIPS_CODE,
 };
@@ -216,6 +218,7 @@ void TrackeditActionsController::init()
     dispatcher()->reg(this, TRACK_SPLIT_STEREO_TO_LR, this, &TrackeditActionsController::splitStereoToLR);
     dispatcher()->reg(this, TRACK_SPLIT_STEREO_TO_CENTER, this, &TrackeditActionsController::splitStereoToCenter);
     dispatcher()->reg(this, TRACK_CHANGE_RATE_CUSTOM, this, &TrackeditActionsController::setCustomTrackRate);
+    dispatcher()->reg(this, TRACK_MAKE_STEREO, this, &TrackeditActionsController::makeStereoTrack);
 
     dispatcher()->reg(this, TRIM_AUDIO_OUTSIDE_SELECTION, this, &TrackeditActionsController::trimAudioOutsideSelection);
     dispatcher()->reg(this, SILENCE_AUDIO_SELECTION, this, &TrackeditActionsController::silenceAudioSelection);
@@ -1347,6 +1350,39 @@ void TrackeditActionsController::setTrackRate(const muse::actions::ActionQuery& 
     if (trackeditInteraction()->changeTracksRate(tracks, rate)) {
         notifyActionCheckedChanged(q.toString());
     }
+}
+
+void TrackeditActionsController::makeStereoTrack(const muse::actions::ActionData&)
+{
+    project::IAudacityProjectPtr project = globalContext()->currentProject();
+    if (!project) {
+        return;
+    }
+
+    const auto selectedTracks = selectionController()->selectedTracks();
+    if (selectedTracks.size() != 1) {
+        return;
+    }
+
+    const std::optional<Track> selectedTrack = project->trackeditProject()->track(selectionController()->selectedTracks().front());
+    if (!selectedTrack || selectedTrack->type != TrackType::Mono) {
+        return;
+    }
+
+    const TrackList tracks = project->trackeditProject()->trackList();
+    const auto it = std::find_if(tracks.begin(), tracks.end(),
+                                 [&selectedTrack](const Track& track) { return track.id == selectedTrack->id; });
+
+    if (it == tracks.end()) {
+        return;
+    }
+
+    const auto nextTrack = std::next(it);
+    if ((nextTrack == tracks.end()) || nextTrack->type != TrackType::Mono) {
+        return;
+    }
+
+    trackeditInteraction()->makeStereoTrack(selectedTrack->id, nextTrack->id);
 }
 
 bool TrackeditActionsController::actionChecked(const ActionCode&) const

--- a/src/trackedit/internal/trackeditactionscontroller.cpp
+++ b/src/trackedit/internal/trackeditactionscontroller.cpp
@@ -74,6 +74,7 @@ static const ActionCode TRACK_SPLIT_STEREO_TO_LR("track-split-stereo-to-lr");
 static const ActionCode TRACK_SPLIT_STEREO_TO_CENTER("track-split-stereo-to-center");
 static const ActionCode TRACK_CHANGE_RATE_CUSTOM("track-change-rate-custom");
 static const ActionCode TRACK_MAKE_STEREO("track-make-stereo");
+static const ActionCode TRACK_RESAMPLE("track-resample");
 
 static const ActionCode TRIM_AUDIO_OUTSIDE_SELECTION("trim-audio-outside-selection");
 static const ActionCode SILENCE_AUDIO_SELECTION("silence-audio-selection");
@@ -143,6 +144,7 @@ static const std::vector<ActionCode> actionsDisabledDuringRecording {
     TRACK_SPLIT_STEREO_TO_CENTER,
     TRACK_CHANGE_RATE_CUSTOM,
     TRACK_MAKE_STEREO,
+    TRACK_RESAMPLE,
     GROUP_CLIPS_CODE,
     UNGROUP_CLIPS_CODE,
 };
@@ -219,6 +221,7 @@ void TrackeditActionsController::init()
     dispatcher()->reg(this, TRACK_SPLIT_STEREO_TO_CENTER, this, &TrackeditActionsController::splitStereoToCenter);
     dispatcher()->reg(this, TRACK_CHANGE_RATE_CUSTOM, this, &TrackeditActionsController::setCustomTrackRate);
     dispatcher()->reg(this, TRACK_MAKE_STEREO, this, &TrackeditActionsController::makeStereoTrack);
+    dispatcher()->reg(this, TRACK_RESAMPLE, this, &TrackeditActionsController::resampleTracks);
 
     dispatcher()->reg(this, TRIM_AUDIO_OUTSIDE_SELECTION, this, &TrackeditActionsController::trimAudioOutsideSelection);
     dispatcher()->reg(this, SILENCE_AUDIO_SELECTION, this, &TrackeditActionsController::silenceAudioSelection);
@@ -1320,6 +1323,7 @@ void TrackeditActionsController::setCustomTrackRate(const muse::actions::ActionD
     }
 
     muse::UriQuery customRateUri("audacity://trackedit/custom_rate");
+    customRateUri.addParam("title", muse::Val(muse::trc("trackedit", "Set rate")));
     customRateUri.addParam("rate", muse::Val(static_cast<int>(focused.value().rate)));
 
     RetVal<Val> rv = interactive()->openSync(customRateUri);
@@ -1383,6 +1387,41 @@ void TrackeditActionsController::makeStereoTrack(const muse::actions::ActionData
     }
 
     trackeditInteraction()->makeStereoTrack(selectedTrack->id, nextTrack->id);
+}
+
+void TrackeditActionsController::resampleTracks(const muse::actions::ActionData& args)
+{
+    project::IAudacityProjectPtr project = globalContext()->currentProject();
+    if (!project) {
+        return;
+    }
+
+    const TrackIdList selectedTracks = selectionController()->selectedTracks();
+    if (selectedTracks.size() == 0) {
+        return;
+    }
+
+    const TrackId focusedTrackId = selectionController()->focusedTrack();
+    const std::optional<Track> focused = project->trackeditProject()->track(focusedTrackId);
+    if (!focused) {
+        return;
+    }
+
+    muse::UriQuery resampleUri("audacity://trackedit/custom_rate");
+    resampleUri.addParam("title", muse::Val(muse::trc("trackedit", "Resample")));
+    resampleUri.addParam("rate", muse::Val(static_cast<int>(focused.value().rate)));
+
+    const RetVal<Val> rv = interactive()->openSync(resampleUri);
+    if (rv.ret.code() != static_cast<int>(Ret::Code::Ok)) {
+        return;
+    }
+
+    const int customRate = rv.val.toInt();
+    if (customRate <= 0) {
+        return;
+    }
+
+    trackeditInteraction()->resampleTracks(selectedTracks, customRate);
 }
 
 bool TrackeditActionsController::actionChecked(const ActionCode&) const

--- a/src/trackedit/internal/trackeditactionscontroller.cpp
+++ b/src/trackedit/internal/trackeditactionscontroller.cpp
@@ -1389,7 +1389,7 @@ void TrackeditActionsController::makeStereoTrack(const muse::actions::ActionData
     trackeditInteraction()->makeStereoTrack(selectedTrack->id, nextTrack->id);
 }
 
-void TrackeditActionsController::resampleTracks(const muse::actions::ActionData& args)
+void TrackeditActionsController::resampleTracks(const muse::actions::ActionData&)
 {
     project::IAudacityProjectPtr project = globalContext()->currentProject();
     if (!project) {
@@ -1408,6 +1408,12 @@ void TrackeditActionsController::resampleTracks(const muse::actions::ActionData&
     }
 
     muse::UriQuery resampleUri("audacity://trackedit/custom_rate");
+
+    muse::ValList availableSampleRates;
+    for (const auto& rate : audioDevicesProvider()->availableSampleRateList()) {
+        availableSampleRates.push_back(muse::Val(static_cast<int>(rate)));
+    }
+    resampleUri.addParam("availableRates", muse::Val(availableSampleRates));
     resampleUri.addParam("title", muse::Val(muse::trc("trackedit", "Resample")));
     resampleUri.addParam("rate", muse::Val(static_cast<int>(focused.value().rate)));
 

--- a/src/trackedit/internal/trackeditactionscontroller.h
+++ b/src/trackedit/internal/trackeditactionscontroller.h
@@ -12,6 +12,7 @@
 #include "iinteractive.h"
 
 #include "projectscene/iprojectsceneconfiguration.h"
+#include "playback/iaudiodevicesprovider.h"
 #include "iprojecthistory.h"
 #include "itrackeditinteraction.h"
 #include "iselectioncontroller.h"
@@ -28,6 +29,7 @@ class TrackeditActionsController : public ITrackeditActionsController, public mu
     muse::Inject<trackedit::ITrackeditInteraction> trackeditInteraction;
     muse::Inject<trackedit::IProjectHistory> projectHistory;
     muse::Inject<projectscene::IProjectSceneConfiguration> projectSceneConfiguration;
+    muse::Inject<playback::IAudioDevicesProvider> audioDevicesProvider;
 
 public:
     void init();

--- a/src/trackedit/internal/trackeditactionscontroller.h
+++ b/src/trackedit/internal/trackeditactionscontroller.h
@@ -124,6 +124,7 @@ private:
     void splitStereoToCenter(const muse::actions::ActionData& args);
     void setCustomTrackRate(const muse::actions::ActionData& args);
     void makeStereoTrack(const muse::actions::ActionData& args);
+    void resampleTracks(const muse::actions::ActionData& args);
 
     void groupClips();
     void ungroupClips();

--- a/src/trackedit/internal/trackeditactionscontroller.h
+++ b/src/trackedit/internal/trackeditactionscontroller.h
@@ -123,6 +123,7 @@ private:
     void splitStereoToLR(const muse::actions::ActionData& args);
     void splitStereoToCenter(const muse::actions::ActionData& args);
     void setCustomTrackRate(const muse::actions::ActionData& args);
+    void makeStereoTrack(const muse::actions::ActionData& args);
 
     void groupClips();
     void ungroupClips();

--- a/src/trackedit/internal/trackeditinteraction.cpp
+++ b/src/trackedit/internal/trackeditinteraction.cpp
@@ -375,6 +375,11 @@ bool TrackeditInteraction::splitStereoTracksToCenterMono(const TrackIdList& trac
     return withPlaybackStop(&ITrackeditInteraction::splitStereoTracksToCenterMono, tracksIds);
 }
 
+bool TrackeditInteraction::makeStereoTrack(const TrackId left, const TrackId right)
+{
+    return withPlaybackStop(&ITrackeditInteraction::makeStereoTrack, left, right);
+}
+
 muse::ProgressPtr TrackeditInteraction::progress() const
 {
     return m_interaction->progress();

--- a/src/trackedit/internal/trackeditinteraction.cpp
+++ b/src/trackedit/internal/trackeditinteraction.cpp
@@ -380,6 +380,13 @@ bool TrackeditInteraction::makeStereoTrack(const TrackId left, const TrackId rig
     return withPlaybackStop(&ITrackeditInteraction::makeStereoTrack, left, right);
 }
 
+bool TrackeditInteraction::resampleTracks(const TrackIdList& tracksIds, int rate)
+{
+    return withProgress([&, this]() {
+        return withPlaybackStop(&ITrackeditInteraction::resampleTracks, tracksIds, rate);
+    });
+}
+
 muse::ProgressPtr TrackeditInteraction::progress() const
 {
     return m_interaction->progress();

--- a/src/trackedit/internal/trackeditinteraction.h
+++ b/src/trackedit/internal/trackeditinteraction.h
@@ -95,6 +95,7 @@ private:
     bool swapStereoChannels(const TrackIdList& tracksIds) override;
     bool splitStereoTracksToLRMono(const TrackIdList& tracksIds) override;
     bool splitStereoTracksToCenterMono(const TrackIdList& tracksIds) override;
+    bool makeStereoTrack(const TrackId left, const TrackId right) override;
 
     muse::ProgressPtr progress() const override;
 

--- a/src/trackedit/internal/trackeditinteraction.h
+++ b/src/trackedit/internal/trackeditinteraction.h
@@ -96,6 +96,7 @@ private:
     bool splitStereoTracksToLRMono(const TrackIdList& tracksIds) override;
     bool splitStereoTracksToCenterMono(const TrackIdList& tracksIds) override;
     bool makeStereoTrack(const TrackId left, const TrackId right) override;
+    bool resampleTracks(const TrackIdList& tracksIds, int rate) override;
 
     muse::ProgressPtr progress() const override;
 

--- a/src/trackedit/internal/trackeditoperationcontroller.cpp
+++ b/src/trackedit/internal/trackeditoperationcontroller.cpp
@@ -589,6 +589,15 @@ bool TrackeditOperationController::splitStereoTracksToCenterMono(const TrackIdLi
     return false;
 }
 
+bool TrackeditOperationController::makeStereoTrack(const TrackId left, const TrackId right)
+{
+    if (trackAndClipOperations()->makeStereoTrack(left, right)) {
+        projectHistory()->pushHistoryState("Make stereo track", "Make stereo track");
+        return true;
+    }
+    return false;
+}
+
 muse::ProgressPtr TrackeditOperationController::progress() const
 {
     return trackAndClipOperations()->progress();

--- a/src/trackedit/internal/trackeditoperationcontroller.cpp
+++ b/src/trackedit/internal/trackeditoperationcontroller.cpp
@@ -598,6 +598,15 @@ bool TrackeditOperationController::makeStereoTrack(const TrackId left, const Tra
     return false;
 }
 
+bool TrackeditOperationController::resampleTracks(const TrackIdList& tracksIds, int rate)
+{
+    if (trackAndClipOperations()->resampleTracks(tracksIds, rate)) {
+        projectHistory()->pushHistoryState("Resampled audio track(s)", "Resample track");
+        return true;
+    }
+    return false;
+}
+
 muse::ProgressPtr TrackeditOperationController::progress() const
 {
     return trackAndClipOperations()->progress();

--- a/src/trackedit/internal/trackeditoperationcontroller.h
+++ b/src/trackedit/internal/trackeditoperationcontroller.h
@@ -104,6 +104,7 @@ public:
     bool swapStereoChannels(const TrackIdList& tracksIds) override;
     bool splitStereoTracksToLRMono(const TrackIdList& tracksIds) override;
     bool splitStereoTracksToCenterMono(const TrackIdList& tracksIds) override;
+    bool makeStereoTrack(const TrackId left, const TrackId right) override;
 
     muse::ProgressPtr progress() const override;
 

--- a/src/trackedit/internal/trackeditoperationcontroller.h
+++ b/src/trackedit/internal/trackeditoperationcontroller.h
@@ -105,6 +105,7 @@ public:
     bool splitStereoTracksToLRMono(const TrackIdList& tracksIds) override;
     bool splitStereoTracksToCenterMono(const TrackIdList& tracksIds) override;
     bool makeStereoTrack(const TrackId left, const TrackId right) override;
+    bool resampleTracks(const TrackIdList& tracksIds, int rate) override;
 
     muse::ProgressPtr progress() const override;
 

--- a/src/trackedit/internal/trackedituiactions.cpp
+++ b/src/trackedit/internal/trackedituiactions.cpp
@@ -212,8 +212,7 @@ UiActionList STATIC_ACTIONS = {
              Checkable::Yes
              ),
     UiAction("track-make-stereo",
-             //! TODO: Change context when making stereo tracks is implemented
-             au::context::UiCtxUnknown,
+             au::context::UiCtxAny,
              au::context::CTX_ANY,
              TranslatableString("action", "Make stereo track"),
              TranslatableString("action", "Make stereo track")

--- a/src/trackedit/internal/trackedituiactions.cpp
+++ b/src/trackedit/internal/trackedituiactions.cpp
@@ -207,8 +207,8 @@ UiActionList STATIC_ACTIONS = {
     UiAction("track-change-rate-custom",
              au::context::UiCtxAny,
              au::context::CTX_ANY,
-             TranslatableString("action", "Other"),
-             TranslatableString("action", "Other"),
+             TranslatableString("action", "Other..."),
+             TranslatableString("action", "Other..."),
              Checkable::Yes
              ),
     UiAction("track-make-stereo",
@@ -236,11 +236,10 @@ UiActionList STATIC_ACTIONS = {
              TranslatableString("action", "Split stereo to center mono")
              ),
     UiAction("track-resample",
-             //! TODO: Change context when resampling is implemented
-             au::context::UiCtxUnknown,
+             au::context::UiCtxAny,
              au::context::CTX_ANY,
-             TranslatableString("action", "Resample track"),
-             TranslatableString("action", "Resample track")
+             TranslatableString("action", "Resample track..."),
+             TranslatableString("action", "Resample track...")
              ),
     UiAction("track-view-waveform",
              au::context::UiCtxAny,

--- a/src/trackedit/itrackandclipoperations.h
+++ b/src/trackedit/itrackandclipoperations.h
@@ -97,6 +97,7 @@ public:
     virtual bool swapStereoChannels(const TrackIdList& tracksIds) = 0;
     virtual bool splitStereoTracksToLRMono(const TrackIdList& tracksIds) = 0;
     virtual bool splitStereoTracksToCenterMono(const TrackIdList& tracksIds) = 0;
+    virtual bool makeStereoTrack(const TrackId left, const TrackId right) = 0;
 
     virtual muse::ProgressPtr progress() const = 0;
 };

--- a/src/trackedit/itrackandclipoperations.h
+++ b/src/trackedit/itrackandclipoperations.h
@@ -98,6 +98,7 @@ public:
     virtual bool splitStereoTracksToLRMono(const TrackIdList& tracksIds) = 0;
     virtual bool splitStereoTracksToCenterMono(const TrackIdList& tracksIds) = 0;
     virtual bool makeStereoTrack(const TrackId left, const TrackId right) = 0;
+    virtual bool resampleTracks(const TrackIdList& tracksIds, int rate) = 0;
 
     virtual muse::ProgressPtr progress() const = 0;
 };

--- a/src/trackedit/itrackeditinteraction.h
+++ b/src/trackedit/itrackeditinteraction.h
@@ -104,6 +104,7 @@ public:
     virtual bool splitStereoTracksToLRMono(const TrackIdList& tracksIds) = 0;
     virtual bool splitStereoTracksToCenterMono(const TrackIdList& tracksIds) = 0;
     virtual bool makeStereoTrack(const TrackId left, const TrackId right) = 0;
+    virtual bool resampleTracks(const TrackIdList& tracksIds, int rate) = 0;
 
     virtual muse::ProgressPtr progress() const = 0;
 };

--- a/src/trackedit/itrackeditinteraction.h
+++ b/src/trackedit/itrackeditinteraction.h
@@ -103,6 +103,7 @@ public:
     virtual bool swapStereoChannels(const TrackIdList& tracksIds) = 0;
     virtual bool splitStereoTracksToLRMono(const TrackIdList& tracksIds) = 0;
     virtual bool splitStereoTracksToCenterMono(const TrackIdList& tracksIds) = 0;
+    virtual bool makeStereoTrack(const TrackId left, const TrackId right) = 0;
 
     virtual muse::ProgressPtr progress() const = 0;
 };

--- a/src/trackedit/qml/Audacity/TrackEdit/CustomRateDialog.qml
+++ b/src/trackedit/qml/Audacity/TrackEdit/CustomRateDialog.qml
@@ -13,8 +13,7 @@ StyledDialogView {
     id: root
 
     property int rate: 44100
-
-    title: qsTrc("effects", "Set rate")
+    property string title: ""
 
     QtObject {
         id: prv

--- a/src/trackedit/qml/Audacity/TrackEdit/CustomRateDialog.qml
+++ b/src/trackedit/qml/Audacity/TrackEdit/CustomRateDialog.qml
@@ -12,6 +12,7 @@ import Preferences
 StyledDialogView {
     id: root
 
+    property var availableRates: []
     property int rate: 44100
     property string title: ""
 
@@ -45,23 +46,79 @@ StyledDialogView {
             text: qsTrc("trackedit/rate", "New sample rate (Hz):")
         }
 
-        IncrementalPropertyControl {
-            id: control
-            width: parent.width * .4
+        Item {
+            id: dropdown
+            width: parent.width *.5
+            height: 30
 
-            currentValue: root.rate
+            TextInputField {
+                id: inputItem
 
-            minValue: 1
-            maxValue: 1000000
-            step: 1
-            decimals: 0
+                anchors.fill: parent
 
-            measureUnitsSymbol: prv.measureUnitsSymbol
+                currentText: root.rate > 0 ? root.rate.toString() : ""
 
-            onValueEdited: function(newValue) {
-                root.rate = newValue;
+                validator: IntValidator { bottom: 1 }
+
+                onTextChanged: function(newValue) {
+                    var val = parseInt(newValue)
+                    root.rate = (val > 0) ? val : 1
+                }
+
             }
-        }        
+
+            StyledIconLabel {
+                id: dropIconItem
+                anchors.verticalCenter: parent.verticalCenter
+                anchors.right: parent.right
+                anchors.rightMargin: 8
+
+                iconCode: IconCode.SMALL_ARROW_DOWN
+
+                visible: root.availableRates && root.availableRates.length > 0
+
+                MouseArea {
+                    id: mouseAreaItem
+                    anchors.fill: parent
+
+                    onClicked: {
+                        menuLoader.toggleOpened(availableRates.map(function(rate) {
+                            return {"title": rate.toString(), "id": rate.toString()}
+                        }))
+                    }
+
+                    onPressed: {
+                        ui.tooltip.hide(dropdown, true)
+                    }
+
+                    onContainsMouseChanged: {
+                        if (!inputItem.truncated || menuLoader.isMenuOpened) {
+                            return
+                        }
+
+                        if (mouseAreaItem.containsMouse) {
+                            ui.tooltip.show(dropdown, inputItem.text)
+                        } else {
+                            ui.tooltip.hide(dropdown)
+                        }
+                    }
+                }
+            }
+
+            StyledMenuLoader {
+                id: menuLoader
+                width: parent.width
+
+                onHandleMenuItem: function(itemId) {
+                    if (itemId === null) {
+                        return
+                    }
+
+                    inputItem.currentText = itemId
+                }
+            }
+        }
+
     }
 
     ButtonBox {


### PR DESCRIPTION
Resolves: #9112 #8983 #9075 

Implement make stereo track and resample on track header context menu

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
