### PR TITLE
9389 properly handle temporary project check

### DIFF
--- a/src/appshell/internal/sessionsmanager.cpp
+++ b/src/appshell/internal/sessionsmanager.cpp
@@ -82,7 +82,7 @@ void SessionsManager::update()
     io::path_t newProjectPath;
 
     if (auto project = globalContext()->currentProject()) {
-        newProjectPath = project->isNewlyCreated() ? projectConfiguration()->newProjectTemporaryPath() : project->path();
+        newProjectPath = project->path();
     }
 
     if (newProjectPath == m_lastOpenedProjectPath) {

--- a/src/appshell/internal/sessionsmanager.cpp
+++ b/src/appshell/internal/sessionsmanager.cpp
@@ -136,8 +136,3 @@ void SessionsManager::removeUnsavedChanges(const muse::io::path_t& projectPath)
         LOGE() << "Failed remove autosave data for project: " << projectPath << ", err: " << ret.toString();
     }
 }
-
-bool SessionsManager::isPathToNewlyCreatedProject(const muse::io::path_t& projectPath) const
-{
-    return projectPath == projectConfiguration()->newProjectTemporaryPath();
-}

--- a/src/appshell/internal/sessionsmanager.cpp
+++ b/src/appshell/internal/sessionsmanager.cpp
@@ -131,15 +131,9 @@ void SessionsManager::removeProjectsUnsavedChanges(const muse::io::paths_t& proj
 
 void SessionsManager::removeUnsavedChanges(const muse::io::path_t& projectPath)
 {
-    const bool success = au3ProjectCreator()->removeAutosaveDataFromFile(projectPath);
-
-    if (!success) {
-        LOGE() << "[project] failed to remove autosave data for project: " << projectPath;
-    }
-
-    // For newly created projects, also remove the temporary file
-    if (isPathToNewlyCreatedProject(projectPath)) {
-        fileSystem()->remove(projectPath);
+    const Ret ret = au3ProjectCreator()->removeUnsavedData(projectPath);
+    if (!ret) {
+        LOGE() << "Failed remove autosave data for project: " << projectPath << ", err: " << ret.toString();
     }
 }
 

--- a/src/appshell/internal/sessionsmanager.h
+++ b/src/appshell/internal/sessionsmanager.h
@@ -64,7 +64,6 @@ private:
 
     void removeProjectsUnsavedChanges(const muse::io::paths_t& projectsPaths);
     void removeUnsavedChanges(const muse::io::path_t& projectPath);
-    bool isPathToNewlyCreatedProject(const muse::io::path_t& projectPath) const;
 
     muse::io::path_t m_lastOpenedProjectPath;
 };

--- a/src/au3wrap/iau3project.h
+++ b/src/au3wrap/iau3project.h
@@ -19,12 +19,13 @@ public:
 
     virtual ~IAu3Project() = default;
 
-    virtual void open() = 0;
-    virtual muse::Ret load(const muse::io::path_t& filePath) = 0;
+    [[nodiscard]] virtual muse::Ret open() = 0;
+    [[nodiscard]] virtual muse::Ret load(const muse::io::path_t& filePath) = 0;
     virtual bool save(const muse::io::path_t& fileName) = 0;
     virtual void close() = 0;
 
     virtual std::string title() const = 0;
+    [[nodiscard]] virtual muse::io::path_t getFileName() const = 0;
 
     // Save status management
     [[nodiscard]] virtual bool hasUnsavedChanges() const = 0;
@@ -34,7 +35,7 @@ public:
 
     // Autosave management
     [[nodiscard]] virtual bool hasAutosaveData() const = 0;
-    virtual bool removeAutosaveData() = 0;
+    [[nodiscard]] virtual muse::Ret removeAutosaveData() = 0;
 
     virtual muse::async::Notification projectChanged() const = 0;
 
@@ -50,6 +51,6 @@ public:
 
     virtual std::shared_ptr<IAu3Project> create() const = 0;
 
-    virtual bool removeAutosaveDataFromFile(const muse::io::path_t& projectPath) const = 0;
+    [[nodiscard]] virtual muse::Ret removeUnsavedData(const muse::io::path_t& projectPath) const = 0;
 };
 }

--- a/src/au3wrap/iau3project.h
+++ b/src/au3wrap/iau3project.h
@@ -30,6 +30,7 @@ public:
     [[nodiscard]] virtual bool hasUnsavedChanges() const = 0;
     virtual void markAsSaved() = 0;
     [[nodiscard]] virtual bool isRecovered() const = 0;
+    [[nodiscard]] virtual bool isTemporary() const = 0;
 
     // Autosave management
     [[nodiscard]] virtual bool hasAutosaveData() const = 0;

--- a/src/au3wrap/internal/au3project.cpp
+++ b/src/au3wrap/internal/au3project.cpp
@@ -306,6 +306,12 @@ bool Au3ProjectAccessor::isRecovered() const
     return projectFileIO.IsRecovered();
 }
 
