### PR TITLE
9031 Fix Cut-Paste Crashes AU4

### DIFF
--- a/src/trackedit/internal/au3/au3interaction.cpp
+++ b/src/trackedit/internal/au3/au3interaction.cpp
@@ -1816,7 +1816,8 @@ bool Au3Interaction::clipSplitDelete(const ClipKey& clipKey)
 
 std::vector<ITrackDataPtr> Au3Interaction::splitCutSelectedOnTracks(const TrackIdList tracksIds, secs_t begin, secs_t end)
 {
-    std::vector<ITrackDataPtr> dataVector(tracksIds.size());
+    std::vector<ITrackDataPtr> dataVector;
+    dataVector.reserve(tracksIds.size());
     for (const auto& trackId : tracksIds) {
         auto data = splitCutSelectedOnTrack(trackId, begin, end);
         if (!data) {


### PR DESCRIPTION
Resolves: [This issue](https://github.com/audacity/audacity/issues/9031)

small typo in pre-allocation

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
