### PR TITLE
9132 speed up destructive effects

### DIFF
--- a/au3/libraries/lib-effects/Effect.cpp
+++ b/au3/libraries/lib-effects/Effect.cpp
@@ -338,7 +338,7 @@ bool Effect::TrackProgress(
 {
     auto updateResult = (mProgress
                          ? mProgress->Poll((whichTrack + frac) * 1000,
-                                           (double)mNumTracks * 1000, msg)
+                                           (double)std::max(mNumTracks, 1) * 1000, msg)
                          : BasicUI::ProgressResult::Success);
     return updateResult != BasicUI::ProgressResult::Success;
 }

--- a/src/au3wrap/internal/au3basicui.cpp
+++ b/src/au3wrap/internal/au3basicui.cpp
@@ -99,11 +99,12 @@ BasicUI::MessageBoxResult Au3BasicUI::DoMessageBox(const TranslatableString& mes
 std::unique_ptr<BasicUI::ProgressDialog> Au3BasicUI::DoMakeProgress(const TranslatableString& title, const TranslatableString& message,
                                                                     unsigned int flags, const TranslatableString& remainingLabelText)
 {
-    Q_UNUSED(title);
-    Q_UNUSED(message);
     Q_UNUSED(flags);
     Q_UNUSED(remainingLabelText);
-    return std::make_unique<ProgressDialog>();
+    auto dialog = std::make_unique<ProgressDialog>();
+    dialog->SetDialogTitle(title);
+    dialog->SetMessage(message);
+    return dialog;
 }
 
 namespace {

--- a/src/au3wrap/internal/progressdialog.cpp
+++ b/src/au3wrap/internal/progressdialog.cpp
@@ -6,11 +6,17 @@
 
 #include "progressdialog.h"
 
-ProgressDialog::ProgressDialog()
+ProgressDialog::ProgressDialog(const std::string& title)
+    : m_progressTitle{title}
 {
     // Of course, the least number of increments to yield a smooth animation depends on the width of the progress bar,
     // yet 300 increments should be enough to provide a smooth animation in most cases.
     m_progress.setMaxNumIncrements(200);
+}
+
+ProgressDialog::ProgressDialog(const TranslatableString& title)
+    : ProgressDialog{title.Translation().ToStdString()}
+{
 }
 
 ProgressDialog::~ProgressDialog()

--- a/src/au3wrap/internal/progressdialog.cpp
+++ b/src/au3wrap/internal/progressdialog.cpp
@@ -24,13 +24,13 @@ void ProgressDialog::Reinit()
 
 void ProgressDialog::SetDialogTitle(const TranslatableString& title)
 {
-    Q_UNUSED(title);
+    m_progressTitle = title.Translation().ToStdString();
 }
 
 ProgressResult ProgressDialog::Poll(unsigned long long numerator, unsigned long long denominator, const TranslatableString& message)
 {
     if (!m_progress.isStarted()) {
-        interactive()->showProgress(std::string(), m_progress);
+        interactive()->showProgress(m_progressTitle, m_progress);
 
         m_progress.canceled().onNotify(this, [this]() {
             m_cancelled = true;
@@ -39,7 +39,11 @@ ProgressResult ProgressDialog::Poll(unsigned long long numerator, unsigned long 
         m_progress.start();
     }
 
-    if (m_progress.progress(numerator, denominator, message.Translation().ToStdString())) {
+    if (!message.empty()) {
+        m_progressMessage = message.Translation().ToStdString();
+    }
+
+    if (m_progress.progress(numerator, denominator, m_progressMessage)) {
         QCoreApplication::processEvents();
     }
 
@@ -51,5 +55,5 @@ ProgressResult ProgressDialog::Poll(unsigned long long numerator, unsigned long 
 
 void ProgressDialog::SetMessage(const TranslatableString& message)
 {
-    Q_UNUSED(message);
+    m_progressMessage = message.Translation().ToStdString();
 }

--- a/src/au3wrap/internal/progressdialog.cpp
+++ b/src/au3wrap/internal/progressdialog.cpp
@@ -8,6 +8,9 @@
 
 ProgressDialog::ProgressDialog()
 {
+    // Of course, the least number of increments to yield a smooth animation depends on the width of the progress bar,
+    // yet 300 increments should be enough to provide a smooth animation in most cases.
+    m_progress.setMaxNumIncrements(200);
 }
 
 ProgressDialog::~ProgressDialog()
@@ -36,8 +39,9 @@ ProgressResult ProgressDialog::Poll(unsigned long long numerator, unsigned long 
         m_progress.start();
     }
 
-    m_progress.progress(numerator, denominator, message.Translation().ToStdString());
-    QCoreApplication::processEvents();
+    if (m_progress.progress(numerator, denominator, message.Translation().ToStdString())) {
+        QCoreApplication::processEvents();
+    }
 
     if (m_cancelled) {
         return ProgressResult::Cancelled;

--- a/src/au3wrap/internal/progressdialog.h
+++ b/src/au3wrap/internal/progressdialog.h
@@ -39,5 +39,7 @@ public:
 
 private:
     mutable muse::Progress m_progress;
+    std::string m_progressTitle;
+    std::string m_progressMessage;
     bool m_cancelled = false;
 };

--- a/src/au3wrap/internal/progressdialog.h
+++ b/src/au3wrap/internal/progressdialog.h
@@ -17,7 +17,8 @@ class ProgressDialog : public BasicUI::ProgressDialog, public muse::async::Async
     muse::Inject<muse::IInteractive> interactive;
 
 public:
-    ProgressDialog();
+    ProgressDialog(const TranslatableString& title = {});
+    ProgressDialog(const std::string& title);
 
 public:
     virtual ~ProgressDialog();

--- a/src/effects/effects_base/internal/effectsprovider.cpp
+++ b/src/effects/effects_base/internal/effectsprovider.cpp
@@ -329,7 +329,13 @@ muse::Ret EffectsProvider::performEffect(au3::Au3Project& project, Effect* effec
         if (skipFlag == false) {
             using namespace BasicUI;
             auto name = effect->GetName();
-            ::ProgressDialog progress{};
+
+            const std::string title
+                = (effect->GetType()
+                   == EffectTypeGenerate ? muse::qtrc("effects", "Generating %1...") : muse::qtrc("effects", "Applying %1...")).arg(
+                      name.Translation().ToStdString()).toStdString();
+
+            ::ProgressDialog progress{ title };
             auto vr = valueRestorer<BasicUI::ProgressDialog*>(effect->mProgress, &progress);
 
             assert(pInstanceEx); // null check above

--- a/src/trackedit/internal/au3/au3interaction.cpp
+++ b/src/trackedit/internal/au3/au3interaction.cpp
@@ -41,6 +41,10 @@
 using namespace au::trackedit;
 using namespace au::au3;
 
+namespace {
+static const std::string mixingDownToMonoLabel = muse::trc("trackedit", "Mixing down to mono...");
+}
+
 Au3Project& Au3Interaction::projectRef() const
 {
     Au3Project* project = reinterpret_cast<Au3Project*>(globalContext()->currentProject()->au3ProjectPtr());
@@ -1077,9 +1081,7 @@ muse::Ret Au3Interaction::paste(const std::vector<ITrackDataPtr>& data, secs_t b
         } else if (trackToPaste->NChannels() == 1 && dstWaveTrack->NChannels() == 2) {
             trackToPaste->MonoToStereo();
         } else if (trackToPaste->NChannels() == 2 && dstWaveTrack->NChannels() == 1) {
-            ok = utils::withProgress(*interactive(),
-                                     muse::trc("trackedit", "Mixing down to mono"),
-                                     [&](utils::ProgressCb progressCb, utils::CancelCb cancelCb)
+            ok = utils::withProgress(*interactive(), mixingDownToMonoLabel, [&](utils::ProgressCb progressCb, utils::CancelCb cancelCb)
             {
                 return trackToPaste->MixDownToMono(progressCb, cancelCb);
             });
@@ -1350,9 +1352,7 @@ bool Au3Interaction::moveClips(secs_t timePositionOffset, int trackPositionOffse
 
         //! TODO AU4: later when having keyboard arrow shortcut for moving clips
         //! make use of UndoPush::CONSOLIDATE arg in UndoManager
-        return utils::withProgress(*interactive(),
-                                   muse::trc("trackedit", "Rendering clips"),
-                                   [&](utils::ProgressCb progressCb, utils::CancelCb cancelCb)
+        return utils::withProgress(*interactive(), mixingDownToMonoLabel, [&](utils::ProgressCb progressCb, utils::CancelCb cancelCb)
         {
             std::vector<std::pair<WaveTrack*, std::shared_ptr<WaveTrack> > > toReplace;
             for (const trackedit::TrackId track : selectionController()->selectedTracks()) {

--- a/src/trackedit/internal/au3/au3interaction.h
+++ b/src/trackedit/internal/au3/au3interaction.h
@@ -169,7 +169,7 @@ private:
 
     muse::async::Channel<trackedit::ClipKey, secs_t /*newStartTime*/, bool /*completed*/> m_clipStartTimeChanged;
 
-    muse::ProgressPtr m_progress;
+    muse::Progress m_progress;
     std::atomic<bool> m_busy = false;
 
     std::optional<TrackListInfo> m_startTracklistInfo;

--- a/src/trackedit/internal/au3/au3interactionutils.cpp
+++ b/src/trackedit/internal/au3/au3interactionutils.cpp
@@ -246,13 +246,15 @@ muse::Ret au::trackedit::utils::withProgress(muse::IInteractive& interactive, co
                                                                                                                                  CancelCb)>& action)
 {
     muse::Progress progress;
+    progress.setMaxNumIncrements(200);
     interactive.showProgress(title, progress);
     progress.started();
 
     ProgressCb progressCb = [&](double progressFraction)
     {
-        progress.progress(progressFraction * 1000, 1000, "");
-        QCoreApplication::processEvents();
+        if (progress.progress(progressFraction * 1000, 1000, "")) {
+            QCoreApplication::processEvents();
+        }
         return !progress.isCanceled();
     };
 


### PR DESCRIPTION
Resolves: #9132
Resolves: #8878

Introduces a helper to execute a task on a separate thread while the main thread updates the progress dialog.
Two improvements:
* the effect/generator task is not blocked by the rendering of the dialog,
* unnecessary renderings of the dialog are avoided.

This should improve performance on all operations that involve the progress bar, especially for long operations.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:
- [ ] Autobot test cases have been run
- [x] Generating audio or applying an effect is about as fast as Au3 (test on at least a 1h clip)
- [x] Generating something can be canceled
- [x] Applying an effect can be canceled
- [x] Progress dialog for effects has "Applying <effect name>..." title
- [x] Progress dialog for generators has "Generating <generator name>..." title (Maybe there a ticket for this?)
- [x] Repair effect when applied to too much data (e.g. 1s) fails and the dialog explaining the reason still appears
- [x] Cancelling an effect or getting it to fail (like Repair) does not add an undo item
- [x] Rendering pitch and speed works and is cancellable
- [x] Same when changing track format
- [x] Same when resampling a track
- [x] Copy/pasting a long stereo clip on a non-empty mono track shows the dialog and is cancellable
- [x] Same with dragging that long stereo clip
