### PR TITLE
Fix typo in project url

### DIFF
--- a/libraries/lib-cloud-audiocom/ServiceConfig.cpp
+++ b/libraries/lib-cloud-audiocom/ServiceConfig.cpp
@@ -358,7 +358,7 @@ std::string ServiceConfig::GetProjectPagePath(
    AudiocomTrace trace) const
 {
    return Substitute(
-      "/{user_slug}/projects/{project_slug}&" MTM_CAMPAIGN,
+      "/{user_slug}/projects/{project_slug}?" MTM_CAMPAIGN,
       {
          { "user_slug", userSlug },
          { "project_slug", projectSlug },


### PR DESCRIPTION
Resolves: -

The MTM tag goes first in the parameters link

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Autobot test cases have been run
