### PR TITLE
follow-up improving playback flow

### DIFF
--- a/src/playback/internal/au3/au3player.cpp
+++ b/src/playback/internal/au3/au3player.cpp
@@ -385,7 +385,6 @@ void Au3Player::setLoopRegion(const PlaybackRegion& region)
     Au3Project& project = projectRef();
     auto& playRegion = ViewInfo::Get(project).playRegion;
 
-    playRegion.SetActive(true);
     playRegion.SetAllTimes(region.start, region.end);
 
     m_loopRegionChanged.notify();

--- a/src/playback/internal/au3/au3player.cpp
+++ b/src/playback/internal/au3/au3player.cpp
@@ -223,6 +223,7 @@ void Au3Player::seek(const muse::secs_t newPosition, bool applyIfPlaying)
     auto& playRegion = ViewInfo::Get(project).playRegion;
     if (!playRegion.Active()) {
         playRegion.SetStart(pos);
+        playRegion.SetEnd(pos);
     }
 
     if (applyIfPlaying && m_playbackStatus.val == PlaybackStatus::Running) {

--- a/src/playback/internal/au3/au3player.cpp
+++ b/src/playback/internal/au3/au3player.cpp
@@ -349,14 +349,13 @@ void Au3Player::setPlaybackRegion(const PlaybackRegion& region)
         return;
     }
 
-    playRegion.SetStart(region.start);
-
+    double end = region.end;
     if (region.start == region.end) {
-        auto& tracks = Au3TrackList::Get(project);
-        playRegion.SetEnd(tracks.GetEndTime());
-    } else {
-        playRegion.SetEnd(region.end);
+        const auto& tracks = Au3TrackList::Get(project);
+        end = tracks.GetEndTime();
     }
+    playRegion.SetStart(region.start);
+    playRegion.SetEnd(end);
 }
 
 PlaybackRegion Au3Player::loopRegion() const

--- a/src/playback/internal/au3/au3player.cpp
+++ b/src/playback/internal/au3/au3player.cpp
@@ -378,8 +378,6 @@ void Au3Player::loopEditingEnd()
     Au3Project& project = projectRef();
     auto& playRegion = ViewInfo::Get(project).playRegion;
     playRegion.Order();
-
-    m_playbackPosition.set(std::max(loopRegion().start.raw(), 0.0));
 }
 
 void Au3Player::setLoopRegion(const PlaybackRegion& region)

--- a/src/playback/internal/au3/au3player.cpp
+++ b/src/playback/internal/au3/au3player.cpp
@@ -341,8 +341,6 @@ PlaybackRegion Au3Player::playbackRegion() const
 
 void Au3Player::setPlaybackRegion(const PlaybackRegion& region)
 {
-    m_playbackPosition.set(std::max(0.0, region.start.raw()));
-
     Au3Project& project = projectRef();
 
     auto& playRegion = ViewInfo::Get(project).playRegion;

--- a/src/playback/internal/playbackcontroller.cpp
+++ b/src/playback/internal/playbackcontroller.cpp
@@ -567,7 +567,7 @@ bool PlaybackController::isPlaybackPositionOnTheEndOfProject() const
 bool PlaybackController::isPlaybackPositionOnTheEndOfPlaybackRegion() const
 {
     PlaybackRegion playbackRegion = player()->playbackRegion();
-    return playbackRegion.isValid() && isEqualToPlaybackPosition(playbackRegion.end);
+    return playbackRegion.isValid() && isEqualToPlaybackPosition(playbackRegion.end) && !player()->isLoopRegionActive();
 }
 
 bool PlaybackController::isPlaybackStartPositionValid() const

--- a/src/playback/internal/playbackcontroller.cpp
+++ b/src/playback/internal/playbackcontroller.cpp
@@ -68,7 +68,9 @@ void PlaybackController::init()
         if (isPlaybackPositionOnTheEndOfProject() || isPlaybackPositionOnTheEndOfPlaybackRegion()) {
             //! NOTE: just stop, without seek
             player()->stop();
-            player()->setPlaybackRegion(m_lastPlaybackRegion);
+            if (player()->playbackRegion() != m_lastPlaybackRegion) {
+                player()->setPlaybackRegion(m_lastPlaybackRegion);
+            }
         }
     });
 
