### PR TITLE
Audio-files filter is first

### DIFF
--- a/src/project/internal/projectactionscontroller.cpp
+++ b/src/project/internal/projectactionscontroller.cpp
@@ -329,21 +329,21 @@ io::path_t ProjectActionsController::selectImportFile()
 {
     std::vector<std::string> filter {
         trc("project",
-            "Video files")
-        + "(*.avi *.mp4 *.mkv *.mov *.flv *.wmv *.asf *.webm *.mpg *.mpeg *.m4v *.ts *.gxf *.mxf *.nut *.dv *.3gp *.3g2 *.mj2)",
-        trc("project",
             "Audio files")
-        + "(*.aac *.ac3 *.mp3 *.wma *.wav *.flac *.ogg *.opus *.aif *.aiff *.amr *.ape *.au *.dts *.mpc *.tta *.wv *.shn *.voc *.mmf)",
+        + " (*.aac *.ac3 *.mp3 *.wma *.wav *.flac *.ogg *.opus *.aif *.aiff *.amr *.ape *.au *.dts *.mpc *.tta *.wv *.shn *.voc *.mmf)",
+        trc("project",
+            "Video files")
+        + " (*.avi *.mp4 *.mkv *.mov *.flv *.wmv *.asf *.webm *.mpg *.mpeg *.m4v *.ts *.gxf *.mxf *.nut *.dv *.3gp *.3g2 *.mj2)",
         trc("project",
             "Game media files")
         +
-        "(*.roq *.bethsoftvid *.c93 *.dsicin *.dxa *.ea *.cdata *.film_cpk *.idcin *.ipmovie *.psxstr *.rl2 *.siff *.smk *.thp *.tiertexseq *.vmd *.wc3movie *.wsaud *.wsvqa *.txd)",
-        trc("project", "Streaming files") + "(*.rtsp *.sdp *.nsv *.pva *.msnwctcp *.lmlm4 *.redir)",
-        trc("project", "Animation and image files") + "(*.gif *.flic *.swf *.image2 *.image2pipe)",
+        " (*.roq *.bethsoftvid *.c93 *.dsicin *.dxa *.ea *.cdata *.film_cpk *.idcin *.ipmovie *.psxstr *.rl2 *.siff *.smk *.thp *.tiertexseq *.vmd *.wc3movie *.wsaud *.wsvqa *.txd)",
+        trc("project", "Streaming files") + " (*.rtsp *.sdp *.nsv *.pva *.msnwctcp *.lmlm4 *.redir)",
+        trc("project", "Animation and image files") + " (*.gif *.flic *.swf *.image2 *.image2pipe)",
         trc("project",
             "Raw files")
         +
-        "(*.al *.ul *.s16be *.u16be *.s8 *.u8 *.ub *.uw *.4xm *.MTV *.afc *.aifc *.apc *.apl *.mac *.avs *.302 *.daud *.ffm *.cgi *.mm *.mpegtsraw *.mpegvideo *.nuv *.sw *.sb *.son *.sol *.vfwcap)"
+        " (*.al *.ul *.s16be *.u16be *.s8 *.u8 *.ub *.uw *.4xm *.MTV *.afc *.aifc *.apc *.apl *.mac *.avs *.302 *.daud *.ffm *.cgi *.mm *.mpegtsraw *.mpegvideo *.nuv *.sw *.sb *.son *.sol *.vfwcap)"
     };
 
     io::path_t defaultDir = configuration()->lastOpenedProjectsPath();


### PR DESCRIPTION
Does not resolve but reduces the risk of hitting https://github.com/audacity/audacity/issues/9414. Users are much, much more likely to need the audio-file filter, and if this is the default one, they probably won't interact with the problematic drop-down at all.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [x] Autobot test cases have been run
