### PR TITLE
Fetch qmlformat during configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -157,6 +157,7 @@ libraries/lib-music-information-retrieval/tests/benchmarking-dataset/
 libraries/lib-music-information-retrieval/tests/TatumQuantizationFitVisualization/debug_output.py
 libraries/lib-music-information-retrieval/tests/TatumQuantizationFitVisualization/stft_log.py
 libraries/lib-music-information-retrieval/tests/TatumQuantizationFitVisualization/__pycache__/
+compile_commands.json
 
 # Emacs backup files
 *~
@@ -244,6 +245,9 @@ dependencies
 VERSION
 /mscore/data/mscore.aps
 /msvc.*
+uncrustify.cfg
+.tools
+
 
 # Files created during build process
 /thirdparty/lame/config.h
@@ -262,3 +266,7 @@ temp_*
 *.AppImage
 
 build.*
+
+# Private developer's files
+.vscode/settings.json
+CMakeUserPresets.json

--- a/.vscode/audacity.code-workspace
+++ b/.vscode/audacity.code-workspace
@@ -5,29 +5,6 @@
         }
     ],
     "settings": {
-        "cmake.generator": "Ninja",
-        "cmake.buildDirectory": "${workspaceFolder}/build/${buildType}",
-        "cmake.installPrefix": "${workspaceFolder}/build/${buildType}/install",
-        "cmake.configureArgs": [
-            // "-DAU_MODULE_EFFECTS_VST=ON"
-        ],
-        "editor.guides.indentation": true,
-        "editor.detectIndentation": true,
-        "editor.guides.highlightActiveIndentation": true,
-        "editor.autoIndent": "full",
-        "editor.tabSize": 4,
-        "explorer.excludeGitIgnore": false,
-        "search.useIgnoreFiles": false,
-        "files.exclude": {
-            "build": true,
-            "builds": true
-        },
-        "C_Cpp.autoAddFileAssociations": false,
-        "uncrustify.configPath.windows": "${workspaceFolder}/build/Debug/_deps/muse_framework-src/buildscripts/ci/checkcodestyle/uncrustify_muse.cfg",
-        "uncrustify.configPath.linux": "${workspaceFolder}/build/Debug/_deps/muse_framework-src/buildscripts/ci/checkcodestyle/uncrustify_muse.cfg",
-        "uncrustify.configPath.osx": "${workspaceFolder}/build/Debug/_deps/muse_framework-src/buildscripts/ci/checkcodestyle/uncrustify_muse.cfg",
-        "editor.defaultFormatter": "zachflower.uncrustify",
-        "cmake.useVsDeveloperEnvironment": "auto",
         "[cpp]": {
             "editor.defaultFormatter": "zachflower.uncrustify"
         },
@@ -35,12 +12,12 @@
             "commands": [
                 {
                     "match": "\\.qml$",
-                    // Requires Qt 6.10.0 (at least the qmlformat tool) to be installed.
-                    // We don't want to use this command for an earlier version, because the semicolon-rule option
-                    // isn't available and running it without would add semicolons after each statement.
-                    "cmd": "C:/Qt/6.10.0/msvc2022_64/bin/qmlformat.exe -i --semicolon-rule=essential ${file}",
+                    "cmd": "${workspaceFolder}/.tools/qmlformat/bin/qmlformat -i --semicolon-rule=essential ${file}"
                 }
             ]
-        }
+        },
+        "search.useIgnoreFiles": false,
+        "C_Cpp.autoAddFileAssociations": false,
+        "cmake.copyCompileCommands": "${workspaceFolder}/compile_commands.json",
     }
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,6 +2,7 @@
     "recommendations": [
         "ms-vscode.cmake-tools",
         "ms-vscode.cpptools",
+        "llvm-vs-code-extensions.vscode-clangd", // Better C++ parsing
         "zachflower.uncrustify", // for code formatting
         "vadimcn.vscode-lldb", // provides a fast debugger (tried on Linux),
         "emeraldwalk.RunOnSave"

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,21 +1,20 @@
 {
     "configurations": [
         {
-            "name": "Launch",
+            "name": "Launch (cdb - Windows)",
             "type": "cppvsdbg",
             "request": "launch",
-            "program": "${workspaceFolder}/build/${command:cmake.buildType}/install/bin/audacity.exe",
+            "preLaunchTask": "CMake: install",
+            "cwd": "${workspaceFolder}",
+            "program": "${command:cmake.launchTargetPath}",
             "args": [
                 // Comment this out to run audacity in plugin registration mode
                 // "--register-audio-plugin", "C:/Program Files/Common Files/VST3/Your plugin.vst3"
             ],
-            "preLaunchTask": "CMake: install",
-            "stopAtEntry": false,
-            "cwd": "${workspaceFolder}",
             "environment": [
                 {
-                    "name": "QTDIR",
-                    "value": "C:/Qt/6.2.4/msvc2019_64"
+                    "name": "PATH",
+                    "value": "${env:PATH};${command:cmake.launchTargetDirectory}\\bin"
                 }
             ],
             "sourceFileMap": {
@@ -29,55 +28,50 @@
         },
         {
             // Requires CodeLLDB extension
-            // Doesn't support visualizerFile but is much faster than cppvsdbg
-            "name": "Launch (Linux - lldb)",
+            // Doesn't support visualizerFile but is much faster than cppdbg
+            "name": "Launch (lldb - macOS/Linux)",
             "type": "lldb",
             "request": "launch",
-            "program": "${workspaceFolder}/build/${command:cmake.buildType}/src/app/audacity",
-            "preLaunchTask": "CMake: build",
+            "preLaunchTask": "CMake: install",
+            "cwd": "${workspaceFolder}",
+            "program": "${command:cmake.launchTargetPath}",
             "args": [
                 // "--register-audio-plugin",
                 // "https://wasted.audio/software/wstd_flangr"
             ],
-            // If you need to debug a plugin, you can do something like this.
-            // (If you don't have these plugins, you'll only get a harmless warning.)
             "initCommands": [
                 "settings set target.load-cwd-lldbinit true"
             ],
+            // If you need to debug a plugin, you can do something like this.
+            // (If you don't have these plugins, you'll only get a harmless warning.)
             "postRunCommands": [
                 "target symbols add /usr/lib/lv2/meters.lv2/meters.so",
                 "target symbols add /usr/lib/lv2/meters.lv2/meters_glui.so",
             ],
-            "cwd": "${workspaceFolder}"
+            "env": {
+                "LD_LIBRARY_PATH": "${command:cmake.launchTargetDirectory}/lib"
+            }
         },
         {
-            "name": "Launch (Linux - cppdbg)",
+            "name": "Launch (gdb - Linux)",
             "type": "cppdbg",
             "MIMode": "gdb",
             "request": "launch",
-            "program": "${workspaceFolder}/build/${command:cmake.buildType}/src/app/audacity",
-            "preLaunchTask": "CMake: build",
+            "preLaunchTask": "CMake: install",
+            "cwd": "${workspaceFolder}",
+            "program": "${command:cmake.launchTargetPath}",
             "args": [
                 // "--register-audio-plugin",
                 // "https://wasted.audio/software/wstd_flangr"
             ],
-            "stopAtEntry": false,
-            "cwd": "${workspaceFolder}/build/${command:cmake.buildType}/src/app",
             "visualizerFile": "${workspaceFolder}/.vscode/qt6.natvis",
-            "showDisplayString": true
-        },
-        {
-            "name": "run audacity (MacOS)",
-            "type": "cppdbg",
-            "request": "launch",
-            "program": "${workspaceFolder}/build/${command:cmake.buildType}/src/app/audacity.app/Contents/MacOS/audacity",
-            "args": [],
-            "preLaunchTask": "CMake: install",
-            "stopAtEntry": false,
-            "cwd": "${fileDirname}",
-            "environment": [],
-            "externalConsole": false,
-            "MIMode": "lldb"
+            "showDisplayString": true,
+            "environment": [
+                {
+                    "name": "LD_LIBRARY_PATH",
+                    "value": "${env:LD_LIBRARY_PATH}:${command:cmake.launchTargetDirectory}/lib"
+                }
+            ]
         }
     ]
 }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,6 +163,8 @@ endif()
 
 include(SetupBuildEnvironment)
 include(GetPlatformInfo)
+include(SetupDevEnvironment)
+
 if (MUE_COMPILE_USE_CCACHE)
     include(TryUseCcache)
 endif(MUE_COMPILE_USE_CCACHE)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,54 @@
+{
+  "version": 2,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 20,
+    "patch": 0
+  },
+  "configurePresets": [
+    {
+      "name": "base",
+      "displayName": "Base Configuration",
+      "description": "Base configuration for all presets.",
+      "binaryDir": "${sourceDir}/build/${presetName}",
+      "hidden": true,
+      "generator": "Ninja",
+      "cacheVariables": {
+        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
+        "CMAKE_INSTALL_PREFIX": "src/app"
+      }
+    },
+    {
+      "name": "audacity-debug",
+      "displayName": "Audacity [Debug]",
+      "description": "Debug profile with debug symbols and no optimizations.",
+      "inherits": "base",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "CMAKE_CXX_FLAGS": "-DQT_QML_DEBUG"
+      }
+    },
+    {
+      "name": "audacity-asan",
+      "displayName": "Audacity [ASan]",
+      "description": "Debug profile with AddressSanitizer enabled.",
+      "inherits": "audacity-debug",
+      "cacheVariables": {
+        "CMAKE_CXX_FLAGS": "-fsanitize=address -fno-omit-frame-pointer",
+        "CMAKE_LINK_FLAGS": "-fsanitize=address -fno-omit-frame-pointer",
+        "CMAKE_EXE_LINKER_FLAGS": "-fsanitize=address",
+        "CMAKE_MODULE_LINKER_FLAGS": "-fsanitize=address",
+        "CMAKE_SHARED_LINKER_FLAGS": "-fsanitize=address"
+      }
+    },
+    {
+      "name": "audacity-release",
+      "displayName": "Audacity [RelWithDebInfo]",
+      "description": "Release profile with optimizations and debug information.",
+      "inherits": "base",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo"
+      }
+    }
+  ]
+}

