### PR TITLE
audacity-8863 Properly recover unsaved projects

### DIFF
--- a/au3/libraries/lib-project-file-io/DBConnection.cpp
+++ b/au3/libraries/lib-project-file-io/DBConnection.cpp
@@ -176,6 +176,7 @@ int DBConnection::OpenStepByStep(const FilePath fileName)
                      sqlite3_errstr(rc));
         return rc;
     }
+    wxLogDebug("Opened primary connection to %s\n", fileName.ToStdString());
 
     rc = SetPageSize();
 

--- a/src/appshell/internal/startupscenario.cpp
+++ b/src/appshell/internal/startupscenario.cpp
@@ -22,9 +22,9 @@
 
 #include "startupscenario.h"
 
-#include "async/async.h"
-#include "translation.h"
-#include "log.h"
+#include "global/async/async.h"
+#include "global/translation.h"
+#include "global/log.h"
 
 using namespace au::appshell;
 using namespace muse::actions;

--- a/src/appshell/internal/startupscenario.h
+++ b/src/appshell/internal/startupscenario.h
@@ -32,10 +32,10 @@
 #include "iappshellconfiguration.h"
 #include "isessionsmanager.h"
 #include "audioplugins/iregisteraudiopluginsscenario.h"
+#include "project/iprojectautosaver.h"
 
 //! TODO AU4
 // #include "multiinstances/imultiinstancesprovider.h"
-// #include "project/iprojectautosaver.h"
 
 namespace au::appshell {
 class StartupScenario : public au::appshell::IStartupScenario, public muse::async::Asyncable
@@ -45,10 +45,10 @@ class StartupScenario : public au::appshell::IStartupScenario, public muse::asyn
     muse::Inject<IAppShellConfiguration> configuration;
     muse::Inject<ISessionsManager> sessionsManager;
     muse::Inject<muse::audioplugins::IRegisterAudioPluginsScenario> registerAudioPluginsScenario;
+    muse::Inject<au::project::IProjectAutoSaver> projectAutoSaver;
 
 //! TODO AU4
     // INJECT(mi::IMultiInstancesProvider, multiInstancesProvider)
-    // INJECT(project::IProjectAutoSaver, projectAutoSaver)
 public:
 
     void setStartupType(const std::optional<std::string>& type) override;

--- a/src/au3wrap/iau3project.h
+++ b/src/au3wrap/iau3project.h
@@ -8,6 +8,7 @@
 
 #include "global/io/path.h"
 #include "global/types/ret.h"
+#include "global/async/notification.h"
 #include "modularity/imoduleinterface.h"
 
 namespace au::au3 {
@@ -24,6 +25,13 @@ public:
     virtual void close() = 0;
 
     virtual std::string title() const = 0;
+
+    // Save status management
+    [[nodiscard]] virtual bool hasUnsavedChanges() const = 0;
+    virtual void markAsSaved() = 0;
+    [[nodiscard]] virtual bool isRecovered() const = 0;
+
+    virtual muse::async::Notification projectChanged() const = 0;
 
     // internal
     virtual uintptr_t au3ProjectPtr() const = 0;

--- a/src/au3wrap/internal/au3project.h
+++ b/src/au3wrap/internal/au3project.h
@@ -6,6 +6,7 @@
 #include <memory>
 
 #include "global/types/ret.h"
+#include "global/async/notification.h"
 #include "au3wrap/iau3project.h"
 #include "libraries/lib-track/Track.h"
 #include "libraries/lib-utility/Observer.h"
@@ -28,6 +29,13 @@ public:
 
     std::string title() const override;
 
+    // Save status management
+    [[nodiscard]] bool hasUnsavedChanges() const override;
+    void markAsSaved() override;
+    [[nodiscard]] bool isRecovered() const override;
+
+    muse::async::Notification projectChanged() const override;
+
     // internal
     uintptr_t au3ProjectPtr() const override;
 
@@ -37,7 +45,9 @@ private:
 
     const std::shared_ptr<Au3ProjectData> m_data;
     Observer::Subscription mTrackListSubstription;
+    Observer::Subscription mUndoSubscription;
     std::shared_ptr<TrackList> m_lastSavedTracks;
+    muse::async::Notification m_projectChanged;
 };
 
 class Au3ProjectCreator : public IAu3ProjectCreator

--- a/src/project/internal/audacityproject.h
+++ b/src/project/internal/audacityproject.h
@@ -13,6 +13,8 @@
 #include "trackedit/itrackeditproject.h"
 #include "importexport/import/iimporter.h"
 
+#include "libraries/lib-utility/Observer.h"
+
 namespace au::au3 {
 class Au3ProjectAccessor;
 }
@@ -109,6 +111,7 @@ private:
     muse::io::path_t m_path;
     muse::async::Notification m_pathChanged;
     muse::async::Notification m_displayNameChanged;
+    muse::async::Notification m_needSaveNotification;
 
     bool m_isNewlyCreated = false; /// true if the file has never been saved yet
     bool m_isImported = false;
@@ -119,6 +122,8 @@ private:
     trackedit::ITrackeditProjectPtr m_trackeditProject;
 
     projectscene::IProjectViewStatePtr m_viewState;
+
+    Observer::Subscription m_undoSubscription;
 };
 }
 

--- a/src/project/internal/audacityproject.h
+++ b/src/project/internal/audacityproject.h
@@ -13,8 +13,6 @@
 #include "trackedit/itrackeditproject.h"
 #include "importexport/import/iimporter.h"
 
-#include "libraries/lib-utility/Observer.h"
-
 namespace au::au3 {
 class Au3ProjectAccessor;
 }
