### PR TITLE
9358 - Multi track selection using shift

### DIFF
--- a/src/projectscene/internal/projectsceneuiactions.cpp
+++ b/src/projectscene/internal/projectsceneuiactions.cpp
@@ -205,6 +205,18 @@ static UiActionList STATIC_ACTIONS = {
              muse::shortcuts::CTX_PROJECT_OPENED,
              TranslatableString("action", "Focus next track"),
              TranslatableString("action", "Focus next track")
+             ),
+    UiAction("shift-up",
+             au::context::UiCtxProjectOpened,
+             muse::shortcuts::CTX_PROJECT_OPENED,
+             TranslatableString("action", "Multi track selection previous"),
+             TranslatableString("action", "Multi track selection previous")
+             ),
+    UiAction("shift-down",
+             au::context::UiCtxProjectOpened,
+             muse::shortcuts::CTX_PROJECT_OPENED,
+             TranslatableString("action", "Multi track selection next"),
+             TranslatableString("action", "Multi track selection next")
              )
 };
 

--- a/src/trackedit/internal/au3/au3selectioncontroller.cpp
+++ b/src/trackedit/internal/au3/au3selectioncontroller.cpp
@@ -649,6 +649,16 @@ int Au3SelectionController::trackDistance(const TrackId previous, const TrackId 
     }
 }
 
+TrackIdList Au3SelectionController::orderedTrackList() const
+{
+    TrackIdList trackIds;
+    auto& tracks = Au3TrackList::Get(projectRef());
+    for (const auto& track : tracks) {
+        trackIds.push_back(track->GetId());
+    }
+    return trackIds;
+}
+
 Au3Project& Au3SelectionController::projectRef() const
 {
     Au3Project* project = reinterpret_cast<Au3Project*>(globalContext()->currentProject()->au3ProjectPtr());

--- a/src/trackedit/internal/au3/au3selectioncontroller.cpp
+++ b/src/trackedit/internal/au3/au3selectioncontroller.cpp
@@ -621,6 +621,34 @@ void Au3SelectionController::updateSelectionController()
     }
 }
 
+int Au3SelectionController::trackDistance(TrackId previous, TrackId next) const
+{
+    if (previous == next) {
+        return 0;
+    }
+
+    const auto& tracks = Au3TrackList::Get(projectRef());
+    auto prevIter = tracks.Find(au3::DomAccessor::findTrack(projectRef(), ::TrackId(previous)));
+    auto nextIter = tracks.Find(au3::DomAccessor::findTrack(projectRef(), ::TrackId(next)));
+
+    if (prevIter == tracks.end() || nextIter == tracks.end()) {
+        return 0;
+    }
+
+    auto tempIter = prevIter;
+    int forwardDistance = 0;
+    while (tempIter != tracks.end() && tempIter != nextIter) {
+        ++tempIter;
+        ++forwardDistance;
+    }
+
+    if (tempIter == nextIter) {
+        return forwardDistance;
+    } else {
+        return -std::distance(nextIter, prevIter);
+    }
+}
+
 Au3Project& Au3SelectionController::projectRef() const
 {
     Au3Project* project = reinterpret_cast<Au3Project*>(globalContext()->currentProject()->au3ProjectPtr());

--- a/src/trackedit/internal/au3/au3selectioncontroller.cpp
+++ b/src/trackedit/internal/au3/au3selectioncontroller.cpp
@@ -621,7 +621,7 @@ void Au3SelectionController::updateSelectionController()
     }
 }
 
