### PR TITLE
Fix project restoration flow

### DIFF
--- a/src/appshell/internal/sessionsmanager.h
+++ b/src/appshell/internal/sessionsmanager.h
@@ -32,6 +32,7 @@
 #include "iappshellconfiguration.h"
 #include "multiinstances/imultiinstancesprovider.h"
 #include "isessionsmanager.h"
+#include "au3wrap/iau3project.h"
 
 #include "project/iprojectconfiguration.h"
 
@@ -43,6 +44,9 @@ class SessionsManager : public ISessionsManager, public muse::async::Asyncable
     INJECT(IAppShellConfiguration, configuration)
     INJECT(muse::mi::IMultiInstancesProvider, multiInstancesProvider)
     INJECT(project::IProjectConfiguration, projectConfiguration)
+    INJECT(muse::io::IFileSystem, fileSystem)
+    INJECT(au::au3::IAu3ProjectCreator, au3ProjectCreator)
+
 public:
     void init();
     void deinit();
@@ -57,6 +61,10 @@ private:
 
     void removeProjectFromSession(const muse::io::path_t& projectPath);
     void addProjectToSession(const muse::io::path_t& projectPath);
+
+    void removeProjectsUnsavedChanges(const muse::io::paths_t& projectsPaths);
+    void removeUnsavedChanges(const muse::io::path_t& projectPath);
+    bool isPathToNewlyCreatedProject(const muse::io::path_t& projectPath) const;
 
     muse::io::path_t m_lastOpenedProjectPath;
 };

--- a/src/appshell/internal/startupscenario.cpp
+++ b/src/appshell/internal/startupscenario.cpp
@@ -228,14 +228,6 @@ void StartupScenario::restoreLastSession()
     if (result.button() == static_cast<int>(muse::IInteractive::Button::Yes)) {
         sessionsManager()->restore();
     } else {
-        removeProjectsUnsavedChanges(configuration()->sessionProjectsPaths());
         sessionsManager()->reset();
-    }
-}
-
-void StartupScenario::removeProjectsUnsavedChanges(const muse::io::paths_t& projectsPaths)
-{
-    for (const muse::io::path_t& path : projectsPaths) {
-        projectAutoSaver()->removeProjectUnsavedChanges(path);
     }
 }

--- a/src/appshell/internal/startupscenario.cpp
+++ b/src/appshell/internal/startupscenario.cpp
@@ -235,8 +235,7 @@ void StartupScenario::restoreLastSession()
 
 void StartupScenario::removeProjectsUnsavedChanges(const muse::io::paths_t& projectsPaths)
 {
-    //! TODO AU4
-    // for (const io::path_t& path : projectsPaths) {
-    //     projectAutoSaver()->removeProjectUnsavedChanges(path);
-    // }
+    for (const muse::io::path_t& path : projectsPaths) {
+        projectAutoSaver()->removeProjectUnsavedChanges(path);
+    }
 }

--- a/src/appshell/internal/startupscenario.h
+++ b/src/appshell/internal/startupscenario.h
@@ -32,7 +32,7 @@
 #include "iappshellconfiguration.h"
 #include "isessionsmanager.h"
 #include "audioplugins/iregisteraudiopluginsscenario.h"
-#include "project/iprojectautosaver.h"
+// #include "project/iprojectautosaver.h"
 
 //! TODO AU4
 // #include "multiinstances/imultiinstancesprovider.h"
@@ -45,7 +45,7 @@ class StartupScenario : public au::appshell::IStartupScenario, public muse::asyn
     muse::Inject<IAppShellConfiguration> configuration;
     muse::Inject<ISessionsManager> sessionsManager;
     muse::Inject<muse::audioplugins::IRegisterAudioPluginsScenario> registerAudioPluginsScenario;
-    muse::Inject<au::project::IProjectAutoSaver> projectAutoSaver;
+    // muse::Inject<au::project::IProjectAutoSaver> projectAutoSaver; // we don't use at the moment 01/09/2025 the project auto saver as we already have the autosave table
 
 //! TODO AU4
     // INJECT(mi::IMultiInstancesProvider, multiInstancesProvider)
@@ -71,7 +71,6 @@ private:
     void openScore(const au::project::ProjectFile& file);
 
     void restoreLastSession();
-    void removeProjectsUnsavedChanges(const muse::io::paths_t& projectsPaths);
 
     std::string m_startupTypeStr;
     au::project::ProjectFile m_startupScoreFile;

--- a/src/appshell/view/mainwindowtitleprovider.cpp
+++ b/src/appshell/view/mainwindowtitleprovider.cpp
@@ -105,5 +105,5 @@ void MainWindowTitleProvider::update()
     setTitle((muse::qtrc("appshell", "%1 - Audacity 4").arg(project->title())));
 
     setFilePath(project->path().toQString());
-    setFileModified(projectAutoSaver()->projectHasUnsavedChanges(project));
+    setFileModified(project->hasUnsavedChanges());
 }

--- a/src/appshell/view/mainwindowtitleprovider.cpp
+++ b/src/appshell/view/mainwindowtitleprovider.cpp
@@ -105,5 +105,5 @@ void MainWindowTitleProvider::update()
     setTitle((muse::qtrc("appshell", "%1 - Audacity 4").arg(project->title())));
 
     setFilePath(project->path().toQString());