@@ -122,8 +120,6 @@ private:
     trackedit::ITrackeditProjectPtr m_trackeditProject;
 
     projectscene::IProjectViewStatePtr m_viewState;
-
-    Observer::Subscription m_undoSubscription;
 };
 }
 

--- a/src/project/internal/projectactionscontroller.cpp
+++ b/src/project/internal/projectactionscontroller.cpp
@@ -514,9 +514,8 @@ Ret ProjectActionsController::doOpenProject(const io::path_t& filePath)
 
     IAudacityProjectPtr project = rv.val;
 
-    //! TODO AU4
-    // bool isNewlyCreated = projectAutoSaver()->isAutosaveOfNewlyCreatedProject(filePath);
-    bool isNewlyCreated = false;
+    // Check if this is an autosave of a newly created project
+    bool isNewlyCreated = projectAutoSaver()->isAutosaveOfNewlyCreatedProject(filePath);
     if (!isNewlyCreated) {
         recentFilesController()->prependRecentFile(makeRecentFile(project));
     }
@@ -569,11 +568,12 @@ RetVal<IAudacityProjectPtr> ProjectActionsController::loadProject(const io::path
     //     project->markAsUnsaved();
     // }
 
-    //! TODO AU4
-    // bool isNewlyCreated = projectAutoSaver()->isAutosaveOfNewlyCreatedProject(filePath);
-    // if (isNewlyCreated) {
-    //     project->markAsNewlyCreated();
-    // }
+    // Mark project as newly created if it's an autosave of a new project
+    bool isNewlyCreated = projectAutoSaver()->isAutosaveOfNewlyCreatedProject(filePath);
+    if (isNewlyCreated) {
+        // Mark as newly created (this will be implemented if needed)
+        // project->markAsNewlyCreated();
+    }
 
     return RetVal<IAudacityProjectPtr>::make_ok(project);
 }

--- a/src/project/internal/projectactionscontroller.cpp
+++ b/src/project/internal/projectactionscontroller.cpp
@@ -7,8 +7,6 @@
 #include "audacityproject.h"
 #include "projecterrors.h"
 
-#include "UndoManager.h"
-
 #include "au3wrap/au3types.h"
 
 #include "log.h"
@@ -208,9 +206,7 @@ bool ProjectActionsController::closeOpenedProject(bool quitApp)
 
     bool result = true;
 
-    au3::Au3Project* internalAu3Project = reinterpret_cast<au3::Au3Project*>(globalContext()->currentProject()->au3ProjectPtr());
-
-    if (UndoManager::Get(*internalAu3Project).UnsavedChanges()) {
+    if (project->needSave().val) {
         IInteractive::Button btn = askAboutSavingProject(project);
 
         if (btn == IInteractive::Button::Cancel) {

--- a/src/project/projectmodule.cpp
+++ b/src/project/projectmodule.cpp
@@ -26,6 +26,7 @@
 #include "internal/projectconfiguration.h"
 #include "internal/projectuiactions.h"
 #include "internal/thumbnailcreator.h"
+#include "internal/projectautosaver.h"
 
 #include "ui/iuiactionsregister.h"
 #include "ui/iinteractiveuriregister.h"
@@ -70,6 +71,7 @@ void ProjectModule::registerExports()
     m_actionsController = std::make_shared<ProjectActionsController>();
     m_uiActions = std::make_shared<ProjectUiActions>(m_actionsController);
     m_thumbnailCreator = std::make_shared<ThumbnailCreator>();
+    m_projectAutoSaver = std::make_shared<ProjectAutoSaver>();
 
 #ifdef Q_OS_MAC
     m_recentFilesController = std::make_shared<MacOSRecentFilesController>();
@@ -84,6 +86,7 @@ void ProjectModule::registerExports()
     ioc()->registerExport<IOpenSaveProjectScenario>(moduleName(), new OpenSaveProjectScenario());
     ioc()->registerExport<IProjectFilesController>(moduleName(), m_actionsController);
     ioc()->registerExport<IThumbnailCreator>(moduleName(), m_thumbnailCreator);
+    ioc()->registerExport<IProjectAutoSaver>(moduleName(), m_projectAutoSaver);
 }
 
 void ProjectModule::resolveImports()
@@ -126,6 +129,7 @@ void ProjectModule::onInit(const muse::IApplication::RunMode&)
     m_actionsController->init();
     m_uiActions->init();
     m_recentFilesController->init();
+    m_projectAutoSaver->init();
 }
 
 void ProjectModule::onDeinit()

--- a/src/project/projectmodule.h
+++ b/src/project/projectmodule.h
@@ -32,6 +32,7 @@ class ProjectActionsController;
 class ProjectUiActions;
 class RecentFilesController;
 class ThumbnailCreator;
+class ProjectAutoSaver;
 class ProjectModule : public muse::modularity::IModuleSetup
 {
 public:
@@ -50,6 +51,7 @@ private:
     std::shared_ptr<RecentFilesController> m_recentFilesController;
     std::shared_ptr<ThumbnailCreator> m_thumbnailCreator;
     std::shared_ptr<ProjectUiActions> m_uiActions;
+    std::shared_ptr<ProjectAutoSaver> m_projectAutoSaver;
 };
 }
 


### PR DESCRIPTION
Resolves: [Collapsed recording issue](https://github.com/audacity/audacity/issues/8863) and [Unsaved project recover issue](https://github.com/audacity/audacity/issues/8948)

The auto saver has been added and it helps recover unsaved projects and fix recording issue on recovered projects as they now are properly setup.

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
