### PR TITLE
Effect menu optimization

### DIFF
--- a/src/appshell/view/appmenumodel.cpp
+++ b/src/appshell/view/appmenumodel.cpp
@@ -831,7 +831,7 @@ MenuItemList AppMenuModel::makeShowItems()
 muse::uicomponents::MenuItem* AppMenuModel::makeMenuEffectItem(const effects::EffectId& effectId)
 {
     return makeMenuItem(effects::makeEffectAction(effects::EFFECT_OPEN_ACTION,
-                                                  effectId).toString());
+                                                  effectId));
 }
 
 muse::uicomponents::MenuItem* AppMenuModel::makeMenuEffect(const muse::String& title, const muse::uicomponents::MenuItemList& items)

--- a/src/effects/audio_unit/internal/audiounitviewlauncher.cpp
+++ b/src/effects/audio_unit/internal/audiounitviewlauncher.cpp
@@ -7,7 +7,7 @@
 
 muse::Ret au::effects::AudioUnitViewLauncher::showEffect(const EffectInstanceId& instanceId) const
 {
-    muse::UriQuery uri(muse::String(EFFECT_VIEWER_URI).toStdString());
+    muse::UriQuery uri(EFFECT_VIEWER_URI);
     uri.addParam("instanceId", muse::Val(instanceId));
     uri.addParam("effectFamily", muse::Val(EffectFamily::AudioUnit));
     return interactive()->openSync(uri).ret;

--- a/src/effects/builtin/internal/builtinviewlauncher.cpp
+++ b/src/effects/builtin/internal/builtinviewlauncher.cpp
@@ -14,7 +14,7 @@ using namespace au::effects;
 
 muse::Ret BuiltinViewLauncher::showEffect(const EffectInstanceId& instanceId) const
 {
-    muse::UriQuery uri(muse::String(EFFECT_VIEWER_URI).toStdString());
+    muse::UriQuery uri(EFFECT_VIEWER_URI);
     uri.addParam("instanceId", muse::Val(instanceId));
     uri.addParam("effectFamily", muse::Val(EffectFamily::Builtin));
     return interactive()->openSync(uri).ret;

--- a/src/effects/effects_base/effectstypes.h
+++ b/src/effects/effects_base/effectstypes.h
@@ -90,15 +90,15 @@ struct EffectMeta {
 
 using EffectMetaList = std::vector<EffectMeta>;
 
-constexpr const char16_t* EFFECT_OPEN_ACTION = u"action://effects/open?effectId=%1";
-constexpr const char16_t* REALTIME_EFFECT_ADD_ACTION = u"action://effects/realtime-add?effectId=%1";
-constexpr const char16_t* REALTIME_EFFECT_REPLACE_ACTION = u"action://effects/realtime-replace?effectId=%1";
+const std::string EFFECT_OPEN_ACTION = "action://effects/open?effectId=%1";
+const std::string REALTIME_EFFECT_ADD_ACTION = "action://effects/realtime-add?effectId=%1";
+const std::string REALTIME_EFFECT_REPLACE_ACTION = "action://effects/realtime-replace?effectId=%1";
 
-constexpr const char16_t* EFFECT_VIEWER_URI = u"audacity://effects/effect_viewer?instanceId=%1&effectFamily=%2";
+const std::string EFFECT_VIEWER_URI = "audacity://effects/effect_viewer?instanceId=%1&effectFamily=%2";
 
-inline muse::actions::ActionQuery makeEffectAction(const char16_t* action, const EffectId id)
+inline std::string makeEffectAction(const std::string& action, const EffectId& id)
 {
-    return muse::actions::ActionQuery(muse::String(action).arg(id));
+    return QString::fromStdString(action).arg(id).toStdString();
 }
 
 inline EffectId effectIdFromAction(const muse::actions::ActionQuery& action)

--- a/src/effects/effects_base/internal/effectsactionscontroller.cpp
+++ b/src/effects/effects_base/internal/effectsactionscontroller.cpp
@@ -34,7 +34,7 @@ void EffectsActionsController::registerActions()
 
     EffectMetaList effects = effectsProvider()->effectMetaList();
     for (const EffectMeta& e : effects) {
-        dispatcher()->reg(this, makeEffectAction(EFFECT_OPEN_ACTION, e.id), [this](const ActionQuery& q) {
+        dispatcher()->reg(this, ActionQuery(makeEffectAction(EFFECT_OPEN_ACTION, e.id)), [this](const ActionQuery& q) {
             onEffectTriggered(q);
         });
     }

--- a/src/effects/effects_base/internal/effectsuiactions.cpp
+++ b/src/effects/effects_base/internal/effectsuiactions.cpp
@@ -8,8 +8,6 @@
 #include "types/translatablestring.h"
 #include "log.h"
 
-#include <unordered_map>
-
 using namespace au::effects;
 using namespace muse;
 using namespace muse::ui;
@@ -67,10 +65,10 @@ EffectsUiActions::EffectsUiActions(std::shared_ptr<EffectsActionsController> con
 }
 
 namespace {
-UiAction makeUiAction(const char16_t* uri, const EffectMeta& meta)
+UiAction makeUiAction(const std::string& uri, const EffectMeta& meta)
 {
     UiAction action;
-    action.code = makeEffectAction(uri, meta.id).toString();
+    action.code = makeEffectAction(uri, meta.id);
     action.uiCtx = au::context::UiCtxProjectOpened;
     action.scCtx = au::context::CTX_PROJECT_FOCUSED;
     action.description = TranslatableString::untranslatable(meta.description);
@@ -114,7 +112,7 @@ void EffectsUiActions::makeActions(EffectMetaList effects)
     for (const EffectMeta& e : effects) {
         m_actions.push_back(makeUiAction(EFFECT_OPEN_ACTION, e));
         if (e.isRealtimeCapable) {
-            for (const auto uri : { REALTIME_EFFECT_ADD_ACTION, REALTIME_EFFECT_REPLACE_ACTION }) {
+            for (const auto& uri : { REALTIME_EFFECT_ADD_ACTION, REALTIME_EFFECT_REPLACE_ACTION }) {
                 m_actions.push_back(makeUiAction(uri, e));
             }
         }

--- a/src/effects/lv2/internal/lv2viewlauncher.cpp
+++ b/src/effects/lv2/internal/lv2viewlauncher.cpp
@@ -13,7 +13,7 @@ using namespace au::effects;
 
 muse::Ret Lv2ViewLauncher::showEffect(const EffectInstanceId& instanceId) const
 {
-    muse::UriQuery uri(muse::String(EFFECT_VIEWER_URI).toStdString());
+    muse::UriQuery uri(EFFECT_VIEWER_URI);
     uri.addParam("instanceId", muse::Val(instanceId));
     uri.addParam("effectFamily", muse::Val(EffectFamily::LV2));
     return interactive()->openSync(uri).ret;

--- a/src/effects/vst/internal/vst3viewlauncher.cpp
+++ b/src/effects/vst/internal/vst3viewlauncher.cpp
@@ -47,7 +47,7 @@ muse::Ret Vst3ViewLauncher::showEffect(const EffectInstanceId& instanceId) const
         return muse::make_ret(muse::Ret::Code::InternalError);
     }
 
-    muse::UriQuery uri(muse::String(EFFECT_VIEWER_URI).toStdString());
+    muse::UriQuery uri(EFFECT_VIEWER_URI);
     uri.addParam("instanceId", muse::Val(instanceId));
     uri.addParam("effectFamily", muse::Val(EffectFamily::VST3));
 

--- a/src/projectscene/view/trackspanel/addeffectmenumodel.cpp
+++ b/src/projectscene/view/trackspanel/addeffectmenumodel.cpp
@@ -42,7 +42,7 @@ void AddEffectMenuModel::handleMenuItem(const QString& itemId)
 
 muse::uicomponents::MenuItem* AddEffectMenuModel::makeMenuEffectItem(const effects::EffectId& effectId)
 {
-    return makeMenuItem(effects::makeEffectAction(effects::REALTIME_EFFECT_ADD_ACTION, effectId).toString());
+    return makeMenuItem(effects::makeEffectAction(effects::REALTIME_EFFECT_ADD_ACTION, effectId));
 }
 
 muse::uicomponents::MenuItem* AddEffectMenuModel::makeMenuEffect(const muse::String& title,

--- a/src/projectscene/view/trackspanel/realtimeeffectlistitemmenumodel.cpp
+++ b/src/projectscene/view/trackspanel/realtimeeffectlistitemmenumodel.cpp
@@ -123,7 +123,7 @@ void RealtimeEffectListItemMenuModel::updateEffectCheckmarks()
 
 muse::uicomponents::MenuItem* RealtimeEffectListItemMenuModel::makeMenuEffectItem(const effects::EffectId& effectId)
 {
-    auto item = makeMenuItem(effects::makeEffectAction(effects::REALTIME_EFFECT_REPLACE_ACTION, effectId).toString());
+    auto item = makeMenuItem(effects::makeEffectAction(effects::REALTIME_EFFECT_REPLACE_ACTION, effectId));
     item->setCheckable(true);
     return item;
 }


### PR DESCRIPTION
Resolves: #9041

The realtime effect button menu is rebuilt when track is recreated, and the track is recreated at every clip movement. Until this behavior is improved (i.e. detecting that the view could be reused) we need to make the menu build process is fast enough

This PR makes the menu build process roughly 4x faster, not great, but good enough for now.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [x] Please test that the effects menu is not affected: real-time effects could be added, removed, replaced, etc.
- [ ] Autobot test cases have been run
