### PR TITLE
Project restoration fix

### DIFF
--- a/src/au3wrap/iau3project.h
+++ b/src/au3wrap/iau3project.h
@@ -20,7 +20,7 @@ public:
     virtual ~IAu3Project() = default;
 
     [[nodiscard]] virtual muse::Ret open() = 0;
-    [[nodiscard]] virtual muse::Ret load(const muse::io::path_t& filePath) = 0;
+    [[nodiscard]] virtual muse::Ret load(const muse::io::path_t& filePath, bool ignoreAutosave = false) = 0;
     virtual bool save(const muse::io::path_t& fileName) = 0;
     virtual void close() = 0;
 

--- a/src/au3wrap/internal/au3project.cpp
+++ b/src/au3wrap/internal/au3project.cpp
@@ -63,7 +63,8 @@ muse::Ret Au3ProjectCreator::removeUnsavedData(const muse::io::path_t& projectPa
     if (!tempProject) {
         return muse::make_ret(static_cast<muse::Ret::Code>(au::project::Err::NoProjectError));
     }
-    auto ret = tempProject->load(projectPath);
+    constexpr auto ignoreAutosave = true;
+    auto ret = tempProject->load(projectPath, ignoreAutosave);
     if (ret) {
         if (tempProject->isTemporary()) {
             tempProject->close();
@@ -120,7 +121,7 @@ muse::Ret Au3ProjectAccessor::open()
     return projectFileIO.OpenProject() ? muse::make_ok() : muse::make_ret(static_cast<muse::Ret::Code>(project::Err::DatabaseError));
 }
 
-muse::Ret Au3ProjectAccessor::load(const muse::io::path_t& filePath)
+muse::Ret Au3ProjectAccessor::load(const muse::io::path_t& filePath, bool ignoreAutosave)
 {
     muse::Ret ret = muse::make_ok();
 
@@ -132,7 +133,7 @@ muse::Ret Au3ProjectAccessor::load(const muse::io::path_t& filePath)
     std::optional<ProjectFileIO::TentativeConnection> conn;
 
     try {
-        conn.emplace(projectFileIO.LoadProject(fileName, false /*ignoreAutosave*/).value());
+        conn.emplace(projectFileIO.LoadProject(fileName, ignoreAutosave).value());
     } catch (AudacityException& exception) {
         LOGE() << "Project loading failed: " << filePath << " with exception";
         ret = project::make_ret(project::Err::AudacityExceptionError, filePath.toString());

--- a/src/au3wrap/internal/au3project.h
+++ b/src/au3wrap/internal/au3project.h
@@ -26,7 +26,7 @@ public:
     Au3ProjectAccessor();
 
     [[nodiscard]] muse::Ret open() override;
-    [[nodiscard]] muse::Ret load(const muse::io::path_t& filePath) override;
+    [[nodiscard]] muse::Ret load(const muse::io::path_t& filePath, bool ignoreAutosave) override;
     bool save(const muse::io::path_t& fileName) override;
     void close() override;
 

--- a/src/trackedit/tests/au3interaction_tests.cpp
+++ b/src/trackedit/tests/au3interaction_tests.cpp
@@ -191,7 +191,8 @@ public:
     {
         m_au3ProjectAccessor = std::make_shared<au3::Au3ProjectAccessor>();
         const muse::io::path_t TEST_PROJECT_PATH = muse::String::fromUtf8(trackedit_tests_DATA_ROOT) + "/data/empty.aup3";
-        muse::Ret ret = m_au3ProjectAccessor->load(TEST_PROJECT_PATH);
+        constexpr auto discardAutosave = false;
+        muse::Ret ret = m_au3ProjectAccessor->load(TEST_PROJECT_PATH, discardAutosave);
 
         ON_CALL(*m_currentProject, au3ProjectPtr())
         .WillByDefault(Return(m_au3ProjectAccessor->au3ProjectPtr()));

--- a/src/trackedit/tests/au3trackeditclipboard_tests.cpp
+++ b/src/trackedit/tests/au3trackeditclipboard_tests.cpp
@@ -55,7 +55,8 @@ public:
     {
         m_au3ProjectAccessor = std::make_shared<au3::Au3ProjectAccessor>();
         const muse::io::path_t TEST_PROJECT_PATH = muse::String::fromUtf8(trackedit_tests_DATA_ROOT) + "/data/testClipboard.aup3";
-        muse::Ret ret = m_au3ProjectAccessor->load(TEST_PROJECT_PATH);
+        constexpr auto discardAutosave = false;
+        muse::Ret ret = m_au3ProjectAccessor->load(TEST_PROJECT_PATH, discardAutosave);
 
         ON_CALL(*m_currentProject, au3ProjectPtr())
         .WillByDefault(Return(m_au3ProjectAccessor->au3ProjectPtr()));


### PR DESCRIPTION
Resolves: #9461

The flag `ignoreAutosave` was not set to `true` when the user decided to discard unsaved data from a crash.  This set the `ProjectFileIO` in an inconsistent state and leading `Au3ProjectAccessor::hasUnsavedData()` to mistakenly return `true` although unsaved data should have been cleaned up. I didn't go follow the error path down to the bottom because other things would likely have gone wrong anyway hadn't it been for this.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Autobot test cases have been run
- [x] Bug is fixed
- [x] Crashing a project with unsaved changes and then saying "yes" to the "do you want to recover" question still works