### PR TITLE
9404 Add concurrency settings to CI workflows to cancel repeated runs

### DIFF
--- a/.github/workflows/au4_build_linux.yml
+++ b/.github/workflows/au4_build_linux.yml
@@ -19,6 +19,10 @@ on:
         required: false
         default: ''
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   CI_DIR: buildscripts/ci
 

--- a/.github/workflows/au4_build_macos.yml
+++ b/.github/workflows/au4_build_macos.yml
@@ -20,6 +20,10 @@ on:
         required: false
         default: ''
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   CI_DIR: buildscripts/ci
   DEVELOPER_DIR: /Applications/Xcode_15.2.app/Contents/Developer

--- a/.github/workflows/au4_build_windows.yml
+++ b/.github/workflows/au4_build_windows.yml
@@ -18,6 +18,11 @@ on:
         description: 'Upload symbols and dumps to Sentry (choose a project): audacity-4(default for stable build), audacity-4-sandbox'
         required: false
         default: ''
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   CI_DIR: buildscripts/ci
 

--- a/.github/workflows/au4_check_unit_tests.yml
+++ b/.github/workflows/au4_check_unit_tests.yml
@@ -11,6 +11,10 @@ on:
   schedule:
     - cron: "0 3 * * 4" # Every Thursday night at 03:00 for master branch
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   CI_DIR: buildscripts/ci
 
@@ -18,11 +22,6 @@ jobs:
   run_tests:
     runs-on: ubuntu-22.04
     steps:
-    - name: Cancel Previous Runs
-      uses: styfle/cancel-workflow-action@0.12.1
-      with:
-        access_token: ${{ github.token }}
-
     - name: Clone repository
       uses: actions/checkout@v4
       with:


### PR DESCRIPTION
Resolves:  Auto-cancel workflow when a follow-up push is made #9404

- [X] I signed [CLA](https://www.audacityteam.org/cla/)
- [X] The title of the pull request describes an issue it addresses
- [X] If changes are extensive, then there is a sequence of easily reviewable commits
- [X] Each commit's message describes its purpose and effects
- [X] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Autobot test cases have been run
