### PR TITLE
9462 avoid start audio stream when no meter data to display

### DIFF
--- a/src/record/CMakeLists.txt
+++ b/src/record/CMakeLists.txt
@@ -14,6 +14,7 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/recorderrors.h
     ${CMAKE_CURRENT_LIST_DIR}/irecordconfiguration.h
     ${CMAKE_CURRENT_LIST_DIR}/irecordcontroller.h
+    ${CMAKE_CURRENT_LIST_DIR}/irecordmetercontroller.h
     ${CMAKE_CURRENT_LIST_DIR}/irecord.h
     ${CMAKE_CURRENT_LIST_DIR}/iaudioinput.h
 
@@ -22,6 +23,8 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/internal/recordconfiguration.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/recordcontroller.cpp
     ${CMAKE_CURRENT_LIST_DIR}/internal/recordcontroller.h
+    ${CMAKE_CURRENT_LIST_DIR}/internal/recordmetercontroller.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/internal/recordmetercontroller.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/recorduiactions.cpp
     ${CMAKE_CURRENT_LIST_DIR}/internal/recorduiactions.h
 

--- a/src/record/internal/au3/au3audioinput.cpp
+++ b/src/record/internal/au3/au3audioinput.cpp
@@ -186,20 +186,30 @@ void Au3AudioInput::stopMonitoring()
     });
 }
 
+bool Au3AudioInput::shouldRestartMonitoring() const
+{
+    if (audibleInputMonitoring()) {
+        return true;
+    }
+
+    if (!configuration()->isMicMeteringOn()) {
+        return false;
+    }
+
+    if (isTrackMeterMonitoring() || meterController()->isRecordMeterVisible()) {
+        return true;
+    }
+
+    return false;
+}
+
 void Au3AudioInput::restartMonitoring()
 {
     stopMonitoring();
 
-    if (!configuration()->isMicMeteringOn() && !audibleInputMonitoring()) {
-        return;
+    if (shouldRestartMonitoring()) {
+        startMonitoring();
     }
-
-    if (!audibleInputMonitoring() && configuration()->isMicMeteringOn() && !isTrackMeterMonitoring()
-        && !meterController()->isRecordMeterVisible()) {
-        return;
-    }
-
-    startMonitoring();
 }
 
 bool Au3AudioInput::isTrackMeterMonitoring() const

--- a/src/record/internal/au3/au3audioinput.h
+++ b/src/record/internal/au3/au3audioinput.h
@@ -6,18 +6,18 @@
 
 #include "global/async/asyncable.h"
 
-#include "libraries/lib-audio-io/AudioIO.h"
-
 #include "modularity/ioc.h"
 #include "context/iglobalcontext.h"
+#include "playback/iplaybackcontroller.h"
+#include "playback/iaudiodevicesprovider.h"
+#include "record/irecordconfiguration.h"
+#include "record/irecordcontroller.h"
+#include "record/irecordmetercontroller.h"
+#include "trackedit/iselectioncontroller.h"
 
 #include "au3wrap/au3types.h"
 #include "au3wrap/internal/au3audiometer.h"
-#include "playback/iplaybackcontroller.h"
-
-#include "../../iaudioinput.h"
-#include "record/irecordconfiguration.h"
-#include "record/irecordcontroller.h"
+#include "record/iaudioinput.h"
 
 namespace au::record {
 class Au3AudioInput : public IAudioInput, public muse::async::Asyncable
@@ -25,7 +25,10 @@ class Au3AudioInput : public IAudioInput, public muse::async::Asyncable
     muse::Inject<au::context::IGlobalContext> globalContext;
     muse::Inject<record::IRecordConfiguration> configuration;
     muse::Inject<record::IRecordController> controller;
+    muse::Inject<record::IRecordMeterController> meterController;
     muse::Inject<playback::IPlaybackController> playbackController;
+    muse::Inject<trackedit::ISelectionController> selectionController;
+    muse::Inject<playback::IAudioDevicesProvider> audioDevicesProvider;
 
 public:
     Au3AudioInput();
@@ -47,9 +50,12 @@ private:
     void startMonitoring();
     void stopMonitoring();
     void restartMonitoring();
+    bool isTrackMeterMonitoring() const;
 
     mutable muse::async::Channel<float> m_recordVolumeChanged;
 
     std::shared_ptr<au::au3::Meter> m_inputMeter;
+    int m_inputChannelsCount{};
+    trackedit::TrackId m_focusedTrackId{};
 };
 }

--- a/src/record/internal/au3/au3audioinput.h
+++ b/src/record/internal/au3/au3audioinput.h
@@ -51,6 +51,7 @@ private:
     void stopMonitoring();
     void restartMonitoring();
     bool isTrackMeterMonitoring() const;
+    bool shouldRestartMonitoring() const;
 
     mutable muse::async::Channel<float> m_recordVolumeChanged;
 

--- a/src/record/internal/au3/au3audioinput.h
+++ b/src/record/internal/au3/au3audioinput.h
@@ -51,12 +51,13 @@ private:
     void stopMonitoring();
     void restartMonitoring();
     bool isTrackMeterMonitoring() const;