+bool Au3ProjectAccessor::isTemporary() const
+{
+    const auto& projectFileIO = ProjectFileIO::Get(m_data->projectRef());
+    return projectFileIO.IsTemporary();
+}
+
 muse::async::Notification Au3ProjectAccessor::projectChanged() const
 {
     return m_projectChanged;

--- a/src/au3wrap/internal/au3project.h
+++ b/src/au3wrap/internal/au3project.h
@@ -7,6 +7,9 @@
 
 #include "global/types/ret.h"
 #include "global/async/notification.h"
+#include "global/io/ifilesystem.h"
+#include "global/modularity/ioc.h"
+
 #include "au3wrap/iau3project.h"
 #include "libraries/lib-track/Track.h"
 #include "libraries/lib-utility/Observer.h"
@@ -22,12 +25,13 @@ public:
 
     Au3ProjectAccessor();
 
-    void open() override;
-    muse::Ret load(const muse::io::path_t& filePath) override;
+    [[nodiscard]] muse::Ret open() override;
+    [[nodiscard]] muse::Ret load(const muse::io::path_t& filePath) override;
     bool save(const muse::io::path_t& fileName) override;
     void close() override;
 
     std::string title() const override;
+    [[nodiscard]] muse::io::path_t getFileName() const override;
 
     // Save status management
     [[nodiscard]] bool hasUnsavedChanges() const override;
@@ -37,7 +41,7 @@ public:
 
     // Autosave management
     [[nodiscard]] bool hasAutosaveData() const override;
-    bool removeAutosaveData() override;
+    [[nodiscard]] muse::Ret removeAutosaveData() override;
 
     muse::async::Notification projectChanged() const override;
 
@@ -57,9 +61,11 @@ private:
 
 class Au3ProjectCreator : public IAu3ProjectCreator
 {
+    muse::Inject<muse::io::IFileSystem> fileSystem;
+
 public:
 
     std::shared_ptr<IAu3Project> create() const override;
-    bool removeAutosaveDataFromFile(const muse::io::path_t& projectPath) const override;
+    [[nodiscard]] muse::Ret removeUnsavedData(const muse::io::path_t& projectPath) const override;
 };
 }

--- a/src/au3wrap/internal/au3project.h
+++ b/src/au3wrap/internal/au3project.h
@@ -33,6 +33,7 @@ public:
     [[nodiscard]] bool hasUnsavedChanges() const override;
     void markAsSaved() override;
     [[nodiscard]] bool isRecovered() const override;
+    [[nodiscard]] bool isTemporary() const override;
 
     // Autosave management
     [[nodiscard]] bool hasAutosaveData() const override;

--- a/src/project/internal/audacityproject.cpp
+++ b/src/project/internal/audacityproject.cpp
@@ -103,12 +103,14 @@ muse::Ret Audacity4Project::doLoad(const io::path_t& path, bool forceMode, const
         return make_ret(Err::ProjectFileNotFound, path);
     }
 
