### PR TITLE
wxWidgets 3.2 API compatibility

### DIFF
--- a/libraries/lib-wave-track/WaveChannelViewConstants.cpp
+++ b/libraries/lib-wave-track/WaveChannelViewConstants.cpp
@@ -8,6 +8,8 @@ Paul Licameli split from class WaveTrack
 
 **********************************************************************/
 
+#include <algorithm>
+
 #include "Internat.h"
 #include "WaveChannelViewConstants.h"
 

--- a/src/TimerRecordDialog.cpp
+++ b/src/TimerRecordDialog.cpp
@@ -230,7 +230,7 @@ TimerRecordDialog::TimerRecordDialog(
 
 TimerRecordDialog::~TimerRecordDialog() = default;
 
-void TimerRecordDialog::OnTimer(wxTimerEvent& WXUNUSED(event))
+void TimerRecordDialog::UpdateStart()
 {
    wxDateTime dateTime_UNow = wxDateTime::UNow();
    if (m_DateTime_Start < dateTime_UNow) {
@@ -239,6 +239,11 @@ void TimerRecordDialog::OnTimer(wxTimerEvent& WXUNUSED(event))
       m_pTimeTextCtrl_Start->SetValue(wxDateTime_to_AudacityTime(m_DateTime_Start));
       this->UpdateEnd(); // Keep Duration constant and update End for changed Start.
    }
+}
+
+void TimerRecordDialog::OnTimer(wxTimerEvent& WXUNUSED(event))
+{
+   this->UpdateStart();
 }
 
 void TimerRecordDialog::OnDatePicker_Start(wxDateEvent& WXUNUSED(event))
@@ -254,12 +259,11 @@ void TimerRecordDialog::OnDatePicker_Start(wxDateEvent& WXUNUSED(event))
 
    // User might have had the dialog up for a while, or
    // had a future day, set hour of day less than now's, then changed day to today.
-   wxTimerEvent dummyTimerEvent;
-   this->OnTimer(dummyTimerEvent);
+   this->UpdateStart();
 
    // Always update End for changed Start, keeping Duration constant.
-   // Note that OnTimer sometimes calls UpdateEnd, so sometimes this is redundant,
-   // but OnTimer doesn't need to always call UpdateEnd, but we must here.
+   // Note that UpdateStart sometimes calls UpdateEnd, so sometimes this is redundant,
+   // but UpdateStart doesn't need to always call UpdateEnd, but we must here.
    this->UpdateEnd();
 }
 
@@ -572,8 +576,7 @@ int TimerRecordDialog::RunWaitDialog()
 
          // Make sure that start and end time are updated, so we always get the full
          // duration, even if there's some delay getting here.
-         wxTimerEvent dummyTimerEvent;
-         this->OnTimer(dummyTimerEvent);
+         this->UpdateStart();
 
          // Loop for progress display during recording.
          while (bIsRecording && (updateResult == ProgressResult::Success)) {

--- a/src/TimerRecordDialog.h
+++ b/src/TimerRecordDialog.h
@@ -87,6 +87,7 @@ private:
 
    void UpdateDuration(); // Update m_TimeSpan_Duration and ctrl based on m_DateTime_Start and m_DateTime_End.
    void UpdateEnd(); // Update m_DateTime_End and ctrls based on m_DateTime_Start and m_TimeSpan_Duration.
+   void UpdateStart(); // Update m_DateTime_Start and ctrls based on m_DateTime_Start and call UpdateEnd.
    ProgressResult WaitForStart();
 
    // Timer Recording Automation Control Events


### PR DESCRIPTION
I tried compiling Audacity 3.7.5 against wxWidgets 3.3.1 and it revealed these two issues.

### Add missing #include <algorithm> to WaveChannelViewConstants

For std::sort() and std::adjacent_find()

### wxTimerEvent::wxTimerEvent() not available in wxWidgets 3.2 API

default ctor creates an unusable event object and should not be used
(in fact, no code outside wxWidgets is supposed to create event objects)https://github.com/wxWidgets/wxWidgets/commit/9e2ff111a4 ("Restore, but deprecate, default ctor of wxTimerEvent", 2019-10-11)

----------

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [ ] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Autobot test cases have been run
