### PR TITLE
9262 Allow writing samples with -1 or 1 amplitude in sample paint mode (and 9273)

### DIFF
--- a/src/projectscene/qml/Audacity/ProjectScene/clipsview/ChannelSplitter.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/clipsview/ChannelSplitter.qml
@@ -47,7 +47,7 @@ Item {
                 return 0
             }
 
-            return Math.round(root.channelHeightRatio * root.height)
+            return Math.round(root.channelHeightRatio * root.height) - 1
         }
     }
 }

--- a/src/projectscene/view/clipsview/au3/connectingdotspainter.cpp
+++ b/src/projectscene/view/clipsview/au3/connectingdotspainter.cpp
@@ -57,7 +57,9 @@ void ConnectingDotsPainter::paint(QPainter& painter, const trackedit::ClipKey& c
     for (size_t index = 0; index < waveClip->NChannels(); index++) {
         waveMetrics.height = channelHeight[index];
         samplespainterutils::drawBackground(painter, waveMetrics, params.style, trimLeft);
-        samplespainterutils::drawBaseLine(painter, waveMetrics, params.style);
+        // Draw center line at the middle of the current channel
+        const int centerY = waveMetrics.top + waveMetrics.height / 2;
+        samplespainterutils::drawCenterLine(painter, waveMetrics, params.style, centerY);
         const auto samples = samplespainterutils::getSampleData(*waveClip, index, waveMetrics, dB, dBRange, zoomMax, zoomMin);
         if (samples.size() == 0) {
             continue;

--- a/src/projectscene/view/clipsview/au3/sampledata.h
+++ b/src/projectscene/view/clipsview/au3/sampledata.h
@@ -4,11 +4,11 @@ namespace au::projectscene {
 struct SampleData {
     std::vector<double> y {};
     std::vector<double> x {};
-    std::vector<int> clippedX {};
+    std::vector<double> clippedX {};
 
     SampleData() = default;
 
-    SampleData(std::vector<double> pY, std::vector<double> pX, std::vector<int> pClippedX)
+    SampleData(std::vector<double> pY, std::vector<double> pX, std::vector<double> pClippedX)
         : y(std::move(pY)), x(std::move(pX)), clippedX(std::move(pClippedX)) {}
 
     size_t size() const { return x.size(); }

--- a/src/projectscene/view/clipsview/au3/samplespainter.cpp
+++ b/src/projectscene/view/clipsview/au3/samplespainter.cpp
@@ -13,10 +13,11 @@
 #include "ZoomInfo.h"
 
 constexpr auto SAMPLE_TICK_SIZE = 4;
+constexpr auto SAMPLE_HEAD_PADDING = (SAMPLE_TICK_SIZE / 2) + 1;
 
 namespace {
 void drawSampleHead(const au::projectscene::SampleData& samples, const au::projectscene::WaveMetrics& metrics, QPainter& painter,
-                    const au::projectscene::IWavePainter::Style& style)
+                    const au::projectscene::IWavePainter::Style& style, const bool showClipping)
 {
     size_t slen = samples.size();
     const ZoomInfo zoomInfo{ metrics.fromTime, metrics.zoom };
@@ -25,21 +26,36 @@ void drawSampleHead(const au::projectscene::SampleData& samples, const au::proje
         = std::max(-10000, std::min(10000, static_cast<int>(zoomInfo.TimeToPosition(metrics.selectionStartTime))));
     const auto selectedEndPosition = std::max(-10000, std::min(10000, static_cast<int>(zoomInfo.TimeToPosition(metrics.selectionEndTime))));
 
-    painter.setBrush(style.sampleBrush);
+    std::set<double> clippedXSet;
+    if (showClipping && !samples.clippedX.empty()) {
+        clippedXSet = std::set<double>(samples.clippedX.begin(), samples.clippedX.end());
+    }
 
-    auto pr = QRectF(0, 0, SAMPLE_TICK_SIZE, SAMPLE_TICK_SIZE);
+    QPen pen;
+    QBrush brush;
     for (size_t s = 0; s < slen; s++) {
         if (samples.y[s] >= 0 && samples.y[s] < metrics.height) {
-            if (selectedStartPosition <= samples.x[s] && samples.x[s] <= selectedEndPosition) {
-                painter.setPen(style.sampleHeadSelection);
+            if (showClipping && clippedXSet.count(samples.x[s]) > 0) {
+                pen = style.clippedPen;
+                brush = QBrush(style.clippedPen);
             } else {
-                painter.setPen(style.sampleHead);
+                pen = style.sampleHead;
+                brush = style.sampleBrush;
             }
+            // selection with change the colour of the pen (the outside of the head)
+            if (selectedStartPosition <= samples.x[s] && samples.x[s] <= selectedEndPosition) {
+                pen = style.sampleHeadSelection;
+            }
+            painter.setPen(pen);
+            painter.setBrush(brush);
 
-            pr.moveLeft(metrics.left + samples.x[s] - SAMPLE_TICK_SIZE / 2);
-            pr.moveTop(metrics.top + samples.y[s] - SAMPLE_TICK_SIZE / 2);
+            const int centerX = static_cast<int>(std::round(metrics.left + samples.x[s]));
+            const int centerY = static_cast<int>(std::round(metrics.top + samples.y[s]));
 
-            painter.drawEllipse(pr);
+            const int left = centerX - SAMPLE_TICK_SIZE / 2;
+            const int top = centerY - SAMPLE_TICK_SIZE / 2;
+
+            painter.drawEllipse(left, top, SAMPLE_TICK_SIZE, SAMPLE_TICK_SIZE);
         }
     }
 }
@@ -49,17 +65,20 @@ void drawSampleStalk(const au::projectscene::SampleData& samples, int yZero, con
 {
     const size_t slen = samples.size();
 
-    std::set<int> clippedXSet;
+    std::set<double> clippedXSet;
     if (showClipping && !samples.clippedX.empty()) {
-        clippedXSet = std::set<int>(samples.clippedX.begin(), samples.clippedX.end());
+        clippedXSet = std::set<double>(samples.clippedX.begin(), samples.clippedX.end());
     }
 
     painter.setPen(style.sampleStalk);
     for (size_t s = 0; s < slen; s++) {
-        const int sampleX = static_cast<int>(samples.x[s]);
-        if (!showClipping || clippedXSet.count(sampleX) == 0) {
-            QPointF p1(metrics.left + samples.x[s], metrics.top + samples.y[s]);
-            QPointF p2(metrics.left + samples.x[s], yZero);
+        // Only draw normal stalk if this sample is not clipped
+        if (!showClipping || clippedXSet.count(samples.x[s]) == 0) {
+            const int x = static_cast<int>(std::round(metrics.left + samples.x[s]));
+            const int y1 = static_cast<int>(std::round(metrics.top + samples.y[s]));
+
+            QPoint p1(x, y1);
+            QPoint p2(x, yZero);
             painter.drawLine(p1, p2);
         }
     }
@@ -69,6 +88,9 @@ void drawSampleStalk(const au::projectscene::SampleData& samples, int yZero, con
 namespace au::projectscene {
 void SamplesPainter::paint(QPainter& painter, const trackedit::ClipKey& clipKey, const IWavePainter::Params& params)
 {
+    painter.save();
+    painter.setRenderHint(QPainter::Antialiasing, false);
+
     au::au3::Au3Project* au3Project = reinterpret_cast<au::au3::Au3Project*>(globalContext()->currentProject()->au3ProjectPtr());
     WaveTrack* track = au::au3::DomAccessor::findWaveTrack(*au3Project, TrackId(clipKey.trackId));
     IF_ASSERT_FAILED(track) {
@@ -98,24 +120,36 @@ void SamplesPainter::paint(QPainter& painter, const trackedit::ClipKey& clipKey,
 
     for (size_t index = 0; index < waveClip->NChannels(); index++) {
         waveMetrics.height = channelHeight[index];
+
+        // Draw background with the full channel area
         samplespainterutils::drawBackground(painter, waveMetrics, params.style, trimLeft);
-        samplespainterutils::drawBaseLine(painter, waveMetrics, params.style);
-        const auto samples = samplespainterutils::getSampleData(*waveClip, index, waveMetrics, dB, dBRange, zoomMax, zoomMin);
+
+        // Create padded metrics for sample rendering with symmetric padding around separator
+        auto paddedMetrics = waveMetrics;
+        paddedMetrics.top += SAMPLE_HEAD_PADDING;
+        paddedMetrics.height -= 2 * SAMPLE_HEAD_PADDING;
+
+        const auto samples = samplespainterutils::getSampleData(*waveClip, index, paddedMetrics, dB, dBRange, zoomMax, zoomMin);
         if (samples.size() == 0) {
             continue;
         }
 
-        int yZero = samplespainterutils::getWaveYPos(0.0, zoomMin, zoomMax, waveMetrics.height, dB, true, dBRange, false);
-        yZero = waveMetrics.top + std::max(-1, std::min(static_cast<int>(waveMetrics.height + waveMetrics.top), yZero));
+        int yZero = samplespainterutils::getWaveYPos(0.0, zoomMin, zoomMax, paddedMetrics.height, dB, true, dBRange, false);
+        yZero = paddedMetrics.top + std::max(-1, std::min(static_cast<int>(paddedMetrics.height + paddedMetrics.top), yZero));
 
-        drawSampleHead(samples, waveMetrics, painter, params.style);
+        auto baselineMetrics = waveMetrics;
+        baselineMetrics.top = yZero;
+        baselineMetrics.height = 0; // Trick to force sample center calculation to use yZero
+        samplespainterutils::drawBaseLine(painter, baselineMetrics, params.style);
 
         if (params.showClipping) {
-            samplespainterutils::drawClippedSamples(samples, waveMetrics, painter, params.style);
+            samplespainterutils::drawClippedSamples(samples, paddedMetrics, painter, params.style);
         }
-
-        drawSampleStalk(samples, yZero, waveMetrics, painter, params.style, params.showClipping);
+        drawSampleStalk(samples, yZero, paddedMetrics, painter, params.style, params.showClipping);
+        // drawSampleHead must be called after drawSampleStalk for the selection effect to work correctly
+        drawSampleHead(samples, paddedMetrics, painter, params.style, params.showClipping);
         waveMetrics.top += waveMetrics.height;
     }
+    painter.restore();
 }
 }

--- a/src/projectscene/view/clipsview/au3/samplespainter.cpp
+++ b/src/projectscene/view/clipsview/au3/samplespainter.cpp
@@ -142,15 +142,11 @@ void SamplesPainter::paint(QPainter& painter, const trackedit::ClipKey& clipKey,
         drawSampleStalk(samples, yZero, paddedMetrics, painter, params.style, params.showClipping);
 
         // draw baseline after the sample stalk to ensure it's on top of it
-        auto baselineMetrics = waveMetrics;
-        baselineMetrics.top = yZero;
-        baselineMetrics.height = 0; // Trick to force sample center calculation to use yZero
-        samplespainterutils::drawBaseLine(painter, baselineMetrics, params.style);
+        samplespainterutils::drawCenterLine(painter, waveMetrics, params.style, yZero);
 
         // drawSampleHead must be called after drawSampleStalk for the selection effect to work correctly
         drawSampleHead(samples, paddedMetrics, painter, params.style, params.showClipping);
         waveMetrics.top += waveMetrics.height;
-        // Check if we should also maybe add the channel separator size here if we have more than one channel to draw
     }
     painter.restore();
 }

--- a/src/projectscene/view/clipsview/au3/samplespainterutils.cpp
+++ b/src/projectscene/view/clipsview/au3/samplespainterutils.cpp
@@ -223,10 +223,11 @@ void drawClippedSamples(const au::projectscene::SampleData& samples,
     }
 
     painter.setPen(style.clippedPen);
-    for (const int clippedX : samples.clippedX) {
-        QPointF p1(metrics.left + clippedX, metrics.top);
-        QPointF p2(metrics.left + clippedX, metrics.top + metrics.height);
-        painter.drawLine(p1, p2);
+    for (const double clippedX : samples.clippedX) {
+        const int x = static_cast<int>(std::round(metrics.left + clippedX));
+        const int y1 = static_cast<int>(std::round(metrics.top));
+        const int y2 = static_cast<int>(std::round(metrics.top + metrics.height));
+        painter.drawLine(x, y1, x, y2);
     }
 }
 
@@ -257,7 +258,7 @@ SampleData getSampleData(const au::au3::Au3WaveClip& clip, int channelIndex, con
 
     auto xpos = std::vector<double>(slen);
     auto ypos = std::vector<double>(slen);
-    auto clippedX = std::vector<int>();
+    auto clippedX = std::vector<double>();
     const auto invRate = 1.0 / rate;
 
     for (size_t s = 0; s < slen; s++) {
@@ -269,7 +270,7 @@ SampleData getSampleData(const au::au3::Au3WaveClip& clip, int channelIndex, con
         const double tt = buffer[s] * value;
 
         if ((tt <= -MAX_AUDIO) || (tt >= MAX_AUDIO)) {
-            clippedX.push_back(static_cast<int>(xx));
+            clippedX.push_back(xx);
         }
 
         ypos[s] = std::max(-1, std::min(static_cast<int>(metrics.height),
@@ -459,7 +460,7 @@ void setIsolatedPoint(const unsigned int currentChannel, const trackedit::ClipKe
     float newValue = samplespainterutils::ValueOfPixel(yy, waveMetrics.height, false, dB, dBRange, zoomMin, zoomMax);
 
     // Ensure value stays within valid audio range
-    newValue = std::max(-1.0f, std::min(1.0f, newValue));
+    newValue = std::clamp(newValue, -1.0f, 1.0f);
 
     WaveChannelUtilities::SetFloatAtTime(*waveChannel, isolatedPointTime + clip->GetPlayStartTime(), newValue, narrowestSampleFormat);
 }
@@ -548,7 +549,7 @@ void setLastClickPos(const unsigned int currentChannel, std::shared_ptr<au::proj
         float newValue = samplespainterutils::ValueOfPixel(yy, waveMetrics.height, false, dB, dBRange, zoomMin, zoomMax);
 
         // Ensure value stays within valid audio range
-        newValue = std::max(-1.0f, std::min(1.0f, newValue));
+        newValue = std::clamp(newValue, -1.0f, 1.0f);
 
         samples.push_back(newValue);
     }

--- a/src/projectscene/view/clipsview/au3/samplespainterutils.cpp
+++ b/src/projectscene/view/clipsview/au3/samplespainterutils.cpp
@@ -206,11 +206,10 @@ void drawBackground(QPainter& painter, const au::projectscene::WaveMetrics& metr
     }
 }
 
-void drawBaseLine(QPainter& painter, const au::projectscene::WaveMetrics& metrics, const IWavePainter::Style& style)
+void drawCenterLine(QPainter& painter, const au::projectscene::WaveMetrics& metrics, const IWavePainter::Style& style, const int y)
 {
     painter.setPen(style.centerLine);
-    painter.drawLine(metrics.left, metrics.top + metrics.height / 2,
-                     metrics.left + metrics.width, metrics.top + metrics.height / 2);
+    painter.drawLine(metrics.left, y, metrics.left + metrics.width, y);
 }
 
 void drawClippedSamples(const au::projectscene::SampleData& samples,

--- a/src/projectscene/view/clipsview/au3/samplespainterutils.cpp
+++ b/src/projectscene/view/clipsview/au3/samplespainterutils.cpp
@@ -441,8 +441,15 @@ void setIsolatedPoint(const unsigned int currentChannel, const trackedit::ClipKe
     auto& cache = WaveformScale::Get(*track);
     cache.GetDisplayBounds(zoomMin, zoomMax);
 
+    const std::vector<double> channelHeights {
+        params.geometry.height * params.channelHeightRatio,
+        params.geometry.height * (1 - params.channelHeightRatio),
+    };
+
+    const int channelTopOffset = (currentChannel == 0) ? 0 : static_cast<int>(channelHeights[0]);
+
     auto waveMetrics = wavepainterutils::getWaveMetrics(project, clipKey, params);
-    waveMetrics.height = channelHeight[currentChannel];
+    waveMetrics.height = channelHeights[currentChannel];
 
     const ZoomInfo zoomInfo { waveMetrics.fromTime, waveMetrics.zoom };
 
@@ -454,7 +461,7 @@ void setIsolatedPoint(const unsigned int currentChannel, const trackedit::ClipKe
     }
 
     const auto y = std::min(
-        static_cast<int>(currentPosition.y() - (currentChannel * waveMetrics.height)), static_cast<int>(waveMetrics.height - 1)); // Allow bottom edge
+        static_cast<int>(currentPosition.y() - channelTopOffset), static_cast<int>(waveMetrics.height - 1)); // Allow bottom edge
     const auto yy = std::max(y, 0); // Allow top edge
 
     float newValue = samplespainterutils::ValueOfPixel(yy, waveMetrics.height, false, dB, dBRange, zoomMin, zoomMax);
@@ -491,10 +498,12 @@ void setLastClickPos(const unsigned int currentChannel, std::shared_ptr<au::proj
 
     const std::vector<QPoint> points = interpolatePoints(lastPosition, currentPosition);
 
-    const std::vector<double> channelHeight {
+    const std::vector<double> channelHeights {
         params.geometry.height * params.channelHeightRatio,
         params.geometry.height * (1 - params.channelHeightRatio),
     };
+
+    const int channelTopOffset = (currentChannel == 0) ? 0 : static_cast<int>(channelHeights[0]);
 
     auto& settings = WaveformSettings::Get(*track);
     const float dBRange = settings.dBRange;
@@ -505,7 +514,7 @@ void setLastClickPos(const unsigned int currentChannel, std::shared_ptr<au::proj
     cache.GetDisplayBounds(zoomMin, zoomMax);
 
     auto waveMetrics = wavepainterutils::getWaveMetrics(project, clipKey, params);
-    waveMetrics.height = channelHeight[currentChannel];
+    waveMetrics.height = channelHeights[currentChannel];
 
     const ZoomInfo zoomInfo { waveMetrics.fromTime, waveMetrics.zoom };
 
@@ -543,7 +552,7 @@ void setLastClickPos(const unsigned int currentChannel, std::shared_ptr<au::proj
         }
 
         const auto y = std::min(
-            static_cast<int>(point.y() - (currentChannel * waveMetrics.height)), static_cast<int>(waveMetrics.height - 1)); // Allow bottom edge
+            static_cast<int>(point.y() - channelTopOffset), static_cast<int>(waveMetrics.height - 1)); // Allow bottom edge
         const auto yy = std::max(y, 0); // Allow top edge
 
         float newValue = samplespainterutils::ValueOfPixel(yy, waveMetrics.height, false, dB, dBRange, zoomMin, zoomMax);

--- a/src/projectscene/view/clipsview/au3/samplespainterutils.cpp
+++ b/src/projectscene/view/clipsview/au3/samplespainterutils.cpp
@@ -453,10 +453,13 @@ void setIsolatedPoint(const unsigned int currentChannel, const trackedit::ClipKe
     }
 
     const auto y = std::min(
-        static_cast<int>(currentPosition.y() - (currentChannel * waveMetrics.height)), static_cast<int>(waveMetrics.height - 2));
-    const auto yy = std::max(y, 2);
+        static_cast<int>(currentPosition.y() - (currentChannel * waveMetrics.height)), static_cast<int>(waveMetrics.height - 1)); // Allow bottom edge
+    const auto yy = std::max(y, 0); // Allow top edge
 
     float newValue = samplespainterutils::ValueOfPixel(yy, waveMetrics.height, false, dB, dBRange, zoomMin, zoomMax);
+
+    // Ensure value stays within valid audio range
+    newValue = std::max(-1.0f, std::min(1.0f, newValue));
 
     WaveChannelUtilities::SetFloatAtTime(*waveChannel, isolatedPointTime + clip->GetPlayStartTime(), newValue, narrowestSampleFormat);
 }
@@ -539,10 +542,14 @@ void setLastClickPos(const unsigned int currentChannel, std::shared_ptr<au::proj
         }
 
         const auto y = std::min(
-            static_cast<int>(point.y() - (currentChannel * waveMetrics.height)), static_cast<int>(waveMetrics.height - 2));
-        const auto yy = std::max(y, 2);
+            static_cast<int>(point.y() - (currentChannel * waveMetrics.height)), static_cast<int>(waveMetrics.height - 1)); // Allow bottom edge
+        const auto yy = std::max(y, 0); // Allow top edge
 
         float newValue = samplespainterutils::ValueOfPixel(yy, waveMetrics.height, false, dB, dBRange, zoomMin, zoomMax);
+
+        // Ensure value stays within valid audio range
+        newValue = std::max(-1.0f, std::min(1.0f, newValue));
+
         samples.push_back(newValue);
     }
 

--- a/src/projectscene/view/clipsview/au3/samplespainterutils.h
+++ b/src/projectscene/view/clipsview/au3/samplespainterutils.h
@@ -14,7 +14,7 @@ float ValueOfPixel(int yy, int height, bool offset, bool dB, double dBRange, flo
 int getWaveYPos(float value, float min, float max, int height, bool dB, bool outer, float dBr, bool clip);
 void drawBackground(QPainter& painter, const au::projectscene::WaveMetrics& metrics, const IWavePainter::Style& style,
                     const double trimLeft);
-void drawBaseLine(QPainter& painter, const au::projectscene::WaveMetrics& metrics, const IWavePainter::Style& style);
+void drawCenterLine(QPainter& painter, const au::projectscene::WaveMetrics& metrics, const IWavePainter::Style& style, int y);
 void drawClippedSamples(const au::projectscene::SampleData& samples, const au::projectscene::WaveMetrics& metrics, QPainter& painter,
                         const au::projectscene::IWavePainter::Style& style);
 SampleData getSampleData(const au::au3::Au3WaveClip& clip, int channelIndex, const au::projectscene::WaveMetrics& metrics, bool dB,


### PR DESCRIPTION
Resolves: [Allow writing samples with -1 or 1 amplitude in sample paint mode](https://github.com/audacity/audacity/issues/9262) and sample painting is erratic for stereo track with custom split channel height #9273

allow pencil edition to write clipped sample 

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