-int Au3SelectionController::trackDistance(TrackId previous, TrackId next) const
+int Au3SelectionController::trackDistance(const TrackId previous, const TrackId next) const
 {
     if (previous == next) {
         return 0;

--- a/src/trackedit/internal/au3/au3selectioncontroller.h
+++ b/src/trackedit/internal/au3/au3selectioncontroller.h
@@ -83,6 +83,7 @@ public:
     void focusTrackByIndex(int index) override;
 
     int trackDistance(const TrackId previous, const TrackId next) const override;
+    TrackIdList orderedTrackList() const override;
 
 private:
     void addSelectedTrack(const trackedit::TrackId& trackId);

--- a/src/trackedit/internal/au3/au3selectioncontroller.h
+++ b/src/trackedit/internal/au3/au3selectioncontroller.h
@@ -82,6 +82,8 @@ public:
     void focusNextTrack() override;
     void focusTrackByIndex(int index) override;
 
+    int trackDistance(TrackId previous, TrackId next) const override;
+
 private:
     void addSelectedTrack(const trackedit::TrackId& trackId);
     void updateSelectionController();

--- a/src/trackedit/internal/au3/au3selectioncontroller.h
+++ b/src/trackedit/internal/au3/au3selectioncontroller.h
@@ -82,7 +82,7 @@ public:
     void focusNextTrack() override;
     void focusTrackByIndex(int index) override;
 
-    int trackDistance(TrackId previous, TrackId next) const override;
+    int trackDistance(const TrackId previous, const TrackId next) const override;
 
 private:
     void addSelectedTrack(const trackedit::TrackId& trackId);

--- a/src/trackedit/internal/itracknavigationcontroller.h
+++ b/src/trackedit/internal/itracknavigationcontroller.h
@@ -18,5 +18,7 @@ public:
     virtual void navigateUp(const muse::actions::ActionData& args) = 0;
     virtual void navigateDown(const muse::actions::ActionData& args) = 0;
     virtual void toggleSelectionOnFocusedTrack() = 0;
+    virtual void multiSelectionUp() = 0;
+    virtual void multiSelectionDown() = 0;
 };
 }

--- a/src/trackedit/internal/tracknavigationcontroller.cpp
+++ b/src/trackedit/internal/tracknavigationcontroller.cpp
@@ -198,6 +198,8 @@ void TrackNavigationController::updateSelectionStart(SelectionDirection directio
         }
 
         if (orderedSelectedTracks.empty()) {
+            m_selectionStart = focusedTrack;
+            selectionController()->setSelectedTracks({ focusedTrack });
             return;
         }
 

