### PR TITLE
Track vertical rulers static version

### DIFF
--- a/src/projectscene/CMakeLists.txt
+++ b/src/projectscene/CMakeLists.txt
@@ -158,6 +158,14 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/view/historypanel/historypanelmodel.cpp
     ${CMAKE_CURRENT_LIST_DIR}/view/historypanel/historypanelmodel.h
 
+    ${CMAKE_CURRENT_LIST_DIR}/view/trackruler/itrackrulermodel.h
+    ${CMAKE_CURRENT_LIST_DIR}/view/trackruler/linearstereoruler.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/view/trackruler/linearstereoruler.h
+    ${CMAKE_CURRENT_LIST_DIR}/view/trackruler/linearmonoruler.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/view/trackruler/linearmonoruler.h
+    ${CMAKE_CURRENT_LIST_DIR}/view/trackruler/trackrulermodel.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/view/trackruler/trackrulermodel.h
+
     )
 
 set(MODULE_QML_IMPORT ${CMAKE_CURRENT_LIST_DIR}/qml )

--- a/src/projectscene/internal/projectviewstate.h
+++ b/src/projectscene/internal/projectviewstate.h
@@ -30,10 +30,12 @@ public:
     muse::ValCh<int> totalTrackHeight() const override;
     muse::ValCh<int> trackHeight(const trackedit::TrackId& trackId) const override;
     muse::ValCh<bool> isTrackCollapsed(const trackedit::TrackId& trackId) const override;
+    muse::ValCh<double> channelHeightRatio(const trackedit::TrackId& trackId) const override;
 
     int trackVerticalPosition(const trackedit::TrackId& trackId) const override;
     void changeTrackHeight(const trackedit::TrackId& trackId, int delta) override;
     void setTrackHeight(const trackedit::TrackId& trackId, int height) override;
+    void setChannelHeightRatio(const trackedit::TrackId& trackId, double ratio) override;
     trackedit::TrackId trackAtPosition(double y) const override;
     trackedit::TrackIdList tracksInRange(double y1, double y2) const override;
 
@@ -88,6 +90,7 @@ private:
     struct TrackData {
         muse::ValCh<int> height;
         muse::ValCh<bool> collapsed;
+        muse::ValCh<double> channelHeightRatio;
     };
 
     mutable muse::ValCh<int> m_totalTracksHeight;

--- a/src/projectscene/iprojectviewstate.h
+++ b/src/projectscene/iprojectviewstate.h
@@ -18,10 +18,12 @@ public:
     virtual muse::ValCh<int> totalTrackHeight() const = 0;
     virtual muse::ValCh<int> trackHeight(const trackedit::TrackId& trackId) const = 0;
     virtual muse::ValCh<bool> isTrackCollapsed(const trackedit::TrackId& trackId) const = 0;
+    virtual muse::ValCh<double> channelHeightRatio(const trackedit::TrackId& trackId) const = 0;
 
     virtual int trackVerticalPosition(const trackedit::TrackId& trackId) const = 0;
     virtual void changeTrackHeight(const trackedit::TrackId& trackId, int deltaY) = 0;
     virtual void setTrackHeight(const trackedit::TrackId& trackId, int height) = 0;
+    virtual void setChannelHeightRatio(const trackedit::TrackId& trackId, double ratio) = 0;
     virtual trackedit::TrackId trackAtPosition(double y) const = 0;
     virtual trackedit::TrackIdList tracksInRange(double y1, double y2) const = 0;
 

--- a/src/projectscene/projectscenemodule.cpp
+++ b/src/projectscene/projectscenemodule.cpp
@@ -65,6 +65,8 @@
 
 #include "view/historypanel/historypanelmodel.h"
 
+#include "view/trackruler/trackrulermodel.h"
+
 using namespace au::projectscene;
 using namespace muse::modularity;
 using namespace muse::ui;
@@ -179,6 +181,9 @@ void ProjectSceneModule::registerUiTypes()
 
     // history panel
     qmlRegisterType<HistoryPanelModel>("Audacity.ProjectScene", 1, 0, "HistoryPanelModel");
+
+    //track ruler
+    qmlRegisterType<TrackRulerModel>("Audacity.ProjectScene", 1, 0, "TrackRulerModel");
 }
 
 void ProjectSceneModule::onInit(const muse::IApplication::RunMode& mode)

