### PR TITLE
Detect unnecessary modules during plugin registration

### DIFF
--- a/src/app/app.cpp
+++ b/src/app/app.cpp
@@ -21,6 +21,7 @@
  */
 
 #include "app.h"
+#include "../ineededmodulesetup.h"
 
 #include <QApplication>
 #include <QQmlApplicationEngine>
@@ -53,37 +54,9 @@ App::App()
 {
 }
 
-void App::addModule(modularity::IModuleSetup* module)
+void App::addModule(au::INeededModuleSetup* module)
 {
     m_modules.push_back(module);
-}
-
-namespace {
-void assertIfUnnecessaryModules(const QList<muse::modularity::IModuleSetup*>& modules)
-{
-    const std::vector<std::string> pluginRegistrationModules {
-        "diagnostics",
-        "audioplugins",
-        "appshell",
-        "effects_vst",
-        "effects_vst_stub",
-        "effects_lv2",
-        "effects_lv2_stub",
-        "effects_audio_unit",
-        "effects_audio_unit_stub",
-    };
-    std::vector<std::string> nonEssentialModules;
-    for (const modularity::IModuleSetup* m : modules) {
-        if (!muse::contains(pluginRegistrationModules, m->moduleName())) {
-            nonEssentialModules.push_back(m->moduleName());
-        }
-    }
-    // To keep plugin registration as fast as possible, it is important that only the modules that are strictly necessary are loaded.
-    // If you add a new module and get this assert, please try to run the app with the `--register-audio-plugin <some plugin path>` option *without* your new module.
-    // If it works, then move the app.addModule(...) statement inside the appropriate `if (!isPluginRegistration) {` branch in main.cpp.
-    // If it doesn't and your module really is needed for plugin registration, then add its name to the `pluginRegistrationModules` list above.
-    assert(nonEssentialModules.empty());
-}
 }
 
 int App::run(QCoreApplication& app, CommandLineParser& commandLineParser)
@@ -114,11 +87,9 @@ int App::run(QCoreApplication& app, CommandLineParser& commandLineParser)
 
     const IApplication::RunMode runMode = commandLineParser.runMode();
 
-#ifdef QT_DEBUG
-    if (runMode == IApplication::RunMode::AudioPluginRegistration) {
-        assertIfUnnecessaryModules(m_modules);
-    }
-#endif
+    assert(std::all_of(m_modules.begin(), m_modules.end(), [runMode](au::INeededModuleSetup* m) {
+        return m->isNeededForRunMode(runMode);
+    }));
 
     // ====================================================
     // Setup modules: apply the command line options

--- a/src/app/app.h
+++ b/src/app/app.h
@@ -32,6 +32,7 @@
 #include "appshell/iappshellconfiguration.h"
 
 #include "commandlineparser.h"
+#include "ineededmodulesetup.h"
 
 namespace au::app {
 class App
@@ -44,7 +45,7 @@ class App
 public:
     App();
 
-    void addModule(muse::modularity::IModuleSetup* module);
+    void addModule(au::INeededModuleSetup* module);
 
     int run(QCoreApplication& app, CommandLineParser& parser);
 
@@ -52,7 +53,7 @@ private:
     void applyCommandLineOptions(const CommandLineParser::Options& options);
     int processAudioPluginRegistration(const CommandLineParser::AudioPluginRegistration& task);
 
-    QList<muse::modularity::IModuleSetup*> m_modules;
+    QList<au::INeededModuleSetup*> m_modules;
 };
 }
 

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -243,15 +243,15 @@ int main(int argc, char** argv)
 
     // modules
     app.addModule(new au::appshell::AppShellModule());
