### PR TITLE
Fix vertical playback meter volume slider position

### DIFF
--- a/src/playback/qml/Audacity/Playback/panels/PlaybackMeterPanel.qml
+++ b/src/playback/qml/Audacity/Playback/panels/PlaybackMeterPanel.qml
@@ -27,6 +27,10 @@ Item {
         }
     }
 
+    Component.onCompleted: {
+        model.init()
+    }
+
     ColumnLayout {
         anchors.fill: parent
         anchors.bottomMargin: 2

--- a/src/playback/view/common/metermodel.cpp
+++ b/src/playback/view/common/metermodel.cpp
@@ -206,6 +206,11 @@ void MeterModel::setVolume(float volume)
     emit positionChanged();
 }
 
+float MeterModel::volume() const
+{
+    return m_volume;
+}
+
 QString MeterModel::description(PlaybackMeterDbRange::DbRange range) const
 {
     switch (range) {

--- a/src/playback/view/common/metermodel.h
+++ b/src/playback/view/common/metermodel.h
@@ -66,6 +66,7 @@ public:
     void setMeterDbRange(PlaybackMeterDbRange::DbRange range);
 
     void setVolume(float volume);
+    float volume() const;
 
     QVariantList smallSteps() const;
     QVariantList fullSteps() const;

--- a/src/playback/view/panels/playbackmeterpanelmodel.h
+++ b/src/playback/view/panels/playbackmeterpanelmodel.h
@@ -38,6 +38,9 @@ class PlaybackMeterPanelModel : public QObject, public muse::async::Asyncable
 public:
     explicit PlaybackMeterPanelModel(QObject* parent = nullptr);
 
+    Q_INVOKABLE void init();
+    Q_INVOKABLE void volumeLevelChangeRequested(float level);
+
     float leftChannelPressure() const;
     float leftChannelRMS() const;
 
@@ -49,8 +52,6 @@ public:
     float level() const;
 
     bool isPlaying() const;
-
-    Q_INVOKABLE void volumeLevelChangeRequested(float level);
 
 public slots:
     void setLeftChannelPressure(float leftChannelPressure);
@@ -83,7 +84,5 @@ private:
     float m_leftChannelRMS = playback::MIN_DISPLAYED_DBFS;
     float m_rightChannelPressure = playback::MIN_DISPLAYED_DBFS;
     float m_rightChannelRMS = playback::MIN_DISPLAYED_DBFS;
-
-    float m_level = 0;
 };
 }


### PR DESCRIPTION
Resolves: #9280 

The volume information should be updated in the meter model to calculate the slider position correctly.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Autobot test cases have been run
