### PR TITLE
9272 - Avoid re-sending PlaybackStatus::Stopped

### DIFF
--- a/src/playback/internal/au3/au3player.cpp
+++ b/src/playback/internal/au3/au3player.cpp
@@ -214,6 +214,10 @@ void Au3Player::rewind()
 
 void Au3Player::stop()
 {
+    if (m_playbackStatus.val == PlaybackStatus::Stopped) {
+        return;
+    }
+
     m_playbackStatus.set(PlaybackStatus::Stopped);
 
     //! NOTE: copied from ProjectAudioManager::Stop


### PR DESCRIPTION
Resolves: #9272 

The PR ensures no `PlaybackStatus::Stopped` messages are sent if the playback is already stopped.
This message triggered the monitoring restart once the playback status change signal was received.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Autobot test cases have been run
