### PR TITLE
9499 9382 Fix initial track id and focus

### DIFF
--- a/src/trackedit/internal/au3/au3selectioncontroller.cpp
+++ b/src/trackedit/internal/au3/au3selectioncontroller.cpp
@@ -55,6 +55,12 @@ void Au3SelectionController::init()
             restorer.selectionSetter = [this](const ClipAndTimeSelection& selection) {
                 restoreSelection(selection);
             };
+
+            auto& tracks = ::TrackList::Get(projectRef());
+            if (!tracks.empty()) {
+                const auto it = tracks.begin();
+                setFocusedTrack(TrackId((*it)->GetId()));
+            }
         } else {
             m_tracksSubc.Reset();
         }

--- a/src/trackedit/internal/au3/au3selectioncontroller.h
+++ b/src/trackedit/internal/au3/au3selectioncontroller.h
@@ -13,6 +13,7 @@
 #include "Track.h"
 
 #include "au3wrap/au3types.h"
+#include "trackedittypes.h"
 
 namespace au::trackedit {
 struct ClipAndTimeSelection;
@@ -95,7 +96,11 @@ private:
 
     template<typename T>
     struct Val {
-        T val = T();
+        Val()
+            : val(T()) {}
+        Val(const T& val)
+            : val(val) {}
+        T val;
         muse::async::Channel<T> changed;
         muse::async::Channel<T> selected;
 
@@ -125,6 +130,6 @@ private:
     Val<trackedit::secs_t> m_selectionStartTime; // indicates where user started selection
 
     // track focus state
-    Val<TrackId> m_focusedTrack;
+    Val<TrackId> m_focusedTrack = Val<TrackId> { TrackId(-1) };
 };
 }


### PR DESCRIPTION
Resolves: #9499
Resolves: #9382 

The default track id was set to 0, so after creating the first track the id hasn't changed and we skip some actions.
Also, I have modified the selectionController to set the focus to the first track if the list of tracks is not empty.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Autobot test cases have been run