--- a/src/trackedit/internal/tracknavigationcontroller.h
+++ b/src/trackedit/internal/tracknavigationcontroller.h
@@ -15,11 +15,8 @@
 #include "trackedit/internal/itracknavigationcontroller.h"
 
 namespace au::trackedit {
-class TrackNavigationController : public QObject, public ITrackNavigationController, public muse::actions::Actionable,
-    public muse::async::Asyncable
+class TrackNavigationController : public ITrackNavigationController, public muse::actions::Actionable, public muse::async::Asyncable
 {
-    Q_OBJECT
-
     muse::Inject<muse::actions::IActionsDispatcher> dispatcher;
     muse::Inject<au::trackedit::ISelectionController> selectionController;
     muse::Inject<muse::ui::INavigationController> navigationController;
@@ -36,7 +33,6 @@ public:
     void multiSelectionDown() override;
 
 private:
-    bool eventFilter(QObject* watched, QEvent* event) override;
     void updateSelectionStart();
     void updateTrackSelection(TrackIdList& selectedTracks, const TrackId& previousFocusedTrack);
 

--- a/src/trackedit/internal/tracknavigationcontroller.h
+++ b/src/trackedit/internal/tracknavigationcontroller.h
@@ -15,6 +15,11 @@
 #include "trackedit/internal/itracknavigationcontroller.h"
 
 namespace au::trackedit {
+enum class SelectionDirection {
+    Up,
+    Down
+};
+
 class TrackNavigationController : public ITrackNavigationController, public muse::actions::Actionable, public muse::async::Asyncable
 {
     muse::Inject<muse::actions::IActionsDispatcher> dispatcher;
@@ -33,7 +38,7 @@ public:
     void multiSelectionDown() override;
 
 private:
-    void updateSelectionStart();
+    void updateSelectionStart(SelectionDirection direction);
     void updateTrackSelection(TrackIdList& selectedTracks, const TrackId& previousFocusedTrack);
 
     std::optional<TrackId> m_selectionStart;

--- a/src/trackedit/internal/tracknavigationcontroller.h
+++ b/src/trackedit/internal/tracknavigationcontroller.h
@@ -15,8 +15,11 @@
 #include "trackedit/internal/itracknavigationcontroller.h"
 
 namespace au::trackedit {
-class TrackNavigationController : public ITrackNavigationController, public muse::actions::Actionable, public muse::async::Asyncable
+class TrackNavigationController : public QObject, public ITrackNavigationController, public muse::actions::Actionable,
+    public muse::async::Asyncable
 {
+    Q_OBJECT
+
     muse::Inject<muse::actions::IActionsDispatcher> dispatcher;
     muse::Inject<au::trackedit::ISelectionController> selectionController;
     muse::Inject<muse::ui::INavigationController> navigationController;
@@ -29,5 +32,14 @@ public:
     void navigateUp(const muse::actions::ActionData& args) override;
     void navigateDown(const muse::actions::ActionData& args) override;
     void toggleSelectionOnFocusedTrack() override;
+    void multiSelectionUp() override;
+    void multiSelectionDown() override;
+
+private:
+    bool eventFilter(QObject* watched, QEvent* event) override;
+    void updateSelectionStart();
+    void updateTrackSelection(TrackIdList& selectedTracks, const TrackId& previousFocusedTrack);
+
+    std::optional<TrackId> m_selectionStart;
 };
 }

--- a/src/trackedit/iselectioncontroller.h
+++ b/src/trackedit/iselectioncontroller.h
@@ -87,5 +87,6 @@ public:
     virtual void focusTrackByIndex(int index) = 0;
 
     virtual int trackDistance(const TrackId previous, const TrackId next) const = 0;
+    virtual TrackIdList orderedTrackList() const = 0;
 };
 }

--- a/src/trackedit/iselectioncontroller.h
+++ b/src/trackedit/iselectioncontroller.h
@@ -86,6 +86,6 @@ public:
     virtual void focusNextTrack() = 0;
     virtual void focusTrackByIndex(int index) = 0;
 
-    virtual int trackDistance(TrackId previous, TrackId next) const = 0;
+    virtual int trackDistance(const TrackId previous, const TrackId next) const = 0;
 };
 }

--- a/src/trackedit/iselectioncontroller.h
+++ b/src/trackedit/iselectioncontroller.h
@@ -85,5 +85,7 @@ public:
     virtual void focusPreviousTrack() = 0;
     virtual void focusNextTrack() = 0;
     virtual void focusTrackByIndex(int index) = 0;
+
+    virtual int trackDistance(TrackId previous, TrackId next) const = 0;
 };
 }

--- a/src/trackedit/tests/mocks/selectioncontrollermock.h
+++ b/src/trackedit/tests/mocks/selectioncontrollermock.h
@@ -63,5 +63,6 @@ public:
     MOCK_METHOD(void, focusTrackByIndex, (int index), (override));
 
     MOCK_METHOD(int, trackDistance, (TrackId previous, TrackId next), (const, override));
+    MOCK_METHOD(TrackIdList, orderedTrackList, (), (const, override));
 };
 }

--- a/src/trackedit/tests/mocks/selectioncontrollermock.h
+++ b/src/trackedit/tests/mocks/selectioncontrollermock.h
@@ -61,5 +61,7 @@ public:
     MOCK_METHOD(void, focusPreviousTrack, (), (override));
     MOCK_METHOD(void, focusNextTrack, (), (override));
     MOCK_METHOD(void, focusTrackByIndex, (int index), (override));
+
+    MOCK_METHOD(int, trackDistance, (TrackId previous, TrackId next), (const, override));
 };
 }


### PR DESCRIPTION
Resolves: #9358 

Enable the user to use shift + arrow keys to select multiple tracks.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Autobot test cases have been run
