### PR TITLE
Fix z-ordering of the timeline, play region and the playhead

### DIFF
--- a/src/projectscene/qml/Audacity/ProjectScene/clipsview/Timeline.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/clipsview/Timeline.qml
@@ -60,13 +60,16 @@ Rectangle {
     }
     // ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+    PlayRegion {
+        id: playRegion
+
+        context: timelineContext
+    }
+
     TimelineRuler {
         id: timelineRuler
 
         anchors.fill: parent
-
-        // Ensure the ruler is drawn on top of selection and play region
-        z: 42
 
         context: timelineContext
     }

--- a/src/projectscene/qml/Audacity/ProjectScene/clipsview/TracksClipsView.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/clipsview/TracksClipsView.qml
@@ -264,12 +264,6 @@ Rectangle {
                 opacity: 0.3
             }
 
-            PlayRegion {
-                id: playRegion
-
-                context: timeline.context
-            }
-
             PlayCursorHead {
                 id: head
 


### PR DESCRIPTION
Fixes timeline notches being drawn on top of the playhead

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Autobot test cases have been run