-    io::File file(path);
-    if (!file.open(io::IODevice::ReadOnly)) {
-        LOGE() << "failed open file (Can't Read): " << path;
-        return make_ret(Err::ProjectFileIsReadProtected, path);
+    {
+        io::File file(path);
+        if (!file.open(io::IODevice::ReadOnly)) {
+            LOGE() << "failed open file (Can't Read): " << path;
+            return make_ret(Err::ProjectFileIsReadProtected, path);
+        }
+        file.close();
     }
-    file.close();
 
     m_au3Project = au3ProjectCreator()->create();
     ret = m_au3Project->load(path);
@@ -135,7 +137,7 @@ muse::Ret Audacity4Project::doLoad(const io::path_t& path, bool forceMode, const
     if (m_au3Project->isRecovered()) {
         m_trackeditProject->reload();
 
-        if (path == configuration()->newProjectTemporaryPath()) {
+        if (m_au3Project->isTemporary()) {
             m_isNewlyCreated = true;
             LOGD() << "[project] Restored never-saved project, marked as newly created";
         }

--- a/src/project/internal/audacityproject.cpp
+++ b/src/project/internal/audacityproject.cpp
@@ -24,7 +24,10 @@ Audacity4Project::Audacity4Project()
 Ret Audacity4Project::createNew()
 {
     m_au3Project = au3ProjectCreator()->create();
-    m_au3Project->open();
+    if (!m_au3Project->open()) {
+        return muse::make_ret(static_cast<Ret::Code>(au::project::Err::NoProjectError));
+    }
+    setPath(m_au3Project->getFileName());
     m_trackeditProject = trackeditProjectCreator()->create(m_au3Project);
     m_isNewlyCreated = true;
     m_viewState = viewStateCreator()->createViewState(m_au3Project);

--- a/src/project/internal/projectautosaver.cpp
+++ b/src/project/internal/projectautosaver.cpp
@@ -86,7 +86,7 @@ void ProjectAutoSaver::init()
 
 void ProjectAutoSaver::removeProjectUnsavedChanges(const muse::io::path_t& projectPath)
 {
-    const bool success = au3ProjectCreator()->removeAutosaveDataFromFile(projectPath);
+    const bool success = au3ProjectCreator()->removeUnsavedData(projectPath);
 
     if (!success) {
         LOGE() << "[autosave] failed to remove autosave data for project: " << projectPath;

--- a/src/project/internal/projectautosaver.h
+++ b/src/project/internal/projectautosaver.h
@@ -24,15 +24,15 @@
 
 #include <QTimer>
 
-#include "async/asyncable.h"
-
-#include "modularity/ioc.h"
+#include "global/async/asyncable.h"
+#include "global/modularity/ioc.h"
+#include "global/io/ifilesystem.h"
 #include "context/iglobalcontext.h"
-#include "io/ifilesystem.h"
-#include "iprojectconfiguration.h"
 
+#include "iprojectconfiguration.h"
 #include "../iprojectautosaver.h"
 #include "au3wrap/iau3project.h"
+// maybe use the #include "appshell/internal/isessionsmanager.h"
 
 namespace au::project {
 class ProjectAutoSaver : public IProjectAutoSaver, public muse::async::Asyncable
@@ -41,15 +41,12 @@ class ProjectAutoSaver : public IProjectAutoSaver, public muse::async::Asyncable
     muse::Inject<muse::io::IFileSystem> fileSystem;
     muse::Inject<IProjectConfiguration> configuration;
     muse::Inject<au::au3::IAu3ProjectCreator> au3ProjectCreator;
+    // maybe use the muse::Inject<au::appshell::ISessionsManager> sessionsManager;
 
 public:
     ProjectAutoSaver() = default;
 
     void init();
-
-    void removeProjectUnsavedChanges(const muse::io::path_t& projectPath) override;
-
-    bool isPathToNewlyCreatedProject(const muse::io::path_t& projectPath) const override;
 
 private:
     IAudacityProjectPtr currentProject() const;
@@ -57,8 +54,6 @@ private:
     void update();
 
     void onTrySave();
-
-    muse::io::path_t projectPath(IAudacityProjectPtr project) const;
 
     QTimer m_timer;
     muse::io::path_t m_lastProjectPathNeedingAutosave;

--- a/src/project/internal/projectconfiguration.cpp
+++ b/src/project/internal/projectconfiguration.cpp
@@ -101,11 +101,6 @@ void ProjectConfiguration::setLastSavedProjectsPath(const muse::io::path_t& path
     muse::settings()->setSharedValue(LAST_SAVED_PROJECTS_PATH, muse::Val(path));
 }
 
-muse::io::path_t ProjectConfiguration::newProjectTemporaryPath() const
-{
-    return temporaryDir() + "/new_project" + DEFAULT_FILE_SUFFIX;
-}
-
 muse::io::path_t ProjectConfiguration::defaultSavingFilePath(IAudacityProjectPtr project, const std::string& filenameAddition,
                                                              const std::string& suffix) const
 {

--- a/src/project/internal/projectconfiguration.h
+++ b/src/project/internal/projectconfiguration.h
@@ -45,8 +45,6 @@ public:
     void setTemporaryDir(const muse::io::path_t& path) override;
     muse::async::Channel<muse::io::path_t> temporaryDirChanged() const override;
 
-    muse::io::path_t newProjectTemporaryPath() const override;
-
     int homeProjectsPageTabIndex() const override;
     void setHomeProjectsPageTabIndex(int index) override;
 

--- a/src/project/iprojectautosaver.h
+++ b/src/project/iprojectautosaver.h
@@ -35,10 +35,6 @@ class IProjectAutoSaver : MODULE_EXPORT_INTERFACE
 
 public:
     virtual ~IProjectAutoSaver() = default;
-
-    virtual void removeProjectUnsavedChanges(const muse::io::path_t& projectPath) = 0;
-
-    virtual bool isPathToNewlyCreatedProject(const muse::io::path_t& projectPath) const = 0;
 };
 }
 

--- a/src/project/iprojectconfiguration.h
+++ b/src/project/iprojectconfiguration.h
@@ -45,8 +45,6 @@ public:
     virtual void setTemporaryDir(const muse::io::path_t& path) = 0;
     virtual muse::async::Channel<muse::io::path_t> temporaryDirChanged() const = 0;
 
-    virtual muse::io::path_t newProjectTemporaryPath() const = 0;
-
     virtual int homeProjectsPageTabIndex() const = 0;
     virtual void setHomeProjectsPageTabIndex(int index) = 0;
 

--- a/src/project/tests/mocks/projectconfigurationmock.h
+++ b/src/project/tests/mocks/projectconfigurationmock.h
@@ -38,8 +38,6 @@ public:
     MOCK_METHOD(void, setTemporaryDir, (const muse::io::path_t& path), (override));
     MOCK_METHOD(muse::async::Channel<muse::io::path_t>, temporaryDirChanged, (), (const, override));
 
-    MOCK_METHOD(muse::io::path_t, newProjectTemporaryPath, (), (const, override));
-
     MOCK_METHOD(int, homeProjectsPageTabIndex, (), (const, override));
     MOCK_METHOD(void, setHomeProjectsPageTabIndex, (int index), (override));
 


### PR DESCRIPTION
Resolves: Recovering a never saved before project misbehaves [#9389](https://github.com/audacity/audacity/issues/9389)


- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Autobot test cases have been run
