### PR TITLE
Use git submodule to checkout framework instead of cmake fetch

### DIFF
--- a/.github/workflows/au4_build_linux.yml
+++ b/.github/workflows/au4_build_linux.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
     - name: Clone repository
       uses: actions/checkout@v4
+    - name: Update submodules
+      run: git submodule update --init --recursive
     - name: "Configure workflow"
       env:
         pull_request_title: ${{ github.event.pull_request.title }}

--- a/.github/workflows/au4_build_linux.yml
+++ b/.github/workflows/au4_build_linux.yml
@@ -28,8 +28,8 @@ jobs:
     steps:
     - name: Clone repository
       uses: actions/checkout@v4
-    - name: Update submodules
-      run: git submodule update --init --recursive
+      with:
+        submodules: recursive
     - name: "Configure workflow"
       env:
         pull_request_title: ${{ github.event.pull_request.title }}

--- a/.github/workflows/au4_build_macos.yml
+++ b/.github/workflows/au4_build_macos.yml
@@ -30,6 +30,8 @@ jobs:
     steps:
     - name: Clone repository
       uses: actions/checkout@v4
+    - name: Update submodules
+      run: git submodule update --init --recursive
     - name: "Configure workflow"
       env:
         pull_request_title: ${{ github.event.pull_request.title }}

--- a/.github/workflows/au4_build_macos.yml
+++ b/.github/workflows/au4_build_macos.yml
@@ -30,8 +30,8 @@ jobs:
     steps:
     - name: Clone repository
       uses: actions/checkout@v4
-    - name: Update submodules
-      run: git submodule update --init --recursive
+      with:
+        submodules: recursive
     - name: "Configure workflow"
       env:
         pull_request_title: ${{ github.event.pull_request.title }}

--- a/.github/workflows/au4_build_windows.yml
+++ b/.github/workflows/au4_build_windows.yml
@@ -29,8 +29,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 3
-    - name: Update submodules
-      run: git submodule update --init --recursive
+        submodules: recursive
     - name: "Configure workflow"
       shell: bash
       env:

--- a/.github/workflows/au4_build_windows.yml
+++ b/.github/workflows/au4_build_windows.yml
@@ -29,6 +29,8 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 3
+    - name: Update submodules
+      run: git submodule update --init --recursive
     - name: "Configure workflow"
       shell: bash
       env:

--- a/.github/workflows/au4_check_unit_tests.yml
+++ b/.github/workflows/au4_check_unit_tests.yml
@@ -25,9 +25,8 @@ jobs:
 
     - name: Clone repository
       uses: actions/checkout@v4
-
-    - name: Update submodules
-      run: git submodule update --init --recursive
+      with:
+        submodules: recursive
 
     - name: "Configure workflow"
       run: |

--- a/.github/workflows/au4_check_unit_tests.yml
+++ b/.github/workflows/au4_check_unit_tests.yml
@@ -26,6 +26,9 @@ jobs:
     - name: Clone repository
       uses: actions/checkout@v4
 
+    - name: Update submodules
+      run: git submodule update --init --recursive
+
     - name: "Configure workflow"
       run: |
         echo "CCACHE_TIMESTAMP=$(date -u +"%F-%T")" | tee -a $GITHUB_ENV

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "muse_framework"]
+	path = muse_framework
+	url = https://github.com/musescore/framework_tmp.git

--- a/.vscode/audacity.code-workspace
+++ b/.vscode/audacity.code-workspace
@@ -16,13 +16,6 @@
                 }
             ]
         },
