### PR TITLE
Remove obsolete MSVS 2019 build from CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -167,18 +167,6 @@ jobs:
       fail-fast: false
       matrix:
         config:
-        - name: Windows MSVC 2019 (x86)
-          os: windows-2019
-          arch: x32
-          generator: Visual Studio 16 2019
-          postfix: '-msvc2019'
-          windows_sdk: '10.0.18362.0'
-        - name: Windows MSVC 2019 (x86_64)
-          os: windows-2019
-          arch: x64
-          generator: Visual Studio 16 2019
-          postfix: '-msvc2019'
-          windows_sdk: '10.0.18362.0'
         - name: Windows MSVC 2022 (x86)
           os: windows-2022
           arch: x32

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -28,7 +28,7 @@ On Linux, `cmake` is usually available from the system package manager. Alternat
 
 ### Windows
 
-We build Audacity using [Microsoft Visual Studio](https://visualstudio.microsoft.com/vs/community/) 2019 and 2022. In order to build Audacity **Desktop development with C++** workload is required.
+We build Audacity using [Microsoft Visual Studio](https://visualstudio.microsoft.com/vs/community/) 2022. In order to build Audacity **Desktop development with C++** workload is required.
 
 ### macOS
 


### PR DESCRIPTION
Remove MSVS build config: https://github.com/actions/runner-images/issues/12045

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