-    app.addModule(new muse::extensions::ExtensionsModule());
-#ifdef MUSE_MODULE_AUTOBOT
-    app.addModule(new muse::autobot::AutobotModule());
-#endif
     app.addModule(new au::effects::AudioUnitEffectsModule());
     app.addModule(new au::effects::Lv2EffectsModule());
     app.addModule(new au::effects::VstEffectsModule());
 
     if (!isPluginRegistration) {
+        app.addModule(new muse::extensions::ExtensionsModule());
+#ifdef MUSE_MODULE_AUTOBOT
+        app.addModule(new muse::autobot::AutobotModule());
+#endif
         app.addModule(new au::context::ContextModule());
         app.addModule(new au::audio::AudioModule());
         app.addModule(new au::projectscene::ProjectSceneModule());

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -29,68 +29,7 @@
 #include "app.h"
 #include "commandlineparser.h"
 #include "log.h"
-
-// Framework
-#include "muse_framework_config.h"
-#include "diagnostics/diagnosticsmodule.h"
-#include "framework/draw/drawmodule.h"
-#include "framework/actions/actionsmodule.h"
-#include "framework/audioplugins/audiopluginsmodule.h"
-#include "framework/ui/uimodule.h"
-#include "framework/shortcuts/shortcutsmodule.h"
-#include "framework/accessibility/accessibilitymodule.h"
-#include "framework/uicomponents/uicomponentsmodule.h"
-#include "framework/dockwindow/dockmodule.h"
-#include "framework/cloud/cloudmodule.h"
-#include "framework/network/networkmodule.h"
-#include "framework/learn/learnmodule.h"
-#include "framework/languages/languagesmodule.h"
-#include "framework/workspace/workspacemodule.h"
-
-// need stubs
-#include "framework/stubs/multiinstances/multiinstancesstubmodule.h"
-
-// -----
-#include "appshell/appshellmodule.h"
-#include "context/contextmodule.h"
-#include "project/projectmodule.h"
-#include "projectscene/projectscenemodule.h"
-#include "au3audio/audiomodule.h"
-#include "playback/playbackmodule.h"
-#include "trackedit/trackeditmodule.h"
-#include "record/recordmodule.h"
-#include "effects/effects_base/effectsmodule.h"
-#include "effects/builtin/builtineffectsmodule.h"
-#ifdef AU_MODULE_EFFECTS_LV2
-#include "effects/lv2/lv2effectsmodule.h"
-#else
-#include "stubs/lv2/lv2effectsstubmodule.h"
-#endif
-#ifdef AU_MODULE_EFFECTS_VST
-#include "effects/vst/vsteffectsmodule.h"
-#else
-#include "stubs/vst/vsteffectsstubmodule.h"
-#endif
-#ifdef AU_MODULE_EFFECTS_AUDIO_UNIT
-#include "effects/audio_unit/audiouniteffectsmodule.h"
-#else
-#include "stubs/audio_unit/audiouniteffectsstubmodule.h"
-#endif
-#include "effects/nyquist/nyquisteffectsmodule.h"
-#include "importexport/import/importermodule.h"
-#include "importexport/export/exportermodule.h"
-
-#ifdef MUSE_MODULE_AUTOBOT
-#include "autobot/autobotmodule.h"
-#endif
-
-#ifdef MUSE_MODULE_EXTENSIONS
-#include "framework/extensions/extensionsmodule.h"
-#else
-#include "framework/stubs/extensions/extensionsstubmodule.h"
-#endif
-
-#include "au3wrap/au3wrapmodule.h"
+#include "neededmodulesetups.h"
 
 #if (defined (_MSCVER) || defined (_MSC_VER))
 #include <vector>
@@ -219,52 +158,52 @@ int main(int argc, char** argv)
 
     au::app::App app;
 
-//! NOTE `diagnostics` must be first, because it installs the crash handler.
-//! For other modules, the order is (an should be) unimportant.
-    app.addModule(new muse::diagnostics::DiagnosticsModule());
+    //! NOTE `diagnostics` must be first, because it installs the crash handler.
+    //! For other modules, the order is (an should be) unimportant.
+    app.addModule(new au::NeededDiagnosticsModule());
 
 // framework
-    app.addModule(new muse::audioplugins::AudioPluginsModule());
+    app.addModule(new au::NeededAudioPluginsModule());
     if (!isPluginRegistration) {
-        app.addModule(new muse::draw::DrawModule());
-        app.addModule(new muse::actions::ActionsModule());
-        app.addModule(new muse::workspace::WorkspaceModule());
-        app.addModule(new muse::accessibility::AccessibilityModule());
-        app.addModule(new muse::mi::MultiInstancesModule());
-        app.addModule(new muse::learn::LearnModule());
-        app.addModule(new muse::languages::LanguagesModule());
-        app.addModule(new muse::ui::UiModule());
-        app.addModule(new muse::uicomponents::UiComponentsModule());
-        app.addModule(new muse::dock::DockModule());
-        app.addModule(new muse::shortcuts::ShortcutsModule());
-        app.addModule(new muse::cloud::CloudModule());
-        app.addModule(new muse::network::NetworkModule());
+        app.addModule(new au::NeededDrawModule());
+        app.addModule(new au::NeededActionsModule());
+        app.addModule(new au::NeededWorkspaceModule());
+        app.addModule(new au::NeededAccessibilityModule());
+        app.addModule(new au::NeededMultiInstancesModule());
+        app.addModule(new au::NeededLearnModule());
+        app.addModule(new au::NeededLanguagesModule());
+        app.addModule(new au::NeededUiModule());
+        app.addModule(new au::NeededUiComponentsModule());
+        app.addModule(new au::NeededDockModule());
+        app.addModule(new au::NeededShortcutsModule());
+        app.addModule(new au::NeededCloudModule());
+        app.addModule(new au::NeededNetworkModule());
     }
 
     // modules
-    app.addModule(new au::appshell::AppShellModule());
-    app.addModule(new au::effects::AudioUnitEffectsModule());
-    app.addModule(new au::effects::Lv2EffectsModule());
-    app.addModule(new au::effects::VstEffectsModule());
+    app.addModule(new au::NeededAppShellModule());
+    app.addModule(new au::NeededAudioUnitEffectsModule());
+    app.addModule(new au::NeededLv2EffectsModule());
+    app.addModule(new au::NeededVstEffectsModule());
 
     if (!isPluginRegistration) {
-        app.addModule(new muse::extensions::ExtensionsModule());
+        app.addModule(new au::NeededExtensionsModule());
 #ifdef MUSE_MODULE_AUTOBOT
-        app.addModule(new muse::autobot::AutobotModule());
+        app.addModule(new au::NeededAutobotModule());
 #endif
-        app.addModule(new au::context::ContextModule());
-        app.addModule(new au::audio::AudioModule());
-        app.addModule(new au::projectscene::ProjectSceneModule());
-        app.addModule(new au::playback::PlaybackModule());
-        app.addModule(new au::record::RecordModule());
-        app.addModule(new au::trackedit::TrackeditModule());
-        app.addModule(new au::project::ProjectModule());
-        app.addModule(new au::importexport::ExporterModule());
-        app.addModule(new au::importexport::ImporterModule());
-        app.addModule(new au::au3::Au3WrapModule());
-        app.addModule(new au::effects::EffectsModule());
-        app.addModule(new au::effects::BuiltinEffectsModule());
-        app.addModule(new au::effects::NyquistEffectsModule());
+        app.addModule(new au::NeededContextModule());
+        app.addModule(new au::NeededAudioModule());
+        app.addModule(new au::NeededProjectSceneModule());
+        app.addModule(new au::NeededPlaybackModule());
+        app.addModule(new au::NeededRecordModule());
+        app.addModule(new au::NeededTrackeditModule());
+        app.addModule(new au::NeededProjectModule());
+        app.addModule(new au::NeededExporterModule());
+        app.addModule(new au::NeededImporterModule());
+        app.addModule(new au::NeededAu3WrapModule());
+        app.addModule(new au::NeededEffectsModule());
+        app.addModule(new au::NeededBuiltinEffectsModule());
+        app.addModule(new au::NeededNyquistEffectsModule());
     }
 
 #if (defined (_MSCVER) || defined (_MSC_VER))

--- a/src/ineededmodulesetup.h
+++ b/src/ineededmodulesetup.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <modularity/imodulesetup.h>
+
+namespace au {
+class INeededModuleSetup : public muse::modularity::IModuleSetup
+{
+public:
+    virtual ~INeededModuleSetup() = default;
+
+    //! Takes ownership
+    INeededModuleSetup(muse::modularity::IModuleSetup* module)
+        : m_module{module} {}
+
+    virtual bool isNeededForRunMode(const muse::IApplication::RunMode&) const { return false; }
+
+    std::string moduleName() const override { return m_module->moduleName(); }
+    void registerExports() override { m_module->registerExports(); }
+    void resolveImports() override { m_module->resolveImports(); }
+    void registerResources() override { m_module->registerResources(); }
+    void registerUiTypes() override { m_module->registerUiTypes(); }
+    void registerApi() override { m_module->registerApi(); }
+    void onPreInit(const muse::IApplication::RunMode& mode) override { m_module->onPreInit(mode); }
+    void onInit(const muse::IApplication::RunMode& mode) override { m_module->onInit(mode); }
+    void onAllInited(const muse::IApplication::RunMode& mode) override { m_module->onAllInited(mode); }
+    void onDelayedInit() override { m_module->onDelayedInit(); }
+    void onDeinit() override { m_module->onDeinit(); }
+    void onDestroy() override { m_module->onDestroy(); }
+    void onStartApp() override { m_module->onStartApp(); }
+
+private:
+    std::unique_ptr<muse::modularity::IModuleSetup> m_module;
+};
+}

--- a/src/neededmodulesetups.h
+++ b/src/neededmodulesetups.h
@@ -1,0 +1,307 @@
+#pragma once
+
+#include "ineededmodulesetup.h"
+
+// Framework
+#include "muse_framework_config.h"
+#include "diagnostics/diagnosticsmodule.h"
+#include "framework/draw/drawmodule.h"
+#include "framework/actions/actionsmodule.h"
+#include "framework/audioplugins/audiopluginsmodule.h"
+#include "framework/ui/uimodule.h"
+#include "framework/shortcuts/shortcutsmodule.h"
+#include "framework/accessibility/accessibilitymodule.h"
+#include "framework/uicomponents/uicomponentsmodule.h"
+#include "framework/dockwindow/dockmodule.h"
+#include "framework/cloud/cloudmodule.h"
+#include "framework/network/networkmodule.h"
+#include "framework/learn/learnmodule.h"
+#include "framework/languages/languagesmodule.h"
+#include "framework/workspace/workspacemodule.h"
+
+// need stubs
+#include "framework/stubs/multiinstances/multiinstancesstubmodule.h"
+
+// -----
+#include "appshell/appshellmodule.h"
+#include "context/contextmodule.h"
+#include "project/projectmodule.h"
+#include "projectscene/projectscenemodule.h"
+#include "au3audio/audiomodule.h"
+#include "playback/playbackmodule.h"
+#include "trackedit/trackeditmodule.h"
+#include "record/recordmodule.h"
+#include "effects/effects_base/effectsmodule.h"
+#include "effects/builtin/builtineffectsmodule.h"
+#ifdef AU_MODULE_EFFECTS_LV2
+#include "effects/lv2/lv2effectsmodule.h"
+#else
+#include "stubs/lv2/lv2effectsstubmodule.h"
+#endif
+#ifdef AU_MODULE_EFFECTS_VST
+#include "effects/vst/vsteffectsmodule.h"
+#else
+#include "stubs/vst/vsteffectsstubmodule.h"
+#endif
+#ifdef AU_MODULE_EFFECTS_AUDIO_UNIT
+#include "effects/audio_unit/audiouniteffectsmodule.h"
+#else
+#include "stubs/audio_unit/audiouniteffectsstubmodule.h"
+#endif
+#include "effects/nyquist/nyquisteffectsmodule.h"
+#include "importexport/import/importermodule.h"
+#include "importexport/export/exportermodule.h"
+
+#ifdef MUSE_MODULE_AUTOBOT
+#include "autobot/autobotmodule.h"
+#endif
+
+#ifdef MUSE_MODULE_EXTENSIONS
+#include "framework/extensions/extensionsmodule.h"
+#else
+#include "framework/stubs/extensions/extensionsstubmodule.h"
+#endif
+
+#include "au3wrap/au3wrapmodule.h"
+
+namespace au {
+class NeededDiagnosticsModule : public INeededModuleSetup
+{
+public:
+    NeededDiagnosticsModule()
+        : INeededModuleSetup(new muse::diagnostics::DiagnosticsModule()) {}
+};
+
+class NeededAudioPluginsModule : public INeededModuleSetup
+{
+public:
+    NeededAudioPluginsModule()
+        : INeededModuleSetup(new muse::audioplugins::AudioPluginsModule()) {}
+};
+
+class NeededDrawModule : public INeededModuleSetup
+{
+public:
+    NeededDrawModule()
+        : INeededModuleSetup(new muse::draw::DrawModule()) {}
+};
+
+class NeededActionsModule : public INeededModuleSetup
+{
+public:
+    NeededActionsModule()
+        : INeededModuleSetup(new muse::actions::ActionsModule()) {}
+};
+
+class NeededWorkspaceModule : public INeededModuleSetup
+{
+public:
+    NeededWorkspaceModule()
+        : INeededModuleSetup(new muse::workspace::WorkspaceModule()) {}
+};
+
+class NeededAccessibilityModule : public INeededModuleSetup
+{
+public:
+    NeededAccessibilityModule()
+        : INeededModuleSetup(new muse::accessibility::AccessibilityModule()) {}
+};
+
+class NeededMultiInstancesModule : public INeededModuleSetup
+{
+public:
+    NeededMultiInstancesModule()
+        : INeededModuleSetup(new muse::mi::MultiInstancesModule()) {}
+};
+
+class NeededLearnModule : public INeededModuleSetup
+{
+public:
+    NeededLearnModule()
+        : INeededModuleSetup(new muse::learn::LearnModule()) {}
+};
+
+class NeededLanguagesModule : public INeededModuleSetup
+{
+public:
+    NeededLanguagesModule()
+        : INeededModuleSetup(new muse::languages::LanguagesModule()) {}
+};
+
+class NeededUiModule : public INeededModuleSetup
+{
+public:
+    NeededUiModule()
+        : INeededModuleSetup(new muse::ui::UiModule()) {}
+};
+
+class NeededUiComponentsModule : public INeededModuleSetup
+{
+public:
+    NeededUiComponentsModule()
+        : INeededModuleSetup(new muse::uicomponents::UiComponentsModule()) {}
+};
+
+class NeededDockModule : public INeededModuleSetup
+{
+public:
+    NeededDockModule()
+        : INeededModuleSetup(new muse::dock::DockModule()) {}
+};
+
+class NeededShortcutsModule : public INeededModuleSetup
+{
+public:
+    NeededShortcutsModule()
+        : INeededModuleSetup(new muse::shortcuts::ShortcutsModule()) {}
+};
+
+class NeededCloudModule : public INeededModuleSetup
+{
+public:
+    NeededCloudModule()
+        : INeededModuleSetup(new muse::cloud::CloudModule()) {}
+};
+
+class NeededNetworkModule : public INeededModuleSetup
+{
+public:
+    NeededNetworkModule()
+        : INeededModuleSetup(new muse::network::NetworkModule()) {}
+};
+
+class NeededAppShellModule : public INeededModuleSetup
+{
+public:
+    NeededAppShellModule()
+        : INeededModuleSetup(new au::appshell::AppShellModule()) {}
+};
+
+class NeededAudioUnitEffectsModule : public INeededModuleSetup
+{
+public:
+    NeededAudioUnitEffectsModule()
+        : INeededModuleSetup(new au::effects::AudioUnitEffectsModule()) {}
+};
+
+class NeededLv2EffectsModule : public INeededModuleSetup
+{
+public:
+    NeededLv2EffectsModule()
+        : INeededModuleSetup(new au::effects::Lv2EffectsModule()) {}
+};
+
+class NeededVstEffectsModule : public INeededModuleSetup
+{
+public:
+    NeededVstEffectsModule()
+        : INeededModuleSetup(new au::effects::VstEffectsModule()) {}
+};
+
+class NeededExtensionsModule : public INeededModuleSetup
+{
+public:
+    NeededExtensionsModule()
+        : INeededModuleSetup(new muse::extensions::ExtensionsModule()) {}
+};
+
+#ifdef MUSE_MODULE_AUTOBOT
+class NeededAutobotModule : public INeededModuleSetup
+{
+public:
+    NeededAutobotModule()
+        : INeededModuleSetup(new muse::autobot::AutobotModule()) {}
+};
+#endif
+
+class NeededContextModule : public INeededModuleSetup
+{
+public:
+    NeededContextModule()
+        : INeededModuleSetup(new au::context::ContextModule()) {}
+};
+
+class NeededAudioModule : public INeededModuleSetup
+{
+public:
+    NeededAudioModule()
+        : INeededModuleSetup(new au::audio::AudioModule()) {}
+};
+
+class NeededProjectSceneModule : public INeededModuleSetup
+{
+public:
+    NeededProjectSceneModule()
+        : INeededModuleSetup(new au::projectscene::ProjectSceneModule()) {}
+};
+
+class NeededPlaybackModule : public INeededModuleSetup
+{
+public:
+    NeededPlaybackModule()
+        : INeededModuleSetup(new au::playback::PlaybackModule()) {}
+};
+
+class NeededRecordModule : public INeededModuleSetup
+{
+public:
+    NeededRecordModule()
+        : INeededModuleSetup(new au::record::RecordModule()) {}
+};
+
+class NeededTrackeditModule : public INeededModuleSetup
+{
+public:
+    NeededTrackeditModule()
+        : INeededModuleSetup(new au::trackedit::TrackeditModule()) {}
+};
+
+class NeededProjectModule : public INeededModuleSetup
+{
+public:
+    NeededProjectModule()
+        : INeededModuleSetup(new au::project::ProjectModule()) {}
+};
+
+class NeededExporterModule : public INeededModuleSetup
+{
+public:
+    NeededExporterModule()
+        : INeededModuleSetup(new au::importexport::ExporterModule()) {}
+};
+
+class NeededImporterModule : public INeededModuleSetup
+{
+public:
+    NeededImporterModule()
+        : INeededModuleSetup(new au::importexport::ImporterModule()) {}
+};
+
+class NeededAu3WrapModule : public INeededModuleSetup
+{
+public:
+    NeededAu3WrapModule()
+        : INeededModuleSetup(new au::au3::Au3WrapModule()) {}
+};
+
+class NeededEffectsModule : public INeededModuleSetup
+{
+public:
+    NeededEffectsModule()
+        : INeededModuleSetup(new au::effects::EffectsModule()) {}
+};
+
+class NeededBuiltinEffectsModule : public INeededModuleSetup
+{
+public:
+    NeededBuiltinEffectsModule()
+        : INeededModuleSetup(new au::effects::BuiltinEffectsModule()) {}
+};
+
+class NeededNyquistEffectsModule : public INeededModuleSetup
+{
+public:
+    NeededNyquistEffectsModule()
+        : INeededModuleSetup(new au::effects::NyquistEffectsModule()) {}
+};
+}


### PR DESCRIPTION
Looking at #9330, I realized that no one noticed that modules that were unnecessary to plugin registration had been added even to the plugin-registration path.
It is critical that plugin scanning stays as fast as possible, hence the idea of this PR as mechanism against inadvertent loading of unnecessary modules.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Autobot test cases have been run
