### PR TITLE
9435 Update meters at a fixed rate despite portaudio

### DIFF
--- a/au3/libraries/lib-audio-devices/IMeterSender.h
+++ b/au3/libraries/lib-audio-devices/IMeterSender.h
@@ -13,18 +13,13 @@ public:
         const float* const buffer;
         const size_t frames;
         const size_t nChannels;
-    };
-
-    struct Sample
-    {
-        float peak;
-        float rms;
+        const double firstSampleTimestamp;
     };
 
     virtual ~IMeterSender() = default;
-    virtual void push(uint8_t channel, const Sample& sample, int64_t key = MASTER_TRACK_ID) = 0;
     virtual void push(uint8_t channel, const InterleavedSampleData& sampleData, int64_t key = MASTER_TRACK_ID) = 0;
     virtual void sendAll() = 0;
     virtual void reset() = 0;
     virtual void reserve(size_t size) = 0;
+    virtual void setSampleRate(double rate) = 0;
 };

--- a/au3/libraries/lib-audio-io/AudioIO.h
+++ b/au3/libraries/lib-audio-io/AudioIO.h
@@ -211,13 +211,14 @@ public:
         unsigned long framesPerBuffer);
     void DoPlaythrough(
         constSamplePtr inputBuffer, float* outputBuffer, unsigned long framesPerBuffer, float* outputMeterFloats);
-    void SendVuInputMeterData(
-        const float* inputSamples, unsigned long framesPerBuffer);
+    void SendVuInputMeterData(const float* inputSamples, unsigned long framesPerBuffer, const PaStreamCallbackTimeInfo* timeInfo);
     void SendVuOutputMeterData(
-        const float* outputMeterFloats, unsigned long framesPerBuffer);
-    void PushMainMeterValues(const std::shared_ptr<IMeterSender>& sender, const float* values, uint8_t channels, unsigned long frames);
-    void PushTrackMeterValues(const std::shared_ptr<IMeterSender>& sender, unsigned long frames);
-    void PushInputMeterValues(const std::shared_ptr<IMeterSender>& sender, const float* values, unsigned long frames);
+        const float* outputMeterFloats, unsigned long framesPerBuffer, const PaStreamCallbackTimeInfo* timeInfo);
+    void PushMainMeterValues(const std::shared_ptr<IMeterSender>& sender, const float* values, uint8_t channels, unsigned long frames,
+                             const PaStreamCallbackTimeInfo* timeInfo);
+    void PushTrackMeterValues(const std::shared_ptr<IMeterSender>& sender, unsigned long frames, const PaStreamCallbackTimeInfo* timeInfo);
+    void PushInputMeterValues(const std::shared_ptr<IMeterSender>& sender, const float* values, unsigned long frames,
+                              const PaStreamCallbackTimeInfo* timeInfo);
 
     /** \brief Get the number of audio samples ready in all of the playback
     * buffers.

--- a/src/au3wrap/internal/au3audiometer.h
+++ b/src/au3wrap/internal/au3audiometer.h
@@ -10,7 +10,10 @@
 #include "au3audio/audiotypes.h"
 
 #include "libraries/lib-audio-devices/IMeterSender.h"
-#include <optional>
+
+namespace {
+constexpr double DEFAULT_SAMPLE_RATE = 44100.0;
+}
 
 namespace au::au3 {
 class Meter : public IMeterSender, public muse::async::Asyncable
@@ -29,8 +32,8 @@ public:
 private:
     struct Sample
     {
-        float peak;
-        float rms;
+        float peak = 0.0f;
+        float rms = 0.0f;
     };
 
     struct Data
@@ -44,11 +47,11 @@ private:
     Sample getSamplesMaxValue(const float* buffer, size_t frames, size_t step);
     void push(uint8_t channel, const Sample& sample, int64_t key);
 
-    double m_sampleRate{ 44100.0 };
+    double m_sampleRate{ DEFAULT_SAMPLE_RATE };
     const float m_smoothingCoef;
     std::vector<Data> m_trackData;
     std::map<int64_t, muse::async::Channel<au::audio::audioch_t, au::audio::MeterSignal> > m_channels;
     std::map<int64_t, Sample> m_maxValue{};
-    std::map<int64_t, std::optional<double> > m_lastSampleTimestamp{};
+    std::map<int64_t, double> m_lastSampleTimestamp{};
 };
 }

--- a/src/au3wrap/internal/au3audiometer.h
+++ b/src/au3wrap/internal/au3audiometer.h
@@ -16,6 +16,7 @@ namespace au::au3 {
 class Meter : public IMeterSender, public muse::async::Asyncable
 {
 public:
+    Meter();
 
     void push(uint8_t channel, const IMeterSender::InterleavedSampleData& sampleData, int64_t key) override;
     void sendAll() override;
@@ -44,6 +45,7 @@ private:
     void push(uint8_t channel, const Sample& sample, int64_t key);
 
     double m_sampleRate{ 44100.0 };
+    const float m_smoothingCoef;
     std::vector<Data> m_trackData;
     std::map<int64_t, muse::async::Channel<au::audio::audioch_t, au::audio::MeterSignal> > m_channels;
     std::map<int64_t, Sample> m_maxValue{};

--- a/src/au3wrap/internal/au3audiometer.h
+++ b/src/au3wrap/internal/au3audiometer.h
@@ -10,19 +10,28 @@
 #include "au3audio/audiotypes.h"
 
 #include "libraries/lib-audio-devices/IMeterSender.h"
+#include <optional>
 
 namespace au::au3 {
 class Meter : public IMeterSender, public muse::async::Asyncable
 {
 public:
+
     void push(uint8_t channel, const IMeterSender::InterleavedSampleData& sampleData, int64_t key) override;
-    void push(uint8_t channel, const IMeterSender::Sample& sample, int64_t key) override;
     void sendAll() override;
     void reset() override;
     void reserve(size_t size) override;
+    void setSampleRate(double rate) override;
+
     muse::async::Channel<au::audio::audioch_t, au::audio::MeterSignal> dataChanged(int64_t key = MASTER_TRACK_ID);
 
 private:
+    struct Sample
+    {
+        float peak;
+        float rms;
+    };
+
     struct Data
     {
         int64_t key;
@@ -31,7 +40,13 @@ private:
         au::audio::AudioSignalVal rms;
     };
 
+    Sample getSamplesMaxValue(const float* buffer, size_t frames, size_t step);
+    void push(uint8_t channel, const Sample& sample, int64_t key);
+
+    double m_sampleRate{ 44100.0 };
     std::vector<Data> m_trackData;
     std::map<int64_t, muse::async::Channel<au::audio::audioch_t, au::audio::MeterSignal> > m_channels;
+    std::map<int64_t, Sample> m_maxValue{};
+    std::map<int64_t, std::optional<double> > m_lastSampleTimestamp{};
 };
 }


### PR DESCRIPTION
Resolves: #9435 

Make the meter update rate independent from portaudio callback execution rate.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Autobot test cases have been run
