### PR TITLE
Encode the redirect URL to keep all parameters in place

### DIFF
--- a/libraries/lib-cloud-audiocom/OAuthService.cpp
+++ b/libraries/lib-cloud-audiocom/OAuthService.cpp
@@ -371,7 +371,7 @@ std::string OAuthService::MakeAudioComAuthorizeURL(std::string_view userId, std:
       GetServiceConfig().GetAuthWithRedirectURL(), "?",
       tokenPrefix, token, "&",
       userPrefix, userId, "&",
-      urlPrefix, redirectUrl
+      urlPrefix, audacity::UrlEncode(redirectUrl)
    );
 
    if (SendAnonymousUsageInfo->Read()) {

--- a/libraries/lib-string-utils/UrlEncode.cpp
+++ b/libraries/lib-string-utils/UrlEncode.cpp
@@ -9,11 +9,12 @@
  **********************************************************************/
 
 #include "UrlEncode.h"
+#include <string_view>
 
 namespace audacity
 {
 
-std::string UrlEncode (const std::string& url)
+std::string UrlEncode (const std::string_view url)
 {
     std::string escaped;
 

--- a/libraries/lib-string-utils/UrlEncode.h
+++ b/libraries/lib-string-utils/UrlEncode.h
@@ -15,6 +15,6 @@
 namespace audacity
 {
 
-STRING_UTILS_API std::string UrlEncode (const std::string& url);
+STRING_UTILS_API std::string UrlEncode (const std::string_view url);
 
 }


### PR DESCRIPTION
If url is not properly encoded, redirect strips it from additional parameters

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
