### PR TITLE
4444 Fix crash on macro

### DIFF
--- a/libraries/lib-project-history/UndoManager.cpp
+++ b/libraries/lib-project-history/UndoManager.cpp
@@ -137,12 +137,12 @@ void UndoManager::RemoveStates(size_t begin, size_t end)
    TransactionScope trans{mProject, "DiscardingUndoStates"};
 
    for (size_t ii = begin; ii < end; ++ii) {
-      RemoveStateAt(begin);
-
       if (current > begin)
         --current;
       if (saved > static_cast<int>(begin))
         --saved;
+
+      RemoveStateAt(begin);
    }
 
    // Success, commit the savepoint


### PR DESCRIPTION
Resolves: #4444

Destructor called at exit of RemoveStateAt(), caused an event loop spin, in which unprocessed UndoEvents resulted in a call to CommandManager::ModifyUndoMenuItems, where it tried to access removed UndoState due to `current` not being updated yet.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
