### PR TITLE
9482 Do not restart monitoring while recording or playing

### DIFF
--- a/src/record/internal/au3/au3audioinput.cpp
+++ b/src/record/internal/au3/au3audioinput.cpp
@@ -40,15 +40,11 @@ Au3AudioInput::Au3AudioInput()
         });
 
         controller()->isRecordingChanged().onNotify(this, [this]() {
-            if (!controller()->isRecording()) {
-                restartMonitoring();
-            }
+            restartMonitoring();
         });
 
         playbackController()->isPlayingChanged().onNotify(this, [this]() {
-            if (playbackController()->isStopped()) {
-                restartMonitoring();
-            }
+            restartMonitoring();
         });
 
         audioDevicesProvider()->inputChannelsChanged().onNotify(this, [this]() {
@@ -236,6 +232,10 @@ int Au3AudioInput::getFocusedTrackChannels() const
 
 void Au3AudioInput::restartMonitoring()
 {
+    if (controller()->isRecording() || playbackController()->isPlaying()) {
+        return;
+    }
+
     stopMonitoring();
 
     if (shouldRestartMonitoring()) {


### PR DESCRIPTION
Resolves: #9482 

Do not restart monitoring while recording or playing

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Autobot test cases have been run