--- a/src/projectscene/qml/Audacity/ProjectScene/clipsview/TrackClipsItem.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/clipsview/TrackClipsItem.qml
@@ -94,7 +94,6 @@ Item {
         z: 1
 
         property double targetHeightRatio: 0.5
-        property double channelHeightRatio: 0.5
         readonly property int minChannelHeight: 20
         readonly property int yMinValue: Math.min(root.height / 2, minChannelHeight)
         readonly property int yMaxValue: Math.max(root.height / 2, root.height - minChannelHeight);
@@ -133,11 +132,11 @@ Item {
 
         function updateChannelHeightRatio(position) {
             const newY = Math.min(Math.max(position, yMinValue), yMaxValue)
-            channelHeightRatio = newY / height
+            trackViewState.changeChannelHeightRatio(newY / height)
         }
 
         function resetTargetHeightRatio() {
-            targetHeightRatio = channelHeightRatio
+            targetHeightRatio = trackViewState.channelHeightRatio
         }
 
         onHeightChanged: {
@@ -291,7 +290,7 @@ Item {
                 leftVisibleMargin: clipItem.leftVisibleMargin
                 rightVisibleMargin: clipItem.rightVisibleMargin
                 collapsed: trackViewState.isTrackCollapsed
-                channelHeightRatio: clipsContainer.channelHeightRatio
+                channelHeightRatio: trackViewState.channelHeightRatio
                 showChannelSplitter: isStereo
 
                 navigation.name: Boolean(clipItem) ? clipItem.title + clipItem.index : ""
@@ -590,7 +589,7 @@ Item {
         anchors.topMargin: trackViewState.isTrackCollapsed ? 1 : 21
         anchors.bottomMargin: 3
 
-        channelHeightRatio: clipsContainer.channelHeightRatio
+        channelHeightRatio: trackViewState.channelHeightRatio
         color: "#FFFFFF"
         opacity: 0.05
         visible: isStereo

--- a/src/projectscene/qml/Audacity/ProjectScene/clipsview/TracksClipsView.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/clipsview/TracksClipsView.qml
@@ -191,7 +191,7 @@ Rectangle {
 
             anchors.top: parent.top
             anchors.left: timelineIndent.right
-            anchors.right: parent.right
+            anchors.right: verticalRulerPanelHeader.left
 
             height: 40
 
@@ -257,6 +257,37 @@ Rectangle {
                 onPlayCursorMousePositionChanged: function(ix) {
                     timeline.updateCursorPosition(ix, -1)
                 }
+            }
+        }
+
+        Rectangle {
+            id: verticalRulerPanelHeader
+
+            anchors.top: parent.top
+            anchors.right: parent.right
+            height: timeline.height
+            width: tracksModel.isVerticalRulersVisible ? 32 : 0
+
+            color: ui.theme.backgroundSecondaryColor
+
+            SeparatorLine {
+                anchors.left: parent.left
+                anchors.bottom: parent.bottom
+
+                width: parent.width
+
+                color: ui.theme.strokeColor
+            }
+
+            SeparatorLine {
+                anchors.top: parent.top
+                anchors.left: parent.left
+
+                orientation: Qt.Vertical
+
+                height: parent.height
+
+                color: ui.theme.strokeColor
             }
         }
     }
@@ -443,6 +474,7 @@ Rectangle {
             id: tracksClipsViewArea
 
             anchors.fill: parent
+            anchors.rightMargin: tracksModel.isVerticalRulersVisible ? verticalRulerPanelHeader.width : 0
 
             view: tracksClipsView
 
@@ -768,9 +800,13 @@ Rectangle {
         VerticalRulersPanel {
             id: verticalRulers
 
-            height: parent.height - timelineHeader.height
-            anchors.right: tracksClipsViewArea.right
-            anchors.bottom: tracksClipsViewArea.bottom
+            model: tracksModel
+            context: timeline.context
+
+            height: parent.height
+            width: verticalRulerPanelHeader.width
+            anchors.right: parent.right
+            anchors.bottom: parent.bottom
 
             visible: tracksModel.isVerticalRulersVisible
         }

--- a/src/projectscene/qml/Audacity/ProjectScene/clipsview/VerticalRulersPanel.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/clipsview/VerticalRulersPanel.qml
@@ -226,6 +226,7 @@ Rectangle {
 
                             anchors.verticalCenter: modelData.alignment == 0 ? parent.verticalCenter : undefined
                             anchors.bottom: modelData.alignment == 1 ? parent.bottom : undefined
+                            anchors.bottomMargin: modelData.alignment == 1 ? 1 : undefined
                             anchors.top: modelData.alignment == -1 ? parent.top : undefined
 
                             height: aLabelMetrics.ascent

--- a/src/projectscene/qml/Audacity/ProjectScene/clipsview/VerticalRulersPanel.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/clipsview/VerticalRulersPanel.qml
@@ -1,33 +1,292 @@
 import QtQuick
+import QtQuick.Layouts
+import QtQuick.Controls
 
+import Muse.Ui
 import Muse.UiComponents
 
 import Audacity.ProjectScene
 
 Rectangle {
-    id: verticalRulersPanel
+    id: root
 
-    width: 48
-    color: ui.theme.backgroundPrimaryColor
-    visible: false
+    property var model: null
+    property var context: null
 
-    //! TODO AU4: create as many rulers as there are tracks
+    width: 32
+    color: ui.theme.backgroundQuarternaryColor
 
     Rectangle {
-        id: tmpLeftBorder
+        id: leftBorder
 
         width: 1
         height: parent.height
         color: ui.theme.strokeColor
+        opacity: 0.1
     }
 
-    Text {
-        id: tmpLabel
+    StyledListView {
+        id: verticalRulersListView
 
-        x: -40
-        y: 80
-        text: qsTr("Vertical rulers mock")
-        rotation : 270
+        anchors.fill: parent
+
+        clip: false
+
+        ScrollBar.vertical: null
+
+        //! NOTE Sync with TracksClipsView
+        TracksViewStateModel {
+            id: tracksViewState
+            onTracksVericalYChanged: {
+                verticalRulersListView.contentY = tracksViewState.tracksVericalY
+            }
+        }
+
+        Component.onCompleted: {
+            tracksViewState.init()
+        }
+
+        header: Rectangle {
+            height: 2
+            width: parent.width
+            color: "transparent"
+        }
+
+        footer: Item {
+            height: tracksViewState.tracksVerticalScrollPadding
+        }
+
+        property real lockedVerticalScrollPosition
+        property bool verticalScrollLocked: tracksViewState.tracksVerticalScrollLocked
+
+        onVerticalScrollLockedChanged: {
+            lockedVerticalScrollPosition = contentY
+        }
+
+        onContentYChanged: {
+            if (verticalScrollLocked) {
+                verticalRulersListView.contentY = lockedVerticalScrollPosition
+            } else {
+                tracksViewState.changeTracksVericalY(verticalRulersListView.contentY)
+            }
+        }
+
+        interactive: false
+
+        model: root.model
+        delegate: Rectangle {
+
+            width: root.width
+            height: trackViewState.trackHeight
+
+            color: ui.theme.backgroundQuarternaryColor
+
+            z: model.isTrackFocused ? 10 : 0
+
+            Component.onCompleted: {
+                trackViewState.init()
+                clipsModel.init()
+            }
+
+            TracksViewStateModel {
+                id: trackViewState
+                trackId: model.trackId
+            }
+
+            ClipsListModel {
+                id: clipsModel
+                context: root.context
+                trackId: model.trackId
+            }
+
+            Rectangle {
+                id: leftBorder
+
+                anchors.left: parent.left
+                anchors.top: parent.top
+
+                width: 1
+                height: parent.height
+                color: ui.theme.strokeColor
+                opacity: 0.1
+            }
+
+            Rectangle {
+                id: header
+
+                anchors.top: parent.top
+                anchors.left: parent.left
+                anchors.right: parent.right
+
+                width: parent.width
+                height: trackViewState.isTrackCollapsed ? 1 : 20
+                color: "#000000"
+                opacity: 0.20
+                visible: !trackViewState.isTrackCollapsed
+            }
+
+            Rectangle {
+                id: topBorder
+
+                anchors.top: parent.top
+                anchors.left: header.left
+                anchors.right: header.right
+                anchors.topMargin: -border.width
+
+                height: border.width
+
+                visible: model.isTrackFocused
+
+                color: "transparent"
+
+                border.color: "#7EB1FF"
+                border.width: 2
+            }
+
+            Rectangle {
+                id: bottomBorder
+
+                anchors.bottom: parent.bottom
+                anchors.left: header.left
+                anchors.right: header.right
+
+                height: 2
+
+                color: "#7EB1FF"
+
+                visible: model.isTrackFocused
+            }
+
+            SeparatorLine {
+                id: sep
+
+                color: "#000000"
+                opacity: 0.20
+                anchors.bottom: parent.bottom
+                thickness: 2
+            }
+
+            Item {
+                id: ruler
+
+                TrackRulerModel {
+                    id: rulerModel
+
+                    isStereo: clipsModel.isStereo
+                    height: ruler.height
+                    isCollapsed: trackViewState.isTrackCollapsed
+                }
+
+                anchors.top: header.bottom
+                anchors.bottom: sep.top
+                anchors.bottomMargin: 1
+                anchors.left: leftBorder.right
+                anchors.right: parent.right
+
+                Repeater {
+                    id: fullStepsRepeater
+
+                    model: rulerModel.fullSteps
+
+                    delegate: Item {
+                        required property var modelData
+
+                        y: modelData.y
+                        width: parent.width
+                        height: 1
+
+                        Rectangle {
+                            id: tick
+
+                            anchors.left: parent.left
+                            anchors.verticalCenter: parent.verticalCenter
+
+                            width: 7
+                            height: 1
+                            color: ui.theme.strokeColor
+                        }
+
+                        Rectangle {
+                            id: tickExtension
+
+                            anchors.left: tick.right
+                            anchors.verticalCenter: parent.verticalCenter
+
+                            width: parent.width - tick.width
+                            height: 1
+
+                            color: "#475157"
+
+                            visible: modelData.fullWidthTick
+                        }
+
+                        Item {
+                            anchors.right: parent.right
+                            anchors.rightMargin: 4
+
+                            anchors.verticalCenter: modelData.alignment == 0 ? parent.verticalCenter : undefined
+                            anchors.bottom: modelData.alignment == 1 ? parent.bottom : undefined
+                            anchors.top: modelData.alignment == -1 ? parent.top : undefined
+
+                            height: aLabelMetrics.ascent
+                            width: parent.width - tick.width - 4
+
+                            Text {
+                                id: aLabel
+
+                                anchors.right: parent.right
+                                anchors.verticalCenter: parent.verticalCenter
+
+                                text: Math.abs(modelData.value).toFixed(1)
+                                color: "#F9F9FA"
+                                font.pixelSize: 10
+
+                                font.bold: modelData.bold
+
+                                FontMetrics {
+                                    id: aLabelMetrics
+                                    font: aLabel.font
+                                }
+                            }
+
+                            Rectangle {
+                                id: minusIndicator
+
+                                anchors.right: aLabel.left
+                                anchors.rightMargin: 1
+                                anchors.verticalCenter: aLabel.verticalCenter
+
+                                width: 3
+                                height: 1
+                                color: "#F9F9FA"
+
+                                visible: modelData.value < 0
+                            }
+                        }
+                    }
+                }
+
+                Repeater {
+                    id: smallStepsRepeater
+
+                    model: rulerModel.smallSteps
+
+                    delegate: Item {
+                        required property var modelData
+
+                        y: modelData.y
+                        width: parent.width
+                        height: 1
+
+                        Rectangle {
+                            width: 3
+                            height: 1
+                            color: "#A9B0BD"
+                            anchors.verticalCenter: parent.verticalCenter
+                        }
+                    }
+                }
+            }
+        }
     }
-
 }

--- a/src/projectscene/qml/Audacity/ProjectScene/clipsview/VerticalRulersPanel.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/clipsview/VerticalRulersPanel.qml
@@ -37,8 +37,8 @@ Rectangle {
         //! NOTE Sync with TracksClipsView
         TracksViewStateModel {
             id: tracksViewState
-            onTracksVericalYChanged: {
-                verticalRulersListView.contentY = tracksViewState.tracksVericalY
+            onTracksVerticalOffsetChanged: {
+                verticalRulersListView.contentY = tracksViewState.tracksVerticalOffset
             }
         }
 
@@ -67,7 +67,7 @@ Rectangle {
             if (verticalScrollLocked) {
                 verticalRulersListView.contentY = lockedVerticalScrollPosition
             } else {
-                tracksViewState.changeTracksVericalY(verticalRulersListView.contentY)
+                tracksViewState.changeTracksVerticalOffset(verticalRulersListView.contentY)
             }
         }
 
@@ -88,7 +88,7 @@ Rectangle {
                 clipsModel.init()
             }
 
-            TracksViewStateModel {
+            TrackViewStateModel {
                 id: trackViewState
                 trackId: model.trackId
             }
@@ -175,6 +175,7 @@ Rectangle {
                     isStereo: clipsModel.isStereo
                     height: ruler.height
                     isCollapsed: trackViewState.isTrackCollapsed
+                    channelHeightRatio: trackViewState.channelHeightRatio
                 }
 
                 anchors.top: header.bottom

--- a/src/projectscene/qml/Audacity/ProjectScene/clipsview/VerticalRulersPanel.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/clipsview/VerticalRulersPanel.qml
@@ -81,8 +81,6 @@ Rectangle {
 
             color: ui.theme.backgroundQuarternaryColor
 
-            z: model.isTrackFocused ? 10 : 0
-
             Component.onCompleted: {
                 trackViewState.init()
                 clipsModel.init()
@@ -119,10 +117,9 @@ Rectangle {
                 anchors.right: parent.right
 
                 width: parent.width
-                height: trackViewState.isTrackCollapsed ? 1 : 20
+                height: trackViewState.isTrackCollapsed ? 0 : 20
                 color: "#000000"
                 opacity: 0.20
-                visible: !trackViewState.isTrackCollapsed
             }
 
             Rectangle {
@@ -180,9 +177,10 @@ Rectangle {
 
                 anchors.top: header.bottom
                 anchors.bottom: sep.top
-                anchors.bottomMargin: 1
                 anchors.left: leftBorder.right
                 anchors.right: parent.right
+
+                anchors.bottomMargin: 1
 
                 Repeater {
                     id: fullStepsRepeater
@@ -204,7 +202,7 @@ Rectangle {
 
                             width: 7
                             height: 1
-                            color: ui.theme.strokeColor
+                            color: ui.theme.isDark ? "#F4F7F9" : "#F4F5F9"
                         }
 
                         Rectangle {
@@ -222,13 +220,13 @@ Rectangle {
                         }
 
                         Item {
-                            anchors.right: parent.right
-                            anchors.rightMargin: 4
-
-                            anchors.verticalCenter: modelData.alignment == 0 ? parent.verticalCenter : undefined
-                            anchors.bottom: modelData.alignment == 1 ? parent.bottom : undefined
-                            anchors.bottomMargin: modelData.alignment == 1 ? 1 : undefined
                             anchors.top: modelData.alignment == -1 ? parent.top : undefined
+                            anchors.bottom: modelData.alignment == 1 ? parent.bottom : undefined
+                            anchors.right: parent.right
+
+                            anchors.rightMargin: 3
+                            anchors.bottomMargin: modelData.alignment == 1 ? 1 : undefined
+                            anchors.verticalCenter: modelData.alignment == 0 ? parent.verticalCenter : undefined
 
                             height: aLabelMetrics.ascent
                             width: parent.width - tick.width - 4
@@ -255,12 +253,12 @@ Rectangle {
                                 id: minusIndicator
 
                                 anchors.right: aLabel.left
-                                anchors.rightMargin: 1
+                                anchors.rightMargin: 2
                                 anchors.verticalCenter: aLabel.verticalCenter
 
                                 width: 3
                                 height: 1
-                                color: "#F9F9FA"
+                                color: "#F4F5F9"
 
                                 visible: modelData.value < 0
                             }
@@ -283,7 +281,7 @@ Rectangle {
                         Rectangle {
                             width: 3
                             height: 1
-                            color: "#A9B0BD"
+                            color: ui.theme.isDark ? "#868B8E": "#8B8C96"
                             anchors.verticalCenter: parent.verticalCenter
                         }
                     }

--- a/src/projectscene/view/common/trackviewstatemodel.cpp
+++ b/src/projectscene/view/common/trackviewstatemodel.cpp
@@ -48,8 +48,18 @@ void TrackViewStateModel::init()
             emit isTrackCollapsedChanged();
         });
 
+        m_channelHeightRatio = vs->channelHeightRatio(m_trackId);
+        m_channelHeightRatio.ch.onReceive(this, [this](double ratio) {
+            if (m_channelHeightRatio.val == ratio) {
+                return;
+            }
+            m_channelHeightRatio.val = ratio;
+            emit channelHeightRatioChanged();
+        });
+
         emit trackHeightChanged();
         emit isTrackCollapsedChanged();
+        emit channelHeightRatioChanged();
     }
 
     playbackController()->isPlayingChanged().onNotify(this, [this]() {
@@ -69,6 +79,14 @@ void TrackViewStateModel::changeTrackHeight(int deltaY)
     IProjectViewStatePtr vs = viewState();
     if (vs) {
         vs->changeTrackHeight(m_trackId, deltaY);
+    }
+}
+
+void TrackViewStateModel::changeChannelHeightRatio(double ratio)
+{
+    IProjectViewStatePtr vs = viewState();
+    if (vs) {
+        vs->setChannelHeightRatio(m_trackId, ratio);
     }
 }
 
@@ -97,6 +115,11 @@ int TrackViewStateModel::trackHeight() const
 bool TrackViewStateModel::isTrackCollapsed() const
 {
     return m_isTrackCollapsed.val;
+}
+
+double TrackViewStateModel::channelHeightRatio() const
+{
+    return m_channelHeightRatio.val;
 }
 
 bool TrackViewStateModel::isPlaying() const

--- a/src/projectscene/view/common/trackviewstatemodel.h
+++ b/src/projectscene/view/common/trackviewstatemodel.h
@@ -23,6 +23,7 @@ class TrackViewStateModel : public QObject, public muse::async::Asyncable
     Q_PROPERTY(QVariant trackId READ trackId WRITE setTrackId NOTIFY trackIdChanged FINAL)
     Q_PROPERTY(int trackHeight READ trackHeight NOTIFY trackHeightChanged FINAL)
     Q_PROPERTY(bool isTrackCollapsed READ isTrackCollapsed NOTIFY isTrackCollapsedChanged FINAL)
+    Q_PROPERTY(double channelHeightRatio READ channelHeightRatio NOTIFY channelHeightRatioChanged FINAL)
 
     Q_PROPERTY(bool isPlaying READ isPlaying NOTIFY isPlayingChanged FINAL)
     Q_PROPERTY(bool isRecording READ isRecording NOTIFY isRecordingChanged FINAL)
@@ -46,6 +47,8 @@ public:
     Q_INVOKABLE void changeTrackHeight(int deltaY);
 
     bool isTrackCollapsed() const;
+    double channelHeightRatio() const;
+    Q_INVOKABLE void changeChannelHeightRatio(double ratio);
 
     playback::PlaybackMeterModel* meterModel() const;
 
@@ -56,6 +59,7 @@ signals:
     void trackIdChanged();
     void trackHeightChanged();
     void isTrackCollapsedChanged();
+    void channelHeightRatioChanged();
     void meterModelChanged();
     void isPlayingChanged();
     void isRecordingChanged();
@@ -66,6 +70,7 @@ private:
     trackedit::TrackId m_trackId = -1;
     muse::ValCh<int> m_trackHeight;
     muse::ValCh<bool> m_isTrackCollapsed;
+    muse::ValCh<double> m_channelHeightRatio;
 
     playback::PlaybackMeterModel* m_meterModel = nullptr;
 };

--- a/src/projectscene/view/trackruler/itrackrulermodel.h
+++ b/src/projectscene/view/trackruler/itrackrulermodel.h
@@ -22,10 +22,11 @@ class ITrackRulerModel
 public:
     virtual ~ITrackRulerModel() = default;
 
-    virtual double stepToPosition(double step, int channel, double height) const = 0;
+    virtual double stepToPosition(double step, int channel) const = 0;
+    virtual void setHeight(int height) = 0;
+    virtual void setChannelHeightRatio(double channelHeightRatio) = 0;
+    virtual void setCollapsed(bool isCollapsed) = 0;
     virtual std::vector<TrackRulerFullStep> fullSteps() const = 0;
     virtual std::vector<TrackRulerSmallStep> smallSteps() const = 0;
-    virtual std::vector<TrackRulerFullStep> collapsedFullSteps() const = 0;
-    virtual std::vector<TrackRulerSmallStep> collapsedSmallSteps() const = 0;
 };
 }

--- a/src/projectscene/view/trackruler/itrackrulermodel.h
+++ b/src/projectscene/view/trackruler/itrackrulermodel.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <stddef.h>
+#include <vector>
+
+namespace au::projectscene {
+struct TrackRulerFullStep {
+    int alignment;
+    double value;
+    size_t channel;
+    bool isBold;
+    bool fullWidthTick;
+};
+
+struct TrackRulerSmallStep {
+    size_t channel;
+    double value;
+};
+
+class ITrackRulerModel
+{
+public:
+    virtual ~ITrackRulerModel() = default;
+
+    virtual double stepToPosition(double step, int channel, double height) const = 0;
+    virtual std::vector<TrackRulerFullStep> fullSteps() const = 0;
+    virtual std::vector<TrackRulerSmallStep> smallSteps() const = 0;
+    virtual std::vector<TrackRulerFullStep> collapsedFullSteps() const = 0;
+    virtual std::vector<TrackRulerSmallStep> collapsedSmallSteps() const = 0;
+};
+}

--- a/src/projectscene/view/trackruler/itrackrulermodel.h
+++ b/src/projectscene/view/trackruler/itrackrulermodel.h
@@ -5,9 +5,9 @@
 
 namespace au::projectscene {
 struct TrackRulerFullStep {
-    int alignment;
     double value;
     size_t channel;
+    int alignment;
     bool isBold;
     bool fullWidthTick;
 };

--- a/src/projectscene/view/trackruler/linearmonoruler.cpp
+++ b/src/projectscene/view/trackruler/linearmonoruler.cpp
@@ -2,55 +2,78 @@
 
 using namespace au::projectscene;
 
-double LinearMonoRuler::stepToPosition(double step, int, double height) const
+namespace {
+constexpr std::array<TrackRulerFullStep, 5> FULL_STEPS = { {
+    TrackRulerFullStep{ -1, 1.0, 0, true, false },
+    TrackRulerFullStep{ 0, 0.5, 0, false, false },
+    TrackRulerFullStep{ 0, 0.0, 0, true, true },
+    TrackRulerFullStep{ 0, -0.5, 0, false, false },
+    TrackRulerFullStep{ 1, -1.0, 0, true, false }
+} };
+
+constexpr std::array<TrackRulerSmallStep, 16> SMALL_STEPS = { {
+    TrackRulerSmallStep{ 0, 0.9 },
+    TrackRulerSmallStep{ 0, 0.8 },
+    TrackRulerSmallStep{ 0, 0.7 },
+    TrackRulerSmallStep{ 0, 0.6 },
+    TrackRulerSmallStep{ 0, 0.4 },
+    TrackRulerSmallStep{ 0, 0.3 },
+    TrackRulerSmallStep{ 0, 0.2 },
+    TrackRulerSmallStep{ 0, 0.1 },
+    TrackRulerSmallStep{ 0, -0.1 },
+    TrackRulerSmallStep{ 0, -0.2 },
+    TrackRulerSmallStep{ 0, -0.3 },
+    TrackRulerSmallStep{ 0, -0.4 },
+    TrackRulerSmallStep{ 0, -0.6 },
+    TrackRulerSmallStep{ 0, -0.7 },
+    TrackRulerSmallStep{ 0, -0.8 },
+    TrackRulerSmallStep{ 0, -0.9 }
+} };
+
+constexpr std::array<TrackRulerFullStep, 1> COLLAPSED_FULL_STEPS = { {
+    TrackRulerFullStep{ 0, 0.0, 0, true, true },
+} };
+
+constexpr std::array<TrackRulerSmallStep, 2> COLLAPSED_SMALL_STEPS = { {
+    TrackRulerSmallStep{ 0, 1.0 },
+    TrackRulerSmallStep{ 0, -1.0 }
+} };
+}
+
+double LinearMonoRuler::stepToPosition(double step, int) const
 {
-    return (1.0 - (step / 2.0 + 0.5)) * height;
+    return (1.0 - (step / 2.0 + 0.5)) * m_height;
+}
+
+void LinearMonoRuler::setHeight(int height)
+{
+    m_height = height;
+}
+
+void LinearMonoRuler::setChannelHeightRatio(double channelHeightRatio)
+{
+    m_channelHeightRatio = channelHeightRatio;
+}
+
+void LinearMonoRuler::setCollapsed(bool isCollapsed)
+{
+    m_collapsed = isCollapsed;
 }
 
 std::vector<TrackRulerFullStep> LinearMonoRuler::fullSteps() const
 {
-    return {
-        TrackRulerFullStep{ -1, 1.0, 0, true, false },
-        TrackRulerFullStep{ 0, 0.5, 0, false, false },
-        TrackRulerFullStep{ 0, 0.0, 0, true, true },
-        TrackRulerFullStep{ 0, -0.5, 0, false, false },
-        TrackRulerFullStep{ 1, -1.0, 0, true, false }
-    };
+    if (m_collapsed) {
+        return { COLLAPSED_FULL_STEPS.begin(), COLLAPSED_FULL_STEPS.end() };
+    }
+
+    return { FULL_STEPS.begin(), FULL_STEPS.end() };
 }
 
 std::vector<TrackRulerSmallStep> LinearMonoRuler::smallSteps() const
 {
-    return {
-        TrackRulerSmallStep{ 0, 0.9 },
-        TrackRulerSmallStep{ 0, 0.8 },
-        TrackRulerSmallStep{ 0, 0.7 },
-        TrackRulerSmallStep{ 0, 0.6 },
-        TrackRulerSmallStep{ 0, 0.4 },
-        TrackRulerSmallStep{ 0, 0.3 },
-        TrackRulerSmallStep{ 0, 0.2 },
-        TrackRulerSmallStep{ 0, 0.1 },
-        TrackRulerSmallStep{ 0, -0.1 },
-        TrackRulerSmallStep{ 0, -0.2 },
-        TrackRulerSmallStep{ 0, -0.3 },
-        TrackRulerSmallStep{ 0, -0.4 },
-        TrackRulerSmallStep{ 0, -0.6 },
-        TrackRulerSmallStep{ 0, -0.7 },
-        TrackRulerSmallStep{ 0, -0.8 },
-        TrackRulerSmallStep{ 0, -0.9 }
-    };
-}
+    if (m_collapsed) {
+        return { COLLAPSED_SMALL_STEPS.begin(), COLLAPSED_SMALL_STEPS.end() };
+    }
 
-std::vector<TrackRulerFullStep> LinearMonoRuler::collapsedFullSteps() const
-{
-    return {
-        TrackRulerFullStep{ 0, 0.0, 0, true, true },
-    };
-}
-
-std::vector<TrackRulerSmallStep> LinearMonoRuler::collapsedSmallSteps() const
-{
-    return {
-        TrackRulerSmallStep{ 0, 1.0 },
-        TrackRulerSmallStep{ 0, -1.0 }
-    };
+    return { SMALL_STEPS.begin(), SMALL_STEPS.end() };
 }

--- a/src/projectscene/view/trackruler/linearmonoruler.cpp
+++ b/src/projectscene/view/trackruler/linearmonoruler.cpp
@@ -1,0 +1,56 @@
+#include "projectscene/view/trackruler/linearmonoruler.h"
+
+using namespace au::projectscene;
+
+double LinearMonoRuler::stepToPosition(double step, int, double height) const
+{
+    return (1.0 - (step / 2.0 + 0.5)) * height;
+}
+
+std::vector<TrackRulerFullStep> LinearMonoRuler::fullSteps() const
+{
+    return {
+        TrackRulerFullStep{ -1, 1.0, 0, true, false },
+        TrackRulerFullStep{ 0, 0.5, 0, false, false },
+        TrackRulerFullStep{ 0, 0.0, 0, true, true },
+        TrackRulerFullStep{ 0, -0.5, 0, false, false },
+        TrackRulerFullStep{ 1, -1.0, 0, true, false }
+    };
+}
+
+std::vector<TrackRulerSmallStep> LinearMonoRuler::smallSteps() const
+{
+    return {
+        TrackRulerSmallStep{ 0, 0.9 },
+        TrackRulerSmallStep{ 0, 0.8 },
+        TrackRulerSmallStep{ 0, 0.7 },
+        TrackRulerSmallStep{ 0, 0.6 },
+        TrackRulerSmallStep{ 0, 0.4 },
+        TrackRulerSmallStep{ 0, 0.3 },
+        TrackRulerSmallStep{ 0, 0.2 },
+        TrackRulerSmallStep{ 0, 0.1 },
+        TrackRulerSmallStep{ 0, -0.1 },
+        TrackRulerSmallStep{ 0, -0.2 },
+        TrackRulerSmallStep{ 0, -0.3 },
+        TrackRulerSmallStep{ 0, -0.4 },
+        TrackRulerSmallStep{ 0, -0.6 },
+        TrackRulerSmallStep{ 0, -0.7 },
+        TrackRulerSmallStep{ 0, -0.8 },
+        TrackRulerSmallStep{ 0, -0.9 }
+    };
+}
+
+std::vector<TrackRulerFullStep> LinearMonoRuler::collapsedFullSteps() const
+{
+    return {
+        TrackRulerFullStep{ 0, 0.0, 0, true, true },
+    };
+}
+
+std::vector<TrackRulerSmallStep> LinearMonoRuler::collapsedSmallSteps() const
+{
+    return {
+        TrackRulerSmallStep{ 0, 1.0 },
+        TrackRulerSmallStep{ 0, -1.0 }
+    };
+}

--- a/src/projectscene/view/trackruler/linearmonoruler.cpp
+++ b/src/projectscene/view/trackruler/linearmonoruler.cpp
@@ -4,11 +4,11 @@ using namespace au::projectscene;
 
 namespace {
 constexpr std::array<TrackRulerFullStep, 5> FULL_STEPS = { {
-    TrackRulerFullStep{ -1, 1.0, 0, true, false },
-    TrackRulerFullStep{ 0, 0.5, 0, false, false },
-    TrackRulerFullStep{ 0, 0.0, 0, true, true },
-    TrackRulerFullStep{ 0, -0.5, 0, false, false },
-    TrackRulerFullStep{ 1, -1.0, 0, true, false }
+    TrackRulerFullStep{ 1.0, 0, -1, true, false },
+    TrackRulerFullStep{ 0.5, 0, 0, false, false },
+    TrackRulerFullStep{ 0.0, 0, 0, true, true },
+    TrackRulerFullStep{ -0.5, 0, 0, false, false },
+    TrackRulerFullStep{ -1.0, 0, 1, true, false }
 } };
 
 constexpr std::array<TrackRulerSmallStep, 16> SMALL_STEPS = { {
@@ -31,7 +31,7 @@ constexpr std::array<TrackRulerSmallStep, 16> SMALL_STEPS = { {
 } };
 
 constexpr std::array<TrackRulerFullStep, 1> COLLAPSED_FULL_STEPS = { {
-    TrackRulerFullStep{ 0, 0.0, 0, true, true },
+    TrackRulerFullStep{ 0.0, 0, 0, true, true },
 } };
 
 constexpr std::array<TrackRulerSmallStep, 2> COLLAPSED_SMALL_STEPS = { {

--- a/src/projectscene/view/trackruler/linearmonoruler.h
+++ b/src/projectscene/view/trackruler/linearmonoruler.h
@@ -6,10 +6,16 @@ namespace au::projectscene {
 class LinearMonoRuler : public ITrackRulerModel
 {
 public:
-    double stepToPosition(double step, int channel, double height) const override;
+    double stepToPosition(double step, int channel) const override;
+    void setHeight(int height) override;
+    void setChannelHeightRatio(double channelHeightRatio) override;
+    void setCollapsed(bool isCollapsed) override;
     std::vector<TrackRulerFullStep> fullSteps() const override;
     std::vector<TrackRulerSmallStep> smallSteps() const override;
-    std::vector<TrackRulerFullStep> collapsedFullSteps() const override;
-    std::vector<TrackRulerSmallStep> collapsedSmallSteps() const override;
+
+private:
+    double m_height = 0.0;
+    double m_channelHeightRatio = 1.0;
+    bool m_collapsed = false;
 };
 }

--- a/src/projectscene/view/trackruler/linearmonoruler.h
+++ b/src/projectscene/view/trackruler/linearmonoruler.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "projectscene/view/trackruler/itrackrulermodel.h"
+
+namespace au::projectscene {
+class LinearMonoRuler : public ITrackRulerModel
+{
+public:
+    double stepToPosition(double step, int channel, double height) const override;
+    std::vector<TrackRulerFullStep> fullSteps() const override;
+    std::vector<TrackRulerSmallStep> smallSteps() const override;
+    std::vector<TrackRulerFullStep> collapsedFullSteps() const override;
+    std::vector<TrackRulerSmallStep> collapsedSmallSteps() const override;
+};
+}

--- a/src/projectscene/view/trackruler/linearstereoruler.cpp
+++ b/src/projectscene/view/trackruler/linearstereoruler.cpp
@@ -1,0 +1,59 @@
+#include "projectscene/view/trackruler/linearstereoruler.h"
+
+using namespace au::projectscene;
+
+double LinearStereoRuler::stepToPosition(double step, int channel, double height) const
+{
+    double position;
+    if (channel == 0) {
+        position = (1.0 - (step / 2.0 + 0.5)) * height / 2;
+        if (step == -1.0) {
+            position += 1;
+        }
+    } else {
+        position = (1.0 - (step / 2.0 + 0.5)) * height / 2 + height / 2;
+        if (step == 1.0) {
+            position += 1;
+        }
+    }
+
+    return position;
+}
+
+std::vector<TrackRulerFullStep> LinearStereoRuler::fullSteps() const
+{
+    return {
+        TrackRulerFullStep{ -1, 1.0, 0, true, false },
+        TrackRulerFullStep{ 0, 0.0, 0, true, true },
+        TrackRulerFullStep{ 1, -1.0, 0, true, true },
+        TrackRulerFullStep{ -1, 1.0, 1, true, true },
+        TrackRulerFullStep{ 0, 0.0, 1, true, true },
+        TrackRulerFullStep{ 1, -1.0, 1, true, false },
+    };
+}
+
+std::vector<TrackRulerSmallStep> LinearStereoRuler::smallSteps() const
+{
+    return {
+        TrackRulerSmallStep{ 0, 0.5 },
+        TrackRulerSmallStep{ 0, -0.5 },
+        TrackRulerSmallStep{ 1, 0.5 },
+        TrackRulerSmallStep{ 1, -0.5 },
+    };
+}
+
+std::vector<TrackRulerFullStep> LinearStereoRuler::collapsedFullSteps() const
+{
+    return {
+        TrackRulerFullStep{ 0, 0.0, 0, true, true },
+        TrackRulerFullStep{ 0, 0.0, 1, true, true },
+    };
+}
+
+std::vector<TrackRulerSmallStep> LinearStereoRuler::collapsedSmallSteps() const
+{
+    return {
+        TrackRulerSmallStep{ 0, 1.0 },
+        TrackRulerSmallStep{ 1, -1.0 }
+    };
+}

--- a/src/projectscene/view/trackruler/linearstereoruler.cpp
+++ b/src/projectscene/view/trackruler/linearstereoruler.cpp
@@ -4,15 +4,15 @@ using namespace au::projectscene;
 
 namespace {
 constexpr std::array<TrackRulerFullStep, 3> FULL_STEPS_CH_0 = { {
-    TrackRulerFullStep{ -1, 1.0, 0, true, false },
-    TrackRulerFullStep{ 0, 0.0, 0, true, true },
-    TrackRulerFullStep{ 1, -1.0, 0, true, true }
+    TrackRulerFullStep{ 1.0, 0, -1, true, false },
+    TrackRulerFullStep{ 0.0, 0, 0, true, true },
+    TrackRulerFullStep{ -1.0, 0, 1, true, true }
 } };
 
 constexpr std::array<TrackRulerFullStep, 3> FULL_STEPS_CH_1 = { {
-    TrackRulerFullStep{ -1, 1.0, 1, true, true },
-    TrackRulerFullStep{ 0, 0.0, 1, true, true },
-    TrackRulerFullStep{ 1, -1.0, 1, true, false },
+    TrackRulerFullStep{ 1.0, 1, -1, true, true },
+    TrackRulerFullStep{ 0.0, 1, 0, true, true },
+    TrackRulerFullStep{ -1.0, 1, 1, true, false },
 } };
 
 constexpr std::array<TrackRulerSmallStep, 2> SMALL_STEPS_CH_0 = { {
@@ -26,11 +26,11 @@ constexpr std::array<TrackRulerSmallStep, 2> SMALL_STEPS_CH_1 = { {
 } };
 
 constexpr std::array<TrackRulerFullStep, 2> COLLAPSED_FULL_STEPS_CH_0 = { {
-    TrackRulerFullStep{ 0, 0.0, 0, true, true },
+    TrackRulerFullStep{ 0.0, 0, 0, true, true },
 } };
 
 constexpr std::array<TrackRulerFullStep, 2> COLLAPSED_FULL_STEPS_CH_1 = { {
-    TrackRulerFullStep{ 0, 0.0, 1, true, true },
+    TrackRulerFullStep{ 0.0, 1, 0, true, true },
 } };
 
 constexpr std::array<TrackRulerSmallStep, 1> COLLAPSED_SMALL_STEPS_CH_0 = { {

--- a/src/projectscene/view/trackruler/linearstereoruler.cpp
+++ b/src/projectscene/view/trackruler/linearstereoruler.cpp
@@ -2,16 +2,58 @@
 
 using namespace au::projectscene;
 
-double LinearStereoRuler::stepToPosition(double step, int channel, double height) const
+namespace {
+constexpr std::array<TrackRulerFullStep, 3> FULL_STEPS_CH_0 = { {
+    TrackRulerFullStep{ -1, 1.0, 0, true, false },
+    TrackRulerFullStep{ 0, 0.0, 0, true, true },
+    TrackRulerFullStep{ 1, -1.0, 0, true, true }
+} };
+
+constexpr std::array<TrackRulerFullStep, 3> FULL_STEPS_CH_1 = { {
+    TrackRulerFullStep{ -1, 1.0, 1, true, true },
+    TrackRulerFullStep{ 0, 0.0, 1, true, true },
+    TrackRulerFullStep{ 1, -1.0, 1, true, false },
+} };
+
+constexpr std::array<TrackRulerSmallStep, 2> SMALL_STEPS_CH_0 = { {
+    TrackRulerSmallStep{ 0, 0.5 },
+    TrackRulerSmallStep{ 0, -0.5 }
+} };
+
+constexpr std::array<TrackRulerSmallStep, 2> SMALL_STEPS_CH_1 = { {
+    TrackRulerSmallStep{ 1, 0.5 },
+    TrackRulerSmallStep{ 1, -0.5 }
+} };
+
+constexpr std::array<TrackRulerFullStep, 2> COLLAPSED_FULL_STEPS_CH_0 = { {
+    TrackRulerFullStep{ 0, 0.0, 0, true, true },
+} };
+
+constexpr std::array<TrackRulerFullStep, 2> COLLAPSED_FULL_STEPS_CH_1 = { {
+    TrackRulerFullStep{ 0, 0.0, 1, true, true },
+} };
+
+constexpr std::array<TrackRulerSmallStep, 1> COLLAPSED_SMALL_STEPS_CH_0 = { {
+    TrackRulerSmallStep{ 0, 1.0 }
+} };
+
+constexpr std::array<TrackRulerSmallStep, 1> COLLAPSED_SMALL_STEPS_CH_1 = { {
+    TrackRulerSmallStep{ 1, -1.0 }
+} };
+
+constexpr double MIN_CHANNEL_HEIGHT = 30.0;
+}
+
+double LinearStereoRuler::stepToPosition(double step, int channel) const
 {
     double position;
     if (channel == 0) {
-        position = (1.0 - (step / 2.0 + 0.5)) * height / 2;
+        position = (1.0 - (step / 2.0 + 0.5)) * m_height * m_channelHeightRatio;
         if (step == -1.0) {
             position += 1;
         }
     } else {
-        position = (1.0 - (step / 2.0 + 0.5)) * height / 2 + height / 2;
+        position = (1.0 - (step / 2.0 + 0.5)) * (1.0 - m_channelHeightRatio) * m_height + m_channelHeightRatio * m_height;
         if (step == 1.0) {
             position += 1;
         }
@@ -20,40 +62,70 @@ double LinearStereoRuler::stepToPosition(double step, int channel, double height
     return position;
 }
 
+void LinearStereoRuler::setHeight(int height)
+{
+    m_height = height;
+}
+
+void LinearStereoRuler::setChannelHeightRatio(double channelHeightRatio)
+{
+    m_channelHeightRatio = channelHeightRatio;
+}
+
+void LinearStereoRuler::setCollapsed(bool isCollapsed)
+{
+    m_collapsed = isCollapsed;
+}
+
 std::vector<TrackRulerFullStep> LinearStereoRuler::fullSteps() const
 {
-    return {
-        TrackRulerFullStep{ -1, 1.0, 0, true, false },
-        TrackRulerFullStep{ 0, 0.0, 0, true, true },
-        TrackRulerFullStep{ 1, -1.0, 0, true, true },
-        TrackRulerFullStep{ -1, 1.0, 1, true, true },
-        TrackRulerFullStep{ 0, 0.0, 1, true, true },
-        TrackRulerFullStep{ 1, -1.0, 1, true, false },
-    };
+    std::vector<TrackRulerFullStep> steps;
+
+    if (m_collapsed) {
+        steps.insert(steps.end(), COLLAPSED_FULL_STEPS_CH_0.begin(), COLLAPSED_FULL_STEPS_CH_0.end());
+        steps.insert(steps.end(), COLLAPSED_FULL_STEPS_CH_1.begin(), COLLAPSED_FULL_STEPS_CH_1.end());
+        return steps;
+    }
+
+    if (m_height * m_channelHeightRatio < MIN_CHANNEL_HEIGHT) {
+        steps.insert(steps.end(), COLLAPSED_FULL_STEPS_CH_0.begin(), COLLAPSED_FULL_STEPS_CH_0.end());
+        steps.insert(steps.end(), FULL_STEPS_CH_1.begin(), FULL_STEPS_CH_1.end());
+        return steps;
+    }
+
+    if (m_height * (1.0 - m_channelHeightRatio) < MIN_CHANNEL_HEIGHT) {
+        steps.insert(steps.end(), FULL_STEPS_CH_0.begin(), FULL_STEPS_CH_0.end());
+        steps.insert(steps.end(), COLLAPSED_FULL_STEPS_CH_1.begin(), COLLAPSED_FULL_STEPS_CH_1.end());
+        return steps;
+    }
+
+    steps.insert(steps.end(), FULL_STEPS_CH_0.begin(), FULL_STEPS_CH_0.end());
+    steps.insert(steps.end(), FULL_STEPS_CH_1.begin(), FULL_STEPS_CH_1.end());
+    return steps;
 }
 
 std::vector<TrackRulerSmallStep> LinearStereoRuler::smallSteps() const
 {
-    return {
-        TrackRulerSmallStep{ 0, 0.5 },
-        TrackRulerSmallStep{ 0, -0.5 },
-        TrackRulerSmallStep{ 1, 0.5 },
-        TrackRulerSmallStep{ 1, -0.5 },
-    };
-}
+    std::vector<TrackRulerSmallStep> steps;
+    if (m_collapsed) {
+        steps.insert(steps.end(), COLLAPSED_SMALL_STEPS_CH_0.begin(), COLLAPSED_SMALL_STEPS_CH_0.end());
+        steps.insert(steps.end(), COLLAPSED_SMALL_STEPS_CH_1.begin(), COLLAPSED_SMALL_STEPS_CH_1.end());
+        return steps;
+    }
 
-std::vector<TrackRulerFullStep> LinearStereoRuler::collapsedFullSteps() const
-{
-    return {
-        TrackRulerFullStep{ 0, 0.0, 0, true, true },
-        TrackRulerFullStep{ 0, 0.0, 1, true, true },
-    };
-}
+    if (m_height * m_channelHeightRatio < MIN_CHANNEL_HEIGHT) {
+        steps.insert(steps.end(), COLLAPSED_SMALL_STEPS_CH_0.begin(), COLLAPSED_SMALL_STEPS_CH_0.end());
+        steps.insert(steps.end(), SMALL_STEPS_CH_1.begin(), SMALL_STEPS_CH_1.end());
+        return steps;
+    }
 
-std::vector<TrackRulerSmallStep> LinearStereoRuler::collapsedSmallSteps() const
-{
-    return {
-        TrackRulerSmallStep{ 0, 1.0 },
-        TrackRulerSmallStep{ 1, -1.0 }
-    };
+    if (m_height * (1.0 - m_channelHeightRatio) < MIN_CHANNEL_HEIGHT) {
+        steps.insert(steps.end(), SMALL_STEPS_CH_0.begin(), SMALL_STEPS_CH_0.end());
+        steps.insert(steps.end(), COLLAPSED_SMALL_STEPS_CH_1.begin(), COLLAPSED_SMALL_STEPS_CH_1.end());
+        return steps;
+    }
+
+    steps.insert(steps.end(), SMALL_STEPS_CH_0.begin(), SMALL_STEPS_CH_0.end());
+    steps.insert(steps.end(), SMALL_STEPS_CH_1.begin(), SMALL_STEPS_CH_1.end());
+    return steps;
 }

--- a/src/projectscene/view/trackruler/linearstereoruler.h
+++ b/src/projectscene/view/trackruler/linearstereoruler.h
@@ -6,10 +6,16 @@ namespace au::projectscene {
 class LinearStereoRuler : public ITrackRulerModel
 {
 public:
-    double stepToPosition(double step, int channel, double height) const override;
+    double stepToPosition(double step, int channel) const override;
+    void setHeight(int height) override;
+    void setChannelHeightRatio(double channelHeightRatio) override;
+    void setCollapsed(bool isCollapsed) override;
     std::vector<TrackRulerFullStep> fullSteps() const override;
     std::vector<TrackRulerSmallStep> smallSteps() const override;
-    std::vector<TrackRulerFullStep> collapsedFullSteps() const override;
-    std::vector<TrackRulerSmallStep> collapsedSmallSteps() const override;
+
+private:
+    double m_height = 0.0;
+    double m_channelHeightRatio = 0.5;
+    bool m_collapsed = false;
 };
 }

--- a/src/projectscene/view/trackruler/linearstereoruler.h
+++ b/src/projectscene/view/trackruler/linearstereoruler.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "projectscene/view/trackruler/itrackrulermodel.h"
+
+namespace au::projectscene {
+class LinearStereoRuler : public ITrackRulerModel
+{
+public:
+    double stepToPosition(double step, int channel, double height) const override;
+    std::vector<TrackRulerFullStep> fullSteps() const override;
+    std::vector<TrackRulerSmallStep> smallSteps() const override;
+    std::vector<TrackRulerFullStep> collapsedFullSteps() const override;
+    std::vector<TrackRulerSmallStep> collapsedSmallSteps() const override;
+};
+}

--- a/src/projectscene/view/trackruler/trackrulermodel.cpp
+++ b/src/projectscene/view/trackruler/trackrulermodel.cpp
@@ -20,7 +20,7 @@ std::vector<QVariantMap> TrackRulerModel::fullSteps() const
         return {};
     }
 
-    const std::vector<TrackRulerFullStep>& steps = m_isCollapsed ? m_model->collapsedFullSteps() : m_model->fullSteps();
+    const std::vector<TrackRulerFullStep>& steps = m_model->fullSteps();
     std::vector<QVariantMap> variantSteps;
     std::transform(steps.begin(), steps.end(), std::back_inserter(variantSteps),
                    [&](const TrackRulerFullStep& step) {
@@ -43,7 +43,7 @@ std::vector<QVariantMap> TrackRulerModel::smallSteps() const
         return {};
     }
 
-    const std::vector<TrackRulerSmallStep>& steps = m_isCollapsed ? m_model->collapsedSmallSteps() : m_model->smallSteps();
+    const std::vector<TrackRulerSmallStep>& steps = m_model->smallSteps();
     std::vector<QVariantMap> variantSteps;
     std::transform(steps.begin(), steps.end(), std::back_inserter(variantSteps),
                    [&](const TrackRulerSmallStep& step) {
@@ -72,10 +72,12 @@ void TrackRulerModel::setIsStereo(bool isStereo)
             m_model = std::make_shared<LinearMonoRuler>();
         }
 
-        emit isStereoChanged();
+        m_model->setHeight(m_height);
+        m_model->setChannelHeightRatio(m_channelHeightRatio);
+        m_model->setCollapsed(m_isCollapsed);
+
         emit fullStepsChanged();
         emit smallStepsChanged();
-        emit heightChanged();
     }
 }
 
@@ -88,10 +90,9 @@ void TrackRulerModel::setIsCollapsed(bool isCollapsed)
 {
     if (m_isCollapsed != isCollapsed) {
         m_isCollapsed = isCollapsed;
-        emit isCollapsedChanged();
+        m_model->setCollapsed(isCollapsed);
         emit fullStepsChanged();
         emit smallStepsChanged();
-        emit heightChanged();
     }
 }
 
@@ -104,7 +105,7 @@ void TrackRulerModel::setHeight(int height)
 {
     if (m_height != height) {
         m_height = height;
-        emit heightChanged();
+        m_model->setHeight(height);
         emit fullStepsChanged();
         emit smallStepsChanged();
     }
@@ -116,5 +117,20 @@ double TrackRulerModel::stepToPosition(double step, int channel) const
         return 0.0;
     }
 
-    return m_model->stepToPosition(step, channel, m_height);
+    return m_model->stepToPosition(step, channel);
+}
+
+double TrackRulerModel::channelHeightRatio() const
+{
+    return m_channelHeightRatio;
+}
+
+void TrackRulerModel::setChannelHeightRatio(double channelHeightRatio)
+{
+    if (m_channelHeightRatio != channelHeightRatio) {
+        m_channelHeightRatio = channelHeightRatio;
+        m_model->setChannelHeightRatio(channelHeightRatio);
+        emit fullStepsChanged();
+        emit smallStepsChanged();
+    }
 }

--- a/src/projectscene/view/trackruler/trackrulermodel.cpp
+++ b/src/projectscene/view/trackruler/trackrulermodel.cpp
@@ -1,0 +1,120 @@
+/*
+* Audacity: A Digital Audio Editor
+*/
+
+#include "projectscene/view/trackruler/trackrulermodel.h"
+#include "projectscene/view/trackruler/linearstereoruler.h"
+#include "projectscene/view/trackruler/linearmonoruler.h"
+
+using namespace au::projectscene;
+
+TrackRulerModel::TrackRulerModel(QObject* parent)
+    : QObject(parent)
+{
+    m_model = std::make_shared<LinearMonoRuler>();
+}
+
+std::vector<QVariantMap> TrackRulerModel::fullSteps() const
+{
+    if (!m_model) {
+        return {};
+    }
+
+    const std::vector<TrackRulerFullStep>& steps = m_isCollapsed ? m_model->collapsedFullSteps() : m_model->fullSteps();
+    std::vector<QVariantMap> variantSteps;
+    std::transform(steps.begin(), steps.end(), std::back_inserter(variantSteps),
+                   [&](const TrackRulerFullStep& step) {
+        return QVariantMap {
+            { "alignment", step.alignment },
+            { "value", step.value },
+            { "y", stepToPosition(step.value, step.channel) },
+            { "channel", static_cast<int>(step.channel) },
+            { "bold", step.isBold },
+            { "fullWidthTick", step.fullWidthTick }
+        };
+    });
+
+    return variantSteps;
+}
+
+std::vector<QVariantMap> TrackRulerModel::smallSteps() const
+{
+    if (!m_model) {
+        return {};
+    }
+
+    const std::vector<TrackRulerSmallStep>& steps = m_isCollapsed ? m_model->collapsedSmallSteps() : m_model->smallSteps();
+    std::vector<QVariantMap> variantSteps;
+    std::transform(steps.begin(), steps.end(), std::back_inserter(variantSteps),
+                   [&](const TrackRulerSmallStep& step) {
+        return QVariantMap {
+            { "channel", static_cast<int>(step.channel) },
+            { "value", step.value },
+            { "y", stepToPosition(step.value, step.channel) }
+        };
+    });
+    return variantSteps;
+}
+
+bool TrackRulerModel::isStereo() const
+{
+    return m_isStereo;
+}
+
+void TrackRulerModel::setIsStereo(bool isStereo)
+{
+    if (m_isStereo != isStereo) {
+        m_isStereo = isStereo;
+
+        if (m_isStereo) {
+            m_model = std::make_shared<LinearStereoRuler>();
+        } else {
+            m_model = std::make_shared<LinearMonoRuler>();
+        }
+
+        emit isStereoChanged();
+        emit fullStepsChanged();
+        emit smallStepsChanged();
+        emit heightChanged();
+    }
+}
+
+bool TrackRulerModel::isCollapsed() const
+{
+    return m_isCollapsed;
+}
+
+void TrackRulerModel::setIsCollapsed(bool isCollapsed)
+{
+    if (m_isCollapsed != isCollapsed) {
+        m_isCollapsed = isCollapsed;
+        emit isCollapsedChanged();
+        emit fullStepsChanged();
+        emit smallStepsChanged();
+        emit heightChanged();
+    }
+}
+
+int TrackRulerModel::height() const
+{
+    return m_height;
+}
+
+void TrackRulerModel::setHeight(int height)
+{
+    if (m_height != height) {
+        m_height = height;
+        emit heightChanged();
+        emit fullStepsChanged();
+        emit smallStepsChanged();
+    }
+}
+
+double TrackRulerModel::stepToPosition(double step, int channel) const
+{
+    if (!m_model) {
+        return 0.0;
+    }
+
+    return m_model->stepToPosition(step, channel, m_height);
+}

--- a/src/projectscene/view/trackruler/trackrulermodel.h
+++ b/src/projectscene/view/trackruler/trackrulermodel.h
@@ -1,0 +1,54 @@
+/*
+* Audacity: A Digital Audio Editor
+*/
+#pragma once
+
+#include "projectscene/view/trackruler/itrackrulermodel.h"
+
+#include <QObject>
+#include <QVariantMap>
+
+namespace au::projectscene {
+class TrackRulerModel : public QObject
+{
+    Q_OBJECT
+
+    Q_PROPERTY(std::vector<QVariantMap> fullSteps READ fullSteps NOTIFY fullStepsChanged)
+    Q_PROPERTY(std::vector<QVariantMap> smallSteps READ smallSteps NOTIFY smallStepsChanged)
+
+    Q_PROPERTY(bool isStereo READ isStereo WRITE setIsStereo NOTIFY isStereoChanged FINAL)
+    Q_PROPERTY(bool isCollapsed READ isCollapsed WRITE setIsCollapsed NOTIFY isCollapsedChanged FINAL)
+    Q_PROPERTY(int height READ height WRITE setHeight NOTIFY heightChanged FINAL)
+
+public:
+    explicit TrackRulerModel(QObject* parent = nullptr);
+
+    std::vector<QVariantMap> fullSteps() const;
+    std::vector<QVariantMap> smallSteps() const;
+
+    bool isStereo() const;
+    void setIsStereo(bool isStereo);
+
+    bool isCollapsed() const;
+    void setIsCollapsed(bool isCollapsed);
+
+    int height() const;
+    void setHeight(int height);
+
+    Q_INVOKABLE double stepToPosition(double step, int channel) const;
+signals:
+    void fullStepsChanged();
+    void smallStepsChanged();
+
+    void isStereoChanged();
+    void isCollapsedChanged();
+    void heightChanged();
+
+private:
+    std::shared_ptr<ITrackRulerModel> m_model =  nullptr;
+
+    bool m_isStereo = false;
+    bool m_isCollapsed = false;
+    int m_height = 0;
+};
+}

--- a/src/projectscene/view/trackruler/trackrulermodel.h
+++ b/src/projectscene/view/trackruler/trackrulermodel.h
@@ -20,6 +20,8 @@ class TrackRulerModel : public QObject
     Q_PROPERTY(bool isCollapsed READ isCollapsed WRITE setIsCollapsed NOTIFY isCollapsedChanged FINAL)
     Q_PROPERTY(int height READ height WRITE setHeight NOTIFY heightChanged FINAL)
 
+    Q_PROPERTY(double channelHeightRatio READ channelHeightRatio WRITE setChannelHeightRatio NOTIFY channelHeightRatioChanged FINAL)
+
 public:
     explicit TrackRulerModel(QObject* parent = nullptr);
 
@@ -35,7 +37,9 @@ public:
     int height() const;
     void setHeight(int height);
 
-    Q_INVOKABLE double stepToPosition(double step, int channel) const;
+    double channelHeightRatio() const;
+    void setChannelHeightRatio(double channelHeightRatio);
+
 signals:
     void fullStepsChanged();
     void smallStepsChanged();
@@ -44,11 +48,15 @@ signals:
     void isCollapsedChanged();
     void heightChanged();
 
+    void channelHeightRatioChanged();
 private:
     std::shared_ptr<ITrackRulerModel> m_model =  nullptr;
+
+    double stepToPosition(double step, int channel) const;
 
     bool m_isStereo = false;
     bool m_isCollapsed = false;
     int m_height = 0;
+    double m_channelHeightRatio = 0.5;
 };
 }


### PR DESCRIPTION
Resolves: #9083 

https://www.figma.com/design/PIavx2Q7WayFAw2FQORrTw/09---Timeline---rulers?node-id=1365-31495&t=13OujLAUwig5wsT5-4

This PR implements vertical rulers static version.
For now no flyout, walf wave, changing the ruler format or zooming is implemented.
Asymmetric stereo channels must also be implemented.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
