### PR TITLE
AbstractEffectModel instance ID is const !

### DIFF
--- a/src/effects/builtin/amplify/AmplifyView.qml
+++ b/src/effects/builtin/amplify/AmplifyView.qml
@@ -18,8 +18,6 @@ EffectBase {
     AmplifyViewModel {
         id: amplify
 
-        instanceId: root.instanceId
-
         onAmpValueChanged: ampSlider.value = ampValue
     }
 

--- a/src/effects/builtin/amplify/amplifyviewmodel.cpp
+++ b/src/effects/builtin/amplify/amplifyviewmodel.cpp
@@ -10,29 +10,15 @@
 
 using namespace au::effects;
 
-AmplifyEffect* AmplifyViewModel::effect() const
-{
-    EffectId effectId = this->effectId();
-    if (effectId.isEmpty()) {
-        return nullptr;
-    }
-    Effect* e = effectsProvider()->effect(effectId);
-    AmplifyEffect* ae = dynamic_cast<AmplifyEffect*>(e);
-    return ae;
-}
-
 void AmplifyViewModel::doReload()
 {
-    AmplifyEffect* ae = effect();
-    IF_ASSERT_FAILED(ae) {
-        return;
-    }
+    auto& ae = effect<AmplifyEffect>();
 
-    const db_t initAmp = ae->defaultAmp();
-    ae->setAmp(initAmp);
+    const db_t initAmp = ae.defaultAmp();
+    ae.setAmp(initAmp);
     m_amp.val = std::numeric_limits<float>::lowest();
 
-    m_canClip = ae->canClip();
+    m_canClip = ae.canClip();
     emit canClipChanged();
 
     update();
@@ -40,13 +26,10 @@ void AmplifyViewModel::doReload()
 
 void AmplifyViewModel::update()
 {
-    AmplifyEffect* ae = effect();
-    IF_ASSERT_FAILED(ae) {
-        return;
-    }
+    const auto& ae = effect<AmplifyEffect>();
 
-    Param<db_t> amp = ae->amp();
-    db_t newPeak = muse::linear_to_db(ae->ratio() * ae->peak());
+    Param<db_t> amp = ae.amp();
+    db_t newPeak = muse::linear_to_db(ae.ratio() * ae.peak());
 
     if (!muse::is_equal(m_amp.val, amp.val)) {
         m_amp = amp;
@@ -55,7 +38,7 @@ void AmplifyViewModel::update()
         emit newPeakValueChanged();
     }
 
-    bool isApplyAllowed = ae->isApplyAllowed();
+    bool isApplyAllowed = ae.isApplyAllowed();
     setIsApplyAllowed(isApplyAllowed);
 }
 
@@ -81,12 +64,8 @@ void AmplifyViewModel::setAmpValue(float newAmpValue)
         return;
     }
 
-    AmplifyEffect* ae = effect();
-    IF_ASSERT_FAILED(ae) {
-        return;
-    }
-
-    ae->setAmp(newAmp);
+    auto& ae = effect<AmplifyEffect>();
+    ae.setAmp(newAmp);
 
     update();
 }
@@ -133,36 +112,25 @@ void AmplifyViewModel::setNewPeakValue(float newNewPeakValue)
         return;
     }
 
-    AmplifyEffect* ae = effect();
-    IF_ASSERT_FAILED(ae) {
-        return;
-    }
+    auto& ae = effect<AmplifyEffect>();
 
-    ratio_t ratio = muse::db_to_linear(newNewPeak) / ae->peak();
+    ratio_t ratio = muse::db_to_linear(newNewPeak) / ae.peak();
     db_t amp = muse::linear_to_db(ratio);
-    ae->setAmp(amp);
+    ae.setAmp(amp);
 
     update();
 }
 
 float AmplifyViewModel::newPeakMin() const
 {
-    AmplifyEffect* ae = effect();
-    if (!ae) {
-        return 0.0;
-    }
-
-    return m_amp.min + muse::linear_to_db(ae->peak());
+    const auto& ae = effect<AmplifyEffect>();
+    return m_amp.min + muse::linear_to_db(ae.peak());
 }
 
 float AmplifyViewModel::newPeakMax() const
 {
-    AmplifyEffect* ae = effect();
-    if (!ae) {
-        return 0.0;
-    }
-
-    return m_amp.max + muse::linear_to_db(ae->peak());
+    const auto& ae = effect<AmplifyEffect>();
+    return m_amp.max + muse::linear_to_db(ae.peak());
 }
 
 QString AmplifyViewModel::newPeakMeasureUnitsSymbol() const
@@ -196,13 +164,9 @@ void AmplifyViewModel::setCanClip(bool newClipping)
         return;
     }
 
-    AmplifyEffect* ae = effect();
-    IF_ASSERT_FAILED(ae) {
-        return;
-    }
+    auto& ae = effect<AmplifyEffect>();
 
-    //! NOTE
-    ae->setCanClip(newClipping);
+    ae.setCanClip(newClipping);
 
     m_canClip = newClipping;
     emit canClipChanged();

--- a/src/effects/builtin/amplify/amplifyviewmodel.h
+++ b/src/effects/builtin/amplify/amplifyviewmodel.h
@@ -6,8 +6,6 @@
 #include "../common/abstracteffectmodel.h"
 #include "../common/params.h"
 
