### PR TITLE
9392 Paused stream should not restart monitoring

### DIFF
--- a/src/record/internal/au3/au3audioinput.cpp
+++ b/src/record/internal/au3/au3audioinput.cpp
@@ -45,7 +45,7 @@ Au3AudioInput::Au3AudioInput()
         });
 
         playbackController()->isPlayingChanged().onNotify(this, [this]() {
-            if (!playbackController()->isPlaying()) {
+            if (playbackController()->isStopped()) {
                 restartMonitoring();
             }
         });


### PR DESCRIPTION
Resolves: #9392 

Avoid restarting monitoring when in paused state.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Autobot test cases have been run
