### PR TITLE
9402 Playback stops at Previous Ranged Selection

### DIFF
--- a/src/projectscene/view/playcursor/playcursorcontroller.cpp
+++ b/src/projectscene/view/playcursor/playcursorcontroller.cpp
@@ -63,10 +63,6 @@ void PlayCursorController::seekToX(double x, bool triggerPlay)
 
 void PlayCursorController::setPlaybackRegion(double x1, double x2)
 {
-    if (muse::RealIsEqual(x1, x2)) {
-        return;
-    }
-
     IProjectViewStatePtr viewState = projectViewState();
     bool snapEnabled = viewState ? viewState->isSnapEnabled() : false;
 


### PR DESCRIPTION
Resolves: Playback stops at Previous Ranged Selection #9402

fix consist in always setting  range because we are going to check its validity anyway

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Autobot test cases have been run