-    setFileModified(project->needSave().val);
+    setFileModified(projectAutoSaver()->projectHasUnsavedChanges(project));
 }

--- a/src/appshell/view/mainwindowtitleprovider.h
+++ b/src/appshell/view/mainwindowtitleprovider.h
@@ -29,6 +29,7 @@
 
 #include "modularity/ioc.h"
 #include "context/iglobalcontext.h"
+#include "project/iprojectautosaver.h"
 
 namespace au::appshell {
 class MainWindowTitleProvider : public QObject, public muse::async::Asyncable
@@ -36,6 +37,7 @@ class MainWindowTitleProvider : public QObject, public muse::async::Asyncable
     Q_OBJECT
 
     muse::Inject<au::context::IGlobalContext> context;
+    muse::Inject<au::project::IProjectAutoSaver> projectAutoSaver;
 
     Q_PROPERTY(QString title READ title NOTIFY titleChanged)
     Q_PROPERTY(QString filePath READ filePath NOTIFY filePathChanged)

--- a/src/appshell/view/mainwindowtitleprovider.h
+++ b/src/appshell/view/mainwindowtitleprovider.h
@@ -29,7 +29,6 @@
 
 #include "modularity/ioc.h"
 #include "context/iglobalcontext.h"
-#include "project/iprojectautosaver.h"
 
 namespace au::appshell {
 class MainWindowTitleProvider : public QObject, public muse::async::Asyncable
@@ -37,7 +36,6 @@ class MainWindowTitleProvider : public QObject, public muse::async::Asyncable
     Q_OBJECT
 
     muse::Inject<au::context::IGlobalContext> context;
-    muse::Inject<au::project::IProjectAutoSaver> projectAutoSaver;
 
     Q_PROPERTY(QString title READ title NOTIFY titleChanged)
     Q_PROPERTY(QString filePath READ filePath NOTIFY filePathChanged)

--- a/src/au3wrap/iau3project.h
+++ b/src/au3wrap/iau3project.h
@@ -31,6 +31,10 @@ public:
     virtual void markAsSaved() = 0;
     [[nodiscard]] virtual bool isRecovered() const = 0;
 
+    // Autosave management
+    [[nodiscard]] virtual bool hasAutosaveData() const = 0;
+    virtual bool removeAutosaveData() = 0;
+
     virtual muse::async::Notification projectChanged() const = 0;
 
     // internal
@@ -44,5 +48,8 @@ public:
     virtual ~IAu3ProjectCreator() = default;
 
     virtual std::shared_ptr<IAu3Project> create() const = 0;
+
+    // Helper method to remove autosave data from a project file without keeping it open
+    virtual bool removeAutosaveDataFromFile(const muse::io::path_t& projectPath) const = 0;
 };
 }

--- a/src/au3wrap/iau3project.h
+++ b/src/au3wrap/iau3project.h
@@ -49,7 +49,6 @@ public:
 
     virtual std::shared_ptr<IAu3Project> create() const = 0;
 
-    // Helper method to remove autosave data from a project file without keeping it open
     virtual bool removeAutosaveDataFromFile(const muse::io::path_t& projectPath) const = 0;
 };
 }

--- a/src/au3wrap/internal/au3project.cpp
+++ b/src/au3wrap/internal/au3project.cpp
@@ -57,6 +57,7 @@ std::shared_ptr<IAu3Project> Au3ProjectCreator::create() const
 
 bool Au3ProjectCreator::removeAutosaveDataFromFile(const muse::io::path_t& projectPath) const
 {
+    // Helper method to remove autosave data from a project file without keeping it open
     const auto tempProject = create();
     if (!tempProject) {
         return false;
@@ -313,7 +314,6 @@ muse::async::Notification Au3ProjectAccessor::projectChanged() const
 bool Au3ProjectAccessor::hasAutosaveData() const
 {
     const auto& projectFileIO = ProjectFileIO::Get(m_data->projectRef());
-    // Autosave data exists if project is recovered and modified
     return projectFileIO.IsRecovered() && projectFileIO.IsModified();
 }
 

--- a/src/au3wrap/internal/au3project.cpp
+++ b/src/au3wrap/internal/au3project.cpp
@@ -55,6 +55,24 @@ std::shared_ptr<IAu3Project> Au3ProjectCreator::create() const
     return std::make_shared<Au3ProjectAccessor>();
 }
 
+bool Au3ProjectCreator::removeAutosaveDataFromFile(const muse::io::path_t& projectPath) const
+{
+    const auto tempProject = create();
+    if (!tempProject) {
+        return false;
+    }
+
+    tempProject->open();
+    auto ret = tempProject->load(projectPath);
+    if (ret) {
+        const bool success = tempProject->removeAutosaveData();
+        tempProject->close();
+        return success;
+    }
+    tempProject->close();
+    return false;
+}
+
 struct au::au3::Au3ProjectData
 {
     std::shared_ptr<Au3Project> project;
@@ -261,7 +279,18 @@ uintptr_t Au3ProjectAccessor::au3ProjectPtr() const
 bool Au3ProjectAccessor::hasUnsavedChanges() const
 {
     const auto& undoManager = UndoManager::Get(m_data->projectRef());
-    return undoManager.UnsavedChanges();
+
+    // Check UndoManager for regular changes
+    if (undoManager.UnsavedChanges()) {
+        return true;
+    }
+
+    // Check for autosave data (recovered projects with modifications)
+    if (hasAutosaveData()) {
+        return true;
+    }
+
+    return false;
 }
 
 void Au3ProjectAccessor::markAsSaved()
@@ -279,4 +308,17 @@ bool Au3ProjectAccessor::isRecovered() const
 muse::async::Notification Au3ProjectAccessor::projectChanged() const
 {
     return m_projectChanged;
+}
+
+bool Au3ProjectAccessor::hasAutosaveData() const
+{
+    const auto& projectFileIO = ProjectFileIO::Get(m_data->projectRef());
+    // Autosave data exists if project is recovered and modified
+    return projectFileIO.IsRecovered() && projectFileIO.IsModified();
+}
+
+bool Au3ProjectAccessor::removeAutosaveData()
+{
+    auto& projectFileIO = ProjectFileIO::Get(m_data->projectRef());
+    return projectFileIO.AutoSaveDelete();
 }

--- a/src/au3wrap/internal/au3project.h
+++ b/src/au3wrap/internal/au3project.h
@@ -34,6 +34,10 @@ public:
     void markAsSaved() override;
     [[nodiscard]] bool isRecovered() const override;
 
+    // Autosave management
+    [[nodiscard]] bool hasAutosaveData() const override;
+    bool removeAutosaveData() override;
+
     muse::async::Notification projectChanged() const override;
 
     // internal
@@ -55,5 +59,6 @@ class Au3ProjectCreator : public IAu3ProjectCreator
 public:
 
     std::shared_ptr<IAu3Project> create() const override;
+    bool removeAutosaveDataFromFile(const muse::io::path_t& projectPath) const override;
 };
 }

