### PR TITLE
Prevent TapHoldShortcut handler to interfere with the user input

### DIFF
--- a/src/projectscene/internal/projectsceneuiactions.cpp
+++ b/src/projectscene/internal/projectsceneuiactions.cpp
@@ -25,7 +25,7 @@ static UiActionList STATIC_ACTIONS = {
              ),
     UiAction("split-tool",
              au::context::UiCtxProjectOpened,
-             au::context::CTX_PROJECT_OPENED,
+             au::context::CTX_PROJECT_FOCUSED,
              TranslatableString("action", "Split Tool"),
              TranslatableString("action", "Split Tool"),
              IconCode::Code::SPLIT_TOOL

--- a/src/projectscene/internal/tapholdshortcut.cpp
+++ b/src/projectscene/internal/tapholdshortcut.cpp
@@ -7,7 +7,7 @@
 #include <QKeyEvent>
 
 namespace au::projectscene {
-TapHoldShortcut::TapHoldShortcut(const std::string& action)
+TapHoldShortcut::TapHoldShortcut(const std::string& action, QObject* target)
     : QObject(nullptr), m_action(action)
 {
     connect(&m_holdTimer, &QTimer::timeout, this, &TapHoldShortcut::onHoldTimeout);
@@ -19,7 +19,11 @@ TapHoldShortcut::TapHoldShortcut(const std::string& action)
 
     updateShortcut(m_action);
 
-    qApp->installEventFilter(this);
+    if (target) {
+        target->installEventFilter(this);
+    } else {
+        qApp->installEventFilter(this);
+    }
 }
 
 void TapHoldShortcut::setAction(const std::string& action)

--- a/src/projectscene/internal/tapholdshortcut.h
+++ b/src/projectscene/internal/tapholdshortcut.h
@@ -20,7 +20,7 @@ class TapHoldShortcut : public QObject
     muse::Inject<context::IUiContextResolver> uicontextResolver;
 
 public:
-    explicit TapHoldShortcut(const std::string& action);
+    explicit TapHoldShortcut(const std::string& action, QObject* target = nullptr);
 
     void setAction(const std::string& action);
 

--- a/src/projectscene/qml/Audacity/ProjectScene/clipsview/TracksClipsView.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/clipsview/TracksClipsView.qml
@@ -130,6 +130,8 @@ Rectangle {
         selectionController.load()
         selectionContextMenuModel.load()
         canvasContextMenuModel.load()
+
+        splitToolController.init(root)
     }
 
     function init() {

--- a/src/projectscene/view/clipsview/splittoolcontroller.cpp
+++ b/src/projectscene/view/clipsview/splittoolcontroller.cpp
@@ -13,6 +13,10 @@ namespace au::projectscene {
 SplitToolController::SplitToolController(QObject* parent)
     : QObject(parent)
 {
+}
+
+void SplitToolController::init(QObject* root)
+{
     QPixmap pixmap(":/images/customCursorShapes/Split.png");
     m_cursor = QCursor(pixmap.scaled(32, 32, Qt::KeepAspectRatio, Qt::SmoothTransformation));
 
@@ -20,7 +24,7 @@ SplitToolController::SplitToolController(QObject* parent)
         setActive(!active());
     });
 
-    m_shortcut = std::make_unique<TapHoldShortcut>("split-tool");
+    m_shortcut = std::make_unique<TapHoldShortcut>("split-tool", root);
 
     m_shortcut->pressed().onNotify(this, [this]() {
         m_prePressState = active();

--- a/src/projectscene/view/clipsview/splittoolcontroller.h
+++ b/src/projectscene/view/clipsview/splittoolcontroller.h
@@ -33,6 +33,8 @@ public:
     SplitToolController(QObject* parent = nullptr);
     ~SplitToolController();
 
+    Q_INVOKABLE void init(QObject* root);
+
     Q_INVOKABLE void mouseDown(double pos);
     Q_INVOKABLE void mouseUp(double pos);
     Q_INVOKABLE void mouseMove(double pos);


### PR DESCRIPTION
Resolves: #[9445](https://github.com/audacity/audacity/issues/9445)

Only hook to the track panel events

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Autobot test cases have been run
