### PR TITLE
Display error messages coming from AU3 source code

### DIFF
--- a/src/au3wrap/internal/au3basicui.h
+++ b/src/au3wrap/internal/au3basicui.h
@@ -5,11 +5,15 @@
 #pragma once
 
 #include "global/async/asyncable.h"
+#include "modularity/ioc.h"
+#include "iinteractive.h"
 
 #include "BasicUI.h"
 
 class Au3BasicUI final : public BasicUI::Services, public muse::async::Asyncable
 {
+    muse::Inject<muse::IInteractive> interactive;
+
 protected:
     void DoCallAfter(const BasicUI::Action& action) override;
     void DoYield() override;


### PR DESCRIPTION
Display messages coming from AU3 source code. 
Skipping errors or informational messages can lead to hard-to-find errors.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Autobot test cases have been run