--- a/src/project/iaudacityproject.h
+++ b/src/project/iaudacityproject.h
@@ -39,6 +39,8 @@ public:
     virtual muse::Ret canSave() const = 0;
     virtual bool needAutoSave() const = 0;
     virtual void setNeedAutoSave(bool val) = 0;
+    virtual bool hasUnsavedChanges() = 0;
+
     virtual muse::async::Notification needSaveChanged() const { return muse::async::Notification(); }
     virtual muse::Ret save(const muse::io::path_t& path = muse::io::path_t(), SaveMode saveMode = SaveMode::Save) = 0;
 

--- a/src/project/internal/audacityproject.cpp
+++ b/src/project/internal/audacityproject.cpp
@@ -331,6 +331,11 @@ Ret Audacity4Project::doSave(const muse::io::path_t& savePath, bool generateBack
         return make_ret(io::Err::FSWriteError);
     }
 
+    if (savePath.empty()) {
+        LOGE() << "failed save, path is empty";
+        return make_ret(io::Err::FSNotExist);
+    }
+
     auto ret = m_au3Project->save(savePath);
     if (!ret) {
         return make_ret(Ret::Code::UnknownError);

--- a/src/project/internal/audacityproject.cpp
+++ b/src/project/internal/audacityproject.cpp
@@ -322,8 +322,13 @@ Ret Audacity4Project::doSave(const muse::io::path_t& savePath, bool generateBack
 
     UNUSED(generateBackup);
 
-    if ((fileSystem()->exists(savePath) && !fileSystem()->isWritable(savePath))) {
-        LOGE() << "failed save, not writable path: " << savePath;
+    if (!fileSystem()->exists(savePath)) {
+        LOGE() << "failed save, path doesn't exist: \"" << savePath << "\"";
+        return make_ret(io::Err::FSNotExist);
+    }
+
+    if (!fileSystem()->isWritable(savePath)) {
+        LOGE() << "failed save, not writable path: \"" << savePath << "\"";
         return make_ret(io::Err::FSWriteError);
     }
 

--- a/src/project/internal/audacityproject.cpp
+++ b/src/project/internal/audacityproject.cpp
@@ -135,6 +135,12 @@ muse::Ret Audacity4Project::doLoad(const io::path_t& path, bool forceMode, const
     // This fixes issues with recording in restored projects.
     if (m_au3Project->isRecovered()) {
         m_trackeditProject->reload();
+
+        // Restore "newly created" state for never-saved recovered projects
+        if (path == configuration()->newProjectTemporaryPath()) {
+            m_isNewlyCreated = true;
+            LOGD() << "[project] Restored never-saved project, marked as newly created";
+        }
     }
 
     return ret;
@@ -231,6 +237,10 @@ ValNt<bool> Audacity4Project::needSave() const
 
     if (m_au3Project) {
         needSave.val = m_au3Project->hasUnsavedChanges();
+
+        if (m_isNewlyCreated) {
+            needSave.val = true;
+        }
     } else {
         needSave.val = false;
     }

--- a/src/project/internal/audacityproject.cpp
+++ b/src/project/internal/audacityproject.cpp
@@ -136,7 +136,6 @@ muse::Ret Audacity4Project::doLoad(const io::path_t& path, bool forceMode, const
     if (m_au3Project->isRecovered()) {
         m_trackeditProject->reload();
 
-        // Restore "newly created" state for never-saved recovered projects
         if (path == configuration()->newProjectTemporaryPath()) {
             m_isNewlyCreated = true;
             LOGD() << "[project] Restored never-saved project, marked as newly created";

--- a/src/project/internal/audacityproject.cpp
+++ b/src/project/internal/audacityproject.cpp
@@ -326,13 +326,8 @@ Ret Audacity4Project::doSave(const muse::io::path_t& savePath, bool generateBack
 
     UNUSED(generateBackup);
 
-    if (!fileSystem()->exists(savePath)) {
-        LOGE() << "failed save, path doesn't exist: \"" << savePath << "\"";
-        return make_ret(io::Err::FSNotExist);
-    }
-
-    if (!fileSystem()->isWritable(savePath)) {
-        LOGE() << "failed save, not writable path: \"" << savePath << "\"";
+    if ((fileSystem()->exists(savePath) && !fileSystem()->isWritable(savePath))) {
+        LOGE() << "failed save, not writable path: " << savePath;
         return make_ret(io::Err::FSWriteError);
     }
 

--- a/src/project/internal/audacityproject.cpp
+++ b/src/project/internal/audacityproject.cpp
@@ -296,9 +296,7 @@ Ret Audacity4Project::save(const muse::io::path_t& path, SaveMode saveMode)
             savePath = m_path;
         }
 
-        std::string suffix = io::suffix(savePath);
-
-        Ret ret = saveProject(savePath, suffix);
+        Ret ret = saveProject(savePath);
         if (ret) {
             if (saveMode != SaveMode::SaveCopy) {
                 markAsSaved(savePath);
@@ -308,25 +306,14 @@ Ret Audacity4Project::save(const muse::io::path_t& path, SaveMode saveMode)
         return ret;
     }
     case SaveMode::AutoSave:
-        std::string suffix = io::suffix(path);
-        if (suffix == IProjectAutoSaver::AUTOSAVE_SUFFIX) {
-            suffix = io::suffix(io::completeBasename(path));
-        }
-
-        // if (suffix.empty()) {
-        //     // Then it must be a MSCX folder
-        //     suffix = engraving::MSCX;
-        // }
-
-        return saveProject(path, suffix, false /*generateBackup*/, false /*createThumbnail*/);
+        return saveProject(path, false /*generateBackup*/, false /*createThumbnail*/);
     }
 
     return make_ret(Err::UnknownError);
 }
 
-Ret Audacity4Project::saveProject(const muse::io::path_t& path, const std::string& fileSuffix, bool generateBackup, bool createThumbnail)
+Ret Audacity4Project::saveProject(const muse::io::path_t& path, bool generateBackup, bool createThumbnail)
 {
-    Q_UNUSED(fileSuffix);
     return doSave(path, generateBackup, createThumbnail);
 }
 

--- a/src/project/internal/audacityproject.cpp
+++ b/src/project/internal/audacityproject.cpp
@@ -1,7 +1,6 @@
 #include "audacityproject.h"
 
 #include "au3wrap/iau3project.h"
-#include "project/iprojectautosaver.h"
 #include "project/projecterrors.h"
 #include "global/log.h"
 #include "global/io/file.h"
@@ -274,6 +273,11 @@ void Audacity4Project::setNeedAutoSave(bool val)
 {
     LOGD() << "[project] setNeedAutoSave: " << val;
     m_needAutoSave = val;
+}
+
+bool Audacity4Project::hasUnsavedChanges()
+{
+    return needSave().val;
 }
 
 Ret Audacity4Project::save(const muse::io::path_t& path, SaveMode saveMode)

--- a/src/project/internal/audacityproject.cpp
+++ b/src/project/internal/audacityproject.cpp
@@ -305,7 +305,7 @@ Ret Audacity4Project::save(const muse::io::path_t& path, SaveMode saveMode)
         return ret;
     }
     case SaveMode::AutoSave:
-        return saveProject(path, false /*generateBackup*/, false /*createThumbnail*/);
+        return saveProject(path, false /*generateBackup*/, true /*createThumbnail*/);
     }
 
     return make_ret(Err::UnknownError);

--- a/src/project/internal/audacityproject.h
+++ b/src/project/internal/audacityproject.h
@@ -99,8 +99,7 @@ private:
     muse::Ret doLoad(const muse::io::path_t& path, bool forceMode, const std::string& format);
     muse::Ret doImport(const muse::io::path_t& path, bool forceMode);
 
-    muse::Ret saveProject(const muse::io::path_t& path, const std::string& fileSuffix, bool generateBackup = true,
-                          bool createThumbnail = true);
+    muse::Ret saveProject(const muse::io::path_t& path, bool generateBackup = true, bool createThumbnail = true);
     muse::Ret doSave(const muse::io::path_t& path, /*engraving::MscIoMode ioMode,*/ bool generateBackup = true,
                      bool createThumbnail = true);
 

--- a/src/project/internal/audacityproject.h
+++ b/src/project/internal/audacityproject.h
@@ -3,6 +3,7 @@
 
 #include "../iaudacityproject.h"
 #include "../ithumbnailcreator.h"
+#include "../iprojectconfiguration.h"
 #include "context/iglobalcontext.h"
 #include "modularity/ioc.h"
 #include "au3wrap/iau3project.h"
@@ -51,6 +52,7 @@ class Audacity4Project : public IAudacityProject, public muse::async::Asyncable
     muse::Inject<au::trackedit::ITrackeditClipboard> clipboard;
     muse::Inject<IThumbnailCreator> thumbnailCreator;
     muse::Inject<importexport::IImporter> importer;
+    muse::Inject<IProjectConfiguration> configuration;
 
 public:
     Audacity4Project();

--- a/src/project/internal/audacityproject.h
+++ b/src/project/internal/audacityproject.h
@@ -82,6 +82,7 @@ public:
 
     bool needAutoSave() const override;
     void setNeedAutoSave(bool val) override;
+    bool hasUnsavedChanges() override;
 
     muse::Ret save(const muse::io::path_t& path = muse::io::path_t(), SaveMode saveMode = SaveMode::Save) override;
 

--- a/src/project/internal/projectactionscontroller.cpp
+++ b/src/project/internal/projectactionscontroller.cpp
@@ -211,7 +211,7 @@ bool ProjectActionsController::closeOpenedProject(bool quitApp)
 
     bool result = true;
 
-    if (project->needSave().val) {
+    if (projectAutoSaver()->projectHasUnsavedChanges(project)) {
         IInteractive::Button btn = askAboutSavingProject(project);
 
         if (btn == IInteractive::Button::Cancel) {
@@ -516,7 +516,7 @@ Ret ProjectActionsController::doOpenProject(const io::path_t& filePath)
     IAudacityProjectPtr project = rv.val;
 
     // Check if this is an autosave of a newly created project
-    bool isNewlyCreated = projectAutoSaver()->isAutosaveOfNewlyCreatedProject(filePath);
+    bool isNewlyCreated = projectAutoSaver()->isNewlyCreatedProject(project);
     if (!isNewlyCreated) {
         recentFilesController()->prependRecentFile(makeRecentFile(project));
     }
@@ -570,7 +570,7 @@ RetVal<IAudacityProjectPtr> ProjectActionsController::loadProject(const io::path
     // }
 
     // Mark project as newly created if it's an autosave of a new project
-    bool isNewlyCreated = projectAutoSaver()->isAutosaveOfNewlyCreatedProject(filePath);
+    bool isNewlyCreated = projectAutoSaver()->isNewlyCreatedProject(project);
     if (isNewlyCreated) {
         // Mark as newly created (this will be implemented if needed)
         // project->markAsNewlyCreated();

--- a/src/project/internal/projectactionscontroller.cpp
+++ b/src/project/internal/projectactionscontroller.cpp
@@ -211,7 +211,7 @@ bool ProjectActionsController::closeOpenedProject(bool quitApp)
 
     bool result = true;
 
-    if (projectAutoSaver()->projectHasUnsavedChanges(project)) {
+    if (project->hasUnsavedChanges()) {
         IInteractive::Button btn = askAboutSavingProject(project);
 
         if (btn == IInteractive::Button::Cancel) {
@@ -516,8 +516,7 @@ Ret ProjectActionsController::doOpenProject(const io::path_t& filePath)
     IAudacityProjectPtr project = rv.val;
 
     // Check if this is an autosave of a newly created project
-    bool isNewlyCreated = projectAutoSaver()->isNewlyCreatedProject(project);
-    if (!isNewlyCreated) {
+    if (!project->isNewlyCreated()) {
         recentFilesController()->prependRecentFile(makeRecentFile(project));
     }
 
@@ -551,8 +550,8 @@ RetVal<IAudacityProjectPtr> ProjectActionsController::loadProject(const io::path
     IAudacityProjectPtr project = std::make_shared<Audacity4Project>();
 
     //! TODO AU4
-    // bool hasUnsavedChanges = projectAutoSaver()->projectHasUnsavedChanges(filePath);
-    // io::path_t loadPath = hasUnsavedChanges ? projectAutoSaver()->projectAutoSavePath(filePath) : filePath;
+    // bool hasUnsavedChanges = project->hasUnsavedChanges();
+    // io::path_t loadPath = hasUnsavedChanges ? project->autoSavePath(filePath) : filePath;
 
     const io::path_t loadPath = filePath;
     const std::string format = io::suffix(filePath);
@@ -570,8 +569,7 @@ RetVal<IAudacityProjectPtr> ProjectActionsController::loadProject(const io::path
     // }
 
     // Mark project as newly created if it's an autosave of a new project
-    bool isNewlyCreated = projectAutoSaver()->isNewlyCreatedProject(project);
-    if (isNewlyCreated) {
+    if (project->isNewlyCreated()) {
         // Mark as newly created (this will be implemented if needed)
         // project->markAsNewlyCreated();
     }

--- a/src/project/internal/projectactionscontroller.h
+++ b/src/project/internal/projectactionscontroller.h
@@ -11,7 +11,6 @@
 #include "global/io/ifilesystem.h"
 #include "../iprojectconfiguration.h"
 #include "irecentfilescontroller.h"
-#include "iprojectautosaver.h"
 #include "iopensaveprojectscenario.h"
 #include "record/irecordcontroller.h"
 #include "trackedit/iprojecthistory.h"
@@ -19,7 +18,6 @@
 #include "project/iprojectfilescontroller.h"
 #include "project/iprojectconfiguration.h"
 #include "project/irecentfilescontroller.h"
-#include "project/iprojectautosaver.h"
 #include "project/iaudacityproject.h"
 
 namespace au::project {
@@ -31,7 +29,6 @@ class ProjectActionsController : public IProjectFilesController, public muse::ac
     muse::Inject<IProjectConfiguration> configuration;
     muse::Inject<muse::io::IFileSystem> fileSystem;
     muse::Inject<IRecentFilesController> recentFilesController;
-    muse::Inject<IProjectAutoSaver> projectAutoSaver;
     muse::Inject<IOpenSaveProjectScenario> openSaveProjectScenario;
     muse::Inject<trackedit::IProjectHistory> projectHistory;
     muse::Inject<record::IRecordController> recordController;

--- a/src/project/internal/projectautosaver.cpp
+++ b/src/project/internal/projectautosaver.cpp
@@ -169,8 +169,7 @@ void ProjectAutoSaver::onTrySave()
         return;
     }
 
-    const muse::io::path_t projectPath = this->projectPath(project);
-    const muse::io::path_t savePath = project->isNewlyCreated() ? projectPath : muse::io::path_t();
+    const muse::io::path_t savePath = this->projectPath(project);
 
     // Perform autosave to enable session restoration
     Ret ret = project->save(savePath, SaveMode::AutoSave);

--- a/src/project/internal/projectautosaver.cpp
+++ b/src/project/internal/projectautosaver.cpp
@@ -84,14 +84,6 @@ void ProjectAutoSaver::init()
     });
 }
 
-bool ProjectAutoSaver::projectHasUnsavedChanges(IAudacityProjectPtr project) const
-{
-    if (project) {
-        return project->needSave().val;
-    }
-    return false;
-}
-
 void ProjectAutoSaver::removeProjectUnsavedChanges(const muse::io::path_t& projectPath)
 {
     const bool success = au3ProjectCreator()->removeAutosaveDataFromFile(projectPath);
@@ -109,14 +101,6 @@ void ProjectAutoSaver::removeProjectUnsavedChanges(const muse::io::path_t& proje
 bool ProjectAutoSaver::isPathToNewlyCreatedProject(const muse::io::path_t& projectPath) const
 {
     return projectPath == configuration()->newProjectTemporaryPath();
-}
-
-bool ProjectAutoSaver::isNewlyCreatedProject(IAudacityProjectPtr project) const
-{
-    if (project) {
-        return project->isNewlyCreated();
-    }
-    return false;
 }
 
 IAudacityProjectPtr ProjectAutoSaver::currentProject() const

--- a/src/project/internal/projectautosaver.cpp
+++ b/src/project/internal/projectautosaver.cpp
@@ -97,7 +97,11 @@ bool ProjectAutoSaver::projectHasUnsavedChanges(const muse::io::path_t& projectP
 
 void ProjectAutoSaver::removeProjectUnsavedChanges(const muse::io::path_t& projectPath)
 {
-    au3ProjectCreator()->removeAutosaveDataFromFile(projectPath);
+    const bool success = au3ProjectCreator()->removeAutosaveDataFromFile(projectPath);
+
+    if (!success) {
+        LOGE() << "[autosave] failed to remove autosave data for project: " << projectPath;
+    }
 
     // For newly created projects, also remove the temporary file
     if (isAutosaveOfNewlyCreatedProject(projectPath)) {
@@ -108,16 +112,6 @@ void ProjectAutoSaver::removeProjectUnsavedChanges(const muse::io::path_t& proje
 bool ProjectAutoSaver::isAutosaveOfNewlyCreatedProject(const muse::io::path_t& projectPath) const
 {
     return projectPath == configuration()->newProjectTemporaryPath();
-}
-
-muse::io::path_t ProjectAutoSaver::projectOriginalPath(const muse::io::path_t& projectAutoSavePath) const
-{
-    return projectAutoSavePath;
-}
-
-muse::io::path_t ProjectAutoSaver::projectAutoSavePath(const muse::io::path_t& projectPath) const
-{
-    return projectPath;
 }
 
 IAudacityProjectPtr ProjectAutoSaver::currentProject() const
@@ -170,8 +164,8 @@ void ProjectAutoSaver::onTrySave()
         return;
     }
 
-    muse::io::path_t projectPath = this->projectPath(project);
-    muse::io::path_t savePath = project->isNewlyCreated() ? projectPath : projectAutoSavePath(projectPath);
+    const muse::io::path_t projectPath = this->projectPath(project);
+    const muse::io::path_t savePath = project->isNewlyCreated() ? projectPath : muse::io::path_t();
 
     // Perform autosave to enable session restoration
     Ret ret = project->save(savePath, SaveMode::AutoSave);

--- a/src/project/internal/projectautosaver.cpp
+++ b/src/project/internal/projectautosaver.cpp
@@ -84,14 +84,11 @@ void ProjectAutoSaver::init()
     });
 }
 
-bool ProjectAutoSaver::projectHasUnsavedChanges(const muse::io::path_t& projectPath) const
+bool ProjectAutoSaver::projectHasUnsavedChanges(IAudacityProjectPtr project) const
 {
-    auto project = currentProject();
-    if (project && (project->path() == projectPath
-                    || (project->isNewlyCreated() && projectPath == configuration()->newProjectTemporaryPath()))) {
+    if (project) {
         return project->needSave().val;
     }
-
     return false;
 }
 
@@ -104,14 +101,22 @@ void ProjectAutoSaver::removeProjectUnsavedChanges(const muse::io::path_t& proje
     }
 
     // For newly created projects, also remove the temporary file
-    if (isAutosaveOfNewlyCreatedProject(projectPath)) {
+    if (isPathToNewlyCreatedProject(projectPath)) {
         fileSystem()->remove(projectPath);
     }
 }
 
-bool ProjectAutoSaver::isAutosaveOfNewlyCreatedProject(const muse::io::path_t& projectPath) const
+bool ProjectAutoSaver::isPathToNewlyCreatedProject(const muse::io::path_t& projectPath) const
 {
     return projectPath == configuration()->newProjectTemporaryPath();
+}
+
+bool ProjectAutoSaver::isNewlyCreatedProject(IAudacityProjectPtr project) const
+{
+    if (project) {
+        return project->isNewlyCreated();
+    }
+    return false;
 }
 
 IAudacityProjectPtr ProjectAutoSaver::currentProject() const

--- a/src/project/internal/projectautosaver.h
+++ b/src/project/internal/projectautosaver.h
@@ -47,11 +47,9 @@ public:
 
     void init();
 
-    bool projectHasUnsavedChanges(IAudacityProjectPtr project) const override;
     void removeProjectUnsavedChanges(const muse::io::path_t& projectPath) override;
 
     bool isPathToNewlyCreatedProject(const muse::io::path_t& projectPath) const override;
-    bool isNewlyCreatedProject(IAudacityProjectPtr project) const override;
 
 private:
     IAudacityProjectPtr currentProject() const;

--- a/src/project/internal/projectautosaver.h
+++ b/src/project/internal/projectautosaver.h
@@ -32,6 +32,7 @@
 #include "iprojectconfiguration.h"
 
 #include "../iprojectautosaver.h"
+#include "au3wrap/iau3project.h"
 
 namespace au::project {
 class ProjectAutoSaver : public IProjectAutoSaver, public muse::async::Asyncable
@@ -39,6 +40,7 @@ class ProjectAutoSaver : public IProjectAutoSaver, public muse::async::Asyncable
     muse::Inject<au::context::IGlobalContext> globalContext;
     muse::Inject<muse::io::IFileSystem> fileSystem;
     muse::Inject<IProjectConfiguration> configuration;
+    muse::Inject<au::au3::IAu3ProjectCreator> au3ProjectCreator;
 
 public:
     ProjectAutoSaver() = default;

--- a/src/project/internal/projectautosaver.h
+++ b/src/project/internal/projectautosaver.h
@@ -47,10 +47,11 @@ public:
 
     void init();
 
-    bool projectHasUnsavedChanges(const muse::io::path_t& projectPath) const override;
+    bool projectHasUnsavedChanges(IAudacityProjectPtr project) const override;
     void removeProjectUnsavedChanges(const muse::io::path_t& projectPath) override;
 
-    bool isAutosaveOfNewlyCreatedProject(const muse::io::path_t& projectPath) const override;
+    bool isPathToNewlyCreatedProject(const muse::io::path_t& projectPath) const override;
+    bool isNewlyCreatedProject(IAudacityProjectPtr project) const override;
 
 private:
     IAudacityProjectPtr currentProject() const;

--- a/src/project/internal/projectautosaver.h
+++ b/src/project/internal/projectautosaver.h
@@ -52,9 +52,6 @@ public:
 
     bool isAutosaveOfNewlyCreatedProject(const muse::io::path_t& projectPath) const override;
 
-    muse::io::path_t projectOriginalPath(const muse::io::path_t& projectAutoSavePath) const override;
-    muse::io::path_t projectAutoSavePath(const muse::io::path_t& projectPath) const override;
-
 private:
     IAudacityProjectPtr currentProject() const;
 

--- a/src/project/iprojectautosaver.h
+++ b/src/project/iprojectautosaver.h
@@ -25,6 +25,7 @@
 #include "io/path.h"
 
 #include "modularity/imoduleinterface.h"
+#include "iaudacityproject.h"
 
 namespace au::project {
 class IProjectAutoSaver : MODULE_EXPORT_INTERFACE
@@ -34,10 +35,11 @@ class IProjectAutoSaver : MODULE_EXPORT_INTERFACE
 public:
     virtual ~IProjectAutoSaver() = default;
 
-    virtual bool projectHasUnsavedChanges(const muse::io::path_t& projectPath) const = 0;
+    virtual bool projectHasUnsavedChanges(IAudacityProjectPtr project) const = 0;
     virtual void removeProjectUnsavedChanges(const muse::io::path_t& projectPath) = 0;
 
-    virtual bool isAutosaveOfNewlyCreatedProject(const muse::io::path_t& projectPath) const = 0;
+    virtual bool isPathToNewlyCreatedProject(const muse::io::path_t& projectPath) const = 0;
+    virtual bool isNewlyCreatedProject(IAudacityProjectPtr project) const = 0;
 };
 }
 

--- a/src/project/iprojectautosaver.h
+++ b/src/project/iprojectautosaver.h
@@ -28,6 +28,7 @@
 #include "iaudacityproject.h"
 
 namespace au::project {
+// we don't use at the moment 01/09/2025 the project auto saver as we already have the autosave table
 class IProjectAutoSaver : MODULE_EXPORT_INTERFACE
 {
     INTERFACE_ID(IProjectAutoSaver)
@@ -35,11 +36,9 @@ class IProjectAutoSaver : MODULE_EXPORT_INTERFACE
 public:
     virtual ~IProjectAutoSaver() = default;
 
-    virtual bool projectHasUnsavedChanges(IAudacityProjectPtr project) const = 0;
     virtual void removeProjectUnsavedChanges(const muse::io::path_t& projectPath) = 0;
 
     virtual bool isPathToNewlyCreatedProject(const muse::io::path_t& projectPath) const = 0;
-    virtual bool isNewlyCreatedProject(IAudacityProjectPtr project) const = 0;
 };
 }
 

--- a/src/project/iprojectautosaver.h
+++ b/src/project/iprojectautosaver.h
@@ -38,11 +38,6 @@ public:
     virtual void removeProjectUnsavedChanges(const muse::io::path_t& projectPath) = 0;
 
     virtual bool isAutosaveOfNewlyCreatedProject(const muse::io::path_t& projectPath) const = 0;
-
-    virtual muse::io::path_t projectOriginalPath(const muse::io::path_t& projectAutoSavePath) const = 0;
-    virtual muse::io::path_t projectAutoSavePath(const muse::io::path_t& projectPath) const = 0;
-
-    static inline const std::string AUTOSAVE_SUFFIX = "autosave";
 };
 }
 

--- a/src/project/projectmodule.cpp
+++ b/src/project/projectmodule.cpp
@@ -71,7 +71,7 @@ void ProjectModule::registerExports()
     m_actionsController = std::make_shared<ProjectActionsController>();
     m_uiActions = std::make_shared<ProjectUiActions>(m_actionsController);
     m_thumbnailCreator = std::make_shared<ThumbnailCreator>();
-    m_projectAutoSaver = std::make_shared<ProjectAutoSaver>();
+    // m_projectAutoSaver = std::make_shared<ProjectAutoSaver>(); // we don't use at the moment 01/09/2025 the project auto saver as we already have the autosave table
 
 #ifdef Q_OS_MAC
     m_recentFilesController = std::make_shared<MacOSRecentFilesController>();
@@ -86,7 +86,7 @@ void ProjectModule::registerExports()
     ioc()->registerExport<IOpenSaveProjectScenario>(moduleName(), new OpenSaveProjectScenario());
     ioc()->registerExport<IProjectFilesController>(moduleName(), m_actionsController);
     ioc()->registerExport<IThumbnailCreator>(moduleName(), m_thumbnailCreator);
-    ioc()->registerExport<IProjectAutoSaver>(moduleName(), m_projectAutoSaver);
+    // ioc()->registerExport<IProjectAutoSaver>(moduleName(), m_projectAutoSaver);
 }
 
 void ProjectModule::resolveImports()
@@ -129,7 +129,7 @@ void ProjectModule::onInit(const muse::IApplication::RunMode&)
     m_actionsController->init();
     m_uiActions->init();
     m_recentFilesController->init();
-    m_projectAutoSaver->init();
+    // m_projectAutoSaver->init();
 }
 
 void ProjectModule::onDeinit()

--- a/src/project/projectmodule.h
+++ b/src/project/projectmodule.h
@@ -51,7 +51,7 @@ private:
     std::shared_ptr<RecentFilesController> m_recentFilesController;
     std::shared_ptr<ThumbnailCreator> m_thumbnailCreator;
     std::shared_ptr<ProjectUiActions> m_uiActions;
-    std::shared_ptr<ProjectAutoSaver> m_projectAutoSaver;
+    // std::shared_ptr<ProjectAutoSaver> m_projectAutoSaver;
 };
 }
 

--- a/src/project/tests/mocks/audacityprojectmock.h
+++ b/src/project/tests/mocks/audacityprojectmock.h
@@ -33,6 +33,7 @@ public:
     MOCK_METHOD(muse::Ret, canSave, (), (const, override));
     MOCK_METHOD(bool, needAutoSave, (), (const, override));
     MOCK_METHOD(void, setNeedAutoSave, (bool val), (override));
+    MOCK_METHOD(bool, hasUnsavedChanges, (), (override));
     MOCK_METHOD(muse::async::Notification, needSaveChanged, (), (const, override));
     MOCK_METHOD(muse::Ret, save, (const muse::io::path_t& path, SaveMode saveMode), (override));
 


### PR DESCRIPTION
Resolves: [If you choose to not restore the project upon a crash and open it, it will have its latest state before the crash](https://github.com/audacity/audacity/issues/8826)


### Implemented Behaviour

A - No changes before crash (Manually saved once before the crash)
1. When user chooses "No" to session restoration
    * Next manual open shows last manually saved state
    * Project is NOT marked as modified
        * Closing it do not prompt user to save
2. When user chooses "Yes" to session restoration
    * Project is restored with its manually saved content
    * Project is NOT marked as modified
        * Closing it do not prompt user to save

B - Unsaved changes before crash (picked up by the autosave mechanism)
1. When user chooses "No" to session restoration
    * Autosave data is properly discarded
    * Next manual open shows last manually saved state
    * Project is NOT marked as modified
        * Closing it do not prompt user to save
2. When user chooses "Yes" to session restoration
    * Project is restored with its autosaved content
    * Project is marked as modified
        * Closing it prompts user to save (the temporary restored auto saved state from before the crash)

C - Recovering never saved before project 
1. User chooses “No” the temp file is destroyed and changes are lost forever
2. User chooses “Yes” the temp project is recovered as newly created project
    * Closing just recovered project should prompt for save location
    * Manual changes are detected and picked up by autosave
        * Closing project prompts user to save to a new location

#### EXTRA:

D - Regular already saved once project usage
* Manual changes are detected and picked up by autosave
    * Closing project prompts user to save 

E - Newly created project never saved usage
* Manual changes are detected and picked up by autosave
    * Closing project prompts user to save to a new location



- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