-#include "effects/effects_base/ieffectsprovider.h"
-
 namespace au::effects {
 class AmplifyEffect;
 class AmplifyViewModel : public AbstractEffectModel
@@ -36,8 +34,6 @@ class AmplifyViewModel : public AbstractEffectModel
     Q_PROPERTY(bool canClip READ canClip WRITE setCanClip NOTIFY canClipChanged FINAL)
 
     Q_PROPERTY(bool isApplyAllowed READ isApplyAllowed NOTIFY isApplyAllowedChanged FINAL)
-
-    muse::Inject<IEffectsProvider> effectsProvider;
 
 public:
     AmplifyViewModel() = default;
@@ -77,8 +73,6 @@ signals:
 
 private:
     void doReload() override;
-
-    AmplifyEffect* effect() const;
 
     void update();
 

--- a/src/effects/builtin/clickremoval/ClickRemovalView.qml
+++ b/src/effects/builtin/clickremoval/ClickRemovalView.qml
@@ -17,8 +17,6 @@ EffectBase {
 
     ClickRemovalViewModel {
         id: clickRemoval
-
-        instanceId: root.instanceId
     }
 
     Component.onCompleted: {

--- a/src/effects/builtin/clickremoval/clickremovalviewmodel.cpp
+++ b/src/effects/builtin/clickremoval/clickremovalviewmodel.cpp
@@ -8,16 +8,6 @@
 #include "global/translation.h"
 
 namespace au::effects {
-ClickRemovalEffect* ClickRemovalViewModel::effect() const
-{
-    const EffectId effectId = this->effectId();
-    if (effectId.isEmpty()) {
-        return nullptr;
-    }
-    Effect* const e = effectsProvider()->effect(effectId);
-    return dynamic_cast<ClickRemovalEffect*>(e);
-}
-
 QString ClickRemovalViewModel::effectTitle() const
 {
     return muse::qtrc("effects/clickremoval", "Click removal");
@@ -30,18 +20,15 @@ QString ClickRemovalViewModel::thresholdLabel() const
 
 int ClickRemovalViewModel::thresholdValue() const
 {
-    ClickRemovalEffect* const ce = effect();
-    return ce ? ce->mThresholdLevel : 0;
+    const auto& ce = effect<ClickRemovalEffect>();
+    return ce.mThresholdLevel;
 }
 
 void ClickRemovalViewModel::setThresholdValue(int newThresholdValue)
 {
-    ClickRemovalEffect* const ce = effect();
-    IF_ASSERT_FAILED(ce) {
-        return;
-    }
-    if (!muse::is_equal(ce->mThresholdLevel, newThresholdValue)) {
-        ce->mThresholdLevel = newThresholdValue;
+    auto& ce = effect<ClickRemovalEffect>();
+    if (!muse::is_equal(ce.mThresholdLevel, newThresholdValue)) {
+        ce.mThresholdLevel = newThresholdValue;
         emit thresholdValueChanged();
     }
 }
@@ -73,18 +60,15 @@ QString ClickRemovalViewModel::widthLabel() const
 
 int ClickRemovalViewModel::widthValue() const
 {
-    ClickRemovalEffect* const ce = effect();
-    return ce ? ce->mClickWidth : 0;
+    const auto& ce = effect<ClickRemovalEffect>();
+    return ce.mClickWidth;
 }
 
 void ClickRemovalViewModel::setWidthValue(int newWidthValue)
 {
-    ClickRemovalEffect* const ce = effect();
-    IF_ASSERT_FAILED(ce) {
-        return;
-    }
-    if (!muse::is_equal(ce->mClickWidth, newWidthValue)) {
-        ce->mClickWidth = newWidthValue;
+    auto& ce = effect<ClickRemovalEffect>();
+    if (!muse::is_equal(ce.mClickWidth, newWidthValue)) {
+        ce.mClickWidth = newWidthValue;
         emit widthValueChanged();
     }
 }

--- a/src/effects/builtin/clickremoval/clickremovalviewmodel.h
+++ b/src/effects/builtin/clickremoval/clickremovalviewmodel.h
@@ -5,8 +5,6 @@
 
 #include "../common/abstracteffectmodel.h"
 
-#include "effects/effects_base/ieffectsprovider.h"
-
 namespace au::effects {
 class ClickRemovalEffect;
 class ClickRemovalViewModel : public AbstractEffectModel
@@ -28,8 +26,6 @@ class ClickRemovalViewModel : public AbstractEffectModel
     Q_PROPERTY(int widthMax READ widthMax CONSTANT FINAL)
     Q_PROPERTY(int widthStep READ widthStep CONSTANT FINAL)
     Q_PROPERTY(int widthDecimals READ widthDecimals CONSTANT FINAL)
-
-    muse::Inject<IEffectsProvider> effectsProvider;
 
 public:
     ClickRemovalViewModel() = default;
@@ -58,7 +54,5 @@ signals:
 
 private:
     void doReload() override;
-
-    ClickRemovalEffect* effect() const;
 };
 }

--- a/src/effects/builtin/common/EffectBase.qml
+++ b/src/effects/builtin/common/EffectBase.qml
@@ -10,7 +10,6 @@ Rectangle {
 
     id: root
 
-    property var instanceId: null
     property var dialogView: null
 
     property AbstractEffectModel model: null

--- a/src/effects/builtin/common/generatoreffectmodel.cpp
+++ b/src/effects/builtin/common/generatoreffectmodel.cpp
@@ -12,11 +12,8 @@ using namespace au::effects;
 
 void GeneratorEffectModel::doReload()
 {
-    GeneratorEffect* const ge = generatorEffect();
-    IF_ASSERT_FAILED(ge) {
-        return;
-    }
-    ge->init(&mutSettings());
+    auto& ge = effect<GeneratorEffect>();
+    ge.init(&mutSettings());
     emit sampleRateChanged();
     emit tempoChanged();
     emit upperTimeSignatureChanged();
@@ -30,60 +27,38 @@ void GeneratorEffectModel::doReload()
 
 double GeneratorEffectModel::sampleRate() const
 {
-    const auto e = generatorEffect();
-    if (!e) {
-        return 1.0;
-    }
-    return e->sampleRate();
+    const auto& e = effect<GeneratorEffect>();
+    return e.sampleRate();
 }
 
 double GeneratorEffectModel::tempo() const
 {
-    const auto e = generatorEffect();
-    if (!e) {
-        return 120.0;
-    }
-    return e->tempo();
+    const auto& e = effect<GeneratorEffect>();
+    return e.tempo();
 }
 
 int GeneratorEffectModel::upperTimeSignature() const
 {
-    const auto e = generatorEffect();
-    if (!e) {
-        return 4;
-    }
-    return e->upperTimeSignature();
+    const auto& e = effect<GeneratorEffect>();
+    return e.upperTimeSignature();
 }
 
 int GeneratorEffectModel::lowerTimeSignature() const
 {
-    const auto e = generatorEffect();
-    if (!e) {
-        return 4;
-    }
-    return e->lowerTimeSignature();
+    const auto& e = effect<GeneratorEffect>();
+    return e.lowerTimeSignature();
 }
 
 double GeneratorEffectModel::duration() const
 {
-    const auto e = generatorEffect();
-    if (!e) {
-        return 0.0;
-    }
-    return e->duration();
+    const auto& e = effect<GeneratorEffect>();
+    return e.duration();
 }
 
 void GeneratorEffectModel::prop_setDuration(double newDuration)
 {
-    if (!m_inited) {
-        return;
-    }
-
-    auto e = generatorEffect();
-    IF_ASSERT_FAILED(e) {
-        return;
-    }
-    e->setDuration(newDuration);
+    auto& e = effect<GeneratorEffect>();
+    e.setDuration(newDuration);
     emit durationChanged();
 
     update();
@@ -91,24 +66,14 @@ void GeneratorEffectModel::prop_setDuration(double newDuration)
 
 QString GeneratorEffectModel::durationFormat() const
 {
-    const auto e = generatorEffect();
-    if (!e) {
-        return "";
-    }
-    return e->durationFormat();
+    const auto& e = effect<GeneratorEffect>();
+    return e.durationFormat();
 }
 
 void GeneratorEffectModel::prop_setDurationFormat(const QString& newDurationFormat)
 {
-    if (!m_inited) {
-        return;
-    }
-
-    auto e = generatorEffect();
-    IF_ASSERT_FAILED(e) {
-        return;
-    }
-    e->setDurationFormat(newDurationFormat);
+    auto& e = effect<GeneratorEffect>();
+    e.setDurationFormat(newDurationFormat);
     emit durationFormatChanged();
 
     update();
@@ -116,11 +81,8 @@ void GeneratorEffectModel::prop_setDurationFormat(const QString& newDurationForm
 
 bool GeneratorEffectModel::isApplyAllowed() const
 {
-    const auto e = generatorEffect();
-    if (!e) {
-        return false;
-    }
-    return e->isApplyAllowed();
+    const auto& e = effect<GeneratorEffect>();
+    return e.isApplyAllowed();
 }
 
 void GeneratorEffectModel::update()
@@ -130,11 +92,4 @@ void GeneratorEffectModel::update()
     if (m_isApplyAllowed != wasAllowed) {
         emit isApplyAllowedChanged();
     }
-}
-
-GeneratorEffect* GeneratorEffectModel::generatorEffect() const
-{
-    EffectId effectId = this->effectId();
-    Effect* e = effectsProvider()->effect(effectId);
-    return dynamic_cast<GeneratorEffect*>(e);
 }

--- a/src/effects/builtin/common/generatoreffectmodel.h
+++ b/src/effects/builtin/common/generatoreffectmodel.h
@@ -5,8 +5,6 @@
 
 #include "../common/abstracteffectmodel.h"
 
-#include "effects/effects_base/ieffectsprovider.h"
-
 namespace au::effects {
 class GeneratorEffect;
 class ToneEffect;
@@ -21,8 +19,6 @@ class GeneratorEffectModel : public AbstractEffectModel
     Q_PROPERTY(int upperTimeSignature READ upperTimeSignature NOTIFY upperTimeSignatureChanged FINAL)
     Q_PROPERTY(int lowerTimeSignature READ lowerTimeSignature NOTIFY lowerTimeSignatureChanged FINAL)
     Q_PROPERTY(bool isApplyAllowed READ isApplyAllowed NOTIFY isApplyAllowedChanged FINAL)
-
-    muse::Inject<IEffectsProvider> effectsProvider;
 
 public:
 
@@ -50,28 +46,20 @@ protected:
     T& mutSettings()
     {
         // Generators have singleton usage ; no risk of concurrency, settings may be returned without protection.
-        EffectSettings* s = const_cast<EffectSettings*>(this->settings());
-        assert(s);
-        if (!s) {
-            static T null;
-            return null;
-        }
-        T* st = s->cast<T>();
+        const T* st = settings().cast<T>();
         assert(st);
-        return *st;
+        return const_cast<T&>(*st);
     }
 
     EffectSettings& mutSettings()
     {
-        return *const_cast<EffectSettings*>(this->settings());
+        return const_cast<EffectSettings&>(settings());
     }
 
 private:
     void doReload() final override;
     virtual void doEmitSignals() = 0;
     void update();
-
-    GeneratorEffect* generatorEffect() const;
 
     bool m_isApplyAllowed = false;
 };

--- a/src/effects/builtin/dtmfgen/DtmfView.qml
+++ b/src/effects/builtin/dtmfgen/DtmfView.qml
@@ -13,6 +13,8 @@ import Preferences
 EffectBase {
     id: root
 
+    property alias instanceId: dtmf.instanceId
+
     property string title: qsTrc("effects/dtmf", "DTMF tones")
     property alias isApplyAllowed: dtmf.isApplyAllowed
 
@@ -29,8 +31,6 @@ EffectBase {
 
     DtmfViewModel {
         id: dtmf
-
-        instanceId: root.instanceId
     }
 
     Component.onCompleted: {

--- a/src/effects/builtin/dtmfgen/dtmfviewmodel.cpp
+++ b/src/effects/builtin/dtmfgen/dtmfviewmodel.cpp
@@ -37,10 +37,6 @@ QString DtmfViewModel::sequence() const
 
 void DtmfViewModel::prop_setSequence(const QString& newSequence)
 {
-    if (!m_inited) {
-        return;
-    }
-
     if (settings<DtmfSettings>().dtmfSequence == newSequence.toStdString()) {
         return;
     }
@@ -63,10 +59,6 @@ double DtmfViewModel::amplitude() const
 
 void DtmfViewModel::prop_setAmplitude(double newAmplitude)
 {
-    if (!m_inited) {
-        return;
-    }
-
     if (settings<DtmfSettings>().dtmfAmplitude == newAmplitude) {
         return;
     }
@@ -88,10 +80,6 @@ double DtmfViewModel::dutyCycle() const
 
 void DtmfViewModel::prop_setDutyCycle(double newDutyCycle)
 {
-    if (!m_inited) {
-        return;
-    }
-
     if (settings<DtmfSettings>().dtmfDutyCycle == newDutyCycle) {
         return;
     }

--- a/src/effects/builtin/graphiceq/GraphicEqView.qml
+++ b/src/effects/builtin/graphiceq/GraphicEqView.qml
@@ -19,8 +19,6 @@ EffectBase {
 
     GraphicEqViewModel {
         id: graphicEq
-
-        instanceId: root.instanceId
     }
 
     Rectangle {

--- a/src/effects/builtin/graphiceq/equalizationbandsliders.h
+++ b/src/effects/builtin/graphiceq/equalizationbandsliders.h
@@ -22,8 +22,6 @@
 #include "libraries/lib-builtin-effects/EqualizationCurvesList.h"
 #include "libraries/lib-builtin-effects/EqualizationFilter.h"
 
-#include <functional>
-
 struct EqualizationBandSliders
 {
 public:
@@ -36,7 +34,7 @@ public:
         2500., 3150., 4000., 5000., 6300., 8000., 10000., 12500., 16000., 20000.,
     };
 
-    EqualizationBandSliders(std::function<EqualizationCurvesList* ()> getCurvesList);
+    EqualizationBandSliders(EqualizationCurvesList&);
     void Init();
     void Flatten();
     void GraphicEQ(Envelope& env);
@@ -49,7 +47,7 @@ public:
     void SetSliderValue(int index, double db);
 
 private:
-    const std::function<EqualizationCurvesList* ()> m_getCurvesList;
+    EqualizationCurvesList& m_curvesList;
 
     double mWhens[NUM_PTS]{};
     double mWhenSliders[NUMBER_OF_BANDS + 1]{};

--- a/src/effects/builtin/graphiceq/graphiceqbandsmodel.cpp
+++ b/src/effects/builtin/graphiceq/graphiceqbandsmodel.cpp
@@ -20,11 +20,8 @@ QString centerFrequencyToString(double frequency)
 }
 }
 
-GraphicEqBandsModel::GraphicEqBandsModel(QObject* parent, std::function<GraphicEq* ()> eqGetter)
-    : QAbstractListModel(parent),  m_getEq(std::move(eqGetter)), mSliders([this]() -> EqualizationCurvesList* {
-    GraphicEq* const eq = m_getEq();
-    return eq ? &eq->mCurvesList : nullptr;
-})
+GraphicEqBandsModel::GraphicEqBandsModel(QObject* parent, GraphicEq& eq)
+    : QAbstractListModel(parent),  m_eq(eq), mSliders(eq.mCurvesList)
 {
 }
 
@@ -42,17 +39,12 @@ void GraphicEqBandsModel::doReload()
 {
     // Adapted from EqualizationUI::TransferDataToWindow
 
-    GraphicEq* const eq = m_getEq();
-    IF_ASSERT_FAILED(eq) {
-        return;
-    }
-
-    auto& drawMode = eq->mCurvesList.mParameters.mDrawMode;
+    auto& drawMode = m_eq.mCurvesList.mParameters.mDrawMode;
 
     // Override draw mode, if we're not displaying the radio buttons.
-    if (eq->GetOptions() == kEqOptionCurve) {
+    if (m_eq.GetOptions() == kEqOptionCurve) {
         drawMode = true;
-    } else if (eq->GetOptions() == kEqOptionGraphic) {
+    } else if (m_eq.GetOptions() == kEqOptionGraphic) {
         drawMode = false;
     }
 
@@ -66,11 +58,7 @@ void GraphicEqBandsModel::doReload()
 
 void GraphicEqBandsModel::updateGraphic()
 {
-    GraphicEq* const eq = m_getEq();
-    IF_ASSERT_FAILED(eq) {
-        return;
-    }
-    auto& parameters = eq->mCurvesList.mParameters;
+    auto& parameters = m_eq.mCurvesList.mParameters;
     const auto& lin = parameters.mLin;
     auto& linEnvelope = parameters.mLinEnvelope;
     auto& logEnvelope = parameters.mLogEnvelope;

--- a/src/effects/builtin/graphiceq/graphiceqbandsmodel.h
+++ b/src/effects/builtin/graphiceq/graphiceqbandsmodel.h
@@ -7,8 +7,6 @@
 
 #include <QAbstractListModel>
 
-#include <functional>
-
 namespace au::effects {
 class GraphicEq;
 
@@ -17,7 +15,7 @@ class GraphicEqBandsModel : public QAbstractListModel
     Q_OBJECT
 
 public:
-    GraphicEqBandsModel(QObject* parent, std::function<GraphicEq* ()> eqGetter);
+    GraphicEqBandsModel(QObject* parent, GraphicEq& eq);
 
     static constexpr auto NUM_BANDS = 31;
     void reload();
@@ -40,7 +38,7 @@ private:
     void doReload();
     void updateGraphic();
 
-    const std::function<GraphicEq* ()> m_getEq;
+    GraphicEq& m_eq;
     EqualizationBandSliders mSliders;
     bool m_inited = false;
 };

--- a/src/effects/builtin/graphiceq/graphiceqviewmodel.cpp
+++ b/src/effects/builtin/graphiceq/graphiceqviewmodel.cpp
@@ -10,18 +10,8 @@
 
 namespace au::effects {
 GraphicEqViewModel::GraphicEqViewModel()
-    : mBandsModel(new GraphicEqBandsModel(this, [this] { return effect(); }))
+    : mBandsModel(new GraphicEqBandsModel(this, effect<GraphicEq>()))
 {
-}
-
-GraphicEq* GraphicEqViewModel::effect() const
-{
-    const EffectId effectId = this->effectId();
-    if (effectId.isEmpty()) {
-        return nullptr;
-    }
-    Effect* const e = effectsProvider()->effect(effectId);
-    return dynamic_cast<GraphicEq*>(e);
 }
 
 void GraphicEqViewModel::doReload()

--- a/src/effects/builtin/graphiceq/graphiceqviewmodel.h
+++ b/src/effects/builtin/graphiceq/graphiceqviewmodel.h
@@ -6,8 +6,6 @@
 #include "../common/abstracteffectmodel.h"
 #include "../common/params.h"
 
-#include "effects/effects_base/ieffectsprovider.h"
-
 namespace au::effects {
 class GraphicEq;
 class GraphicEqBandsModel;
@@ -17,8 +15,6 @@ class GraphicEqViewModel : public AbstractEffectModel
     Q_PROPERTY(GraphicEqBandsModel * bandsModel READ bandsModel NOTIFY bandsModelChanged FINAL)
     Q_PROPERTY(double minDbGain READ minDbGain CONSTANT FINAL)
     Q_PROPERTY(double maxDbGain READ maxDbGain CONSTANT FINAL)
-
-    muse::Inject<IEffectsProvider> effectsProvider;
 
 public:
     GraphicEqViewModel();
@@ -31,7 +27,6 @@ signals:
     void bandsModelChanged();
 
 private:
-    GraphicEq* effect() const;
     void doReload() override;
 
     GraphicEqBandsModel* const mBandsModel;

--- a/src/effects/builtin/loudness/NormalizeLoudnessView.qml
+++ b/src/effects/builtin/loudness/NormalizeLoudnessView.qml
@@ -17,8 +17,6 @@ EffectBase {
 
     NormalizeLoudnessViewModel {
         id: normalizeLoudness
-
-        instanceId: root.instanceId
     }
 
     Column {

--- a/src/effects/builtin/loudness/normalizeloudnessviewmodel.cpp
+++ b/src/effects/builtin/loudness/normalizeloudnessviewmodel.cpp
@@ -8,16 +8,6 @@
 #include "global/translation.h"
 
 namespace au::effects {
-NormalizeLoudnessEffect* NormalizeLoudnessViewModel::effect() const
-{
-    const EffectId effectId = this->effectId();
-    if (effectId.isEmpty()) {
-        return nullptr;
-    }
-    Effect* const e = effectsProvider()->effect(effectId);
-    return dynamic_cast<NormalizeLoudnessEffect*>(e);
-}
-
 void NormalizeLoudnessViewModel::doReload()
 {
     emit useRmsAlgorithmChanged();
@@ -42,21 +32,15 @@ QStringList NormalizeLoudnessViewModel::algorithmOptions() const
 
 bool NormalizeLoudnessViewModel::useRmsAlgorithm() const
 {
-    const NormalizeLoudnessEffect* e = effect();
-    if (!e) {
-        return false;
-    }
-    return e->mNormalizeTo == NormalizeLoudnessEffect::kRMS;
+    const auto& e = effect<NormalizeLoudnessEffect>();
+    return e.mNormalizeTo == NormalizeLoudnessEffect::kRMS;
 }
 
 void NormalizeLoudnessViewModel::setUseRmsAlgorithm(bool useRmsAlgorithm)
 {
-    NormalizeLoudnessEffect* const e = effect();
-    if (!e) {
-        return;
-    }
-    modifySettings([e, useRmsAlgorithm](EffectSettings&) {
-        e->mNormalizeTo = useRmsAlgorithm ? NormalizeLoudnessEffect::kRMS : NormalizeLoudnessEffect::kLoudness;
+    auto& e = effect<NormalizeLoudnessEffect>();
+    modifySettings([&e, useRmsAlgorithm](EffectSettings&) {
+        e.mNormalizeTo = useRmsAlgorithm ? NormalizeLoudnessEffect::kRMS : NormalizeLoudnessEffect::kLoudness;
     });
     emit useRmsAlgorithmChanged();
 }
@@ -73,42 +57,30 @@ QString NormalizeLoudnessViewModel::currentMeasureUnitsSymbol() const
 
 double NormalizeLoudnessViewModel::perceivedLoudnessTarget() const
 {
-    const NormalizeLoudnessEffect* e = effect();
-    if (!e) {
-        return 0.0;
-    }
-    return e->mLUFSLevel;
+    const auto& e = effect<NormalizeLoudnessEffect>();
+    return e.mLUFSLevel;
 }
 
 void NormalizeLoudnessViewModel::setPerceivedLoudnessTarget(double perceivedLoudnessTarget)
 {
-    NormalizeLoudnessEffect* const e = effect();
-    if (!e) {
-        return;
-    }
-    modifySettings([e, perceivedLoudnessTarget](EffectSettings&) {
-        e->mLUFSLevel = perceivedLoudnessTarget;
+    auto& e = effect<NormalizeLoudnessEffect>();
+    modifySettings([&e, perceivedLoudnessTarget](EffectSettings&) {
+        e.mLUFSLevel = perceivedLoudnessTarget;
     });
     emit perceivedLoudnessTargetChanged();
 }
 
 double NormalizeLoudnessViewModel::rmsTarget() const
 {
-    const NormalizeLoudnessEffect* e = effect();
-    if (!e) {
-        return 0.0;
-    }
-    return e->mRMSLevel;
+    const auto& e = effect<NormalizeLoudnessEffect>();
+    return e.mRMSLevel;
 }
 
 void NormalizeLoudnessViewModel::setRmsTarget(double rmsTarget)
 {
-    NormalizeLoudnessEffect* const e = effect();
-    if (!e) {
-        return;
-    }
-    modifySettings([e, rmsTarget](EffectSettings&) {
-        e->mRMSLevel = rmsTarget;
+    auto& e = effect<NormalizeLoudnessEffect>();
+    modifySettings([&e, rmsTarget](EffectSettings&) {
+        e.mRMSLevel = rmsTarget;
     });
     emit rmsTargetChanged();
 }
@@ -144,21 +116,15 @@ QString NormalizeLoudnessViewModel::normalizeLabel() const
 
 bool NormalizeLoudnessViewModel::normalizeStereoChannelsIndependently() const
 {
-    const NormalizeLoudnessEffect* e = effect();
-    if (!e) {
-        return false;
-    }
-    return e->mStereoInd;
+    const auto& e = effect<NormalizeLoudnessEffect>();
+    return e.mStereoInd;
 }
 
 void NormalizeLoudnessViewModel::setNormalizeStereoChannelsIndependently(bool normalizeStereoChannelsIndependently)
 {
-    NormalizeLoudnessEffect* const e = effect();
-    if (!e) {
-        return;
-    }
-    modifySettings([e, normalizeStereoChannelsIndependently](EffectSettings&) {
-        e->mStereoInd = normalizeStereoChannelsIndependently;
+    auto& e = effect<NormalizeLoudnessEffect>();
+    modifySettings([&e, normalizeStereoChannelsIndependently](EffectSettings&) {
+        e.mStereoInd = normalizeStereoChannelsIndependently;
     });
     emit normalizeStereoChannelsIndependentlyChanged();
 }
@@ -175,21 +141,15 @@ QString NormalizeLoudnessViewModel::useDualMonoLabel() const
 
 bool NormalizeLoudnessViewModel::useDualMono() const
 {
-    const NormalizeLoudnessEffect* e = effect();
-    if (!e) {
-        return false;
-    }
-    return e->mDualMono;
+    const auto& e = effect<NormalizeLoudnessEffect>();
+    return e.mDualMono;
 }
 
 void NormalizeLoudnessViewModel::setUseDualMono(bool newUseDualMono)
 {
-    NormalizeLoudnessEffect* const e = effect();
-    if (!e) {
-        return;
-    }
-    modifySettings([e, newUseDualMono](EffectSettings&) {
-        e->mDualMono = newUseDualMono;
+    auto& e = effect<NormalizeLoudnessEffect>();
+    modifySettings([&e, newUseDualMono](EffectSettings&) {
+        e.mDualMono = newUseDualMono;
     });
     emit useDualMonoChanged();
 }

--- a/src/effects/builtin/loudness/normalizeloudnessviewmodel.h
+++ b/src/effects/builtin/loudness/normalizeloudnessviewmodel.h
@@ -5,15 +5,11 @@
 
 #include "../common/abstracteffectmodel.h"
 
-#include "effects/effects_base/ieffectsprovider.h"
-
 namespace au::effects {
 class NormalizeLoudnessEffect;
 class NormalizeLoudnessViewModel : public AbstractEffectModel
 {
     Q_OBJECT
-
-    muse::Inject<IEffectsProvider> effectsProvider;
 
     Q_PROPERTY(QString effectTitle READ effectTitle CONSTANT FINAL)
     Q_PROPERTY(QStringList algorithmOptions READ algorithmOptions CONSTANT FINAL)
@@ -75,7 +71,5 @@ signals:
 
 private:
     void doReload() override;
-
-    NormalizeLoudnessEffect* effect() const;
 };
 }

--- a/src/effects/builtin/noisegen/NoiseView.qml
+++ b/src/effects/builtin/noisegen/NoiseView.qml
@@ -22,8 +22,6 @@ EffectBase {
 
     NoiseViewModel {
         id: noise
-
-        instanceId: root.instanceId
     }
 
     Component.onCompleted: {

--- a/src/effects/builtin/noisegen/noiseviewmodel.cpp
+++ b/src/effects/builtin/noisegen/noiseviewmodel.cpp
@@ -48,10 +48,6 @@ double NoiseViewModel::amplitude() const
 
 void NoiseViewModel::prop_setAmplitude(double newAmplitude)
 {
-    if (!m_inited) {
-        return;
-    }
-
     bool wasAllowed = isApplyAllowed();
 
     if (settings<NoiseSettings>().amplitude == newAmplitude) {
@@ -73,10 +69,6 @@ int NoiseViewModel::type() const
 
 void NoiseViewModel::prop_setType(int type)
 {
-    if (!m_inited) {
-        return;
-    }
-
     bool wasAllowed = isApplyAllowed();
 
     NoiseSettings::Type noiseType = static_cast<NoiseSettings::Type>(type);

--- a/src/effects/builtin/noisereduction/NoiseReductionView.qml
+++ b/src/effects/builtin/noisereduction/NoiseReductionView.qml
@@ -18,8 +18,6 @@ EffectBase {
 
     NoiseReductionViewModel {
         id: noiseReduction
-
-        instanceId: root.instanceId
     }
 
     Component.onCompleted: {

--- a/src/effects/builtin/noisereduction/noisereductionviewmodel.h
+++ b/src/effects/builtin/noisereduction/noisereductionviewmodel.h
@@ -6,9 +6,6 @@
 #include "../common/abstracteffectmodel.h"
 #include "../common/params.h"
 
-#include "effects/effects_base/ieffectsprovider.h"
-#include "effects/effects_base/ieffectinstancesregister.h"
-
 #include "global/iinteractive.h"
 
 namespace au::effects {
@@ -34,8 +31,6 @@ class NoiseReductionViewModel : public AbstractEffectModel
 
     Q_PROPERTY(int reductionMode READ reductionMode WRITE setReductionMode NOTIFY reductionModeChanged FINAL)
 
-    muse::Inject<IEffectsProvider> effectsProvider;
-    muse::Inject<IEffectInstancesRegister> instancesRegister;
     muse::Inject<muse::IInteractive> interactive;
 
 public:
@@ -74,7 +69,5 @@ signals:
 private:
     void doReload() override;
     bool usesPresets() const override { return false; }
-
-    NoiseReductionEffect* effect() const;
 };
 }

--- a/src/effects/builtin/normalize/NormalizeView.qml
+++ b/src/effects/builtin/normalize/NormalizeView.qml
@@ -18,8 +18,6 @@ EffectBase {
 
     NormalizeViewModel {
         id: normalize
-
-        instanceId: root.instanceId
     }
 
     Component.onCompleted: {

--- a/src/effects/builtin/normalize/normalizeviewmodel.cpp
+++ b/src/effects/builtin/normalize/normalizeviewmodel.cpp
@@ -8,110 +8,76 @@
 #include "log.h"
 
 namespace au::effects {
-NormalizeEffect* NormalizeViewModel::effect() const
-{
-    const EffectId effectId = this->effectId();
-    if (effectId.isEmpty()) {
-        return nullptr;
-    }
-    Effect* const e = effectsProvider()->effect(effectId);
-    return dynamic_cast<NormalizeEffect*>(e);
-}
-
 bool NormalizeViewModel::removeDC() const
 {
-    const NormalizeEffect* const fx = effect();
-    if (!fx) {
-        return false;
-    }
-    return fx->mDC;
+    const auto& fx = effect<NormalizeEffect>();
+    return fx.mDC;
 }
 
 void NormalizeViewModel::setRemoveDC(bool removeDC)
 {
-    NormalizeEffect* const fx = effect();
-    IF_ASSERT_FAILED(fx) {
+    auto& fx = effect<NormalizeEffect>();
+
+    if (fx.mDC == removeDC) {
         return;
     }
 
-    if (fx->mDC == removeDC) {
-        return;
-    }
-
-    fx->mDC = removeDC;
+    fx.mDC = removeDC;
     emit removeDCChanged();
 }
 
 bool NormalizeViewModel::normalizePeakAmplitude() const
 {
-    const NormalizeEffect* const fx = effect();
-    if (!fx) {
-        return false;
-    }
-    return fx->mGain;
+    const auto& fx = effect<NormalizeEffect>();
+    return fx.mGain;
 }
 
 void NormalizeViewModel::setNormalizePeakAmplitude(bool normalizePeakAmplitude)
 {
-    NormalizeEffect* const fx = effect();
-    IF_ASSERT_FAILED(fx) {
+    auto& fx = effect<NormalizeEffect>();
+
+    if (fx.mGain == normalizePeakAmplitude) {
         return;
     }
 
-    if (fx->mGain == normalizePeakAmplitude) {
-        return;
-    }
-
-    fx->mGain = normalizePeakAmplitude;
+    fx.mGain = normalizePeakAmplitude;
     emit normalizePeakAmplitudeChanged();
 }
 
 double NormalizeViewModel::peakAmplitudeTarget() const
 {
-    const NormalizeEffect* const fx = effect();
-    if (!fx) {
-        return 0.0f;
-    }
-    return fx->mPeakLevel;
+    const auto& fx = effect<NormalizeEffect>();
+    return fx.mPeakLevel;
 }
 
 void NormalizeViewModel::setPeakAmplitudeTarget(double peakAmplitudeTarget)
 {
-    NormalizeEffect* const fx = effect();
-    IF_ASSERT_FAILED(fx) {
-        return;
-    }
+    auto& fx = effect<NormalizeEffect>();
 
     const double newLevel = muse::check_valid(peakAmplitudeTarget);
-    if (muse::is_equal(fx->mPeakLevel, newLevel)) {
+    if (muse::is_equal(fx.mPeakLevel, newLevel)) {
         return;
     }
 
-    fx->mPeakLevel = newLevel;
+    fx.mPeakLevel = newLevel;
     emit peakAmplitudeTargetChanged();
 }
 
 bool NormalizeViewModel::normalizeStereoChannelsIndependently() const
 {
-    const NormalizeEffect* const fx = this->effect();
-    if (!fx) {
-        return false;
-    }
-    return fx->mStereoInd;
+    const auto& fx = effect<NormalizeEffect>();
+    return fx.mStereoInd;
 }
 
 void NormalizeViewModel::setNormalizeStereoChannelsIndependently(bool normalizeStereoChannelsIndependently)
 {
-    NormalizeEffect* const fx = effect();
-    IF_ASSERT_FAILED(fx) {
+    auto& fx = effect<NormalizeEffect>();
+
+    if (fx.mStereoInd == normalizeStereoChannelsIndependently) {
         return;
     }
 
-    if (fx->mStereoInd == normalizeStereoChannelsIndependently) {
-        return;
-    }
-
-    fx->mStereoInd = normalizeStereoChannelsIndependently;
+    fx.mStereoInd = normalizeStereoChannelsIndependently;
     emit normalizeStereoChannelsIndependentlyChanged();
 }
 

--- a/src/effects/builtin/normalize/normalizeviewmodel.h
+++ b/src/effects/builtin/normalize/normalizeviewmodel.h
@@ -6,8 +6,6 @@
 #include "../common/abstracteffectmodel.h"
 #include "../common/params.h"
 
-#include "effects/effects_base/ieffectsprovider.h"
-
 namespace au::effects {
 class NormalizeEffect;
 class NormalizeViewModel : public AbstractEffectModel
@@ -19,8 +17,6 @@ class NormalizeViewModel : public AbstractEffectModel
     Q_PROPERTY(
         bool normalizeStereoChannelsIndependently READ normalizeStereoChannelsIndependently WRITE setNormalizeStereoChannelsIndependently NOTIFY normalizeStereoChannelsIndependentlyChanged FINAL)
     Q_PROPERTY(double peakAmplitudeTarget READ peakAmplitudeTarget WRITE setPeakAmplitudeTarget NOTIFY peakAmplitudeTargetChanged FINAL)
-
-    muse::Inject<IEffectsProvider> effectsProvider;
 
 public:
     NormalizeViewModel() = default;
@@ -45,7 +41,5 @@ signals:
 
 private:
     void doReload() override;
-
-    NormalizeEffect* effect() const;
 };
 }

--- a/src/effects/builtin/reverb/ReverbView.qml
+++ b/src/effects/builtin/reverb/ReverbView.qml
@@ -28,8 +28,6 @@ EffectBase {
 
     ReverbViewModel {
         id: reverb
-
-        instanceId: root.instanceId
     }
 
     Component.onCompleted: {

--- a/src/effects/builtin/silencegen/SilenceView.qml
+++ b/src/effects/builtin/silencegen/SilenceView.qml
@@ -17,8 +17,6 @@ EffectBase {
 
     SilenceViewModel {
         id: silence
-
-        instanceId: root.instanceId
     }
 
     Component.onCompleted: {

--- a/src/effects/builtin/tonegen/ChirpView.qml
+++ b/src/effects/builtin/tonegen/ChirpView.qml
@@ -32,8 +32,6 @@ EffectBase {
 
     ToneViewModel {
         id: chirp
-
-        instanceId: root.instanceId
     }
 
     Component.onCompleted: {

--- a/src/effects/builtin/tonegen/ToneView.qml
+++ b/src/effects/builtin/tonegen/ToneView.qml
@@ -31,8 +31,6 @@ EffectBase {
 
     ToneViewModel {
         id: tone
-
-        instanceId: root.instanceId
     }
 
     Component.onCompleted: {

--- a/src/effects/builtin/tonegen/toneviewmodel.cpp
+++ b/src/effects/builtin/tonegen/toneviewmodel.cpp
@@ -62,10 +62,6 @@ double ToneViewModel::amplitudeStart() const
 
 void ToneViewModel::prop_setAmplitudeStart(double newAmplitude)
 {
-    if (!m_inited) {
-        return;
-    }
-
     const auto wasAllowed = isApplyAllowed();
 
     ToneEffect* const te = effect();
@@ -99,10 +95,6 @@ double ToneViewModel::amplitudeEnd() const
 
 void ToneViewModel::prop_setAmplitudeEnd(double newAmplitude)
 {
-    if (!m_inited) {
-        return;
-    }
-
     const auto wasAllowed = isApplyAllowed();
 
     ToneEffect* const te = effect();
@@ -136,10 +128,6 @@ double ToneViewModel::frequencyStart() const
 
 void ToneViewModel::prop_setFrequencyStart(double newFrequency)
 {
-    if (!m_inited) {
-        return;
-    }
-
     const auto wasAllowed = isApplyAllowed();
 
     ToneEffect* const te = effect();
@@ -173,10 +161,6 @@ double ToneViewModel::frequencyEnd() const
 
 void ToneViewModel::prop_setFrequencyEnd(double newFrequency)
 {
-    if (!m_inited) {
-        return;
-    }
-
     const auto wasAllowed = isApplyAllowed();
 
     ToneEffect* const te = effect();
@@ -210,10 +194,6 @@ int ToneViewModel::waveform() const
 
 void ToneViewModel::prop_setWaveform(int newWaveform)
 {
-    if (!m_inited) {
-        return;
-    }
-
     ToneEffect* const te = effect();
 
     IF_ASSERT_FAILED(te) {
@@ -241,10 +221,6 @@ int ToneViewModel::interpolation() const
 
 void ToneViewModel::prop_setInterpolation(int newInterpolation)
 {
-    if (!m_inited) {
-        return;
-    }
-
     ToneEffect* const te = effect();
 
     IF_ASSERT_FAILED(te) {

--- a/src/effects/builtin/view/builtineffectviewloader.cpp
+++ b/src/effects/builtin/view/builtineffectviewloader.cpp
@@ -33,6 +33,10 @@
 
 using namespace au::effects;
 
+namespace {
+static int gInitializationInstanceId = -1;
+}
+
 BuiltinEffectViewLoader::BuiltinEffectViewLoader(QObject* parent)
     : QObject(parent)
 {}
@@ -78,12 +82,14 @@ void BuiltinEffectViewLoader::load(const QString& instanceId, QObject* itemParen
         return;
     }
 
+    gInitializationInstanceId = instanceId.toInt();
     QObject* obj = component.createWithInitialProperties(
     {
         { "parent", QVariant::fromValue(itemParent) },
         { "instanceId", QVariant::fromValue(instanceId) },
         { "dialogView", QVariant::fromValue(dialogView) }
     });
+    gInitializationInstanceId = -1;
 
     m_contentItem = qobject_cast<QQuickItem*>(obj);
     if (!m_contentItem) {
@@ -107,6 +113,11 @@ void BuiltinEffectViewLoader::load(const QString& instanceId, QObject* itemParen
     }
 
     emit contentItemChanged();
+}
+
+int BuiltinEffectViewLoader::initializationInstanceId()
+{
+    return gInitializationInstanceId;
 }
 
 QQuickItem* BuiltinEffectViewLoader::contentItem() const

--- a/src/effects/builtin/view/builtineffectviewloader.h
+++ b/src/effects/builtin/view/builtineffectviewloader.h
@@ -35,6 +35,8 @@ public:
 
     Q_INVOKABLE void load(const QString& instanceId, QObject* itemParent, QObject* dialogView);
 
+    static int initializationInstanceId();
+
 signals:
     void titleChanged();
     void contentItemChanged();


### PR DESCRIPTION
As it stands on master, `instanceId` is a property of `EffectBase.qml` that defaults to `null`.

Since in QML, child elements are instantiated first, the effect model was instantiated with `null` as instance ID, and then `EffectBase.instanceId` is initialized to a proper value. In other words, there is no guarantee in the models that instance ID isn't null, which requires sanity checks and less optimized code.

We know for a fact, though, that the instance ID exists before built-in effect models are created. (By the way, `BuiltinEffectModel` is probably a better name.) This PR proposes a way setting m_instanceId at construction time, making it const and guaranteeing availability of effect instances and settings the entire lifetime of the model and its many derived classes ...

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:
This is a pure refactoring PR and no behavioral change is expected.
The base class of built-in effects and generators was modified, and the specific effects and generators were accordingly adapted. This is meant for the better, but a mistake in the process cannot be excluded.

Please smoke-test (see below) all built-in effects and generators, also in realtime mode for those which support it, on at least one platform (preferably MacOS or Linux, as I already have done my own testing on Windows). On the other platforms, smoke-testing one generator and one effect is then probably sufficient.
The smoke test should include
* opening the UI
* changing at least one setting
* applying
* re-opening the UI and making sure the settings were remembered
* changing the presets