### PR TITLE
Meters use a LockFreeQueue

### DIFF
--- a/au3/libraries/lib-audio-devices/AudioIOBase.cpp
+++ b/au3/libraries/lib-audio-devices/AudioIOBase.cpp
@@ -318,7 +318,6 @@ void AudioIOBase::SetCaptureMeter(
     auto meter = wMeter.lock();
     if (meter) {
         mInputMeter = meter;
-        meter->reset();
     } else {
         mInputMeter.reset();
     }
@@ -335,7 +334,6 @@ void AudioIOBase::SetPlaybackMeter(
     auto meter = wMeter.lock();
     if (meter) {
         mOutputMeter = meter;
-        meter->reset();
     } else {
         mOutputMeter.reset();
     }

--- a/au3/libraries/lib-audio-devices/IMeterSender.h
+++ b/au3/libraries/lib-audio-devices/IMeterSender.h
@@ -16,10 +16,17 @@ public:
         const double firstSampleTimestamp;
     };
 
+    struct TrackId {
+        TrackId() = default;
+        explicit TrackId(int64_t v)
+            : value(v) {}
+        int64_t value = -1;
+        bool operator<(const TrackId& other) const { return value < other.value; }
+    };
+
     virtual ~IMeterSender() = default;
-    virtual void push(uint8_t channel, const InterleavedSampleData& sampleData, int64_t key = MASTER_TRACK_ID) = 0;
-    virtual void sendAll() = 0;
-    virtual void reset() = 0;
-    virtual void reserve(size_t size) = 0;
+    virtual void push(uint8_t channel, const InterleavedSampleData& sampleData, TrackId = TrackId { MASTER_TRACK_ID }) = 0;
+    virtual void start() = 0;
+    virtual void stop() = 0;
     virtual void setSampleRate(double rate) = 0;
 };

--- a/au3/libraries/lib-audio-io/AudioIO.h
+++ b/au3/libraries/lib-audio-io/AudioIO.h
@@ -558,9 +558,10 @@ public:
 private:
     bool DelayingActions() const;
 
-    /** \brief Set the current VU meters - this should be done once after
-     * each call to StartStream currently */
-    void SetMeters();
+    /**
+     * \brief Start the current VU meters
+     */
+    void StartMeters();
 
     /** \brief Opens the portaudio stream(s) used to do playback or recording
      * (or both) through.

--- a/src/playback/internal/au3/au3audiooutput.cpp
+++ b/src/playback/internal/au3/au3audiooutput.cpp
@@ -111,7 +111,7 @@ muse::async::Channel<au::audio::audioch_t, au::audio::MeterSignal> Au3AudioOutpu
 muse::async::Channel<au::audio::audioch_t, au::audio::MeterSignal> Au3AudioOutput::playbackTrackSignalChanges(
     int64_t key) const
 {
-    return m_outputMeter->dataChanged(key);
+    return m_outputMeter->dataChanged(IMeterSender::TrackId { key });
 }
 
 Au3Project* Au3AudioOutput::projectRef() const

--- a/src/playback/internal/au3/au3player.cpp
+++ b/src/playback/internal/au3/au3player.cpp
@@ -268,12 +268,12 @@ void Au3Player::stop()
     auto& projectAudioIO = ProjectAudioIO::Get(project);
     auto playbackMeter = projectAudioIO.GetPlaybackMeter();
     if (playbackMeter) {
-        playbackMeter->reset();
+        playbackMeter->stop();
     }
 
     auto captureMeter= projectAudioIO.GetCaptureMeter();
     if (captureMeter) {
-        captureMeter->reset();
+        captureMeter->stop();
     }
 
     while (isBusy()) {

--- a/src/record/internal/au3/au3audioinput.cpp
+++ b/src/record/internal/au3/au3audioinput.cpp
@@ -120,7 +120,7 @@ muse::async::Channel<au::audio::audioch_t, au::audio::MeterSignal> Au3AudioInput
 muse::async::Channel<au::audio::audioch_t, au::audio::MeterSignal> Au3AudioInput::recordTrackSignalChanges(
     int64_t key) const
 {
-    return m_inputMeter->dataChanged(key);
+    return m_inputMeter->dataChanged(IMeterSender::TrackId { key });
 }
 
 bool Au3AudioInput::audibleInputMonitoring() const

--- a/src/record/internal/au3/au3record.cpp
+++ b/src/record/internal/au3/au3record.cpp
@@ -345,12 +345,12 @@ muse::Ret Au3Record::stop()
     auto& projectAudioIO = ProjectAudioIO::Get(project);
     auto playbackMeter = projectAudioIO.GetPlaybackMeter();
     if (playbackMeter) {
-        playbackMeter->reset();
+        playbackMeter->stop();
     }
 
     auto captureMeter = projectAudioIO.GetCaptureMeter();
     if (captureMeter) {
-        captureMeter->reset();
+        captureMeter->stop();
     }
 
     return make_ok();


### PR DESCRIPTION
Resolves: #9475

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:
- [x] No regression with respect to playback and recording meters
- [x] Performance is not worse than before when microphone meter display is on
- [ ] Autobot test cases have been run