+    int getFocusedTrackChannels() const;
     bool shouldRestartMonitoring() const;
 
     mutable muse::async::Channel<float> m_recordVolumeChanged;
 
     std::shared_ptr<au::au3::Meter> m_inputMeter;
     int m_inputChannelsCount{};
-    trackedit::TrackId m_focusedTrackId{};
+    int m_focusedTrackChannels{};
 };
 }

--- a/src/record/internal/recordmetercontroller.cpp
+++ b/src/record/internal/recordmetercontroller.cpp
@@ -1,0 +1,27 @@
+/*
+* Audacity: A Digital Audio Editor
+*/
+
+#include "recordmetercontroller.h"
+
+using namespace au::record;
+
+bool RecordMeterController::isRecordMeterVisible() const
+{
+    return m_recordMeterVisible;
+}
+
+void RecordMeterController::setRecordMeterVisible(bool visible)
+{
+    if (m_recordMeterVisible == visible) {
+        return;
+    }
+
+    m_recordMeterVisible = visible;
+    m_isRecordMeterVisibleChanged.notify();
+}
+
+muse::async::Notification RecordMeterController::isRecordMeterVisibleChanged() const
+{
+    return m_isRecordMeterVisibleChanged;
+}

--- a/src/record/internal/recordmetercontroller.h
+++ b/src/record/internal/recordmetercontroller.h
@@ -1,0 +1,20 @@
+/*
+* Audacity: A Digital Audio Editor
+*/
+#pragma once
+
+#include "record/irecordmetercontroller.h"
+
+namespace au::record {
+class RecordMeterController : public IRecordMeterController
+{
+public:
+    [[nodiscard]] bool isRecordMeterVisible() const override;
+    void setRecordMeterVisible(bool visible) override;
+    [[nodiscard]] muse::async::Notification isRecordMeterVisibleChanged() const override;
+
+private:
+    muse::async::Notification m_isRecordMeterVisibleChanged;
+    bool m_recordMeterVisible = false;
+};
+}

--- a/src/record/irecordmetercontroller.h
+++ b/src/record/irecordmetercontroller.h
@@ -1,0 +1,21 @@
+/*
+* Audacity: A Digital Audio Editor
+*/
+#pragma once
+
+#include "modularity/imoduleinterface.h"
+#include "async/notification.h"
+
+namespace au::record {
+class IRecordMeterController : MODULE_EXPORT_INTERFACE
+{
+    INTERFACE_ID(IRecordMeterController)
+
+public:
+    virtual ~IRecordMeterController() = default;
+
+    [[nodiscard]] virtual bool isRecordMeterVisible() const = 0;
+    virtual void setRecordMeterVisible(bool visible) = 0;
+    [[nodiscard]] virtual muse::async::Notification isRecordMeterVisibleChanged() const = 0;
+};
+}

--- a/src/record/qml/Audacity/Record/RecordLevel.qml
+++ b/src/record/qml/Audacity/Record/RecordLevel.qml
@@ -55,8 +55,6 @@ FlatButton {
         } else {
             popup.open()
         }