-        "search.useIgnoreFiles": false,
-        "search.exclude": {
-            "**/build.ninja": true,
-            "**/*.depends": true,
-            "**/qrc_*.cpp": true,
-            "**/moc_*.cpp": true,
-        },
         "C_Cpp.autoAddFileAssociations": false,
         "cmake.copyCompileCommands": "${workspaceFolder}/compile_commands.json",
         "cmake.configureArgs": [

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -21,9 +21,9 @@ As large parts of Audacity 4 are based on MuseScore Studio, the general setup st
 1. [Set up a developer environment](https://github.com/musescore/MuseScore/wiki/Set-up-developer-environment)
 2. [Install Qt and Qt Creator](https://github.com/musescore/MuseScore/wiki/Install-Qt-and-Qt-Creator) (with Qt version 6.2.4; not the latest version)
 
-### Get the Audacity source
+### Get the Audacity source and its submodules
 
-To get the source, `git clone https://github.com/audacity/audacity.git` in the folder of your choice. See the [Github help](https://docs.github.com/en/get-started/getting-started-with-git/about-remote-repositories) for more information. 
+To get the source and submodules in one command, `git clone --recurse-submodules https://github.com/audacity/audacity.git` in the folder of your choice. See the [Github help](https://docs.github.com/en/get-started/getting-started-with-git/about-remote-repositories) for more information. 
 
 ### Get dependencies
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,20 +20,9 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 ###########################################
 set(FETCHCONTENT_QUIET OFF)
 set(FETCHCONTENT_BASE_DIR ${PROJECT_BINARY_DIR}/_deps)
-include(FetchContent)
-FetchContent_Declare(
-  muse_framework
-  GIT_REPOSITORY https://github.com/musescore/framework_tmp.git
-  GIT_TAG        u250905_2
-)
 
-FetchContent_GetProperties(muse_framework)
-if(NOT muse_framework_POPULATED)
-  FetchContent_Populate(muse_framework)
-endif()
-
-set(MUSE_FRAMEWORK_PATH ${muse_framework_SOURCE_DIR})
-set(MUSE_FRAMEWORK_SRC_PATH ${muse_framework_SOURCE_DIR}/framework)
+set(MUSE_FRAMEWORK_PATH ${CMAKE_SOURCE_DIR}/muse_framework)
+set(MUSE_FRAMEWORK_SRC_PATH ${MUSE_FRAMEWORK_PATH}/framework)
 
 set(CMAKE_MODULE_PATH
     ${CMAKE_CURRENT_LIST_DIR}
@@ -179,7 +168,7 @@ if (MUSE_ENABLE_UNIT_TESTS)
     message(STATUS "Enabled testing")
 endif()
 
-add_subdirectory(${muse_framework_SOURCE_DIR}/framework ${muse_framework_BINARY_DIR})
+add_subdirectory(${MUSE_FRAMEWORK_SRC_PATH})
 add_subdirectory(src)
 add_subdirectory(share)
 

--- a/buildscripts/cmake/SetupDevEnvironment.cmake
+++ b/buildscripts/cmake/SetupDevEnvironment.cmake
@@ -38,7 +38,7 @@ endfunction()
 populate(qmlformat "qmlformat/6.10")
 
 configure_file(
-    ${CMAKE_BINARY_DIR}/_deps/muse_framework-src/buildscripts/ci/checkcodestyle/uncrustify_muse.cfg
+    ${CMAKE_SOURCE_DIR}/muse_framework/buildscripts/ci/checkcodestyle/uncrustify_muse.cfg
     ${CMAKE_SOURCE_DIR}/uncrustify.cfg
     COPYONLY
 )

--- a/src/au3wrap/lv2sdk/CMakeLists.txt
+++ b/src/au3wrap/lv2sdk/CMakeLists.txt
@@ -3,6 +3,7 @@
 #
 declare_module(lv2sdk)
 
+include(FetchContent)
 FetchContent_Declare(
    lv2
    GIT_REPOSITORY https://gitlab.com/lv2/lv2.git
@@ -26,7 +27,7 @@ FetchContent_Declare(
    GIT_TAG v0.6.2
 )
 FetchContent_MakeAvailable(zix)
-   
+
 set( SORD_VERSION 0.16.18 )
 FetchContent_Declare(
    sord


### PR DESCRIPTION
Use git submodule to checkout framework instead of cmake fetch. The Audacity developers are globally more comfortable with this new integration.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [x] Autobot test cases have been run - not needed
