### PR TITLE
Add Vertical red lines in clipped waveforms

### DIFF
--- a/src/projectscene/view/clipsview/au3/connectingdotspainter.cpp
+++ b/src/projectscene/view/clipsview/au3/connectingdotspainter.cpp
@@ -62,6 +62,10 @@ void ConnectingDotsPainter::paint(QPainter& painter, const trackedit::ClipKey& c
         if (samples.size() == 0) {
             continue;
         }
+        if (params.showClipping) {
+            samplespainterutils::drawClippedSamples(samples, waveMetrics, painter, params.style);
+        }
+
         drawConnectingPoints(samples, waveMetrics, painter, params.style);
         waveMetrics.top += waveMetrics.height;
     }

--- a/src/projectscene/view/clipsview/au3/sampledata.h
+++ b/src/projectscene/view/clipsview/au3/sampledata.h
@@ -4,11 +4,12 @@ namespace au::projectscene {
 struct SampleData {
     std::vector<double> y {};
     std::vector<double> x {};
+    std::vector<int> clippedX {};
 
     SampleData() = default;
 
-    SampleData(std::vector<double> pY, std::vector<double> pX)
-        : y(std::move(pY)), x(std::move(pX)) {}
+    SampleData(std::vector<double> pY, std::vector<double> pX, std::vector<int> pClippedX)
+        : y(std::move(pY)), x(std::move(pX)), clippedX(std::move(pClippedX)) {}
 
     size_t size() const { return x.size(); }
 };

--- a/src/projectscene/view/clipsview/au3/samplespainterutils.h
+++ b/src/projectscene/view/clipsview/au3/samplespainterutils.h
@@ -15,6 +15,8 @@ int getWaveYPos(float value, float min, float max, int height, bool dB, bool out
 void drawBackground(QPainter& painter, const au::projectscene::WaveMetrics& metrics, const IWavePainter::Style& style,
                     const double trimLeft);
 void drawBaseLine(QPainter& painter, const au::projectscene::WaveMetrics& metrics, const IWavePainter::Style& style);
+void drawClippedSamples(const au::projectscene::SampleData& samples, const au::projectscene::WaveMetrics& metrics, QPainter& painter,
+                        const au::projectscene::IWavePainter::Style& style);
 SampleData getSampleData(const au::au3::Au3WaveClip& clip, int channelIndex, const au::projectscene::WaveMetrics& metrics, bool dB,
                          float dBRange, float zoomMax, float zoomMin);
 std::optional<int> hitChannelIndex(std::shared_ptr<au::project::IAudacityProject> project, const trackedit::ClipKey& clipKey,


### PR DESCRIPTION
Resolves: [Vertical red lines in clipped waveforms](https://github.com/audacity/audacity/issues/9239)

visual red lines are added to indicate clipped samples

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
