### PR TITLE
Fix #9439, 9495: Generator/effect views are distorted

### DIFF
--- a/src/effects/builtin/noisereduction/NoiseReductionView.qml
+++ b/src/effects/builtin/noisereduction/NoiseReductionView.qml
@@ -1,6 +1,8 @@
 import QtQuick
 import QtQuick.Layouts
+
 import Muse.UiComponents
+
 import Audacity.Effects
 import Audacity.BuiltinEffects
 
@@ -10,8 +12,8 @@ BuiltinEffectBase {
     property string title: qsTrc("effects/noisereduction", "Noise Reduction")
     property bool isApplyAllowed: noiseReduction.isApplyAllowed
 
-    width: row.width
-    implicitHeight: column.height
+    implicitHeight: column.implicitHeight
+    implicitWidth: row.implicitWidth
 
     model: noiseReduction
 

--- a/src/effects/builtin/silencegen/SilenceView.qml
+++ b/src/effects/builtin/silencegen/SilenceView.qml
@@ -12,29 +12,28 @@ BuiltinEffectBase {
     property string title: qsTrc("projectscene/silence", "Silence")
     property alias isApplyAllowed: silence.isApplyAllowed
 
-    implicitHeight: 60
+    implicitWidth: 300
+    implicitHeight: column.implicitHeight
+
     model: silence
 
     SilenceViewModel {
         id: silence
     }
 
-    Row {
-        id: row
+    Column {
+        id: column
 
         anchors.fill: parent
-        anchors.margins: 0
+
         spacing: 16
 
         StyledTextLabel {
             text: qsTrc("projectscene/silence", "Duration:")
-            anchors.verticalCenter: parent.verticalCenter
         }
 
         Timecode {
             id: timecode
-
-            anchors.verticalCenter: parent.verticalCenter
 
             value: silence.duration
             mode: TimecodeModeSelector.Duration

--- a/src/effects/builtin/silencegen/silenceviewmodel.h
+++ b/src/effects/builtin/silencegen/silenceviewmodel.h
@@ -18,5 +18,6 @@ public:
 
 private:
     void doEmitSignals() override {}
+    bool usesPresets() const override { return false; }
 };
 }

--- a/src/effects/effects_base/qml/Audacity/Effects/EffectsViewerDialog.qml
+++ b/src/effects/effects_base/qml/Audacity/Effects/EffectsViewerDialog.qml
@@ -36,9 +36,7 @@ EffectStyledDialogView {
     contentWidth: Math.max(viewerLoader.width + prv.viewMargins * 2, prv.minimumWidth)
     contentHeight: {
         let height = viewerLoader.height + bottomPanel.height
-        if (prv.showPresets) {
-            height += topPanel.height
-        }
+        height += prv.showPresets ? topPanel.height : prv.viewMargins
         return height
     }
 
@@ -71,6 +69,8 @@ EffectStyledDialogView {
         anchors.fill: parent
 
         WindowContainer {
+            visible: prv.showPresets
+
             window: Window {
                 id: topPanel
 
@@ -98,8 +98,6 @@ EffectStyledDialogView {
 
                         parentWindow: root.window
                         instanceId: root.instanceId
-
-                        visible: prv.showPresets
                     }
                 }
 
@@ -110,9 +108,18 @@ EffectStyledDialogView {
                     anchors.left: parent.left
                     anchors.right: parent.right
 
-                    visible: effectFamily == EffectFamily.Builtin && prv.showPresets
+                    visible: effectFamily == EffectFamily.Builtin
                 }
             }
+        }
+
+        Item {
+            id: spacer
+
+            visible: !prv.showPresets
+
+            width: parent.width
+            height: prv.viewMargins
         }
 
         Loader {


### PR DESCRIPTION
Resolves: #9439
Resolves: #9495

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] All destructive effects are displayed correctly
- [ ] Autobot test cases have been run
