### PR TITLE
Make sure LinkSucceededDialog is not obscured by other windows

### DIFF
--- a/modules/sharing/mod-cloud-audiocom/ui/dialogs/LinkSucceededDialog.cpp
+++ b/modules/sharing/mod-cloud-audiocom/ui/dialogs/LinkSucceededDialog.cpp
@@ -26,7 +26,7 @@ namespace audacity::cloud::audiocom
 LinkSucceededDialog::LinkSucceededDialog(wxWindow* parent)
     : wxDialogWrapper(
          parent, wxID_ANY, XO("Link account"), wxDefaultPosition, { 442, -1 },
-         wxDEFAULT_DIALOG_STYLE)
+         wxDEFAULT_DIALOG_STYLE | wxSTAY_ON_TOP)
 {
    SetMinSize({ 442, -1 });
 


### PR DESCRIPTION
Resolves: #9166

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
