### PR TITLE
Vertical meter tooltip

### DIFF
--- a/src/playback/qml/Audacity/Playback/components/VerticalVolumeSlider.qml
+++ b/src/playback/qml/Audacity/Playback/components/VerticalVolumeSlider.qml
@@ -63,8 +63,6 @@ Slider {
 
         parent: root.handle
 
-        y: (parent.height - height) / 2
-
         placementPolicies: PopupView.PreferLeft
         decimalPlaces: root.meterModel ? (root.meterModel.meterType == PlaybackMeterType.Linear ? 2 : 1) : 1
         minValue: root.meterModel ? (root.meterModel.meterType == PlaybackMeterType.Linear ? 1.0 : meterModel.dbRange) : 0

--- a/src/playback/qml/Audacity/Playback/components/VerticalVolumeSlider.qml
+++ b/src/playback/qml/Audacity/Playback/components/VerticalVolumeSlider.qml
@@ -8,6 +8,9 @@ import QtQuick.Controls 2.15
 import Muse.Ui 1.0
 import Muse.UiComponents 1.0
 
+import Audacity.ProjectScene 1.0
+import Audacity.Playback 1.0
+
 Slider {
     id: root
 
@@ -50,9 +53,24 @@ Slider {
         readonly property int rulerXPos: root.width / 2
 
         property real dragStartOffset: 0.0
+        property bool dragActive: false
     }
 
     onFromChanged: () => root.volumeLevelMoved(Math.max(root.from, root.volumeLevel))
+
+    VolumeTooltip {
+        id: tooltip
+
+        parent: root.handle
+
+        y: (parent.height - height) / 2
+
+        placementPolicies: PopupView.PreferLeft
+        decimalPlaces: root.meterModel ? (root.meterModel.meterType == PlaybackMeterType.Linear ? 2 : 1) : 1
+        minValue: root.meterModel ? (root.meterModel.meterType == PlaybackMeterType.Linear ? 1.0 : meterModel.dbRange) : 0
+        unitText: root.meterModel ? (root.meterModel.meterType == PlaybackMeterType.Linear ? "" : "dB") : ""
+        volume: root.meterModel ? (root.meterModel.meterType ==  PlaybackMeterType.Linear ? root.meterModel.position : root.volumeLevel) : 0
+    }
 
     NavigationControl {
         id: navCtrl
@@ -103,6 +121,8 @@ Slider {
         MouseArea {
             anchors.fill: parent
 
+            hoverEnabled: true
+
             onDoubleClicked: {
                 // Double click resets the volume
                 root.volumeLevelMoved(0.0)
@@ -117,11 +137,17 @@ Slider {
             preventStealing: true // Don't let a Flickable steal the mouse
 
             onPressed: function(mouse) {
+                prv.dragActive = true
                 prv.dragStartOffset = mouse.y
                 root.handlePressed()
+                tooltip.show(true)
             }
 
             onPositionChanged: function(mouse)  {
+                if (!prv.dragActive) {
+                    return;
+                }
+
                 let mousePosInRoot = mapToItem(root, 0, mouse.y - prv.dragStartOffset).y
                 if (prv.rulerLineHeight === 0) {
                     return;
@@ -129,6 +155,21 @@ Slider {
                 let proportionFromTop = mousePosInRoot / prv.rulerLineHeight
                 let clampedProportion = Math.max(0.0, Math.min(proportionFromTop, 1.0))
                 root.volumeLevelMoved(root.meterModel.positionToSample(1.0 - clampedProportion))
+            }
+
+            onReleased: function(mouse) {
+                prv.dragActive = false
+                tooltip.hide(true)
+            }
+
+            onEntered: function() {
+                tooltip.show()
+            }
+
+            onExited: function() {
+                if (!prv.dragActive) {
+                    tooltip.hide(true)
+                }
             }
         }
 

--- a/src/playback/qml/Audacity/Playback/components/VolumeSlider.qml
+++ b/src/playback/qml/Audacity/Playback/components/VolumeSlider.qml
@@ -132,7 +132,6 @@ Slider {
             onDoubleClicked: {
                 // Double click resets the volume
                 root.volumeLevelMoved(0.0)
-                root.meterModel.volumeChangeRequested(0.0)
             }
 
             // The MouseArea steals mouse press events from the slider.
@@ -201,6 +200,5 @@ Slider {
     onMoved: {
         navigation.requestActiveByInteraction()
         root.volumeLevelMoved(value)
-        root.meterModel.volumeChangeRequested(value)
     }
 }

--- a/src/playback/qml/Audacity/Playback/components/VolumeSlider.qml
+++ b/src/playback/qml/Audacity/Playback/components/VolumeSlider.qml
@@ -72,6 +72,7 @@ Slider {
         id: tooltip
 
         parent: root.handle
+
         decimalPlaces: root.meterModel ? (root.meterModel.meterType == PlaybackMeterType.Linear ? 2 : 1) : 1
         minValue: root.meterModel ? (root.meterModel.meterType == PlaybackMeterType.Linear ? 1.0 : meterModel.dbRange) : 0
         unitText: root.meterModel ? (root.meterModel.meterType == PlaybackMeterType.Linear ? "" : "dB") : ""
@@ -194,6 +195,15 @@ Slider {
                 opacity: 0.7
             }
 
+        }
+    }
+
+    onPressedChanged: {
+        prv.dragActive = root.pressed
+        if (root.pressed) {
+            tooltip.show(true)
+        } else {
+            tooltip.hide(true)
         }
     }
 

--- a/src/playback/qml/Audacity/Playback/components/VolumeSlider.qml
+++ b/src/playback/qml/Audacity/Playback/components/VolumeSlider.qml
@@ -132,6 +132,7 @@ Slider {
             onDoubleClicked: {
                 // Double click resets the volume
                 root.volumeLevelMoved(0.0)
+                root.meterModel.volumeChangeRequested(0.0)
             }
 
             // The MouseArea steals mouse press events from the slider.
@@ -200,5 +201,6 @@ Slider {
     onMoved: {
         navigation.requestActiveByInteraction()
         root.volumeLevelMoved(value)
+        root.meterModel.volumeChangeRequested(value)
     }
 }

--- a/src/playback/qml/Audacity/Playback/components/VolumeSlider.qml
+++ b/src/playback/qml/Audacity/Playback/components/VolumeSlider.qml
@@ -72,7 +72,6 @@ Slider {
         id: tooltip
 
         parent: root.handle
-
         decimalPlaces: root.meterModel ? (root.meterModel.meterType == PlaybackMeterType.Linear ? 2 : 1) : 1
         minValue: root.meterModel ? (root.meterModel.meterType == PlaybackMeterType.Linear ? 1.0 : meterModel.dbRange) : 0
         unitText: root.meterModel ? (root.meterModel.meterType == PlaybackMeterType.Linear ? "" : "dB") : ""

--- a/src/playback/qml/Audacity/Playback/panels/PlaybackMeterPanel.qml
+++ b/src/playback/qml/Audacity/Playback/panels/PlaybackMeterPanel.qml
@@ -51,6 +51,9 @@ Item {
             PlaybackMeterCustomisePopup {
                 id: popup
 
+                placementPolicies: PopupView.PreferLeft
+                y: -32
+
                 model: model.meterModel
             }
         }
@@ -76,8 +79,7 @@ Item {
                     id: leftVolumePressure
 
                     anchors.top: parent.top
-                    anchors.bottom: parent.bottom
-                    anchors.bottomMargin: ruler.bottomTextMargin
+                    height: parent.height - ruler.bottomTextMargin
 
                     overloadHeight: 10
 
@@ -94,8 +96,7 @@ Item {
 
 
                     anchors.top: parent.top
-                    anchors.bottom: parent.bottom
-                    anchors.bottomMargin: ruler.bottomTextMargin
+                    height: parent.height - ruler.bottomTextMargin
 
                     overloadHeight: 10
 
@@ -115,7 +116,6 @@ Item {
                     anchors.top: parent.top
                     anchors.topMargin: leftVolumePressure.overloadHeight - topTextMargin
                     anchors.bottom: parent.bottom
-                    anchors.bottomMargin: bottomTextMargin
                 }
             }
 

--- a/src/playback/qml/Audacity/Playback/panels/PlaybackMeterPanel.qml
+++ b/src/playback/qml/Audacity/Playback/panels/PlaybackMeterPanel.qml
@@ -52,7 +52,7 @@ Item {
                 id: popup
 
                 placementPolicies: PopupView.PreferLeft
-                y: -32
+                y: -28
 
                 model: model.meterModel
             }

--- a/src/playback/view/common/playbackmetermodel.cpp
+++ b/src/playback/view/common/playbackmetermodel.cpp
@@ -231,27 +231,3 @@ QString PlaybackMeterModel::description(PlaybackMeterDbRange::DbRange range) con
 
     return "";
 }
-
-QString PlaybackMeterModel::description(PlaybackMeterDbRange::DbRange range) const
-{
-    switch (range) {
-    case PlaybackMeterDbRange::DbRange::Range36:
-        return DB36_DESCRIPTION;
-    case PlaybackMeterDbRange::DbRange::Range48:
-        return DB48_DESCRIPTION;
-    case PlaybackMeterDbRange::DbRange::Range60:
-        return DB60_DESCRIPTION;
-    case PlaybackMeterDbRange::DbRange::Range72:
-        return DB72_DESCRIPTION;
-    case PlaybackMeterDbRange::DbRange::Range84:
-        return DB84_DESCRIPTION;
-    case PlaybackMeterDbRange::DbRange::Range96:
-        return DB96_DESCRIPTION;
-    case PlaybackMeterDbRange::DbRange::Range120:
-        return DB120_DESCRIPTION;
-    case PlaybackMeterDbRange::DbRange::Range144:
-        return DB144_DESCRIPTION;
-    }
-
-    return "";
-}

--- a/src/playback/view/common/playbackmetermodel.cpp
+++ b/src/playback/view/common/playbackmetermodel.cpp
@@ -229,3 +229,27 @@ QString PlaybackMeterModel::description(PlaybackMeterDbRange::DbRange range) con
 
     return "";
 }
+
+QString PlaybackMeterModel::description(PlaybackMeterDbRange::DbRange range) const
+{
+    switch (range) {
+    case PlaybackMeterDbRange::DbRange::Range36:
+        return DB36_DESCRIPTION;
+    case PlaybackMeterDbRange::DbRange::Range48:
+        return DB48_DESCRIPTION;
+    case PlaybackMeterDbRange::DbRange::Range60:
+        return DB60_DESCRIPTION;
+    case PlaybackMeterDbRange::DbRange::Range72:
+        return DB72_DESCRIPTION;
+    case PlaybackMeterDbRange::DbRange::Range84:
+        return DB84_DESCRIPTION;
+    case PlaybackMeterDbRange::DbRange::Range96:
+        return DB96_DESCRIPTION;
+    case PlaybackMeterDbRange::DbRange::Range120:
+        return DB120_DESCRIPTION;
+    case PlaybackMeterDbRange::DbRange::Range144:
+        return DB144_DESCRIPTION;
+    }
+
+    return "";
+}

--- a/src/playback/view/common/playbackmetermodel.cpp
+++ b/src/playback/view/common/playbackmetermodel.cpp
@@ -19,6 +19,8 @@ constexpr const char* DB84_DESCRIPTION = "-84 dB (PCM range of 14 bit samples)";
 constexpr const char* DB96_DESCRIPTION = "-96 dB (PCM range of 16 bit samples)";
 constexpr const char* DB120_DESCRIPTION = "-120 dB (approximate limit of human hearing)";
 constexpr const char* DB144_DESCRIPTION = "-145 dB (PCM range of 24 bit samples)";
+
+constexpr float LINEAR_METER_MIN_VOLUME = -60.0f;
 }
 
 PlaybackMeterModel::PlaybackMeterModel(QObject* parent)
@@ -179,7 +181,7 @@ PlaybackMeterDbRange::DbRange PlaybackMeterModel::meterDbRange() const
 float PlaybackMeterModel::dbRange() const
 {
     if (meterType() == PlaybackMeterType::MeterType::Linear) {
-        return -60.0;
+        return LINEAR_METER_MIN_VOLUME;
     }
 
     return PlaybackMeterDbRange::toDouble(meterDbRange());

--- a/src/playback/view/common/playbackmetermodel.h
+++ b/src/playback/view/common/playbackmetermodel.h
@@ -32,11 +32,6 @@ class PlaybackMeterModel : public QObject, public muse::async::Asyncable
 
     Q_PROPERTY(float position READ position NOTIFY positionChanged FINAL)
 
-    Q_PROPERTY(std::vector<PlaybackMeterDbRange::DbRange> dbRangeList READ dbRangeList CONSTANT)
-    Q_PROPERTY(float dbRange READ dbRange NOTIFY dbRangeChanged FINAL)
-
-    Q_PROPERTY(float position READ position NOTIFY positionChanged FINAL)
-
     muse::Inject<IPlaybackMeterController> meterController;
     muse::Inject<IPlaybackConfiguration> configuration;
     muse::Inject<IPlayback> playback;

--- a/src/playback/view/common/playbackmetermodel.h
+++ b/src/playback/view/common/playbackmetermodel.h
@@ -32,6 +32,7 @@ class PlaybackMeterModel : public QObject, public muse::async::Asyncable
 
     Q_PROPERTY(float position READ position NOTIFY positionChanged FINAL)
 
+    Q_PROPERTY(std::vector<PlaybackMeterDbRange::DbRange> dbRangeList READ dbRangeList CONSTANT)
     Q_PROPERTY(float dbRange READ dbRange NOTIFY dbRangeChanged FINAL)
 
     Q_PROPERTY(float position READ position NOTIFY positionChanged FINAL)

--- a/src/playback/view/common/playbackmetermodel.h
+++ b/src/playback/view/common/playbackmetermodel.h
@@ -32,6 +32,10 @@ class PlaybackMeterModel : public QObject, public muse::async::Asyncable
 
     Q_PROPERTY(float position READ position NOTIFY positionChanged FINAL)
 
+    Q_PROPERTY(float dbRange READ dbRange NOTIFY dbRangeChanged FINAL)
+
+    Q_PROPERTY(float position READ position NOTIFY positionChanged FINAL)
+
     muse::Inject<IPlaybackMeterController> meterController;
     muse::Inject<IPlaybackConfiguration> configuration;
     muse::Inject<IPlayback> playback;


### PR DESCRIPTION
Resolves: #9141 #8910

Add volume tooltip to the vertical playback meter.
This PR also fixes the playback meter flyout position, as shown on the image below.

<img width="505" height="556" alt="image" src="https://github.com/user-attachments/assets/47ab63f4-d512-4831-9efa-e59e1e601818" />

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [ ] If changes are extensive, then there is a sequence of easily reviewable commits
- [ ] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [ ] Each commit compiles and runs on my machine without known undesirable changes of behavior
