### PR TITLE
Focused track change and selection using arrow keys.

### DIFF
--- a/src/app/configs/data/shortcuts.xml
+++ b/src/app/configs/data/shortcuts.xml
@@ -58,6 +58,11 @@
         <seq>Left</seq>
     </SC>
     <SC>
+        <key>track-toggle-focused-selection</key>
+        <seq>Return</seq>
+        <seq>Enter</seq>
+    </SC>
+    <SC>
         <key>nav-up</key>
         <seq>Up</seq>
     </SC>

--- a/src/app/configs/data/shortcuts.xml
+++ b/src/app/configs/data/shortcuts.xml
@@ -467,16 +467,16 @@
         <seq>Ctrl+Shift+F6</seq>
     </SC>
     <SC>
-        <key>next-frame</key>
-        <seq>Ctrl+F6</seq>
-    </SC>
-    <SC>
         <key>focus-prev-track</key>
         <seq>Up</seq>
     </SC>
     <SC>
         <key>focus-next-track</key>
         <seq>Down</seq>
+    </SC>
+    <SC>
+        <key>next-frame</key>
+        <seq>Ctrl+F6</seq>
     </SC>
     <SC>
         <key>prev-track</key>

--- a/src/app/configs/data/shortcuts.xml
+++ b/src/app/configs/data/shortcuts.xml
@@ -471,6 +471,14 @@
         <seq>Ctrl+F6</seq>
     </SC>
     <SC>
+        <key>focus-prev-track</key>
+        <seq>Up</seq>
+    </SC>
+    <SC>
+        <key>focus-next-track</key>
+        <seq>Down</seq>
+    </SC>
+    <SC>
         <key>prev-track</key>
         <seq>Up</seq>
     </SC>

--- a/src/appshell/qml/ProjectPage/ProjectPage.qml
+++ b/src/appshell/qml/ProjectPage/ProjectPage.qml
@@ -29,6 +29,7 @@ import Muse.Dock
 import Audacity.AppShell
 import Audacity.ProjectScene
 import Audacity.Playback
