### PR TITLE
8930 handle edge cases of auto-scroll disconnection logic in ClipsListModel

### DIFF
--- a/src/projectscene/view/clipsview/clipslistmodel.h
+++ b/src/projectscene/view/clipsview/clipslistmodel.h
@@ -139,6 +139,7 @@ private:
     bool isKeyboardTriggered() const;
 
     void handleAutoScroll(bool ok, bool completed, const std::function<void()>& onAutoScrollFrame);
+    void disconnectAutoScroll();
 
     Qt::KeyboardModifiers keyboardModifiers() const;
 


### PR DESCRIPTION
Resolves: [This Issue](https://github.com/audacity/audacity/issues/8930)

Prevent unwanted clip movement during zoom operations after interrupted drag

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