@@ -256,6 +258,8 @@ void PlaybackController::play(bool ignoreSelection)
         if (selectionRegion.isValid()) {
             doChangePlaybackRegion(selectionRegion);
         } else {
+            LOGW() << "playback region is not valid";
+            // here check if we should use the doSeek(m_lastPlaybackSeekTime); when not valid?
             // update the playback region "manually" even when not paused
             // (that's why we aren't using the doChangePlaybackRegion)
             player()->setPlaybackRegion(m_lastPlaybackRegion);

--- a/src/playback/internal/playbackcontroller.cpp
+++ b/src/playback/internal/playbackcontroller.cpp
@@ -387,13 +387,8 @@ void PlaybackController::stop()
 
     player()->stop();
 
-    PlaybackRegion loopRegion = player()->playbackRegion();
-    if (loopRegion.isValid()) {
-        seek(loopRegion.start);
-    } else {
-        seek(m_lastPlaybackSeekTime);
-        player()->setPlaybackRegion(m_lastPlaybackRegion);
-    }
+    seek(m_lastPlaybackSeekTime);
+    player()->setPlaybackRegion(m_lastPlaybackRegion);
 }
 
 void PlaybackController::resume()

--- a/src/playback/internal/playbackcontroller.cpp
+++ b/src/playback/internal/playbackcontroller.cpp
@@ -68,7 +68,7 @@ void PlaybackController::init()
         if (isPlaybackPositionOnTheEndOfProject() || isPlaybackPositionOnTheEndOfPlaybackRegion()) {
             //! NOTE: just stop, without seek
             player()->stop();
-            if (player()->playbackRegion() != m_lastPlaybackRegion) {
+            if (player()->playbackRegion() != m_lastPlaybackRegion && !isEqualToPlaybackPosition(m_lastPlaybackRegion.end)) {
                 player()->setPlaybackRegion(m_lastPlaybackRegion);
             }
         }
@@ -282,7 +282,7 @@ void PlaybackController::rewindToStart()
     //! NOTE: In Audacity 3 we can't rewind while playing
     stop();
 
-    seek(0.0);
+    doSeek(0.0);
 
     selectionController()->resetTimeSelection();
 }

--- a/src/playback/internal/playbackcontroller.cpp
+++ b/src/playback/internal/playbackcontroller.cpp
@@ -68,6 +68,7 @@ void PlaybackController::init()
         if (isPlaybackPositionOnTheEndOfProject() || isPlaybackPositionOnTheEndOfPlaybackRegion()) {
             //! NOTE: just stop, without seek
             player()->stop();
+            player()->setPlaybackRegion(m_lastPlaybackRegion);
         }
     });
 

--- a/src/playback/internal/playbackcontroller.cpp
+++ b/src/playback/internal/playbackcontroller.cpp
@@ -255,6 +255,10 @@ void PlaybackController::play(bool ignoreSelection)
         PlaybackRegion selectionRegion = selectionPlaybackRegion();
         if (selectionRegion.isValid()) {
             doChangePlaybackRegion(selectionRegion);
+        } else {
+            // update the playback region "manually" even when not paused
+            // (that's why we aren't using the doChangePlaybackRegion)
+            player()->setPlaybackRegion(m_lastPlaybackRegion);
         }
     } else {
         doChangePlaybackRegion({});

--- a/src/playback/internal/playbackcontroller.cpp
+++ b/src/playback/internal/playbackcontroller.cpp
@@ -138,15 +138,16 @@ bool PlaybackController::isLoopActive() const
 
 PlaybackRegion PlaybackController::selectionPlaybackRegion() const
 {
-    if (selectionController()->timeSelectionIsNotEmpty()) {
-        return { selectionController()->dataSelectedStartTime(),
-                 selectionController()->dataSelectedEndTime() };
-    }
-
+    // clip selection have priority over time selection
     if (selectionController()->selectedClips().size() == 1) {
         secs_t clipStartTime = selectionController()->selectedClipStartTime();
         secs_t clipEndTime = selectionController()->selectedClipEndTime();
         return { clipStartTime, clipEndTime };
+    }
+
+    if (selectionController()->timeSelectionIsNotEmpty()) {
+        return { selectionController()->dataSelectedStartTime(),
+                 selectionController()->dataSelectedEndTime() };
     }
 
     return PlaybackRegion();

--- a/src/playback/internal/playbackcontroller.cpp
+++ b/src/playback/internal/playbackcontroller.cpp
@@ -290,9 +290,9 @@ void PlaybackController::rewindToStart()
 void PlaybackController::rewindToEnd()
 {
     //! NOTE: In Audacity 3 we can't rewind while playing
+    m_lastPlaybackSeekTime = totalPlayTime();
+    m_lastPlaybackRegion = { totalPlayTime(), totalPlayTime() };
     stop();
-
-    seek(totalPlayTime());
 
     selectionController()->resetTimeSelection();
 }

--- a/src/playback/internal/playbackcontroller.cpp
+++ b/src/playback/internal/playbackcontroller.cpp
@@ -369,6 +369,7 @@ void PlaybackController::stop()
         seek(loopRegion.start);
     } else {
         seek(m_lastPlaybackSeekTime);
+        player()->setPlaybackRegion(m_lastPlaybackRegion);
     }
 }
 