-
-        root.isPopupOpened(popup.isOpened)
     }
 
     onClicked: function(mouse) {
@@ -111,6 +109,12 @@ FlatButton {
         onOpened: {
             leftVolumePressure.requestPaint()
             rightVolumePressure.requestPaint()
+
+            root.isPopupOpened(true)
+        }
+
+        onClosed: {
+            root.isPopupOpened(false)
         }
 
         Column {

--- a/src/record/recordmodule.cpp
+++ b/src/record/recordmodule.cpp
@@ -12,6 +12,7 @@
 
 #include "internal/recordconfiguration.h"
 #include "internal/recordcontroller.h"
+#include "internal/recordmetercontroller.h"
 #include "internal/recorduiactions.h"
 #include "internal/au3/au3record.h"
 #include "view/common/recordmetermodel.h"
@@ -36,11 +37,13 @@ void RecordModule::registerExports()
 {
     m_configuration = std::make_shared<RecordConfiguration>();
     m_controller = std::make_shared<RecordController>();
+    m_meterController = std::make_shared<RecordMeterController>();
     m_uiActions = std::make_shared<RecordUiActions>(m_controller);
     m_record = std::make_shared<Au3Record>();
 
     ioc()->registerExport<IRecordConfiguration>(moduleName(), m_configuration);
     ioc()->registerExport<IRecordController>(moduleName(), m_controller);
+    ioc()->registerExport<IRecordMeterController>(moduleName(), m_meterController);
     ioc()->registerExport<IRecord>(moduleName(), m_record);
 }
 

--- a/src/record/recordmodule.h
+++ b/src/record/recordmodule.h
@@ -11,6 +11,7 @@
 namespace au::record {
 class RecordConfiguration;
 class RecordController;
+class RecordMeterController;
 class RecordUiActions;
 class Au3Record;
 class RecordModule : public muse::modularity::IModuleSetup
@@ -28,6 +29,7 @@ public:
 private:
     std::shared_ptr<RecordConfiguration> m_configuration;
     std::shared_ptr<RecordController> m_controller;
+    std::shared_ptr<RecordMeterController> m_meterController;
     std::shared_ptr<RecordUiActions> m_uiActions;
     std::shared_ptr<Au3Record> m_record;
 };

--- a/src/record/view/toolbars/playbacktoolbarrecordlevelitem.cpp
+++ b/src/record/view/toolbars/playbacktoolbarrecordlevelitem.cpp
@@ -189,6 +189,7 @@ PlaybackMeterStyle::MeterStyle PlaybackToolBarRecordLevelItem::meterStyle() cons
 
 void PlaybackToolBarRecordLevelItem::listenMainAudioInput(bool listen)
 {
+    recordMeterController()->setRecordMeterVisible(listen);
     if (listen) {
         record()->audioInput()->recordSignalChanges().onReceive(this,
                                                                 [this](const audioch_t audioChNum, const audio::MeterSignal& meterSignal) {

--- a/src/record/view/toolbars/playbacktoolbarrecordlevelitem.h
+++ b/src/record/view/toolbars/playbacktoolbarrecordlevelitem.h
@@ -9,6 +9,7 @@
 #include "record/irecord.h"
 #include "record/irecordconfiguration.h"
 #include "record/irecordcontroller.h"
+#include "record/irecordmetercontroller.h"
 #include "playback/iplaybackconfiguration.h"
 #include "playback/iaudiodevicesprovider.h"
 
@@ -40,6 +41,7 @@ class PlaybackToolBarRecordLevelItem : public muse::uicomponents::ToolBarItem
     muse::Inject<record::IRecord> record;
     muse::Inject<record::IRecordConfiguration> recordConfiguration;
     muse::Inject<record::IRecordController> recordController;
+    muse::Inject<record::IRecordMeterController> recordMeterController;
     muse::Inject<playback::IPlaybackConfiguration> playbackConfiguration;
     muse::Inject<playback::IAudioDevicesProvider> audioDevicesProvider;
 

--- a/src/trackedit/internal/au3/au3interaction.cpp
+++ b/src/trackedit/internal/au3/au3interaction.cpp
@@ -15,6 +15,7 @@
 #include "global/types/number.h"
 #include "global/concurrency/concurrent.h"
 
+#include "itrackeditproject.h"
 #include "libraries/lib-project/Project.h"
 #include "libraries/lib-wave-track/WaveTrack.h"
 #include "libraries/lib-track/Track.h"
@@ -1946,6 +1947,8 @@ bool Au3Interaction::deleteTracks(const TrackIdList& trackIds)
     auto& project = projectRef();
     auto& tracks = Au3TrackList::Get(project);
 
+    TrackId focusedTrack = selectionController()->focusedTrack();
+
     for (const auto& trackId : trackIds) {
         Au3Track* au3Track = DomAccessor::findTrack(project, Au3TrackId(trackId));
         IF_ASSERT_FAILED(au3Track) {
@@ -1957,6 +1960,12 @@ bool Au3Interaction::deleteTracks(const TrackIdList& trackIds)
 
         trackedit::ITrackeditProjectPtr trackEdit = globalContext()->currentTrackeditProject();
         trackEdit->notifyAboutTrackRemoved(track);
+    }
+
+    if (muse::contains(trackIds, focusedTrack)) {
+        trackedit::ITrackeditProjectPtr trackEdit = globalContext()->currentTrackeditProject();
+        const auto trackIds = trackEdit->trackIdList();
+        selectionController()->setFocusedTrack(trackIds.empty() ? -1 : trackIds.front());
     }
 
     return true;

--- a/src/trackedit/internal/au3/au3interaction.cpp
+++ b/src/trackedit/internal/au3/au3interaction.cpp
@@ -1964,8 +1964,8 @@ bool Au3Interaction::deleteTracks(const TrackIdList& trackIds)
 
     if (muse::contains(trackIds, focusedTrack)) {
         trackedit::ITrackeditProjectPtr trackEdit = globalContext()->currentTrackeditProject();
-        const auto trackIds = trackEdit->trackIdList();
-        selectionController()->setFocusedTrack(trackIds.empty() ? -1 : trackIds.front());
+        const auto notRemovedTracks = trackEdit->trackIdList();
+        selectionController()->setFocusedTrack(notRemovedTracks.empty() ? -1 : notRemovedTracks.front());
     }
 
     return true;

--- a/src/trackedit/internal/au3/au3selectioncontroller.cpp
+++ b/src/trackedit/internal/au3/au3selectioncontroller.cpp
@@ -511,13 +511,6 @@ au::trackedit::TrackId Au3SelectionController::focusedTrack() const
 
 void Au3SelectionController::setFocusedTrack(TrackId trackId)
 {
-    Au3Track* track = au3::DomAccessor::findTrack(projectRef(), ::TrackId(trackId));
-    IF_ASSERT_FAILED(track) {
-        return;
-    }
-    auto& trackFocus = TrackFocus::Get(projectRef());
-    trackFocus.SetFocus(track->shared_from_this());
-
     m_focusedTrack.set(trackId, true);
 }
 


### PR DESCRIPTION
Resolves: #9462

If there is no meter to show the audio data avoid starting the audio stream.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Autobot test cases have been run