--- a/buildscripts/cmake/SetupBuildEnvironment.cmake
+++ b/buildscripts/cmake/SetupBuildEnvironment.cmake
@@ -118,8 +118,8 @@ endif()
 include(SetupCompileWarnings)
 
 # Common
-string(TOUPPER ${CMAKE_BUILD_TYPE} CMAKE_BUILD_TYPE)
-if(CMAKE_BUILD_TYPE MATCHES "DEBUG") #Debug
+string(TOUPPER ${CMAKE_BUILD_TYPE} _BUILD_TYPE)
+if(_BUILD_TYPE MATCHES "DEBUG") #Debug
 
     add_definitions(-DQT_QML_DEBUG)
 


### PR DESCRIPTION
To format QML files with respect to the current style: no semicolons, we need to use qmlformat bundled with Qt 6.10. To spare developers time on formatting files, and not to bother them to install 6.10.beta (at the time of creating the PR) the tool was moved to muse_deps repo.

Automated CI codestyle check will follow

Other changes

- CMake presets created for better build profile management, this removes hardcoded build locations and allows for multiple build profiles (release, debug etc) at the same
 time
- Personal editor configuration removed from the workspace file, settings.json should be used for non essential configuration
- launch.json cleanup, hardcoded paths removed, names more descriptive and consistent
- Dependendcies and dev-tools are now installed to more appropriate places to ease the configuration burden for non-vscode users:
  - compile_commands.json into the project's root
  - uncrustify.cfg into the project's root
  - qmlformat into project's root/.tools/qmlformat

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
