### PR TITLE
Fix #9463: Crash when accessing preferences after the project was closed

### DIFF
--- a/src/projectscene/internal/tapholdshortcut.cpp
+++ b/src/projectscene/internal/tapholdshortcut.cpp
@@ -13,7 +13,7 @@ TapHoldShortcut::TapHoldShortcut(const std::string& action)
     connect(&m_holdTimer, &QTimer::timeout, this, &TapHoldShortcut::onHoldTimeout);
     m_holdTimer.setSingleShot(true);
 
-    shortcutsRegister()->shortcutsChanged().onNotify(nullptr, [this]() {
+    shortcutsRegister()->shortcutsChanged().onNotify(this, [this]() {
         updateShortcut(m_action);
     });
 

--- a/src/projectscene/internal/tapholdshortcut.h
+++ b/src/projectscene/internal/tapholdshortcut.h
@@ -8,11 +8,12 @@
 #include <QTimer>
 
 #include "modularity/ioc.h"
+#include "async/asyncable.h"
 #include "context/iuicontextresolver.h"
 #include "shortcuts/ishortcutsregister.h"
 
 namespace au::projectscene {
-class TapHoldShortcut : public QObject
+class TapHoldShortcut : public QObject, muse::async::Asyncable
 {
     Q_OBJECT
 


### PR DESCRIPTION
Resolves: #9463
The connection was not destroyed on project close

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Autobot test cases have been run
