### PR TITLE
fix: Handle 32bit FLAC files

### DIFF
--- a/modules/import-export/mod-flac/ImportFLAC.cpp
+++ b/modules/import-export/mod-flac/ImportFLAC.cpp
@@ -248,7 +248,7 @@ FLAC__StreamDecoderWriteStatus MyFLACFile::write_callback(const FLAC__Frame *fra
                      int24Sample);
          } else {
             auto tmp = ArrayOf<float>{ frame->header.blocksize };
-            float divisor  = static_cast<float>( 1 << 31 );
+            float divisor  = static_cast<float>( 1 << (frame->header.bits_per_sample-1) );
             for (unsigned int s = 0; s < frame->header.blocksize; s++) {
                tmp[s] = static_cast<float>(buffer[chn][s]) / divisor;
             }


### PR DESCRIPTION
Thanks for all your work such a fantastic tool!

This PR resurrects & extends #6638, to solve #6606, namely the inappropriate conversion of 32bit PCM FLAC files to floating point tracks.

We handle this by promoting 24/32bit FLAC files to floating point tracks, doing the int->float during import of each frame.

This fixes #6606 for me, though I am still testing on more sample data, and comparing to external conversion with ffmpeg to check.

This should port pretty nicely to AU4, so once you are happy with this I can make a separate PR for AU4/main branch.

Resolves: #6606 


<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