--- a/src/playback/internal/playbackcontroller.cpp
+++ b/src/playback/internal/playbackcontroller.cpp
@@ -274,7 +274,6 @@ void PlaybackController::play(bool ignoreSelection)
             doChangePlaybackRegion(selectionRegion);
         } else {
             LOGW() << "playback region is not valid";
-            // here check if we should use the doSeek(m_lastPlaybackSeekTime); when not valid?
             // update the playback region "manually" even when not paused
             // (that's why we aren't using the doChangePlaybackRegion)
             player()->setPlaybackRegion(m_lastPlaybackRegion);

--- a/src/playback/internal/playbackcontroller.cpp
+++ b/src/playback/internal/playbackcontroller.cpp
@@ -88,6 +88,20 @@ void PlaybackController::init()
     recordController()->isRecordingChanged().onNotify(this, [this]() {
         m_isPlayAllowedChanged.notify();
     });
+
+    selectionController()->clipsSelected().onReceive(this, [this](const trackedit::ClipKeyList& clipKeyList) {
+        if (clipKeyList.empty()) {
+            return;
+        }
+        if (!isPlaying()) {
+            player()->stop();
+            PlaybackRegion selectionRegion = selectionPlaybackRegion();
+            if (selectionRegion.isValid()) {
+                doChangePlaybackRegion(selectionRegion);
+            }
+            doSeek(m_lastPlaybackSeekTime);
+        }
+    });
 }
 
 void PlaybackController::deinit()

--- a/src/projectscene/view/timeline/playregioncontroller.cpp
+++ b/src/projectscene/view/timeline/playregioncontroller.cpp
@@ -85,7 +85,6 @@ void PlayRegionController::mouseMove(double pos)
     }
 
     auto player = playback()->player();
-    player->setLoopRegionActive(true);
 
     double visibleStartPos = context()->timeToPosition(context()->frameStartTime());
     double visibleEndPos = context()->timeToPosition(context()->frameEndTime());


### PR DESCRIPTION
## Follow-up of https://github.com/audacity/audacity/pull/9410

FIXES:
- While the playback is playing you can now:
    - position the playhead for next playback to start (you don’t need anymore to pause or stop for that to happen like in au3)
    - Create a range selection that will be playing on the next playback start  (you don’t need anymore to pause or stop for that to happen like in au3)
        - This was hanging the playback if done during play and needed stop to make it work 
    - Selecting a clip will create a new selection and on pause or stop the playhead will jump to it’s beginning and next playback will play it
        - Before we needed to be stopped or pause for the next playback to play the new selection (and the playhead wasn’t jumping at the beginning of the selection)
    - 
- When playback reaches the end of either the project or the region the playhead will jump back at the next playback start position 

NEED to FIX:
- [x] If in a paused state selecting a clip won’t make next playback start from clip beginning
- [x] If on a selected clip playing paused and selecting another clip will crash
- [x] If during playing user create is selecting region then pause then play/resume should playback jump to new selection : au3 YES
    - [ ] If during playing a selection user click on the timeline pause play won’t jump there until selection finishes playing
    - [ ] If during playing a selection user make a selection on the timeline pause play won’t jump there until selection finishes playing
    - [ ] If during playing user click on the timeline pause play won’t jump there 
    - [ ] If during playing user make a selection on the timeline pause play won’t jump there 
- [x] If there is an existing selection 
    - [x] Cursor update on mouse click down when inside selection but on mouse up when outside selection
- [x] Rewind backward should go to 0.0 and loose selection
- [x] Rewind forward should go to end of project and loose selection
- [x] When not playing: Clicking at the right of a existing selection do not register correctly the clicks
- [x] When looping, Playback sometimes randomly stops looping at the end of a loop.


---


- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [ ] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [ ] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Autobot test cases have been run