+import Audacity.TrackEdit
 
 DockPage {
     id: root
@@ -39,6 +40,15 @@ DockPage {
     property var topToolKeyNavSec
 
     property ProjectPageModel pageModel: ProjectPageModel {}
+
+    TrackNavigationModel {
+        id: tracksNavModel
+
+        Component.onCompleted: {
+            var section = root.navigationPanelSec(tracksPanel.location)
+            tracksNavModel.init(section)
+        }
+    }
 
     property NavigationSection playbackToolBarKeyNavSec: NavigationSection {
         id: keynavSec
@@ -264,8 +274,6 @@ DockPage {
             objectName: pageModel.tracksPanelName()
             title: qsTrc("appshell", "Tracks")
 
-            navigationSection: root.navigationPanelSec(tracksPanel.location)
-
             width: panelWidth
             minimumWidth: panelWidth
             maximumWidth: panelWidth
@@ -295,7 +303,7 @@ DockPage {
             TracksPanel {
                 id: tracksPanelContent
 
-                navigationSection: tracksPanel.navigationSection
+                navpanels: tracksNavModel.trackItemPanels
                 effectsSectionWidth: tracksPanel.effectsSectionWidth
 
                 trackEffectsNavigationSection: root.trackEffectsKeyNavSec
@@ -307,6 +315,10 @@ DockPage {
 
                 onShowEffectsSectionChanged: {
                     tracksPanel.showEffectsSection = showEffectsSection
+                }
+
+                onPanelActive: function (index) {
+                    tracksNavModel.moveFocusTo(index)
                 }
 
                 Connections {
@@ -369,7 +381,7 @@ DockPage {
     central: TracksClipsView {
         id: clipsView
 
-        navigationSection: tracksPanel.navigationSection
+        navpanels: tracksNavModel.clipItemPanels
     }
 
     statusBar: DockStatusBar {

--- a/src/appshell/qml/ProjectPage/ProjectPage.qml
+++ b/src/appshell/qml/ProjectPage/ProjectPage.qml
@@ -303,7 +303,7 @@ DockPage {
             TracksPanel {
                 id: tracksPanelContent
 
-                navpanels: tracksNavModel.trackItemPanels
+                navPanels: tracksNavModel.trackItemPanels
                 effectsSectionWidth: tracksPanel.effectsSectionWidth
 
                 trackEffectsNavigationSection: root.trackEffectsKeyNavSec
@@ -381,7 +381,7 @@ DockPage {
     central: TracksClipsView {
         id: clipsView
 
-        navpanels: tracksNavModel.clipItemPanels
+        navPanels: tracksNavModel.clipItemPanels
     }
 
     statusBar: DockStatusBar {

--- a/src/context/internal/uicontextresolver.cpp
+++ b/src/context/internal/uicontextresolver.cpp
@@ -35,6 +35,7 @@ static const Uri PROJECT_PAGE_URI("audacity://project");
 //! but we don't have that yet, so binding it to
 //! area that's being focused when opening a project
 static const QString PROJECT_NAVIGATION_PANEL("MainToolBar");
+static const QString DEFAULT_NAVIGATION_PANEL("Main Panel");
 
 void UiContextResolver::init()
 {
@@ -112,11 +113,11 @@ UiContext UiContextResolver::currentUiContext() const
 
         INavigationPanel* activePanel = navigationController()->activePanel();
         if (activePanel) {
-            //if (activePanel->name() == PROJECT_NAVIGATION_PANEL) {
-            //    return context::UiCtxProjectFocused;
-            //} else {
-            return context::UiCtxProjectPlayback;
-            //}
+            if (activePanel->name() == DEFAULT_NAVIGATION_PANEL) {
+                return context::UiCtxProjectFocused;
+            } else {
+                return context::UiCtxProjectPlayback;
+            }
         }
 
         return context::UiCtxProjectOpened;

--- a/src/context/internal/uicontextresolver.cpp
+++ b/src/context/internal/uicontextresolver.cpp
@@ -112,11 +112,11 @@ UiContext UiContextResolver::currentUiContext() const
 
         INavigationPanel* activePanel = navigationController()->activePanel();
         if (activePanel) {
-            if (activePanel->name() == PROJECT_NAVIGATION_PANEL) {
-                return context::UiCtxProjectFocused;
-            } else {
-                return context::UiCtxProjectPlayback;
-            }
+            //if (activePanel->name() == PROJECT_NAVIGATION_PANEL) {
+            //    return context::UiCtxProjectFocused;
+            //} else {
+            return context::UiCtxProjectPlayback;
+            //}
         }
 
         return context::UiCtxProjectOpened;

--- a/src/projectscene/internal/projectsceneuiactions.cpp
+++ b/src/projectscene/internal/projectsceneuiactions.cpp
@@ -188,23 +188,23 @@ static UiActionList STATIC_ACTIONS = {
              TranslatableString("action", "Show clipping in waveform"),
              Checkable::Yes
              ),
-    UiAction("prev-track",
-             au::context::UiCtxProjectOpened,
-             muse::shortcuts::CTX_PROJECT_OPENED,
-             TranslatableString("action", "Previous track"),
-             TranslatableString("action", "Previous track")
-             ),
-    UiAction("next-track",
-             au::context::UiCtxProjectOpened,
-             muse::shortcuts::CTX_PROJECT_OPENED,
-             TranslatableString("action", "Next track"),
-             TranslatableString("action", "Next track")
-             ),
     UiAction("track-toggle-focused-selection",
              au::context::UiCtxProjectOpened,
              muse::shortcuts::CTX_PROJECT_OPENED,
              TranslatableString("action", "Select track"),
              TranslatableString("action", "Select track")
+             ),
+    UiAction("focus-prev-track",
+             au::context::UiCtxProjectOpened,
+             muse::shortcuts::CTX_PROJECT_OPENED,
+             TranslatableString("action", "Focus previous track"),
+             TranslatableString("action", "Focus previous track")
+             ),
+    UiAction("focus-next-track",
+             au::context::UiCtxProjectOpened,
+             muse::shortcuts::CTX_PROJECT_OPENED,
+             TranslatableString("action", "Focus next track"),
+             TranslatableString("action", "Focus next track")
              )
 };
 

--- a/src/projectscene/internal/projectsceneuiactions.cpp
+++ b/src/projectscene/internal/projectsceneuiactions.cpp
@@ -187,6 +187,24 @@ static UiActionList STATIC_ACTIONS = {
              TranslatableString("action", "Show clipping in waveform"),
              TranslatableString("action", "Show clipping in waveform"),
              Checkable::Yes
+             ),
+    UiAction("prev-track",
+             au::context::UiCtxProjectOpened,
+             muse::shortcuts::CTX_PROJECT_OPENED,
+             TranslatableString("action", "Previous track"),
+             TranslatableString("action", "Previous track")
+             ),
+    UiAction("next-track",
+             au::context::UiCtxProjectOpened,
+             muse::shortcuts::CTX_PROJECT_OPENED,
+             TranslatableString("action", "Next track"),
+             TranslatableString("action", "Next track")
+             ),
+    UiAction("track-toggle-focused-selection",
+             au::context::UiCtxProjectOpened,
+             muse::shortcuts::CTX_PROJECT_OPENED,
+             TranslatableString("action", "Select track"),
+             TranslatableString("action", "Select track")
              )
 };
 

--- a/src/projectscene/qml/Audacity/ProjectScene/clipsview/TrackClipsItem.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/clipsview/TrackClipsItem.qml
@@ -295,8 +295,7 @@ Item {
 
                 navigation.name: Boolean(clipItem) ? clipItem.title + clipItem.index : ""
                 navigation.panel: root.navigationPanel
-                navigation.column: index
-                navigation.row: root.trackIdx
+                navigation.column: clipItem ? Math.floor(clipItem.x) : 0
                 navigation.accessible.name: Boolean(clipItem) ? clipItem.title : ""
                 navigation.onActiveChanged: {
                     if (navigation.active) {

--- a/src/projectscene/qml/Audacity/ProjectScene/clipsview/TracksClipsView.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/clipsview/TracksClipsView.qml
@@ -12,7 +12,7 @@ Rectangle {
 
     id: root
 
-    property NavigationSection navigationSection: null
+    property var navpanels: null
 
     property bool clipHovered: false
     property bool clipHeaderHovered: false
@@ -520,9 +520,6 @@ Rectangle {
                 anchors.fill: parent
                 clip: false // do not clip so clip handles are visible
 
-                navigation.section: root.navigationSection
-                navigation.order: 3
-
                 property bool moveActive: false
 
                 ScrollBar.horizontal: null
@@ -622,8 +619,17 @@ Rectangle {
                     }
 
                     trackIdx: model.index
-                    navigationSection: root.navigationSection
-                    navigationPanel: tracksClipsView.navigation
+                    navigationPanel: navpanels && navpanels[model.index] ? navpanels[model.index] : null
+
+                    Connections {
+                        target: root
+
+                        function onNavpanelsChanged() {
+                            if (root.navpanels && root.navpanels[model.index]) {
+                                navigationPanel = root.navpanels[model.index]
+                            }
+                        }
+                    }
 
                     onTrackItemMousePositionChanged: function(xWithinTrack, yWithinTrack, clipKey) {
                         let xGlobalPosition = xWithinTrack

--- a/src/projectscene/qml/Audacity/ProjectScene/clipsview/TracksClipsView.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/clipsview/TracksClipsView.qml
@@ -12,7 +12,7 @@ Rectangle {
 
     id: root
 
-    property var navpanels: null
+    property var navPanels: null
 
     property bool clipHovered: false
     property bool clipHeaderHovered: false
@@ -619,17 +619,7 @@ Rectangle {
                     }
 
                     trackIdx: model.index
-                    navigationPanel: navpanels && navpanels[model.index] ? navpanels[model.index] : null
-
-                    Connections {
-                        target: root
-
-                        function onNavpanelsChanged() {
-                            if (root.navpanels && root.navpanels[model.index]) {
-                                navigationPanel = root.navpanels[model.index]
-                            }
-                        }
-                    }
+                    navigationPanel: navPanels && navPanels[model.index] ? navPanels[model.index] : null
 
                     onTrackItemMousePositionChanged: function(xWithinTrack, yWithinTrack, clipKey) {
                         let xGlobalPosition = xWithinTrack

--- a/src/projectscene/qml/Audacity/ProjectScene/trackspanel/TrackItem.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/trackspanel/TrackItem.qml
@@ -63,19 +63,12 @@ ListItemBlank {
         }
     }
 
-    property NavigationPanel navigationPanel: NavigationPanel {
-        name: "Track" + root.item.title + "Panel"
-        enabled: root.enabled && root.visible
-        direction: NavigationPanel.Horizontal
-        onActiveChanged: function(active) {
-            if (active) {
-                root.forceActiveFocus()
-            }
-        }
-    }
-
     height: trackViewState.trackHeight
     opacity: dragged ? 0.5 : 1
+
+    focusBorder.anchors.leftMargin: spacer.width + 2
+    focusBorder.anchors.rightMargin: volumePressureContainer.width + separatorLine.width + 10
+    focusBorder.anchors.bottomMargin: 2
 
     background.color: (root.isSelected || hoverHandler.hovered) ?
                    ui.theme.backgroundPrimaryColor : ui.theme.backgroundSecondaryColor
@@ -271,6 +264,7 @@ ListItemBlank {
         }
 
         SeparatorLine {
+            id: separatorLine
             Layout.bottomMargin: 2 * bottomSeparator.thickness
         }
 
@@ -367,6 +361,7 @@ ListItemBlank {
                 if(!root.isSelected) {
                     root.selectionRequested(false)
                 }
+                navigation.requestActive(true)
             }
         }
 

--- a/src/projectscene/qml/Audacity/ProjectScene/trackspanel/TrackItem.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/trackspanel/TrackItem.qml
@@ -67,7 +67,7 @@ ListItemBlank {
     opacity: dragged ? 0.5 : 1
 
     focusBorder.anchors.leftMargin: spacer.width + 2
-    focusBorder.anchors.rightMargin: volumePressureContainer.width + separatorLine.width + 10
+    focusBorder.anchors.rightMargin: 24 + separatorLine.width
     focusBorder.anchors.bottomMargin: 2
 
     background.color: (root.isSelected || hoverHandler.hovered) ?
@@ -361,7 +361,6 @@ ListItemBlank {
                 if(!root.isSelected) {
                     root.selectionRequested(false)
                 }
-                navigation.requestActive(true)
             }
         }
 

--- a/src/projectscene/qml/Audacity/ProjectScene/trackspanel/TracksPanel.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/trackspanel/TracksPanel.qml
@@ -13,10 +13,11 @@ import Audacity.ProjectScene
 Item {
     id: root
 
-    property NavigationSection navigationSection: null
-    property NavigationPanel navigationPanel: view.count > 0 ? view.itemAtIndex(0).navigationPanel : null // first panel
+    property var navpanels: null
     property alias tracksModel: tracksModel
+
     signal openEffectsRequested()
+    signal panelActive(int index)
 
     property NavigationSection trackEffectsNavigationSection: null
     property NavigationSection masterEffectsNavigationSection: null
@@ -180,8 +181,6 @@ Item {
                     height: tracksViewState.tracksVerticalScrollPadding
                 }
 
-                navigation.section: root.navigationSection
-                navigation.order: 1
                 delegate: TrackItem {
                     item: itemData
                     isSelected: Boolean(item) ? item.isSelected : false
@@ -189,11 +188,12 @@ Item {
                     container: view
 
                     navigation.name: Boolean(item) ? item.title + item.index : ""
-                    navigation.panel: view.navigation
+                    navigation.panel: root.navpanels && root.navpanels[model.index] ? root.navpanels[model.index] : null
                     navigation.row: model.index
                     navigation.accessible.name: Boolean(item) ? item.title : ""
                     navigation.onActiveChanged: {
                         if (navigation.active) {
+                            root.panelActive(model.index)
                             prv.currentItemNavigationName = navigation.name
                             view.positionViewAtIndex(index, ListView.Contain)
                         }
@@ -224,6 +224,15 @@ Item {
                         mousePressed.connect(dragHandler.startDrag)
                         mouseReleased.connect(dragHandler.endDrag)
                         mouseMoved.connect(dragHandler.onMouseMove)
+                    }
+
+                    Connections {
+                        target: root
+                        function onNavpanelsChanged() {
+                            if (root.navpanels && root.navpanels[model.index]) {
+                                navigation.panel = root.navpanels[model.index]
+                            }
+                        }
                     }
                 }
 

--- a/src/projectscene/qml/Audacity/ProjectScene/trackspanel/TracksPanel.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/trackspanel/TracksPanel.qml
@@ -13,7 +13,7 @@ import Audacity.ProjectScene
 Item {
     id: root
 
-    property var navpanels: null
+    property var navPanels: null
     property alias tracksModel: tracksModel
 
     signal openEffectsRequested()
@@ -188,7 +188,7 @@ Item {
                     container: view
 
                     navigation.name: Boolean(item) ? item.title + item.index : ""
-                    navigation.panel: root.navpanels && root.navpanels[model.index] ? root.navpanels[model.index] : null
+                    navigation.panel: root.navPanels && root.navPanels[model.index] ? root.navPanels[model.index] : null
                     navigation.row: model.index
                     navigation.accessible.name: Boolean(item) ? item.title : ""
                     navigation.onActiveChanged: {
@@ -224,15 +224,6 @@ Item {
                         mousePressed.connect(dragHandler.startDrag)
                         mouseReleased.connect(dragHandler.endDrag)
                         mouseMoved.connect(dragHandler.onMouseMove)
-                    }
-
-                    Connections {
-                        target: root
-                        function onNavpanelsChanged() {
-                            if (root.navpanels && root.navpanels[model.index]) {
-                                navigation.panel = root.navpanels[model.index]
-                            }
-                        }
                     }
                 }
 

--- a/src/projectscene/view/trackspanel/trackslistmodel.cpp
+++ b/src/projectscene/view/trackspanel/trackslistmodel.cpp
@@ -595,23 +595,6 @@ void TracksListModel::onSelectedTracks(const TrackIdList& trackIds)
 
 void TracksListModel::onFocusedTrack(const trackedit::TrackId& trackId)
 {
-    int trackIndex = -1;
-    for (int i = 0; i < m_trackList.size(); ++i) {
-        if (m_trackList.at(i)->trackId() == trackId) {
-            trackIndex = i;
-            break;
-        }
-    }
-
-    if (trackIndex == -1) {
-        return;
-    }
-
-    const auto activePanel = navigationController()->activePanel();
-    if (activePanel && activePanel->name() != QString("Track %1 Panel").arg(trackId)) {
-        navigationController()->requestActivateByName("Main Section", "Main Panel", "Main Control");
-    }
-
     for (int i = 0; i < m_trackList.size(); ++i) {
         auto& track = m_trackList.at(i);
         track->setIsFocused(track->trackId() == trackId);

--- a/src/projectscene/view/trackspanel/trackslistmodel.cpp
+++ b/src/projectscene/view/trackspanel/trackslistmodel.cpp
@@ -595,6 +595,23 @@ void TracksListModel::onSelectedTracks(const TrackIdList& trackIds)
 
 void TracksListModel::onFocusedTrack(const trackedit::TrackId& trackId)
 {
+    int trackIndex = -1;
+    for (int i = 0; i < m_trackList.size(); ++i) {
+        if (m_trackList.at(i)->trackId() == trackId) {
+            trackIndex = i;
+            break;
+        }
+    }
+
+    if (trackIndex == -1) {
+        return;
+    }
+
+    const auto activePanel = navigationController()->activePanel();
+    if (activePanel && activePanel->name() != QString("Track %1 Panel").arg(trackId)) {
+        navigationController()->requestActivateByName("Main Section", "Main Panel", "Main Control");
+    }
+
     for (int i = 0; i < m_trackList.size(); ++i) {
         auto& track = m_trackList.at(i);
         track->setIsFocused(track->trackId() == trackId);

--- a/src/projectscene/view/trackspanel/trackslistmodel.h
+++ b/src/projectscene/view/trackspanel/trackslistmodel.h
@@ -11,6 +11,7 @@
 #include "types/projectscenetypes.h"
 #include "trackedit/iselectioncontroller.h"
 #include "trackedit/iprojecthistory.h"
+#include "ui/inavigationcontroller.h"
 
 #include "trackitem.h"
 
@@ -37,6 +38,7 @@ class TracksListModel : public QAbstractListModel, public muse::async::Asyncable
     muse::Inject<trackedit::ITrackeditInteraction> trackeditInteraction;
     muse::Inject<trackedit::IProjectHistory> projectHistory;
     muse::Inject<muse::actions::IActionsDispatcher> dispatcher;
+    muse::Inject<muse::ui::INavigationController> navigationController;
 
 public:
     explicit TracksListModel(QObject* parent = nullptr);

--- a/src/projectscene/view/trackspanel/trackslistmodel.h
+++ b/src/projectscene/view/trackspanel/trackslistmodel.h
@@ -11,7 +11,6 @@
 #include "types/projectscenetypes.h"
 #include "trackedit/iselectioncontroller.h"
 #include "trackedit/iprojecthistory.h"
-#include "ui/inavigationcontroller.h"
 
 #include "trackitem.h"
 
@@ -38,7 +37,6 @@ class TracksListModel : public QAbstractListModel, public muse::async::Asyncable
     muse::Inject<trackedit::ITrackeditInteraction> trackeditInteraction;
     muse::Inject<trackedit::IProjectHistory> projectHistory;
     muse::Inject<muse::actions::IActionsDispatcher> dispatcher;
-    muse::Inject<muse::ui::INavigationController> navigationController;
 
 public:
     explicit TracksListModel(QObject* parent = nullptr);

--- a/src/trackedit/CMakeLists.txt
+++ b/src/trackedit/CMakeLists.txt
@@ -42,6 +42,9 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/internal/trackedituiactions.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/trackeditactionscontroller.cpp
     ${CMAKE_CURRENT_LIST_DIR}/internal/trackeditactionscontroller.h
+    ${CMAKE_CURRENT_LIST_DIR}/internal/tracknavigationcontroller.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/internal/tracknavigationcontroller.h
+    ${CMAKE_CURRENT_LIST_DIR}/internal/itracknavigationcontroller.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/changedetection.cpp
     ${CMAKE_CURRENT_LIST_DIR}/internal/changedetection.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/deletebehavioronboardingscenario.cpp
@@ -70,6 +73,8 @@ set(MODULE_SRC
 
     ${CMAKE_CURRENT_LIST_DIR}/view/deletebehaviorpanelmodel.cpp
     ${CMAKE_CURRENT_LIST_DIR}/view/deletebehaviorpanelmodel.h
+    ${CMAKE_CURRENT_LIST_DIR}/view/tracknavigationmodel.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/view/tracknavigationmodel.h
     )
 
 # AU3

--- a/src/trackedit/internal/au3/au3selectioncontroller.cpp
+++ b/src/trackedit/internal/au3/au3selectioncontroller.cpp
@@ -511,6 +511,61 @@ muse::async::Channel<au::trackedit::TrackId> Au3SelectionController::focusedTrac
     return m_focusedTrack.changed;
 }
 
+void Au3SelectionController::focusPreviousTrack()
+{
+    const au::trackedit::TrackId currentFocusedTrack = focusedTrack();
+
+    Au3Track* au3FocusedTrack = au3::DomAccessor::findTrack(projectRef(), ::TrackId(currentFocusedTrack));
+    if (!au3FocusedTrack) {
+        return;
+    }
+
+    auto& tracks = Au3TrackList::Get(projectRef());
+    auto currentIter = tracks.Find(au3FocusedTrack);
+    if (currentIter != tracks.begin()) {
+        --currentIter;
+        if (*currentIter) {
+            const TrackId trackId = TrackId((*currentIter)->GetId());
+            setFocusedTrack(trackId);
+        }
+    }
+}
+
+void Au3SelectionController::focusNextTrack()
+{
+    const au::trackedit::TrackId currentFocusedTrack = focusedTrack();
+
+    Au3Track* au3FocusedTrack = au3::DomAccessor::findTrack(projectRef(), ::TrackId(currentFocusedTrack));
+    if (!au3FocusedTrack) {
+        return;
+    }
+
+    auto& tracks = Au3TrackList::Get(projectRef());
+    auto currentIter = tracks.Find(au3FocusedTrack);
+    if (currentIter != tracks.end()) {
+        ++currentIter;
+        if (currentIter != tracks.end() && *currentIter) {
+            const TrackId trackId = TrackId((*currentIter)->GetId());
+            setFocusedTrack(trackId);
+        }
+    }
+}
+
+void Au3SelectionController::focusTrackByIndex(int index)
+{
+    if (index < 0) {
+        return;
+    }
+
+    auto& tracks = Au3TrackList::Get(projectRef());
+    auto iter = tracks.begin();
+    std::advance(iter, index);
+    if (iter != tracks.end() && *iter) {
+        const TrackId trackId = TrackId((*iter)->GetId());
+        setFocusedTrack(trackId);
+    }
+}
+
 muse::async::Channel<au::trackedit::secs_t> Au3SelectionController::dataSelectedEndTimeChanged() const
 {
     return m_selectedEndTime.changed;

--- a/src/trackedit/internal/au3/au3selectioncontroller.h
+++ b/src/trackedit/internal/au3/au3selectioncontroller.h
@@ -77,6 +77,10 @@ public:
     void setFocusedTrack(TrackId trackId) override;
     muse::async::Channel<trackedit::TrackId> focusedTrackChanged() const override;
 
+    void focusPreviousTrack() override;
+    void focusNextTrack() override;
+    void focusTrackByIndex(int index) override;
+
 private:
     void addSelectedTrack(const trackedit::TrackId& trackId);
     void updateSelectionController();

--- a/src/trackedit/internal/itracknavigationcontroller.h
+++ b/src/trackedit/internal/itracknavigationcontroller.h
@@ -1,0 +1,22 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+#pragma once
+
+#include "global/modularity/imoduleinterface.h"
+
+namespace au::trackedit {
+class ITrackNavigationController : MODULE_EXPORT_INTERFACE
+{
+    INTERFACE_ID(ITrackNavigationController);
+public:
+    virtual ~ITrackNavigationController() = default;
+
+    virtual void focusTrackByIndex(const muse::actions::ActionData& args) = 0;
+    virtual void focusPrevTrack() = 0;
+    virtual void focusNextTrack() = 0;
+    virtual void navigateUp(const muse::actions::ActionData& args) = 0;
+    virtual void navigateDown(const muse::actions::ActionData& args) = 0;
+    virtual void toggleSelectionOnFocusedTrack() = 0;
+};
+}

--- a/src/trackedit/internal/tracknavigationcontroller.cpp
+++ b/src/trackedit/internal/tracknavigationcontroller.cpp
@@ -81,7 +81,15 @@ void TrackNavigationController::navigateUp(const muse::actions::ActionData& args
         return p->index().order() == 2 * position;
     });
 
+    if (panel == panels.end()) {
+        return;
+    }
+
     const auto firstControl = (*panel)->controls().begin();
+    if (!(*firstControl)) {
+        return;
+    }
+
     navigationController()->setIsResetOnMousePress(false);
     navigationController()->setIsHighlight(true);
     navigationController()->requestActivateByName(section->name().toStdString(),
@@ -114,6 +122,10 @@ void TrackNavigationController::navigateDown(const muse::actions::ActionData& ar
     }
 
     const auto firstControl = (*panel)->controls().begin();
+    if (!(*firstControl)) {
+        return;
+    }
+
     navigationController()->setIsResetOnMousePress(false);
     navigationController()->setIsHighlight(true);
     navigationController()->requestActivateByName(section->name().toStdString(),

--- a/src/trackedit/internal/tracknavigationcontroller.cpp
+++ b/src/trackedit/internal/tracknavigationcontroller.cpp
@@ -23,6 +23,13 @@ void TrackNavigationController::init()
     dispatcher()->reg(this, PREV_TRACK_CODE, this, &TrackNavigationController::navigateUp);
     dispatcher()->reg(this, NEXT_TRACK_CODE, this, &TrackNavigationController::navigateDown);
     dispatcher()->reg(this, TRACK_TOGGLE_SELECTION_CODE, this, &TrackNavigationController::toggleSelectionOnFocusedTrack);
+
+    selectionController()->focusedTrackChanged().onReceive(this, [this](const trackedit::TrackId& trackId) {
+        const auto activePanel = navigationController()->activePanel();
+        if (activePanel && activePanel->name() != QString("Track %1 Panel").arg(trackId)) {
+            navigationController()->requestActivateByName("Main Section", "Main Panel", "Main Control");
+        }
+    });
 }
 
 void TrackNavigationController::focusTrackByIndex(const muse::actions::ActionData& args)

--- a/src/trackedit/internal/tracknavigationcontroller.cpp
+++ b/src/trackedit/internal/tracknavigationcontroller.cpp
@@ -1,0 +1,128 @@
+/*
+* Audacity: A Digital Audio Editor
+*/
+
+#include "tracknavigationcontroller.h"
+
+#include "global/containers.h"
+
+using namespace au::trackedit;
+
+static const muse::actions::ActionCode FOCUS_TRACK_INDEX_CODE("focus-track-index");
+static const muse::actions::ActionCode FOCUS_PREV_TRACK_CODE("focus-prev-track");
+static const muse::actions::ActionCode FOCUS_NEXT_TRACK_CODE("focus-next-track");
+static const muse::actions::ActionCode PREV_TRACK_CODE("prev-track");
+static const muse::actions::ActionCode NEXT_TRACK_CODE("next-track");
+static const muse::actions::ActionCode TRACK_TOGGLE_SELECTION_CODE("track-toggle-focused-selection");
+
+void TrackNavigationController::init()
+{
+    dispatcher()->reg(this, FOCUS_TRACK_INDEX_CODE, this, &TrackNavigationController::focusTrackByIndex);
+    dispatcher()->reg(this, FOCUS_PREV_TRACK_CODE, this, &TrackNavigationController::focusPrevTrack);
+    dispatcher()->reg(this, FOCUS_NEXT_TRACK_CODE, this, &TrackNavigationController::focusNextTrack);
+    dispatcher()->reg(this, PREV_TRACK_CODE, this, &TrackNavigationController::navigateUp);
+    dispatcher()->reg(this, NEXT_TRACK_CODE, this, &TrackNavigationController::navigateDown);
+    dispatcher()->reg(this, TRACK_TOGGLE_SELECTION_CODE, this, &TrackNavigationController::toggleSelectionOnFocusedTrack);
+}
+
+void TrackNavigationController::focusTrackByIndex(const muse::actions::ActionData& args)
+{
+    if (args.count() != 1) {
+        return;
+    }
+
+    const int index = args.arg<int>(0);
+    if (index < 0) {
+        return;
+    }
+
+    selectionController()->focusTrackByIndex(index);
+}
+
+void TrackNavigationController::focusPrevTrack()
+{
+    selectionController()->focusPreviousTrack();
+}
+
+void TrackNavigationController::focusNextTrack()
+{
+    selectionController()->focusNextTrack();
+}
+
+void TrackNavigationController::navigateUp(const muse::actions::ActionData& args)
+{
+    if (args.count() != 1) {
+        return;
+    }
+
+    const auto section = navigationController()->activeSection();
+    if (!section) {
+        return;
+    }
+
+    const int position = args.arg<int>(0) - 1;
+    if (position < 0) {
+        return;
+    }
+
+    const auto panels = section->panels();
+    if (static_cast<size_t>(2 * position) >= panels.size()) {
+        return;
+    }
+
+    const auto& panel = std::find_if(panels.begin(), panels.end(), [position](const muse::ui::INavigationPanel* p) {
+        return p->index().order() == 2 * position;
+    });
+
+    const auto firstControl = (*panel)->controls().begin();
+    navigationController()->setIsResetOnMousePress(false);
+    navigationController()->setIsHighlight(true);
+    navigationController()->requestActivateByName(section->name().toStdString(),
+                                                  (*panel)->name().toStdString(), (*firstControl)->name().toStdString());
+}
+
+void TrackNavigationController::navigateDown(const muse::actions::ActionData& args)
+{
+    if (args.count() != 1) {
+        return;
+    }
+
+    const auto section = navigationController()->activeSection();
+    if (!section) {
+        return;
+    }
+
+    const int position = args.arg<int>(0) + 1;
+    const auto panels = section->panels();
+    if (static_cast<size_t>(2 * position) >= panels.size()) {
+        return;
+    }
+
+    const auto& panel = std::find_if(panels.begin(), panels.end(), [position](const muse::ui::INavigationPanel* p) {
+        return p->index().order() == 2 * position;
+    });
+
+    if (panel == panels.end()) {
+        return;
+    }
+
+    const auto firstControl = (*panel)->controls().begin();
+    navigationController()->setIsResetOnMousePress(false);
+    navigationController()->setIsHighlight(true);
+    navigationController()->requestActivateByName(section->name().toStdString(),
+                                                  (*panel)->name().toStdString(), (*firstControl)->name().toStdString());
+}
+
+void TrackNavigationController::toggleSelectionOnFocusedTrack()
+{
+    const au::trackedit::TrackId focusedTrack = selectionController()->focusedTrack();
+    au::trackedit::TrackIdList selectedTracks = selectionController()->selectedTracks();
+
+    if (muse::contains(selectedTracks, focusedTrack)) {
+        selectedTracks.erase(std::remove(selectedTracks.begin(), selectedTracks.end(), focusedTrack), selectedTracks.end());
+    } else {
+        selectedTracks.push_back(focusedTrack);
+    }
+
+    selectionController()->setSelectedTracks(selectedTracks);
+}

--- a/src/trackedit/internal/tracknavigationcontroller.h
+++ b/src/trackedit/internal/tracknavigationcontroller.h
@@ -1,0 +1,32 @@
+/*
+* Audacity: A Digital Audio Editor
+*/
+
+#pragma once
+
+#include "framework/actions/actionable.h"
+
+#include "framework/global/modularity/ioc.h"
+#include "trackedit/iselectioncontroller.h"
+#include "actions/iactionsdispatcher.h"
+#include "ui/inavigationcontroller.h"
+
+#include "trackedit/internal/itracknavigationcontroller.h"
+
+namespace au::trackedit {
+class TrackNavigationController : public ITrackNavigationController, public muse::actions::Actionable
+{
+    muse::Inject<muse::actions::IActionsDispatcher> dispatcher;
+    muse::Inject<au::trackedit::ISelectionController> selectionController;
+    muse::Inject<muse::ui::INavigationController> navigationController;
+
+public:
+    void init();
+    void focusTrackByIndex(const muse::actions::ActionData& args) override;
+    void focusPrevTrack() override;
+    void focusNextTrack() override;
+    void navigateUp(const muse::actions::ActionData& args) override;
+    void navigateDown(const muse::actions::ActionData& args) override;
+    void toggleSelectionOnFocusedTrack() override;
+};
+}

--- a/src/trackedit/internal/tracknavigationcontroller.h
+++ b/src/trackedit/internal/tracknavigationcontroller.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "framework/actions/actionable.h"
+#include "async/asyncable.h"
 
 #include "framework/global/modularity/ioc.h"
 #include "trackedit/iselectioncontroller.h"
@@ -14,7 +15,7 @@
 #include "trackedit/internal/itracknavigationcontroller.h"
 
 namespace au::trackedit {
-class TrackNavigationController : public ITrackNavigationController, public muse::actions::Actionable
+class TrackNavigationController : public ITrackNavigationController, public muse::actions::Actionable, public muse::async::Asyncable
 {
     muse::Inject<muse::actions::IActionsDispatcher> dispatcher;
     muse::Inject<au::trackedit::ISelectionController> selectionController;

--- a/src/trackedit/iselectioncontroller.h
+++ b/src/trackedit/iselectioncontroller.h
@@ -80,5 +80,9 @@ public:
     virtual TrackId focusedTrack() const = 0;
     virtual void setFocusedTrack(TrackId trackId) = 0;
     virtual muse::async::Channel<trackedit::TrackId> focusedTrackChanged() const = 0;
+
+    virtual void focusPreviousTrack() = 0;
+    virtual void focusNextTrack() = 0;
+    virtual void focusTrackByIndex(int index) = 0;
 };
 }

--- a/src/trackedit/tests/mocks/selectioncontrollermock.h
+++ b/src/trackedit/tests/mocks/selectioncontrollermock.h
@@ -56,5 +56,9 @@ public:
     MOCK_METHOD(TrackId, focusedTrack, (), (const, override));
     MOCK_METHOD(void, setFocusedTrack, (TrackId trackId), (override));
     MOCK_METHOD(muse::async::Channel<trackedit::TrackId>, focusedTrackChanged, (), (const, override));
+
+    MOCK_METHOD(void, focusPreviousTrack, (), (override));
+    MOCK_METHOD(void, focusNextTrack, (), (override));
+    MOCK_METHOD(void, focusTrackByIndex, (int index), (override));
 };
 }

--- a/src/trackedit/trackeditmodule.cpp
+++ b/src/trackedit/trackeditmodule.cpp
@@ -30,9 +30,11 @@
 #include "internal/trackeditinteraction.h"
 #include "internal/trackeditconfiguration.h"
 #include "internal/trackeditoperationcontroller.h"
+#include "internal/tracknavigationcontroller.h"
 #include "internal/undomanager.h"
 
 #include "view/deletebehaviorpanelmodel.h"
+#include "view/tracknavigationmodel.h"
 
 #include "internal/au3/au3trackeditproject.h"
 #include "internal/au3/au3interaction.h"
@@ -65,6 +67,7 @@ void TrackeditModule::registerExports()
     m_trackeditUiActions = std::make_shared<TrackeditUiActions>(m_trackeditController);
     m_selectionController = std::make_shared<Au3SelectionController>();
     m_configuration = std::make_shared<TrackeditConfiguration>();
+    m_trackNavigationController = std::make_shared<TrackNavigationController>();
 
     ioc()->registerExport<ITrackeditActionsController>(moduleName(), m_trackeditController);
     ioc()->registerExport<ITrackeditProjectCreator>(moduleName(), new Au3TrackeditProjectCreator());
@@ -76,11 +79,13 @@ void TrackeditModule::registerExports()
     ioc()->registerExport<IProjectHistory>(moduleName(), new Au3ProjectHistory());
     ioc()->registerExport<ITrackeditClipboard>(moduleName(), new Au3TrackeditClipboard());
     ioc()->registerExport<ITrackeditConfiguration>(moduleName(), m_configuration);
+    ioc()->registerExport<ITrackNavigationController>(moduleName(), m_trackNavigationController);
 }
 
 void TrackeditModule::registerUiTypes()
 {
     qmlRegisterType<DeleteBehaviorPanelModel>("Audacity.TrackEdit", 1, 0, "DeleteBehaviorPanelModel");
+    qmlRegisterType<TrackNavigationModel>("Audacity.TrackEdit", 1, 0, "TrackNavigationModel");
 }
 
 void TrackeditModule::resolveImports()
@@ -111,6 +116,7 @@ void TrackeditModule::onInit(const muse::IApplication::RunMode&)
     m_trackeditUiActions->init();
     m_selectionController->init();
     m_configuration->init();
+    m_trackNavigationController->init();
 
     TimeSignatureRestorer::reg();
 

--- a/src/trackedit/trackeditmodule.h
+++ b/src/trackedit/trackeditmodule.h
@@ -10,6 +10,7 @@ class TrackeditActionsController;
 class TrackeditUiActions;
 class Au3SelectionController;
 class TrackeditConfiguration;
+class TrackNavigationController;
 class TrackeditModule : public muse::modularity::IModuleSetup
 {
 public:
@@ -27,5 +28,6 @@ private:
     std::shared_ptr<TrackeditUiActions> m_trackeditUiActions;
     std::shared_ptr<Au3SelectionController> m_selectionController;
     std::shared_ptr<TrackeditConfiguration> m_configuration;
+    std::shared_ptr<TrackNavigationController> m_trackNavigationController;
 };
 }

--- a/src/trackedit/view/tracknavigationmodel.cpp
+++ b/src/trackedit/view/tracknavigationmodel.cpp
@@ -1,0 +1,253 @@
+#include "tracknavigationmodel.h"
+
+using namespace au::trackedit;
+TrackNavigationModel::TrackNavigationModel(QObject* parent)
+    : QObject(parent)
+{
+    globalContext()->currentTrackeditProjectChanged().onNotify(this, [this]() {
+        init();
+    });
+}
+
+void TrackNavigationModel::init(muse::ui::NavigationSection* section)
+{
+    if (section) {
+        m_section = section;
+    }
+
+    const ITrackeditProjectPtr prj = globalContext()->currentTrackeditProject();
+    if (!prj) {
+        return;
+    }
+
+    prj->tracksChanged().onReceive(this, [this](std::vector<au::trackedit::Track>) {
+    });
+
+    prj->trackAdded().onReceive(this, [this](const Track& track) {
+        const int pos = m_trackItemPanels.size();
+
+        muse::ui::NavigationPanel* trackPanel = new muse::ui::NavigationPanel(this);
+        trackPanel->setName(QString("Track %1 Panel").arg(track.id));
+        trackPanel->setIndex({ 2 * pos, 0 });
+        trackPanel->setOrder(2 * pos);
+        trackPanel->setSection(m_section);
+
+        connect(trackPanel, &muse::ui::NavigationPanel::navigationEvent, this, [this, pos](QVariant event) {
+            muse::ui::NavigationEvent navEvent = event.value<muse::ui::NavigationEvent>();
+
+            if (navEvent.type() == muse::ui::NavigationEvent::Type::Up) {
+                const auto args = muse::actions::ActionData::make_arg1<int>(pos);
+                dispatcher()->dispatch("prev-track", args);
+                navEvent.setAccepted(true);
+            } else if (navEvent.type() == muse::ui::NavigationEvent::Type::Down) {
+                const auto args = muse::actions::ActionData::make_arg1<int>(pos);
+                dispatcher()->dispatch("next-track", args);
+                navEvent.setAccepted(true);
+            } else if (navEvent.type() == muse::ui::NavigationEvent::Type::Trigger) {
+                dispatcher()->dispatch("track-toggle-focused-selection");
+                navEvent.setAccepted(true);
+            }
+        });
+
+        muse::ui::NavigationPanel* clipPanel = new muse::ui::NavigationPanel(this);
+        clipPanel->setName(QString("Clip %1 Panel").arg(track.id));
+        clipPanel->setIndex({ 2 * pos + 1, 0 });
+        clipPanel->setOrder(2 * pos + 1);
+        clipPanel->setSection(m_section);
+
+        m_trackItemPanels.append(trackPanel);
+        m_clipItemPanels.append(clipPanel);
+
+        emit trackItemPanelsChanged();
+        emit clipItemPanelsChanged();
+    });
+
+    prj->trackRemoved().onReceive(this, [this](const Track& track) {
+        for (int i = 0; i < m_trackItemPanels.size(); ++i) {
+            if (m_trackItemPanels.at(i)->name() == QString("Track %1 Panel").arg(track.id)) {
+                muse::ui::NavigationPanel* trackPanel = m_trackItemPanels.takeAt(i);
+                trackPanel->deleteLater();
+                break;
+            }
+        }
+
+        for (int i = 0; i < m_clipItemPanels.size(); ++i) {
+            if (m_clipItemPanels.at(i)->name() == QString("Clip %1 Panel").arg(track.id)) {
+                muse::ui::NavigationPanel* clipPanel = m_clipItemPanels.takeAt(i);
+                clipPanel->deleteLater();
+                break;
+            }
+        }
+
+        emit trackItemPanelsChanged();
+        emit clipItemPanelsChanged();
+    });
+
+    prj->trackChanged().onReceive(this, [this](const Track&) {});
+
+    prj->trackInserted().onReceive(this, [this](const Track& track, int pos) {
+        muse::ui::NavigationPanel* trackPanel = new muse::ui::NavigationPanel(this);
+        trackPanel->setName(QString("Track %1 Panel").arg(track.id));
+        trackPanel->setIndex({ 2 * pos, 0 });
+        trackPanel->setOrder(pos);
+        trackPanel->setSection(m_section);
+
+        muse::ui::NavigationPanel* clipPanel = new muse::ui::NavigationPanel(this);
+        clipPanel->setName(QString("Clip %1 Panel").arg(track.id));
+        clipPanel->setIndex({ 2 * pos + 1, 1 });
+        clipPanel->setOrder(pos);
+        clipPanel->setSection(m_section);
+
+        m_trackItemPanels.append(trackPanel);
+        m_clipItemPanels.append(clipPanel);
+
+        emit trackItemPanelsChanged();
+        emit clipItemPanelsChanged();
+    });
+
+    prj->trackMoved().onReceive(this, [this](const Track& track, int pos) {
+        for (int i = 0; i < m_trackItemPanels.size(); ++i) {
+            if (m_trackItemPanels.at(i)->name() == QString("Track %1 Panel").arg(track.id)) {
+                auto trackPanel = m_trackItemPanels.takeAt(i);
+                m_trackItemPanels.insert(pos, trackPanel);
+                break;
+            }
+        }
+
+        for (int i = 0; i < m_clipItemPanels.size(); ++i) {
+            if (m_clipItemPanels.at(i)->name() == QString("Clip %1 Panel").arg(track.id)) {
+                auto clipPanel = m_clipItemPanels.takeAt(i);
+                m_clipItemPanels.insert(pos, clipPanel);
+                break;
+            }
+        }
+
+        for (int i = 0; i < m_trackItemPanels.size(); ++i) {
+            m_trackItemPanels.at(i)->setOrder(i);
+        }
+
+        for (int i = 0; i < m_clipItemPanels.size(); ++i) {
+            m_clipItemPanels.at(i)->setOrder(i);
+        }
+
+        emit trackItemPanelsChanged();
+        emit clipItemPanelsChanged();
+    });
+
+    const auto trackList = prj->trackList();
+    for (const auto& track : trackList) {
+        const int pos = m_trackItemPanels.size();
+        muse::ui::NavigationPanel* trackPanel = new muse::ui::NavigationPanel(this);
+        trackPanel->setName(QString("Track %1 Panel").arg(track.id));
+        trackPanel->setIndex({ 2 * pos, 0 });
+        trackPanel->setOrder(2 * pos);
+        trackPanel->setSection(m_section);
+
+        connect(trackPanel, &muse::ui::NavigationPanel::navigationEvent, this, [this, pos](QVariant event) {
+            muse::ui::NavigationEvent navEvent = event.value<muse::ui::NavigationEvent>();
+
+            if (navEvent.type() == muse::ui::NavigationEvent::Type::Up) {
+                const auto args = muse::actions::ActionData::make_arg1<int>(pos);
+                dispatcher()->dispatch("prev-track", args);
+                navEvent.setAccepted(true);
+            } else if (navEvent.type() == muse::ui::NavigationEvent::Type::Down) {
+                const auto args = muse::actions::ActionData::make_arg1<int>(pos);
+                dispatcher()->dispatch("next-track", args);
+                navEvent.setAccepted(true);
+            } else if (navEvent.type() == muse::ui::NavigationEvent::Type::Trigger) {
+                dispatcher()->dispatch("track-toggle-focused-selection");
+                navEvent.setAccepted(true);
+            }
+        });
+
+        m_trackItemPanels.append(trackPanel);
+    }
+
+    for (const auto& track : trackList) {
+        const int pos = m_clipItemPanels.size();
+        muse::ui::NavigationPanel* clipPanel = new muse::ui::NavigationPanel(this);
+        clipPanel->setName(QString("Clip %1 Panel").arg(track.id));
+        clipPanel->setIndex({ 2 * pos + 1, 0 });
+        clipPanel->setOrder(2 * pos + 1);
+        clipPanel->setSection(m_section);
+
+        m_clipItemPanels.append(clipPanel);
+    }
+    emit trackItemPanelsChanged();
+    emit clipItemPanelsChanged();
+
+    m_default_section = new muse::ui::NavigationSection(this);
+    m_default_section->setName("Main Section");
+    m_default_section->setIndex({ 0, 0 });
+    m_default_section->setOrder(0);
+
+    m_default_panel = new muse::ui::NavigationPanel(this);
+    m_default_panel->setName("Main Panel");
+    m_default_panel->setIndex({ 0, 0 });
+    m_default_panel->setOrder(0);
+    m_default_panel->setSection(m_default_section);
+
+    m_default_control = new muse::ui::NavigationControl(this);
+    m_default_control->setName("Main Control");
+    m_default_control->setIndex({ 0, 0 });
+    m_default_control->setOrder(0);
+    m_default_control->setPanel(m_default_panel);
+
+    connect(m_default_control, &muse::ui::NavigationControl::navigationEvent, this, [this](QVariant event) {
+        muse::ui::NavigationEvent navEvent = event.value<muse::ui::NavigationEvent>();
+
+        if (navEvent.type() == muse::ui::NavigationEvent::Type::Up) {
+            dispatcher()->dispatch("focus-prev-track");
+            navEvent.setAccepted(true);
+        } else if (navEvent.type() == muse::ui::NavigationEvent::Type::Down) {
+            dispatcher()->dispatch("focus-next-track");
+            navEvent.setAccepted(true);
+        } else if (navEvent.type() == muse::ui::NavigationEvent::Type::Trigger) {
+            dispatcher()->dispatch("track-toggle-focused-selection");
+            navEvent.setAccepted(true);
+        }
+    });
+
+    navigationController()->reg(m_default_section);
+    navigationController()->requestActivateByName(m_default_section->name().toStdString(),
+                                                  m_default_panel->name().toStdString(), m_default_control->name().toStdString());
+    navigationController()->setDefaultNavigationControl(m_default_control);
+}
+
+void TrackNavigationModel::requestActivateByIndex(int index)
+{
+    if (index < 0 || index >= m_trackItemPanels.size()) {
+        return;
+    }
+
+    const auto& panel = m_trackItemPanels.at(index);
+    if (!panel) {
+        return;
+    }
+
+    const auto firstControl = panel->controls().begin();
+
+    navigationController()->setIsResetOnMousePress(false);
+    navigationController()->setIsHighlight(true);
+    navigationController()->requestActivateByName(m_section->name().toStdString(), panel->name().toStdString(),
+                                                  (*firstControl)->name().toStdString());
+}
+
+void TrackNavigationModel::moveFocusTo(int index)
+{
+    if (index < 0 || index >= m_trackItemPanels.size()) {
+        return;
+    }
+
+    dispatcher()->dispatch("focus-track-index", muse::actions::ActionData::make_arg1<int>(index));
+}
+
+QList<muse::ui::NavigationPanel*> TrackNavigationModel::trackItemPanels() const
+{
+    return m_trackItemPanels;
+}
+
+QList<muse::ui::NavigationPanel*> TrackNavigationModel::clipItemPanels() const
+{
+    return m_clipItemPanels;
+}

--- a/src/trackedit/view/tracknavigationmodel.h
+++ b/src/trackedit/view/tracknavigationmodel.h
@@ -24,7 +24,7 @@ class TrackNavigationModel : public QObject, public muse::async::Asyncable
 public:
     explicit TrackNavigationModel(QObject* parent = nullptr);
 
-    Q_INVOKABLE void init(muse::ui::NavigationSection* section = nullptr);
+    Q_INVOKABLE void init(muse::ui::NavigationSection* section);
     Q_INVOKABLE void requestActivateByIndex(int index);
     Q_INVOKABLE void moveFocusTo(int index);
 
@@ -38,6 +38,7 @@ signals:
 private:
     void load();
     void cleanup();
+    void clearPanels();
 
     void addPanels(trackedit::TrackId trackId, int pos);
     void resetPanelOrder();

--- a/src/trackedit/view/tracknavigationmodel.h
+++ b/src/trackedit/view/tracknavigationmodel.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include "ui/view/navigationsection.h"
+#include "ui/view/navigationpanel.h"
+#include "global/async/asyncable.h"
+
+#include "global/modularity/ioc.h"
+#include "context/iglobalcontext.h"
+#include "actions/iactionsdispatcher.h"
+#include "ui/inavigationcontroller.h"
+
+namespace au::trackedit {
+class TrackNavigationModel : public QObject, public muse::async::Asyncable
+{
+    Q_OBJECT
+
+    muse::Inject<au::context::IGlobalContext> globalContext;
+    muse::Inject<muse::actions::IActionsDispatcher> dispatcher;
+    muse::Inject<muse::ui::INavigationController> navigationController;
+
+    Q_PROPERTY(QList<muse::ui::NavigationPanel*> trackItemPanels READ trackItemPanels NOTIFY trackItemPanelsChanged)
+    Q_PROPERTY(QList<muse::ui::NavigationPanel*> clipItemPanels READ clipItemPanels NOTIFY clipItemPanelsChanged)
+
+public:
+    explicit TrackNavigationModel(QObject* parent = nullptr);
+
+    Q_INVOKABLE void init(muse::ui::NavigationSection* section = nullptr);
+    Q_INVOKABLE void requestActivateByIndex(int index);
+    Q_INVOKABLE void moveFocusTo(int index);
+
+    QList<muse::ui::NavigationPanel*> trackItemPanels() const;
+    QList<muse::ui::NavigationPanel*> clipItemPanels() const;
+
+signals:
+    void trackItemPanelsChanged();
+    void clipItemPanelsChanged();
+
+private:
+    muse::ui::NavigationControl* m_default_control = nullptr;
+    muse::ui::NavigationPanel* m_default_panel = nullptr;
+    muse::ui::NavigationSection* m_default_section = nullptr;
+
+    muse::ui::INavigationSection* m_section = nullptr;
+
+    QList<muse::ui::NavigationPanel*> m_trackItemPanels;
+    QList<muse::ui::NavigationPanel*> m_clipItemPanels;
+};
+}

--- a/src/trackedit/view/tracknavigationmodel.h
+++ b/src/trackedit/view/tracknavigationmodel.h
@@ -36,6 +36,13 @@ signals:
     void clipItemPanelsChanged();
 
 private:
+    void load();
+    void cleanup();
+
+    void addPanels(trackedit::TrackId trackId, int pos);
+    void resetPanelOrder();
+    void addDefaultNavigation();
+
     muse::ui::NavigationControl* m_default_control = nullptr;
     muse::ui::NavigationPanel* m_default_panel = nullptr;
     muse::ui::NavigationSection* m_default_section = nullptr;


### PR DESCRIPTION
Resolves: #9263 

This PR allows the user to change the focused track using the up and down arrow keys.
Also, the user can add or remove the track from the list of selected tracks using the arrow key.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
