### PR TITLE
ESC or losing focus cancels dragging operations

### DIFF
--- a/au3/libraries/lib-project-history/ProjectHistory.cpp
+++ b/au3/libraries/lib-project-history/ProjectHistory.cpp
@@ -102,6 +102,12 @@ void ProjectHistory::ModifyState(bool bWantsAutoSave)
     undoManager.ModifyState();
 }
 
+void ProjectHistory::ModifyState(const std::type_index& restorerType)
+{
+    auto& project = mProject;
+    ::UndoManager::Get(project).ModifyState(restorerType);
+}
+
 // LL:  Is there a memory leak here as "l" and "t" are not deleted???
 // Vaughan, 2010-08-29: No, as "l" is a TrackList* of an Undo stack state.
 //    Need to keep it and its tracks "t" available for Undo/Redo/SetStateTo.
@@ -115,7 +121,7 @@ void ProjectHistory::PopState(const UndoState& state, bool doAutosave)
     // remaining no-fail operations "commit" the changes of undo manager state
 
     // Restore extra state
-    for (auto& pExtension : state.extensions) {
+    for (auto& [_, pExtension] : state.extensions) {
         if (pExtension) {
             pExtension->RestoreUndoRedoState(project);
         }

--- a/au3/libraries/lib-project-history/ProjectHistory.h
+++ b/au3/libraries/lib-project-history/ProjectHistory.h
@@ -14,6 +14,8 @@ Paul Licameli split from ProjectManager.h
 #include "ClientData.h"
 #include "GlobalVariable.h"
 
+#include <typeindex>
+
 class AudacityProject;
 struct UndoState;
 enum class UndoPush : unsigned char;
@@ -51,6 +53,7 @@ public:
         const TranslatableString& desc, const TranslatableString& shortDesc, UndoPush flags);
     void RollbackState();
     void ModifyState(bool bWantsAutoSave);   // if true, writes auto-save file.
+    void ModifyState(const std::type_index& restorerType);
     // Should set only if you really want the state change restored after
     // a crash, as it can take many seconds for large (eg. 10 track-hours)
     // projects

--- a/au3/libraries/lib-project-history/UndoManager.h
+++ b/au3/libraries/lib-project-history/UndoManager.h
@@ -92,6 +92,16 @@ public:
     virtual bool CanUndoOrRedo(const AudacityProject& project);
 };
 
+struct UndoState {
+    using Extensions = std::vector<std::shared_ptr<UndoStateExtension> >;
+
+    UndoState(Extensions extensions)
+        : extensions(std::move(extensions))
+    {}
+
+    Extensions extensions;
+};
+
 class PROJECT_HISTORY_API UndoRedoExtensionRegistry
 {
 public:
@@ -104,16 +114,6 @@ public:
     struct PROJECT_HISTORY_API Entry {
         Entry(const Saver& saver);
     };
-};
-
-struct UndoState {
-    using Extensions = std::vector<std::shared_ptr<UndoStateExtension> >;
-
-    UndoState(Extensions extensions)
-        : extensions(std::move(extensions))
-    {}
-
-    Extensions extensions;
 };
 
 struct UndoStackElem {

--- a/au3/libraries/lib-tags/Tags.cpp
+++ b/au3/libraries/lib-tags/Tags.cpp
@@ -553,8 +553,7 @@ static ProjectFileIORegistry::ObjectWriterEntry entry {
 };
 
 // Undo/redo handling
-static UndoRedoExtensionRegistry::Entry sEntry {
-    [](AudacityProject& project) -> std::shared_ptr<UndoStateExtension> {
+static UndoRedoExtensionRegistry::Entry<Tags> sEntry { [](AudacityProject& project) -> std::shared_ptr<UndoStateExtension> {
         return Tags::Get(project).shared_from_this();
     }
 };

--- a/au3/libraries/lib-time-frequency-selection/ViewInfo.cpp
+++ b/au3/libraries/lib-time-frequency-selection/ViewInfo.cpp
@@ -329,8 +329,7 @@ struct SelectedRegionRestorer final : UndoStateExtension {
     SelectedRegion mSelectedRegion;
 };
 
-UndoRedoExtensionRegistry::Entry sEntry {
-    [](AudacityProject& project) -> std::shared_ptr<UndoStateExtension> {
+UndoRedoExtensionRegistry::Entry<SelectedRegionRestorer> sEntry { [](AudacityProject& project) -> std::shared_ptr<UndoStateExtension> {
         return std::make_shared<SelectedRegionRestorer>(project);
     }
 };

--- a/au3/libraries/lib-track/UndoTracks.cpp
+++ b/au3/libraries/lib-track/UndoTracks.cpp
@@ -43,8 +43,7 @@ struct TrackListRestorer final : UndoStateExtension {
     const std::shared_ptr<TrackList> mpTracks;
 };
 
-UndoRedoExtensionRegistry::Entry sEntry {
-    [](AudacityProject& project) -> std::shared_ptr<UndoStateExtension> {
+UndoRedoExtensionRegistry::Entry<TrackListRestorer> sEntry { [] (AudacityProject& project)->std::shared_ptr<UndoStateExtension> {
         return std::make_shared<TrackListRestorer>(project);
     }
 };
@@ -54,11 +53,11 @@ TrackList* UndoTracks::Find(const UndoStackElem& state)
 {
     auto& exts = state.state.extensions;
     auto end = exts.end(),
-         iter = std::find_if(exts.begin(), end, [](auto& pExt){
-        return dynamic_cast<TrackListRestorer*>(pExt.get());
+         iter = std::find_if(exts.begin(), end, [](const std::pair<const std::type_index, std::shared_ptr<UndoStateExtension> >& entry){
+        return dynamic_cast<TrackListRestorer*>(entry.second.get());
     });
     if (iter != end) {
-        return static_cast<TrackListRestorer*>(iter->get())->mpTracks.get();
+        return static_cast<TrackListRestorer*>(iter->second.get())->mpTracks.get();
     }
     return nullptr;
 }

--- a/au3/src/toolbars/TimeSignatureToolBar.cpp
+++ b/au3/src/toolbars/TimeSignatureToolBar.cpp
@@ -301,8 +301,8 @@ struct TimeSignatureRestorer final : UndoStateExtension
     int mLower;
 };
 
-UndoRedoExtensionRegistry::Entry sEntry {
-    [](AudacityProject& project) -> std::shared_ptr<UndoStateExtension>
+UndoRedoExtensionRegistry::Entry sEntry { typeid(TimeSignatureRestorer),
+                                          [](AudacityProject& project) -> std::shared_ptr<UndoStateExtension>
     { return std::make_shared<TimeSignatureRestorer>(project); }
 };
 }

--- a/src/effects/effects_base/internal/realtimeeffectrestorer.cpp
+++ b/src/effects/effects_base/internal/realtimeeffectrestorer.cpp
@@ -100,8 +100,7 @@ private:
     const std::unique_ptr<RealtimeEffectList> m_masterEffectList;
 };
 
-static UndoRedoExtensionRegistry::Entry sEntry {
-    [](au3::Au3Project& project) -> std::shared_ptr<UndoStateExtension>
+static UndoRedoExtensionRegistry::Entry<RealtimeEffectRestorer> sEntry { [](au3::Au3Project& project) -> std::shared_ptr<UndoStateExtension>
     {
         return std::make_shared<RealtimeEffectRestorer>(project);
     }

--- a/src/playback/internal/au3/au3trackplaybackcontrol.cpp
+++ b/src/playback/internal/au3/au3trackplaybackcontrol.cpp
@@ -117,7 +117,7 @@ void Au3TrackPlaybackControl::setSolo(long trackId, bool solo)
 bool Au3TrackPlaybackControl::solo(long trackId) const
 {
     Au3WaveTrack* track = DomAccessor::findWaveTrack(projectRef(), Au3TrackId(trackId));
-    IF_ASSERT_FAILED(track) {
+    if (!track) {
         return false;
     }
 
@@ -147,7 +147,7 @@ void Au3TrackPlaybackControl::setMuted(long trackId, bool mute)
 bool Au3TrackPlaybackControl::muted(long trackId) const
 {
     Au3WaveTrack* track = DomAccessor::findWaveTrack(projectRef(), Au3TrackId(trackId));
-    IF_ASSERT_FAILED(track) {
+    if (!track) {
         return false;
     }
 

--- a/src/projectscene/CMakeLists.txt
+++ b/src/projectscene/CMakeLists.txt
@@ -31,7 +31,7 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/internal/projectsceneuiactions.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/projectsceneactionscontroller.cpp
     ${CMAKE_CURRENT_LIST_DIR}/internal/projectsceneactionscontroller.h
-    
+
     ${CMAKE_CURRENT_LIST_DIR}/internal/tapholdshortcut.cpp
     ${CMAKE_CURRENT_LIST_DIR}/internal/tapholdshortcut.h
 
@@ -116,6 +116,8 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/view/clipsview/cliplistitem.h
     ${CMAKE_CURRENT_LIST_DIR}/view/clipsview/clipcontextmenumodel.cpp
     ${CMAKE_CURRENT_LIST_DIR}/view/clipsview/clipcontextmenumodel.h
+    ${CMAKE_CURRENT_LIST_DIR}/view/clipsview/mousehelper.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/view/clipsview/mousehelper.h
     ${CMAKE_CURRENT_LIST_DIR}/view/clipsview/multiclipcontextmenumodel.cpp
     ${CMAKE_CURRENT_LIST_DIR}/view/clipsview/multiclipcontextmenumodel.h
     ${CMAKE_CURRENT_LIST_DIR}/view/clipsview/trackslistclipsmodel.cpp

--- a/src/projectscene/internal/au3/viewinfo.cpp
+++ b/src/projectscene/internal/au3/viewinfo.cpp
@@ -125,8 +125,7 @@ struct ViewStateRestorer final : UndoStateExtension {
 }
 
 namespace {
-UndoRedoExtensionRegistry::Entry sEntry {
-    [](AudacityProject& project) -> std::shared_ptr<UndoStateExtension> {
+UndoRedoExtensionRegistry::Entry<ViewStateRestorer> sEntry { [](AudacityProject& project) -> std::shared_ptr<UndoStateExtension> {
         return std::make_shared<ViewStateRestorer>(project);
     }
 };

--- a/src/projectscene/internal/au3/viewinfo.h
+++ b/src/projectscene/internal/au3/viewinfo.h
@@ -7,6 +7,8 @@
 #include "Observer.h"
 #include "Project.h"
 
+#include "global/async/notification.h"
+
 class AudacityProject;
 
 namespace au::au3 {
@@ -27,8 +29,19 @@ public:
     double hPos() const;
 
 private:
+    friend struct ViewStateRestorer;
+    ViewInfo& operator=(const ViewInfo& other)
+    {
+        m_zoom = other.m_zoom;
+        m_vpos = other.m_vpos;
+        m_hpos = other.m_hpos;
+        return *this;
+    }
+
     double m_zoom{ 0.0 };
     int m_vpos{ 0 };
     double m_hpos{ 0.0 };
 };
+
+void setViewStateRestorerNotification(AudacityProject&, muse::async::Notification);
 }

--- a/src/projectscene/internal/projectsceneuiactions.cpp
+++ b/src/projectscene/internal/projectsceneuiactions.cpp
@@ -16,6 +16,10 @@ using namespace muse::ui;
 using namespace muse::actions;
 
 static UiActionList STATIC_ACTIONS = {
+    UiAction("escape",
+             au::context::UiCtxProjectFocused,
+             muse::shortcuts::CTX_PROJECT_FOCUSED
+             ),
     UiAction("automation",
              au::context::UiCtxUnknown,
              au::context::CTX_PROJECT_OPENED,

--- a/src/projectscene/internal/projectsceneuiactions.cpp
+++ b/src/projectscene/internal/projectsceneuiactions.cpp
@@ -16,10 +16,6 @@ using namespace muse::ui;
 using namespace muse::actions;
 
 static UiActionList STATIC_ACTIONS = {
-    UiAction("escape",
-             au::context::UiCtxProjectFocused,
-             muse::shortcuts::CTX_PROJECT_FOCUSED
-             ),
     UiAction("automation",
              au::context::UiCtxUnknown,
              au::context::CTX_PROJECT_OPENED,

--- a/src/projectscene/internal/projectviewstate.cpp
+++ b/src/projectscene/internal/projectviewstate.cpp
@@ -73,6 +73,8 @@ ProjectViewState::ProjectViewState(std::shared_ptr<au::au3::IAu3Project> project
         return;
     }
 
+    au3::setViewStateRestorerNotification(*au3Project, m_rolledBack);
+
     m_tracksVerticalOffset.set(getProjectZoomState(au3Project).tracksVerticalOffset);
     m_tracksVerticalOffset.ch.onReceive(this, [au3Project](const int y) {
         ZoomState zoomState = getProjectZoomState(au3Project);
@@ -516,6 +518,11 @@ ZoomState ProjectViewState::zoomState() const
 {
     au::au3::Au3Project* project = reinterpret_cast<au::au3::Au3Project*>(globalContext()->currentProject()->au3ProjectPtr());
     return getProjectZoomState(project);
+}
+
+muse::async::Notification ProjectViewState::rolledBack() const
+{
+    return m_rolledBack;
 }
 
 muse::ValCh<bool> ProjectViewState::altPressed() const

--- a/src/projectscene/internal/projectviewstate.h
+++ b/src/projectscene/internal/projectviewstate.h
@@ -85,6 +85,8 @@ public:
     void setZoomState(const ZoomState& state) override;
     ZoomState zoomState() const override;
 
+    muse::async::Notification rolledBack() const override;
+
     muse::ValCh<bool> altPressed() const override;
     muse::ValCh<bool> ctrlPressed() const override;
 
@@ -128,5 +130,7 @@ private:
 
     muse::ValCh<bool> m_altPressed;
     muse::ValCh<bool> m_ctrlPressed;
+
+    muse::async::Notification m_rolledBack;
 };
 }

--- a/src/projectscene/iprojectviewstate.h
+++ b/src/projectscene/iprojectviewstate.h
@@ -2,6 +2,7 @@
 
 #include <memory>
 
+#include "global/async/notification.h"
 #include "global/types/retval.h"
 
 #include "trackedit/trackedittypes.h"
@@ -70,6 +71,8 @@ public:
 
     virtual void setZoomState(const ZoomState& state) = 0;
     virtual ZoomState zoomState() const = 0;
+
+    virtual muse::async::Notification rolledBack() const = 0;
 
     virtual muse::ValCh<bool> altPressed() const = 0;
     virtual muse::ValCh<bool> ctrlPressed() const = 0;

--- a/src/projectscene/projectscenemodule.cpp
+++ b/src/projectscene/projectscenemodule.cpp
@@ -38,6 +38,7 @@
 #include "view/clipsview/cliplistitem.h"
 #include "view/clipsview/waveview.h"
 #include "view/clipsview/clipcontextmenumodel.h"
+#include "view/clipsview/mousehelper.h"
 #include "view/clipsview/multiclipcontextmenumodel.h"
 #include "view/clipsview/canvascontextmenumodel.h"
 #include "view/clipsview/selectioncontextmenumodel.h"
@@ -158,6 +159,7 @@ void ProjectSceneModule::registerUiTypes()
     // clips view
     qmlRegisterType<TracksListClipsModel>("Audacity.ProjectScene", 1, 0, "TracksListClipsModel");
     qmlRegisterType<ClipsListModel>("Audacity.ProjectScene", 1, 0, "ClipsListModel");
+    qmlRegisterType<MouseHelper>("Audacity.ProjectScene", 1, 0, "MouseHelper");
     qmlRegisterUncreatableType<ClipListItem>("Audacity.ProjectScene", 1, 0, "ClipListItem", "Not creatable from QML");
     qmlRegisterType<WaveView>("Audacity.ProjectScene", 1, 0, "WaveView");
     qmlRegisterType<ClipContextMenuModel>("Audacity.ProjectScene", 1, 0, "ClipContextMenuModel");

--- a/src/projectscene/qml/Audacity/ProjectScene/clipsview/ClipHandles.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/clipsview/ClipHandles.qml
@@ -28,8 +28,8 @@ Item {
 
     property var trimStartPos
 
-    signal clipStartEditRequested()
-    signal clipEndEditRequested()
+    signal clipStartEditRequested
+    signal clipEndEditRequested
 
     signal trimLeftRequested(bool completed, int action)
     signal trimRightRequested(bool completed, int action)
@@ -38,7 +38,7 @@ Item {
     signal stretchRightRequested(bool completed, int action)
 
     //! NOTE: auto-scroll for trimming is triggered from clipslistmodel
-    signal stopAutoScroll()
+    signal stopAutoScroll
 
     Item {
         id: leftTrimHandle
@@ -58,7 +58,6 @@ Item {
 
             visible: debugRectsVisible
         }
-
 
         StyledIconLabel {
             id: leftArrow
@@ -99,12 +98,12 @@ Item {
                     root.leftTrimActive = !root.leftTrimActive
                 }
 
-                onNavigationEvent: function(event) {
+                onNavigationEvent: function (event) {
                     if (!root.leftTrimActive) {
                         return
                     }
 
-                    switch(event.type) {
+                    switch (event.type) {
                     case NavigationEvent.Left:
                         root.trimLeftRequested(true, ClipBoundaryAction.Expand)
                         event.accepted = true
@@ -150,13 +149,13 @@ Item {
             hoverEnabled: true
             cursorShape: Qt.SizeHorCursor
 
-            onPressed: function(e) {
+            onPressed: function (e) {
                 root.clipStartEditRequested()
             }
 
-            onReleased: function(e) {
+            onReleased: function (e) {
                 root.trimLeftRequested(true, ClipBoundaryAction.Auto)
-                root.stopAutoScroll()
+                root.stopAutoScroll();
 
                 // this needs to be always at the very end
                 root.clipEndEditRequested()
@@ -172,7 +171,7 @@ Item {
                 }
             }
 
-            onPositionChanged: function(e) {
+            onPositionChanged: function (e) {
                 clipHandlesMousePositionChanged(mouseX + leftTrimHandle.x, mouseY)
 
                 if (pressed) {
@@ -240,12 +239,12 @@ Item {
                     root.rightTrimActive = !root.rightTrimActive
                 }
 
-                onNavigationEvent: function(event) {
+                onNavigationEvent: function (event) {
                     if (!root.rightTrimActive) {
                         return
                     }
 
-                    switch(event.type) {
+                    switch (event.type) {
                     case NavigationEvent.Left:
                         root.trimRightRequested(true, ClipBoundaryAction.Shrink)
                         event.accepted = true
@@ -291,13 +290,13 @@ Item {
             hoverEnabled: true
             cursorShape: Qt.SizeHorCursor
 
-            onPressed: function(e) {
+            onPressed: function (e) {
                 root.clipStartEditRequested()
             }
 
-            onReleased: function(e) {
+            onReleased: function (e) {
                 root.trimRightRequested(true, ClipBoundaryAction.Auto)
-                root.stopAutoScroll()
+                root.stopAutoScroll();
 
                 // this needs to be always at the very end
                 root.clipEndEditRequested()
@@ -313,7 +312,7 @@ Item {
                 }
             }
 
-            onPositionChanged: function(e) {
+            onPositionChanged: function (e) {
                 clipHandlesMousePositionChanged(mouseX + rightTrimHandle.x, mouseY)
 
                 if (pressed) {
@@ -391,12 +390,12 @@ Item {
                     root.leftStretchActive = !root.leftStretchActive
                 }
 
-                onNavigationEvent: function(event) {
+                onNavigationEvent: function (event) {
                     if (!root.leftStretchActive) {
                         return
                     }
 
-                    switch(event.type) {
+                    switch (event.type) {
                     case NavigationEvent.Left:
                         root.stretchLeftRequested(true, ClipBoundaryAction.Expand)
                         event.accepted = true
@@ -455,7 +454,7 @@ Item {
 
             onReleased: {
                 root.stretchLeftRequested(true, ClipBoundaryAction.Auto)
-                root.stopAutoScroll()
+                root.stopAutoScroll();
 
                 // this needs to be always at the very end
                 root.clipEndEditRequested()
@@ -545,12 +544,12 @@ Item {
                         root.rightStretchActive = !root.rightStretchActive
                     }
 
-                    onNavigationEvent: function(event) {
+                    onNavigationEvent: function (event) {
                         if (!root.rightStretchActive) {
                             return
                         }
 
-                        switch(event.type) {
+                        switch (event.type) {
                         case NavigationEvent.Left:
                             root.stretchRightRequested(true, ClipBoundaryAction.Shrink)
                             event.accepted = true
@@ -610,7 +609,7 @@ Item {
 
             onReleased: {
                 root.stretchRightRequested(true, ClipBoundaryAction.Auto)
-                root.stopAutoScroll()
+                root.stopAutoScroll();
 
                 // this needs to be always at the very end
                 root.clipEndEditRequested()
@@ -642,33 +641,53 @@ Item {
             name: "NORMAL"
             when: !leftTrimMa.containsMouse && !rightTrimMa.containsMouse && !leftTimeMa.containsMouse && !rightTimeMa.containsMouse
         },
-
         State {
             name: "LEFT_TRIM_HOVERED"
             when: leftTrimMa.containsMouse
-            PropertyChanges { target: leftArrow; font.pixelSize: 40 }
-            PropertyChanges { target: leftArrow; anchors.leftMargin: -10}
+            PropertyChanges {
+                target: leftArrow
+                font.pixelSize: 40
+            }
+            PropertyChanges {
+                target: leftArrow
+                anchors.leftMargin: -10
+            }
         },
-
         State {
             name: "RIGHT_TRIM_HOVERED"
             when: rightTrimMa.containsMouse
-            PropertyChanges { target: rightArrow; font.pixelSize: 40 }
-            PropertyChanges { target: rightArrow; anchors.rightMargin: -10}
+            PropertyChanges {
+                target: rightArrow
+                font.pixelSize: 40
+            }
+            PropertyChanges {
+                target: rightArrow
+                anchors.rightMargin: -10
+            }
         },
-
         State {
             name: "LEFT_TIME_HOVERED"
             when: leftTimeMa.containsMouse
-            PropertyChanges { target: leftClockIcon; font.pixelSize: 18 }
-            PropertyChanges { target: leftClock; anchors.leftMargin: 2 }
+            PropertyChanges {
+                target: leftClockIcon
+                font.pixelSize: 18
+            }
+            PropertyChanges {
+                target: leftClock
+                anchors.leftMargin: 2
+            }
         },
-
         State {
             name: "RIGHT_TIME_HOVERED"
             when: rightTimeMa.containsMouse
-            PropertyChanges { target: rightClockIcon; font.pixelSize: 18 }
-            PropertyChanges { target: rightClock; anchors.rightMargin: 2 }
+            PropertyChanges {
+                target: rightClockIcon
+                font.pixelSize: 18
+            }
+            PropertyChanges {
+                target: rightClock
+                anchors.rightMargin: 2
+            }
         }
     ]
 

--- a/src/projectscene/qml/Audacity/ProjectScene/clipsview/ClipHandles.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/clipsview/ClipHandles.qml
@@ -30,6 +30,7 @@ Item {
 
     signal clipStartEditRequested
     signal clipEndEditRequested
+    signal cancelClipDragEditRequested
 
     signal trimLeftRequested(bool completed, int action)
     signal trimRightRequested(bool completed, int action)
@@ -178,6 +179,10 @@ Item {
                     root.trimLeftRequested(false, ClipBoundaryAction.Auto)
                 }
             }
+
+            onCanceled: function (e) {
+                cancelClipDragEditRequested()
+            }
         }
     }
 
@@ -318,6 +323,10 @@ Item {
                 if (pressed) {
                     root.trimRightRequested(false, ClipBoundaryAction.Auto)
                 }
+            }
+
+            onCanceled: function (e) {
+                cancelClipDragEditRequested()
             }
         }
     }
@@ -477,6 +486,10 @@ Item {
                     root.stretchLeftRequested(false, ClipBoundaryAction.Auto)
                 }
             }
+
+            onCanceled: function (e) {
+                cancelClipDragEditRequested()
+            }
         }
     }
 
@@ -631,6 +644,10 @@ Item {
                 if (pressed) {
                     root.stretchRightRequested(false, ClipBoundaryAction.Auto)
                 }
+            }
+
+            onCanceled: function (e) {
+                cancelClipDragEditRequested()
             }
         }
     }

--- a/src/projectscene/qml/Audacity/ProjectScene/clipsview/ClipItem.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/clipsview/ClipItem.qml
@@ -144,7 +144,7 @@ Rectangle {
         name: "ClipNavigationPanel"
         enabled: navCtrl.active
         direction: NavigationPanel.Horizontal
-        section: navigation.panel.section
+        section: navigation.panel ? navigation.panel.section : null
         onActiveChanged: function (active) {
             if (active) {
                 root.forceActiveFocus()

--- a/src/projectscene/qml/Audacity/ProjectScene/clipsview/ClipItem.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/clipsview/ClipItem.qml
@@ -54,6 +54,7 @@ Rectangle {
 
     signal clipStartEditRequested
     signal clipEndEditRequested
+    signal cancelClipDragEditRequested
 
     signal clipLeftTrimRequested(bool completed, int action)
     signal clipRightTrimRequested(bool completed, int action)
@@ -353,6 +354,10 @@ Rectangle {
                 }
             }
         }
+
+        onCanceled: e => {
+            root.cancelClipDragEditRequested()
+        }
     }
 
     MouseArea {
@@ -409,6 +414,10 @@ Rectangle {
                     root.clipRightTrimRequested(false, ClipBoundaryAction.Shrink)
                 }
             }
+        }
+
+        onCanceled: e => {
+            root.cancelClipDragEditRequested()
         }
     }
 
@@ -812,6 +821,10 @@ Rectangle {
 
         onClipEndEditRequested: function () {
             root.clipEndEditRequested()
+        }
+
+        onCancelClipDragEditRequested: function () {
+            root.cancelClipDragEditRequested()
         }
 
         onTrimLeftRequested: function (completed, action) {

--- a/src/projectscene/qml/Audacity/ProjectScene/clipsview/ClipItem.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/clipsview/ClipItem.qml
@@ -138,7 +138,6 @@ Rectangle {
         readonly property int doubleClickMaxDistance: 5
     }
 
-
     // panel for navigating within the clip's items
     property NavigationPanel clipNavigationPanel: NavigationPanel {
         name: "ClipNavigationPanel"
@@ -495,9 +494,7 @@ Rectangle {
                 onPositionChanged: function (e) {
                     // Reset double click timer if the mouse has moved,
                     // to prevent rapid clip movement activate title editing
-                    if (Math.abs(e.x - doubleClickStartPosition.x) > prv.doubleClickMaxDistance ||
-                        Math.abs(e.y - doubleClickStartPosition.y) > prv.doubleClickMaxDistance) {
-
+                    if (Math.abs(e.x - doubleClickStartPosition.x) > prv.doubleClickMaxDistance || Math.abs(e.y - doubleClickStartPosition.y) > prv.doubleClickMaxDistance) {
                         lastClickTime = 0
                     }
 

--- a/src/projectscene/qml/Audacity/ProjectScene/clipsview/TrackClipsItem.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/clipsview/TrackClipsItem.qml
@@ -6,7 +6,6 @@ import Muse.UiComponents
 import Audacity.ProjectScene
 
 Item {
-
     id: root
 
     property NavigationSection navigationSection: null
@@ -38,14 +37,14 @@ Item {
     property bool selectionInProgress: false
     property bool hover: false
 
-    signal interactionStarted()
-    signal interactionEnded()
+    signal interactionStarted
+    signal interactionEnded
     // mouse position event is not propagated on overlapping mouse areas
     // so we are handling it manually
     signal trackItemMousePositionChanged(real x, real y, var clipKey)
     signal setHoveredClipKey(var clipKey)
-    signal clipSelectedRequested()
-    signal selectionResetRequested()
+    signal clipSelectedRequested
+    signal selectionResetRequested
     signal updateMoveActive(bool completed)
     signal requestSelectionContextMenu(real x, real y)
 
@@ -81,7 +80,10 @@ Item {
 
     onCtrlPressedChanged: {
         if (!root.ctrlPressed) {
-            clipsContainer.mapToAllClips({x: 0, y: 0}, function(clipItem, mouseEvent) {
+            clipsContainer.mapToAllClips({
+                x: 0,
+                y: 0
+            }, function (clipItem, mouseEvent) {
                 clipItem.isIsolationMode = false
             })
         }
@@ -96,7 +98,7 @@ Item {
         property double targetHeightRatio: 0.5
         readonly property int minChannelHeight: 20
         readonly property int yMinValue: Math.min(root.height / 2, minChannelHeight)
-        readonly property int yMaxValue: Math.max(root.height / 2, root.height - minChannelHeight);
+        readonly property int yMaxValue: Math.max(root.height / 2, root.height - minChannelHeight)
 
         property bool isNearSample: false
         property bool multiSampleEdit: false
@@ -113,7 +115,12 @@ Item {
                 let clipLoader = repeator.itemAt(i)
                 if (clipLoader && clipLoader.item) {
                     let clipPos = clipLoader.mapFromItem(this, e.x, e.y)
-                    f(clipLoader.item, {button: e.button, modifiers: e.modifiers, x: clipPos.x, y: clipPos.y})
+                    f(clipLoader.item, {
+                        button: e.button,
+                        modifiers: e.modifiers,
+                        x: clipPos.x,
+                        y: clipPos.y
+                    })
                 }
             }
         }
@@ -149,32 +156,29 @@ Item {
             hoverEnabled: true
             pressAndHoldInterval: 0
             enabled: !root.selectionInProgress && (clipsContainer.isNearSample || clipsContainer.isBrush)
-            cursorShape: root.selectionEditInProgress ? Qt.SizeHorCursor : Qt.IBeamCursor 
+            cursorShape: root.selectionEditInProgress ? Qt.SizeHorCursor : Qt.IBeamCursor
 
             anchors.fill: parent
 
-            onDoubleClicked: function(e) {
+            onDoubleClicked: function (e) {
                 e.accepted = true
             }
 
-            onPressAndHold: function(e) {
+            onPressAndHold: function (e) {
                 if (clipsContainer.isNearSample || root.altPressed) {
-
                     if (root.ctrlPressed) {
                         clipsContainer.isIsolationMode = true
-                    }
-                    else if (!root.altPressed) {
+                    } else if (!root.altPressed) {
                         clipsContainer.multiSampleEdit = true
                     }
 
-                    clipsContainer.mapToAllClips(e, function(clipItem, mouseEvent) {
+                    clipsContainer.mapToAllClips(e, function (clipItem, mouseEvent) {
                         clipItem.mousePressAndHold(mouseEvent.x, mouseEvent.y)
                         clipItem.setLastSample(mouseEvent.x, mouseEvent.y)
 
                         if (root.ctrlPressed) {
                             clipItem.isIsolationMode = true
-                        }
-                        else if (!root.altPressed) {
+                        } else if (!root.altPressed) {
                             clipItem.multiSampleEdit = true
                         }
                         clipItem.currentChannel = clipsContainer.currentChannel
@@ -185,26 +189,29 @@ Item {
                 }
             }
 
-            onReleased: function(e) {
+            onReleased: function (e) {
                 clipsContainer.multiSampleEdit = false
                 clipsContainer.isIsolationMode = false
 
-                clipsContainer.mapToAllClips(e, function(clipItem, mouseEvent) {
+                clipsContainer.mapToAllClips(e, function (clipItem, mouseEvent) {
                     clipItem.multiSampleEdit = false
                     clipItem.isIsolationMode = false
                     clipItem.mouseReleased(mouseEvent.x, mouseEvent.y)
                 })
             }
 
-            onPositionChanged: function(e) {
-                clipsContainer.mapToAllClips(e, function(clipItem, mouseEvent) {
+            onPositionChanged: function (e) {
+                clipsContainer.mapToAllClips(e, function (clipItem, mouseEvent) {
                     clipItem.mousePositionChanged(mouseEvent.x, mouseEvent.y)
                     clipItem.setLastSample(mouseEvent.x, mouseEvent.y)
                 })
             }
 
-            onContainsMouseChanged: function() {
-                clipsContainer.mapToAllClips({x: mouseX, y: mouseY}, function(clipItem, mouseEvent) {
+            onContainsMouseChanged: function () {
+                clipsContainer.mapToAllClips({
+                    x: mouseX,
+                    y: mouseY
+                }, function (clipItem, mouseEvent) {
                     clipItem.containsMouseChanged(containsMouse)
                 })
             }
@@ -284,8 +291,7 @@ Item {
 
                 //! NOTE: use the same integer rounding as in WaveBitmapCache
                 selectionStart: root.context.selectionStartPosition < clipItem.x ? 0 : Math.floor(root.context.selectionStartPosition - clipItem.x + 0.5)
-                selectionWidth: root.context.selectionStartPosition < clipItem.x ?
-                                    Math.round(root.context.selectionEndPosition - clipItem.x) : Math.floor(root.context.selectionEndPosition - clipItem.x + 0.5)  - Math.floor(root.context.selectionStartPosition - clipItem.x + 0.5)
+                selectionWidth: root.context.selectionStartPosition < clipItem.x ? Math.round(root.context.selectionEndPosition - clipItem.x) : Math.floor(root.context.selectionEndPosition - clipItem.x + 0.5) - Math.floor(root.context.selectionStartPosition - clipItem.x + 0.5)
 
                 leftVisibleMargin: clipItem.leftVisibleMargin
                 rightVisibleMargin: clipItem.rightVisibleMargin
@@ -319,8 +325,8 @@ Item {
                     return rightNeighbor.x - (clipItem.x + clipItem.width)
                 }
 
-                onIsNearSampleChanged: function() {
-                    clipsContainer.isNearSample = clipsContainer.checkIfAnyClip(function(clipItem) {
+                onIsNearSampleChanged: function () {
+                    clipsContainer.isNearSample = clipsContainer.checkIfAnyClip(function (clipItem) {
                         if (clipItem.isNearSample) {
                             clipsContainer.currentChannel = clipItem.currentChannel
                         }
@@ -328,75 +334,75 @@ Item {
                     })
                 }
 
-                onHoverChanged: function() {
-                    root.hover = clipsContainer.checkIfAnyClip(function(clipItem) {
+                onHoverChanged: function () {
+                    root.hover = clipsContainer.checkIfAnyClip(function (clipItem) {
                         return clipItem && clipItem.hover
                     })
                 }
 
-                onIsBrushChanged: function() {
-                    clipsContainer.isBrush = clipsContainer.checkIfAnyClip(function(clipItem) {
+                onIsBrushChanged: function () {
+                    clipsContainer.isBrush = clipsContainer.checkIfAnyClip(function (clipItem) {
                         return clipItem && clipItem.isBrush
                     })
                 }
 
-                onLeftTrimContainsMouseChanged: function() {
-                    clipsContainer.leftTrimContainsMouse = clipsContainer.checkIfAnyClip(function(clipItem) {
+                onLeftTrimContainsMouseChanged: function () {
+                    clipsContainer.leftTrimContainsMouse = clipsContainer.checkIfAnyClip(function (clipItem) {
                         return clipItem && clipItem.leftTrimContainsMouse
                     })
                 }
 
-                onRightTrimContainsMouseChanged: function() {
-                    clipsContainer.rightTrimContainsMouse = clipsContainer.checkIfAnyClip(function(clipItem) {
+                onRightTrimContainsMouseChanged: function () {
+                    clipsContainer.rightTrimContainsMouse = clipsContainer.checkIfAnyClip(function (clipItem) {
                         return clipItem && clipItem.rightTrimContainsMouse
                     })
                 }
 
-                onLeftTrimPressedButtonsChanged: function() {
-                    clipsContainer.leftTrimPressedButtons = clipsContainer.checkIfAnyClip(function(clipItem) {
+                onLeftTrimPressedButtonsChanged: function () {
+                    clipsContainer.leftTrimPressedButtons = clipsContainer.checkIfAnyClip(function (clipItem) {
                         return clipItem && clipItem.leftTrimPressedButtons
                     })
                 }
 
-                onRightTrimPressedButtonsChanged: function() {
-                    clipsContainer.rightTrimPressedButtons = clipsContainer.checkIfAnyClip(function(clipItem) {
+                onRightTrimPressedButtonsChanged: function () {
+                    clipsContainer.rightTrimPressedButtons = clipsContainer.checkIfAnyClip(function (clipItem) {
                         return clipItem && clipItem.rightTrimPressedButtons
                     })
                 }
 
-                onHeaderHoveredChanged: function() {
+                onHeaderHoveredChanged: function () {
                     root.clipHeaderHoveredChanged(headerHovered)
                 }
 
-                onClipStartEditRequested: function() {
+                onClipStartEditRequested: function () {
                     clipsModel.startEditClip(clipItem.key)
                 }
 
-                onClipEndEditRequested: function() {
+                onClipEndEditRequested: function () {
                     clipsModel.endEditClip(clipItem.key)
 
                     root.triggerClipGuideline(false, -1)
                 }
 
-                onClipLeftTrimRequested: function(completed, action) {
+                onClipLeftTrimRequested: function (completed, action) {
                     clipsModel.trimLeftClip(clipItem.key, completed, action)
 
                     handleClipGuideline(clipItem.key, Direction.Left, completed)
                 }
 
-                onClipRightTrimRequested: function(completed, action) {
+                onClipRightTrimRequested: function (completed, action) {
                     clipsModel.trimRightClip(clipItem.key, completed, action)
 
                     handleClipGuideline(clipItem.key, Direction.Right, completed)
                 }
 
-                onClipLeftStretchRequested: function(completed, action) {
+                onClipLeftStretchRequested: function (completed, action) {
                     clipsModel.stretchLeftClip(clipItem.key, completed, action)
 
                     handleClipGuideline(clipItem.key, Direction.Left, completed)
                 }
 
-                onClipRightStretchRequested: function(completed, action) {
+                onClipRightStretchRequested: function (completed, action) {
                     clipsModel.stretchRightClip(clipItem.key, completed, action)
 
                     handleClipGuideline(clipItem.key, Direction.Right, completed)
@@ -410,7 +416,7 @@ Item {
                     root.context.stopAutoScroll()
                 }
 
-                onClipItemMousePositionChanged: function(xWithinClip, yWithinClip) {
+                onClipItemMousePositionChanged: function (xWithinClip, yWithinClip) {
                     var yWithinTrack = yWithinClip
                     var xWithinTrack = xWithinClip + clipItem.x
 
@@ -434,7 +440,7 @@ Item {
                     clipsModel.selectClip(clipItem.key)
                 }
 
-                onTitleEditAccepted: function(newTitle) {
+                onTitleEditAccepted: function (newTitle) {
                     root.changeClipTitle(clipItem.key, newTitle)
                 }
 
@@ -489,19 +495,19 @@ Item {
         anchors.fill: parent
         z: 1
 
-        onSelectionDraged: function(x1, x2, completed) {
+        onSelectionDraged: function (x1, x2, completed) {
             root.selectionDraged(x1, x2, completed)
             if (completed) {
                 root.seekToX(Math.min(x1, x2))
             }
         }
 
-        onRequestSelectionContextMenu: function(x, y) {
+        onRequestSelectionContextMenu: function (x, y) {
             let position = mapToItem(root.parent, Qt.point(x, y))
             root.requestSelectionContextMenu(position.x, position.y)
         }
 
-        onHandleGuideline: function(x, completed) {
+        onHandleGuideline: function (x, completed) {
             root.handleTimeGuideline(x, completed)
         }
     }
@@ -562,7 +568,7 @@ Item {
             root.interactionStarted()
         }
 
-        onPositionChanged: function(mouse) {
+        onPositionChanged: function (mouse) {
             const resizeVerticalMargin = 10
             mouse.accepted = true
 
@@ -593,7 +599,7 @@ Item {
         opacity: 0.05
         visible: isStereo
 
-        onPositionChangeRequested: function(position) {
+        onPositionChangeRequested: function (position) {
             clipsContainer.updateChannelHeightRatio(position)
             clipsContainer.resetTargetHeightRatio()
         }
@@ -628,15 +634,15 @@ Item {
 
         function onClipMoveRequested(clipKey, completed) {
             // this one notifies every ClipListModel about moveActive
-            root.updateMoveActive(completed)
+            root.updateMoveActive(completed);
 
             // this one moves the clips
-            let clipMovedToOtherTrack = clipsModel.moveSelectedClips(clipKey, completed)
+            let clipMovedToOtherTrack = clipsModel.moveSelectedClips(clipKey, completed);
 
             // clip might change its' track, we need to update grabbed clipKey
             if (clipMovedToOtherTrack) {
                 clipKey = clipsModel.updateClipTrack(clipKey)
-                setHoveredClipKey(clipsModel.updateClipTrack(clipKey));
+                setHoveredClipKey(clipsModel.updateClipTrack(clipKey))
             }
 
             handleClipGuideline(clipKey, Direction.Auto, completed)

--- a/src/projectscene/qml/Audacity/ProjectScene/clipsview/TrackClipsItem.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/clipsview/TrackClipsItem.qml
@@ -56,6 +56,7 @@ Item {
 
     signal handleTimeGuideline(real x, bool completed)
     signal triggerClipGuideline(real x, bool completed)
+    signal clipDragEditCanceled
 
     height: trackViewState.trackHeight
 
@@ -384,6 +385,12 @@ Item {
                     root.triggerClipGuideline(false, -1)
                 }
 
+                onCancelClipDragEditRequested: function () {
+                    if (clipsModel.cancelClipDragEdit(clipItem.key)) {
+                        root.clipDragEditCanceled()
+                    }
+                }
+
                 onClipLeftTrimRequested: function (completed, action) {
                     clipsModel.trimLeftClip(clipItem.key, completed, action)
 
@@ -654,6 +661,12 @@ Item {
 
         function onClipEndEditRequested(clipKey) {
             clipsModel.endEditClip(clipKey)
+        }
+
+        function onCancelClipDragEditRequested(clipKey) {
+            if (clipsModel.cancelClipDragEdit(clipKey)) {
+                root.clipDragEditCanceled()
+            }
         }
 
         function onStartAutoScroll() {

--- a/src/projectscene/qml/Audacity/ProjectScene/clipsview/TracksClipsView.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/clipsview/TracksClipsView.qml
@@ -48,11 +48,13 @@ Rectangle {
         id: prv
 
         property bool playRegionActivated: false
+        property bool releasedThroughCancel: false
 
         function cancelClipDragEdit() {
             if (root.hoveredClipKey) {
                 tracksClipsView.cancelClipDragEditRequested(root.hoveredClipKey)
             }
+            releasedThroughCancel = true
         }
     }
 
@@ -402,6 +404,7 @@ Rectangle {
                 }
 
                 if (e.button === Qt.LeftButton) {
+                    prv.releasedThroughCancel = false
                     tracksModel.startUserInteraction()
 
                     if (root.clipHeaderHovered) {
@@ -447,6 +450,16 @@ Rectangle {
 
             onReleased: e => {
                 if (e.button !== Qt.LeftButton) {
+                    return
+                }
+
+                if (prv.releasedThroughCancel) {
+                    prv.releasedThroughCancel = false
+                    return
+                }
+
+                if (prv.releasedThroughCancel) {
+                    prv.releasedThroughCancel = false
                     return
                 }
 

--- a/src/projectscene/qml/Audacity/ProjectScene/clipsview/TracksClipsView.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/clipsview/TracksClipsView.qml
@@ -405,7 +405,6 @@ Rectangle {
 
                 if (e.button === Qt.LeftButton) {
                     prv.releasedThroughCancel = false
-                    tracksModel.startUserInteraction()
 
                     if (root.clipHeaderHovered) {
                         tracksClipsView.clipStartEditRequested(hoveredClipKey)
@@ -485,8 +484,6 @@ Rectangle {
 
                     playCursorController.setPlaybackRegion(timeline.context.selectionStartPosition, timeline.context.selectionEndPosition)
                 }
-
-                tracksModel.endUserInteraction()
             }
 
             onCanceled: e => {
@@ -716,7 +713,6 @@ Rectangle {
                     onClipDragEditCanceled: {
                         root.hoveredClipKey = null
                         root.clipHeaderHovered = false
-                        tracksModel.endUserInteraction()
                     }
 
                     onIsBrushChanged: function () {

--- a/src/projectscene/qml/Audacity/ProjectScene/clipsview/TracksClipsView.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/clipsview/TracksClipsView.qml
@@ -445,8 +445,7 @@ Rectangle {
                     tracksClipsView.clipMoveRequested(hoveredClipKey, true)
                     tracksClipsView.stopAutoScroll()
                     tracksClipsView.clipEndEditRequested(hoveredClipKey)
-                }
-                else {
+                } else {
                     splitToolController.mouseUp(e.x)
 
                     if (selectionController.isLeftSelection(e.x)) {

--- a/src/projectscene/qml/Audacity/ProjectScene/clipsview/TracksClipsView.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/clipsview/TracksClipsView.qml
@@ -709,6 +709,7 @@ Rectangle {
                     onClipDragEditCanceled: {
                         root.hoveredClipKey = null
                         root.clipHeaderHovered = false
+                        tracksClipsView.moveActive = false
                         timeline.context.updateSelectedClipTime()
                     }
 

--- a/src/projectscene/qml/Audacity/ProjectScene/clipsview/TracksClipsView.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/clipsview/TracksClipsView.qml
@@ -44,6 +44,18 @@ Rectangle {
 
     property int interactionState: TracksClipsView.State.Idle
 
+    QtObject {
+        id: prv
+
+        property bool playRegionActivated: false
+
+        function cancelClipDragEdit() {
+            if (root.hoveredClipKey) {
+                tracksClipsView.cancelClipDragEditRequested(root.hoveredClipKey)
+            }
+        }
+    }
+
     PlaybackStateModel {
         id: playbackState
     }
@@ -53,6 +65,10 @@ Rectangle {
 
         onTotalTracksHeightChanged: {
             timeline.context.onResizeFrameContentHeight(tracksModel.totalTracksHeight)
+        }
+
+        onEscapePressed: {
+            prv.cancelClipDragEdit()
         }
     }
 
@@ -220,12 +236,6 @@ Rectangle {
                 id: timelineMouseArea
                 anchors.fill: parent
                 hoverEnabled: true
-
-                QtObject {
-                    id: prv
-
-                    property bool playRegionActivated: false
-                }
 
                 onPositionChanged: function (e) {
                     timeline.updateCursorPosition(e.x, e.y)
@@ -469,7 +479,7 @@ Rectangle {
             onCanceled: e => {
                 console.log("User interaction canceled")
                 root.interactionState = TracksClipsView.State.Idle
-                tracksModel.endUserInteraction()
+                prv.cancelClipDragEdit()
             }
 
             onClicked: e => {
@@ -542,6 +552,7 @@ Rectangle {
                 signal clipMoveRequested(var clipKey, bool completed)
                 signal clipStartEditRequested(var clipKey)
                 signal clipEndEditRequested(var clipKey)
+                signal cancelClipDragEditRequested(var clipKey)
                 signal startAutoScroll
                 signal stopAutoScroll
 
@@ -687,6 +698,12 @@ Rectangle {
 
                     onInteractionEnded: {
                         tracksViewState.requestVerticalScrollUnlock()
+                    }
+
+                    onClipDragEditCanceled: {
+                        root.hoveredClipKey = null
+                        root.clipHeaderHovered = false
+                        tracksModel.endUserInteraction()
                     }
 
                     onIsBrushChanged: function () {

--- a/src/projectscene/qml/Audacity/ProjectScene/clipsview/TracksClipsView.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/clipsview/TracksClipsView.qml
@@ -713,6 +713,7 @@ Rectangle {
                     onClipDragEditCanceled: {
                         root.hoveredClipKey = null
                         root.clipHeaderHovered = false
+                        timeline.context.updateSelectedClipTime()
                     }
 
                     onIsBrushChanged: function () {

--- a/src/projectscene/view/clipsview/clipslistmodel.cpp
+++ b/src/projectscene/view/clipsview/clipslistmodel.cpp
@@ -730,7 +730,6 @@ bool ClipsListModel::cancelClipDragEdit(const ClipKey& key)
     vs->setMoveInitiated(false);
 
     m_context->stopAutoScroll();
-    m_context->scrollHorizontal(0);
     disconnectAutoScroll();
 
     trackeditInteraction()->cancelClipEdit();

--- a/src/projectscene/view/clipsview/clipslistmodel.cpp
+++ b/src/projectscene/view/clipsview/clipslistmodel.cpp
@@ -713,6 +713,33 @@ void ClipsListModel::endEditClip(const ClipKey& key)
     vs->updateClipsBoundaries(true);
 }
 
+bool ClipsListModel::cancelClipDragEdit(const ClipKey& key)
+{
+    ClipListItem* item = itemByKey(key.key);
+    if (!item) {
+        return false;
+    }
+
+    auto vs = globalContext()->currentProject()->viewState();
+    IF_ASSERT_FAILED(vs) {
+        return false;
+    }
+
+    vs->setClipEditStartTimeOffset(-1.0);
+    vs->setClipEditEndTimeOffset(-1.0);
+    vs->setMoveInitiated(false);
+
+    m_context->stopAutoScroll();
+    m_context->scrollHorizontal(0);
+    disconnectAutoScroll();
+
+    trackeditInteraction()->cancelClipEdit();
+
+    vs->updateClipsBoundaries(true);
+
+    return true;
+}
+
 /*!
  * \brief Moves all selected clips
  * \param key - the key from which the offset will be calculated to move all clips

--- a/src/projectscene/view/clipsview/clipslistmodel.cpp
+++ b/src/projectscene/view/clipsview/clipslistmodel.cpp
@@ -686,6 +686,8 @@ void ClipsListModel::startEditClip(const ClipKey& key)
         return;
     }
 
+    projectHistory()->startUserInteraction();
+
     double mousePositionTime = m_context->mousePositionTime();
 
     vs->setClipEditStartTimeOffset(mousePositionTime - item->clip().startTime);
@@ -711,6 +713,8 @@ void ClipsListModel::endEditClip(const ClipKey& key)
     vs->setClipEditEndTimeOffset(-1.0);
     vs->setMoveInitiated(false);
     vs->updateClipsBoundaries(true);
+
+    projectHistory()->endUserInteraction();
 }
 
 bool ClipsListModel::cancelClipDragEdit(const ClipKey& key)
@@ -735,6 +739,9 @@ bool ClipsListModel::cancelClipDragEdit(const ClipKey& key)
     trackeditInteraction()->cancelClipDragEdit();
 
     vs->updateClipsBoundaries(true);
+
+    constexpr auto modifyState = false;
+    projectHistory()->endUserInteraction(modifyState);
 
     return true;
 }

--- a/src/projectscene/view/clipsview/clipslistmodel.cpp
+++ b/src/projectscene/view/clipsview/clipslistmodel.cpp
@@ -473,7 +473,8 @@ int ClipsListModel::calculateTrackPositionOffset(const ClipKey& key) const
     }
 
     bool pointingAtEmptySpace = yPos > vs->totalTrackHeight().val - vs->tracksVerticalOffset().val;
-    int trackPositionOffset = pointingAtEmptySpace ? tracks.size() : tracks.size() - 1;
+    const auto numTracks = static_cast<int>(tracks.size());
+    int trackPositionOffset = pointingAtEmptySpace ? numTracks : numTracks - 1;
 
     if (!muse::RealIsEqualOrMore(yPos, trackVerticalPosition)) {
         trackPositionOffset = -trackPositionOffset;
@@ -1021,8 +1022,8 @@ void ClipsListModel::selectClip(const ClipKey& key)
     if (clipGroupId != -1) {
         //! NOTE: clip belongs to a group, select the whole group
         if (modifiers.testFlag(Qt::ShiftModifier)) {
-            for (const auto& key : trackeditInteraction()->clipsInGroup(clipGroupId)) {
-                selectionController()->addSelectedClip(key);
+            for (const auto& groupClipKey : trackeditInteraction()->clipsInGroup(clipGroupId)) {
+                selectionController()->addSelectedClip(groupClipKey);
             }
         } else {
             selectionController()->setSelectedClips(trackeditInteraction()->clipsInGroup(clipGroupId), complete);

--- a/src/projectscene/view/clipsview/clipslistmodel.cpp
+++ b/src/projectscene/view/clipsview/clipslistmodel.cpp
@@ -732,7 +732,7 @@ bool ClipsListModel::cancelClipDragEdit(const ClipKey& key)
     m_context->stopAutoScroll();
     disconnectAutoScroll();
 
-    trackeditInteraction()->cancelClipEdit();
+    trackeditInteraction()->cancelClipDragEdit();
 
     vs->updateClipsBoundaries(true);
 

--- a/src/projectscene/view/clipsview/clipslistmodel.h
+++ b/src/projectscene/view/clipsview/clipslistmodel.h
@@ -58,6 +58,7 @@ public:
 
     Q_INVOKABLE void startEditClip(const ClipKey& key);
     Q_INVOKABLE void endEditClip(const ClipKey& key);
+    Q_INVOKABLE bool cancelClipDragEdit(const ClipKey& key);
 
     Q_INVOKABLE bool moveSelectedClips(const ClipKey& key, bool completed);
     Q_INVOKABLE bool trimLeftClip(const ClipKey& key, bool completed, ClipBoundary::Action action = ClipBoundary::Action::Shrink);

--- a/src/projectscene/view/clipsview/clipslistmodel.h
+++ b/src/projectscene/view/clipsview/clipslistmodel.h
@@ -16,6 +16,7 @@
 #include "trackedit/iselectioncontroller.h"
 #include "trackedit/itrackeditinteraction.h"
 #include "trackedit/trackedittypes.h"
+#include "trackedit/iprojecthistory.h"
 #include "../timeline/timelinecontext.h"
 
 #include "cliplistitem.h"
@@ -41,6 +42,7 @@ class ClipsListModel : public QAbstractListModel, public muse::async::Asyncable,
     muse::Inject<trackedit::ISelectionController> selectionController;
     muse::Inject<projectscene::IProjectSceneConfiguration> projectSceneConfiguration;
     muse::Inject<muse::workspace::IWorkspaceManager> workspacesManager;
+    muse::Inject<trackedit::IProjectHistory> projectHistory;
 
 public:
     explicit ClipsListModel(QObject* parent = nullptr);

--- a/src/projectscene/view/clipsview/mousehelper.cpp
+++ b/src/projectscene/view/clipsview/mousehelper.cpp
@@ -1,0 +1,13 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+#include "mousehelper.h"
+
+namespace au::projectscene {
+void MouseHelper::callUngrabMouseOnItem(QQuickItem* item)
+{
+    if (item) {
+        item->ungrabMouse();
+    }
+}
+}

--- a/src/projectscene/view/clipsview/mousehelper.h
+++ b/src/projectscene/view/clipsview/mousehelper.h
@@ -1,0 +1,15 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+#pragma once
+
+#include <QQuickItem>
+
+namespace au::projectscene {
+class MouseHelper : public QObject
+{
+    Q_OBJECT
+public:
+    Q_INVOKABLE void callUngrabMouseOnItem(QQuickItem* item);
+};
+}

--- a/src/projectscene/view/clipsview/trackslistclipsmodel.cpp
+++ b/src/projectscene/view/clipsview/trackslistclipsmodel.cpp
@@ -23,6 +23,8 @@ void TracksListClipsModel::load()
         load();
     });
 
+    dispatcher()->reg(this, "escape", [this] { emit escapePressed(); });
+
     au::trackedit::ITrackeditProjectPtr prj = globalContext()->currentTrackeditProject();
     if (!prj) {
         return;

--- a/src/projectscene/view/clipsview/trackslistclipsmodel.cpp
+++ b/src/projectscene/view/clipsview/trackslistclipsmodel.cpp
@@ -23,12 +23,14 @@ void TracksListClipsModel::load()
         load();
     });
 
-    dispatcher()->reg(this, "escape", [this] { emit escapePressed(); });
-
     au::trackedit::ITrackeditProjectPtr prj = globalContext()->currentTrackeditProject();
     if (!prj) {
         return;
     }
+
+    trackeditInteraction()->cancelDragEditRequested().onNotify(this, [this]() {
+        emit escapePressed();
+    });
 
     setIsVerticalRulersVisible(configuration()->isVerticalRulersVisible());
 

--- a/src/projectscene/view/clipsview/trackslistclipsmodel.cpp
+++ b/src/projectscene/view/clipsview/trackslistclipsmodel.cpp
@@ -176,16 +176,6 @@ void TracksListClipsModel::load()
     });
 }
 
-void TracksListClipsModel::startUserInteraction()
-{
-    projectHistory()->startUserInteraction();
-}
-
-void TracksListClipsModel::endUserInteraction()
-{
-    projectHistory()->endUserInteraction();
-}
-
 void TracksListClipsModel::handleDroppedFiles(const QStringList& fileUrls)
 {
     std::vector<muse::io::path_t> localPaths;

--- a/src/projectscene/view/clipsview/trackslistclipsmodel.cpp
+++ b/src/projectscene/view/clipsview/trackslistclipsmodel.cpp
@@ -31,7 +31,7 @@ void TracksListClipsModel::load()
     setIsVerticalRulersVisible(configuration()->isVerticalRulersVisible());
 
     trackPlaybackControl()->muteOrSoloChanged().onReceive(this, [this] (long) {
-        emit dataChanged(index(0), index(m_trackList.size() - 1), { IsTrackAudibleRole });
+        emit dataChanged(index(0), index(static_cast<int>(m_trackList.size()) - 1), { IsTrackAudibleRole });
     });
 
     projectHistory()->historyChanged().onNotify(this, [this]() {

--- a/src/projectscene/view/clipsview/trackslistclipsmodel.h
+++ b/src/projectscene/view/clipsview/trackslistclipsmodel.h
@@ -27,6 +27,7 @@ class TracksListClipsModel : public QAbstractListModel, public muse::async::Asyn
     Q_PROPERTY(bool isVerticalRulersVisible READ isVerticalRulersVisible NOTIFY isVerticalRulersVisibleChanged)
     Q_PROPERTY(int totalTracksHeight READ totalTracksHeight NOTIFY totalTracksHeightChanged FINAL)
 
+    muse::Inject<muse::actions::IActionsDispatcher> dispatcher;
     muse::Inject<au::context::IGlobalContext> globalContext;
     muse::Inject<IProjectSceneConfiguration> configuration;
     muse::Inject<trackedit::ISelectionController> selectionController;
@@ -54,6 +55,7 @@ signals:
     void isVerticalRulersVisibleChanged(bool isVerticalRulersVisible);
 
     void totalTracksHeightChanged();
+    void escapePressed();
 
 private:
     void setIsVerticalRulersVisible(bool isVerticalRulersVisible);

--- a/src/projectscene/view/clipsview/trackslistclipsmodel.h
+++ b/src/projectscene/view/clipsview/trackslistclipsmodel.h
@@ -6,7 +6,6 @@
 #include <QAbstractListModel>
 
 #include <actions/actionable.h>
-#include <actions/iactionsdispatcher.h>
 
 #include "global/async/asyncable.h"
 
@@ -15,6 +14,7 @@
 #include "iprojectsceneconfiguration.h"
 #include "trackedit/iselectioncontroller.h"
 #include "trackedit/iprojecthistory.h"
+#include "trackedit/itrackeditinteraction.h"
 #include "playback/itrackplaybackcontrol.h"
 
 #include "trackedit/dom/track.h"
@@ -27,11 +27,11 @@ class TracksListClipsModel : public QAbstractListModel, public muse::async::Asyn
     Q_PROPERTY(bool isVerticalRulersVisible READ isVerticalRulersVisible NOTIFY isVerticalRulersVisibleChanged)
     Q_PROPERTY(int totalTracksHeight READ totalTracksHeight NOTIFY totalTracksHeightChanged FINAL)
 
-    muse::Inject<muse::actions::IActionsDispatcher> dispatcher;
     muse::Inject<au::context::IGlobalContext> globalContext;
     muse::Inject<IProjectSceneConfiguration> configuration;
     muse::Inject<trackedit::ISelectionController> selectionController;
     muse::Inject<trackedit::IProjectHistory> projectHistory;
+    muse::Inject<trackedit::ITrackeditInteraction> trackeditInteraction;
     muse::Inject<playback::ITrackPlaybackControl> trackPlaybackControl;
 
 public:

--- a/src/projectscene/view/clipsview/trackslistclipsmodel.h
+++ b/src/projectscene/view/clipsview/trackslistclipsmodel.h
@@ -38,8 +38,6 @@ public:
     explicit TracksListClipsModel(QObject* parent = nullptr);
 
     Q_INVOKABLE void load();
-    Q_INVOKABLE void startUserInteraction();
-    Q_INVOKABLE void endUserInteraction();
     Q_INVOKABLE void handleDroppedFiles(const QStringList& fileUrls);
 
     int rowCount(const QModelIndex& parent) const override;

--- a/src/projectscene/view/timeline/timelinecontext.cpp
+++ b/src/projectscene/view/timeline/timelinecontext.cpp
@@ -397,6 +397,8 @@ void TimelineContext::onProjectChanged()
     project->timeSignatureChanged().onReceive(this, [this](const trackedit::TimeSignature&) {
         updateTimeSignature();
     });
+
+    updateTimeSignature();
 }
 
 void TimelineContext::zoomIn()

--- a/src/projectscene/view/timeline/timelinecontext.h
+++ b/src/projectscene/view/timeline/timelinecontext.h
@@ -129,7 +129,7 @@ public:
 
     qreal verticalScrollbarSize() const;
 
-    void updateSelectedClipTime();
+    Q_INVOKABLE void updateSelectedClipTime();
 
     bool playbackOnRulerClickEnabled() const;
 

--- a/src/projectscene/view/timeline/timelinecontext.h
+++ b/src/projectscene/view/timeline/timelinecontext.h
@@ -166,6 +166,8 @@ signals:
 private:
     trackedit::ITrackeditProjectPtr trackEditProject() const;
     IProjectViewStatePtr viewState() const;
+    void initToViewState(double frameWidth);
+
     void onProjectChanged();
 
     void zoomIn();
@@ -215,7 +217,7 @@ private:
 
     double m_lastZoomEndTime = 0.0;
 
-    double m_zoom = 1.0; // see init
+    double m_zoom = 1.0; // see initToViewState
     int m_BPM = 120;
     // time signature
     int m_timeSigUpper = 4;

--- a/src/trackedit/internal/au3/au3interaction.cpp
+++ b/src/trackedit/internal/au3/au3interaction.cpp
@@ -1377,7 +1377,7 @@ bool Au3Interaction::moveClips(secs_t timePositionOffset, int trackPositionOffse
     }
 }
 
-void Au3Interaction::cancelClipEdit()
+void Au3Interaction::cancelClipDragEdit()
 {
     // If false, then the edit wasn't a clip drag (could have been trim or stretch)
     if (m_tracksWhenDragStarted.has_value()) {

--- a/src/trackedit/internal/au3/au3interaction.cpp
+++ b/src/trackedit/internal/au3/au3interaction.cpp
@@ -1304,8 +1304,8 @@ bool Au3Interaction::moveClips(secs_t timePositionOffset, int trackPositionOffse
 
     const trackedit::ITrackeditProjectPtr prj = globalContext()->currentTrackeditProject();
 
-    if (!m_startTracklistInfo) {
-        m_startTracklistInfo.emplace(utils::getTrackListInfo(Au3TrackList::Get(projectRef())));
+    if (!m_tracksWhenDragStarted) {
+        m_tracksWhenDragStarted.emplace(utils::getTrackListInfo(Au3TrackList::Get(projectRef())));
     }
 
     //! NOTE: check if offset is applicable to every clip and recalculate if needed
@@ -1340,7 +1340,7 @@ bool Au3Interaction::moveClips(secs_t timePositionOffset, int trackPositionOffse
     if (!completed) {
         return true;
     } else {
-        m_startTracklistInfo.reset();
+        m_tracksWhenDragStarted.reset();
 
         const muse::Defer defer2([&] {
             m_moveClipsNeedsDownmixing = false;
@@ -1379,12 +1379,15 @@ bool Au3Interaction::moveClips(secs_t timePositionOffset, int trackPositionOffse
 
 void Au3Interaction::cancelClipEdit()
 {
-    if (const auto prj = globalContext()->currentTrackeditProject()) {
-        // Doesn't matter it tracks are now empty or not - we're canceling the action.
-        constexpr auto emptyOnly = false;
-        removeDragAddedTracks(*prj, emptyOnly);
+    // If false, then the edit wasn't a clip drag (could have been trim or stretch)
+    if (m_tracksWhenDragStarted.has_value()) {
+        if (const auto prj = globalContext()->currentTrackeditProject()) {
+            // Doesn't matter it tracks are now empty or not - we're canceling the action.
+            constexpr auto emptyOnly = false;
+            removeDragAddedTracks(*prj, m_tracksWhenDragStarted->size, emptyOnly);
+        }
+        m_tracksWhenDragStarted.reset();
     }
-    m_startTracklistInfo.reset();
     m_moveClipsNeedsDownmixing = false;
 }
 
@@ -1462,11 +1465,11 @@ NeedsDownmixing Au3Interaction::moveSelectedClipsUpOrDown(int offset)
     // Tracks that were empty at the start of the interaction, are empty now and differ in format must be restored.
     const TrackListInfo copyInfo = utils::getTrackListInfo(*copy);
     for (const size_t index : copyInfo.emptyTrackIndices) {
-        if (index >= m_startTracklistInfo->size) {
+        if (index >= m_tracksWhenDragStarted->size) {
             continue;
         }
         const auto isStereoNow = muse::contains(copyInfo.stereoTrackIndices, index);
-        const auto wasStereoBefore = muse::contains(m_startTracklistInfo->stereoTrackIndices, index);
+        const auto wasStereoBefore = muse::contains(m_tracksWhenDragStarted->stereoTrackIndices, index);
         if (isStereoNow != wasStereoBefore) {
             // Toggle back the way it was.
             utils::toggleStereo(*copy, index);
@@ -1535,21 +1538,18 @@ NeedsDownmixing Au3Interaction::moveSelectedClipsUpOrDown(int offset)
     if (offset < 0) {
         // The user dragged up. It's possible that the bottom-most tracks were created during this interaction,
         // in which case we make it nice to the user and remove them automatically.
-        // `m_startTracklistInfo` tells use what the tracks looks like at the start of the interaction. We check all extra tracks.
+        // `m_tracksWhenDragStarted` tells use what the tracks looks like at the start of the interaction. We check all extra tracks.
         constexpr auto emptyOnly = true;
-        removeDragAddedTracks(*prj, emptyOnly);
+        removeDragAddedTracks(*prj, m_tracksWhenDragStarted->size, emptyOnly);
     }
 
     return needsDownmixing;
 }
 
-void Au3Interaction::removeDragAddedTracks(ITrackeditProject& prj, bool emptyOnly)
+void Au3Interaction::removeDragAddedTracks(ITrackeditProject& prj, size_t numTracksWhenDragStarted, bool emptyOnly)
 {
-    IF_ASSERT_FAILED(m_startTracklistInfo) {
-        return;
-    }
     const auto tracks = prj.trackList();
-    for (auto i = m_startTracklistInfo->size; i < tracks.size(); ++i) {
+    for (auto i = numTracksWhenDragStarted; i < tracks.size(); ++i) {
         const auto& track = tracks[i];
         Au3WaveTrack* const waveTrack = DomAccessor::findWaveTrack(projectRef(), Au3TrackId(track.id));
         if (!emptyOnly || waveTrack->IsEmpty()) {

--- a/src/trackedit/internal/au3/au3interaction.h
+++ b/src/trackedit/internal/au3/au3interaction.h
@@ -58,6 +58,7 @@ public:
     bool removeClips(const trackedit::ClipKeyList& clipKeyList, bool moveClips) override;
     bool removeTracksData(const TrackIdList& tracksIds, secs_t begin, secs_t end, bool moveClips) override;
     bool moveClips(secs_t timePositionOffset, int trackPositionOffset, bool completed, bool& clipsMovedToOtherTracks) override;
+    void cancelClipEdit() override;
     bool splitTracksAt(const TrackIdList& tracksIds, std::vector<secs_t> pivots) override;
     bool splitClipsAtSilences(const ClipKeyList& clipKeyList) override;
     bool splitRangeSelectionAtSilences(const TrackIdList& tracksIds, secs_t begin, secs_t end) override;
@@ -162,6 +163,7 @@ private:
     int trackPosition(const TrackId trackId);
     void moveTrack(const TrackId trackId, const TrackMoveDirection direction);
     void moveTrackTo(const TrackId trackId, int pos);
+    void removeDragAddedTracks(ITrackeditProject& prj, bool emptyOnly);
 
     bool doChangeClipSpeed(const ClipKey& clipKey, double speed);
 

--- a/src/trackedit/internal/au3/au3interaction.h
+++ b/src/trackedit/internal/au3/au3interaction.h
@@ -58,7 +58,7 @@ public:
     bool removeClips(const trackedit::ClipKeyList& clipKeyList, bool moveClips) override;
     bool removeTracksData(const TrackIdList& tracksIds, secs_t begin, secs_t end, bool moveClips) override;
     bool moveClips(secs_t timePositionOffset, int trackPositionOffset, bool completed, bool& clipsMovedToOtherTracks) override;
-    void cancelClipEdit() override;
+    void cancelClipDragEdit() override;
     bool splitTracksAt(const TrackIdList& tracksIds, std::vector<secs_t> pivots) override;
     bool splitClipsAtSilences(const ClipKeyList& clipKeyList) override;
     bool splitRangeSelectionAtSilences(const TrackIdList& tracksIds, secs_t begin, secs_t end) override;

--- a/src/trackedit/internal/au3/au3interaction.h
+++ b/src/trackedit/internal/au3/au3interaction.h
@@ -163,7 +163,7 @@ private:
     int trackPosition(const TrackId trackId);
     void moveTrack(const TrackId trackId, const TrackMoveDirection direction);
     void moveTrackTo(const TrackId trackId, int pos);
-    void removeDragAddedTracks(ITrackeditProject& prj, bool emptyOnly);
+    void removeDragAddedTracks(ITrackeditProject& prj, size_t numTracksWhenDragStarted, bool emptyOnly);
 
     bool doChangeClipSpeed(const ClipKey& clipKey, double speed);
 
@@ -174,7 +174,7 @@ private:
     muse::Progress m_progress;
     std::atomic<bool> m_busy = false;
 
-    std::optional<TrackListInfo> m_startTracklistInfo;
+    std::optional<TrackListInfo> m_tracksWhenDragStarted;
     bool m_moveClipsNeedsDownmixing = false;
 };
 }

--- a/src/trackedit/internal/au3/au3projecthistory.cpp
+++ b/src/trackedit/internal/au3/au3projecthistory.cpp
@@ -105,6 +105,15 @@ void Au3ProjectHistory::modifyState(bool autoSave)
     ::ProjectHistory::Get(project).ModifyState(autoSave);
 }
 
+void Au3ProjectHistory::modifyState(const std::type_index& restorerType)
+{
+    if (m_interactionOngoing) {
+        return;
+    }
+    auto& project = projectRef();
+    ::ProjectHistory::Get(project).ModifyState(restorerType);
+}
+
 void Au3ProjectHistory::markUnsaved()
 {
     LOGI() << "markUnsaved()";

--- a/src/trackedit/internal/au3/au3projecthistory.cpp
+++ b/src/trackedit/internal/au3/au3projecthistory.cpp
@@ -73,6 +73,9 @@ void au::trackedit::Au3ProjectHistory::rollbackState()
 void Au3ProjectHistory::startUserInteraction()
 {
     LOGI() << "startUserInteraction()";
+    // Modify the state, so that if the interaction gets canceled,
+    // rollbackState would revert to the state at the beginning of the action.
+    modifyState(false);
     IF_ASSERT_FAILED(!m_interactionOngoing) {
         return;
     }

--- a/src/trackedit/internal/au3/au3projecthistory.cpp
+++ b/src/trackedit/internal/au3/au3projecthistory.cpp
@@ -82,13 +82,15 @@ void Au3ProjectHistory::startUserInteraction()
     m_interactionOngoing = true;
 }
 
-void Au3ProjectHistory::endUserInteraction()
+void Au3ProjectHistory::endUserInteraction(bool modifyState)
 {
     LOGI() << "endUserInteraction()";
     if (m_interactionOngoing) {
         m_interactionOngoing = false;
-        // No new history entry was pushed -> update the state.
-        modifyState(false);
+        if (modifyState) {
+            // No new history entry was pushed -> update the state.
+            this->modifyState(true);
+        }
     }
 }
 

--- a/src/trackedit/internal/au3/au3projecthistory.cpp
+++ b/src/trackedit/internal/au3/au3projecthistory.cpp
@@ -73,12 +73,12 @@ void au::trackedit::Au3ProjectHistory::rollbackState()
 void Au3ProjectHistory::startUserInteraction()
 {
     LOGI() << "startUserInteraction()";
-    // Modify the state, so that if the interaction gets canceled,
-    // rollbackState would revert to the state at the beginning of the action.
-    modifyState(false);
     IF_ASSERT_FAILED(!m_interactionOngoing) {
         return;
     }
+    // Modify the state, so that if the interaction gets canceled,
+    // rollbackState would revert to the state at the beginning of the action.
+    modifyState(false);
     m_interactionOngoing = true;
 }
 

--- a/src/trackedit/internal/au3/au3projecthistory.h
+++ b/src/trackedit/internal/au3/au3projecthistory.h
@@ -32,7 +32,7 @@ public:
     void markUnsaved() override;
 
     void startUserInteraction() override;
-    void endUserInteraction() override;
+    void endUserInteraction(bool modifyState) override;
     bool interactionOngoing() const override { return m_interactionOngoing; }
 
     void undoRedoToIndex(size_t index) override;

--- a/src/trackedit/internal/au3/au3projecthistory.h
+++ b/src/trackedit/internal/au3/au3projecthistory.h
@@ -30,8 +30,10 @@ public:
     void rollbackState() override;
     void modifyState(bool autoSave) override;
     void markUnsaved() override;
+
     void startUserInteraction() override;
     void endUserInteraction() override;
+    bool interactionOngoing() const override { return m_interactionOngoing; }
 
     void undoRedoToIndex(size_t index) override;
 

--- a/src/trackedit/internal/au3/au3projecthistory.h
+++ b/src/trackedit/internal/au3/au3projecthistory.h
@@ -29,6 +29,7 @@ public:
         const std::string& longDescription, const std::string& shortDescription, UndoPushType flags) override;
     void rollbackState() override;
     void modifyState(bool autoSave) override;
+    void modifyState(const std::type_index& undoStateExtensionTypeIndex) override;
     void markUnsaved() override;
 
     void startUserInteraction() override;

--- a/src/trackedit/internal/au3/au3trackeditproject.cpp
+++ b/src/trackedit/internal/au3/au3trackeditproject.cpp
@@ -413,8 +413,7 @@ void TimeSignatureRestorer::RestoreUndoRedoState(AudacityProject& project)
 
 void TimeSignatureRestorer::reg()
 {
-    static UndoRedoExtensionRegistry::Entry sEntry {
-        [](AudacityProject& project) -> std::shared_ptr<UndoStateExtension>
+    static UndoRedoExtensionRegistry::Entry<TimeSignatureRestorer> sEntry { [](AudacityProject& project) -> std::shared_ptr<UndoStateExtension>
         { return std::make_shared<TimeSignatureRestorer>(project); }
     };
 }

--- a/src/trackedit/internal/au3/selectionrestorer.cpp
+++ b/src/trackedit/internal/au3/selectionrestorer.cpp
@@ -35,8 +35,7 @@ private:
     const ClipAndTimeSelection m_selection;
 };
 
-UndoRedoExtensionRegistry::Entry sEntry {
-    [](AudacityProject& project) -> std::shared_ptr<UndoStateExtension> {
+UndoRedoExtensionRegistry::Entry<ClipAndTimeSelectionState> sEntry { [](AudacityProject& project) -> std::shared_ptr<UndoStateExtension> {
         return std::make_shared<ClipAndTimeSelectionState>(project);
     }
 };

--- a/src/trackedit/internal/trackeditactionscontroller.cpp
+++ b/src/trackedit/internal/trackeditactionscontroller.cpp
@@ -459,8 +459,7 @@ void TrackeditActionsController::doGlobalDelete()
 
 void TrackeditActionsController::doGlobalCancel()
 {
-    LOGDA() << "trackedit cancel";
-    // Do cancel and notify the model about it.
+    trackeditInteraction()->notifyAboutCancelDragEdit();
 }
 
 void TrackeditActionsController::doGlobalDeletePerClipRipple()

--- a/src/trackedit/internal/trackeditinteraction.cpp
+++ b/src/trackedit/internal/trackeditinteraction.cpp
@@ -145,9 +145,9 @@ bool TrackeditInteraction::moveClips(secs_t timePositionOffset, int trackPositio
                             clipsMovedToOtherTrack);
 }
 
-void TrackeditInteraction::cancelClipEdit()
+void TrackeditInteraction::cancelClipDragEdit()
 {
-    m_interaction->cancelClipEdit();
+    m_interaction->cancelClipDragEdit();
 }
 
 bool TrackeditInteraction::splitTracksAt(const TrackIdList& tracksIds, std::vector<secs_t> pivots)

--- a/src/trackedit/internal/trackeditinteraction.cpp
+++ b/src/trackedit/internal/trackeditinteraction.cpp
@@ -338,6 +338,16 @@ bool TrackeditInteraction::undoRedoToIndex(size_t index)
     return m_interaction->undoRedoToIndex(index);
 }
 
+muse::async::Notification TrackeditInteraction::cancelDragEditRequested() const
+{
+    return m_interaction->cancelDragEditRequested();
+}
+
+void TrackeditInteraction::notifyAboutCancelDragEdit()
+{
+    m_interaction->notifyAboutCancelDragEdit();
+}
+
 bool TrackeditInteraction::insertSilence(const TrackIdList& trackIds, secs_t begin, secs_t end, secs_t duration)
 {
     return withPlaybackStop(&ITrackeditInteraction::insertSilence, trackIds, begin, end, duration);

--- a/src/trackedit/internal/trackeditinteraction.cpp
+++ b/src/trackedit/internal/trackeditinteraction.cpp
@@ -145,6 +145,11 @@ bool TrackeditInteraction::moveClips(secs_t timePositionOffset, int trackPositio
                             clipsMovedToOtherTrack);
 }
 
+void TrackeditInteraction::cancelClipEdit()
+{
+    m_interaction->cancelClipEdit();
+}
+
 bool TrackeditInteraction::splitTracksAt(const TrackIdList& tracksIds, std::vector<secs_t> pivots)
 {
     return withPlaybackStop(&ITrackeditInteraction::splitTracksAt, tracksIds, pivots);

--- a/src/trackedit/internal/trackeditinteraction.h
+++ b/src/trackedit/internal/trackeditinteraction.h
@@ -46,6 +46,7 @@ private:
     bool removeClips(const ClipKeyList& clipKeyList, bool moveClips) override;
     bool removeTracksData(const TrackIdList& tracksIds, secs_t begin, secs_t end, bool moveClips) override;
     bool moveClips(secs_t timePositionOffset, int trackPositionOffset, bool completed, bool&) override;
+    void cancelClipEdit() override;
     bool splitTracksAt(const TrackIdList& tracksIds, std::vector<secs_t> pivots) override;
     bool splitClipsAtSilences(const ClipKeyList& clipKeyList) override;
     bool splitRangeSelectionAtSilences(const TrackIdList& tracksIds, secs_t begin, secs_t end) override;

--- a/src/trackedit/internal/trackeditinteraction.h
+++ b/src/trackedit/internal/trackeditinteraction.h
@@ -84,6 +84,9 @@ private:
     bool canRedo() override;
     bool undoRedoToIndex(size_t index) override;
 
+    muse::async::Notification cancelDragEditRequested() const override;
+    void notifyAboutCancelDragEdit() override;
+
     bool insertSilence(const TrackIdList& trackIds, secs_t begin, secs_t end, secs_t duration) override;
 
     bool toggleStretchToMatchProjectTempo(const ClipKey& clipKey) override;

--- a/src/trackedit/internal/trackeditinteraction.h
+++ b/src/trackedit/internal/trackeditinteraction.h
@@ -46,7 +46,7 @@ private:
     bool removeClips(const ClipKeyList& clipKeyList, bool moveClips) override;
     bool removeTracksData(const TrackIdList& tracksIds, secs_t begin, secs_t end, bool moveClips) override;
     bool moveClips(secs_t timePositionOffset, int trackPositionOffset, bool completed, bool&) override;
-    void cancelClipEdit() override;
+    void cancelClipDragEdit() override;
     bool splitTracksAt(const TrackIdList& tracksIds, std::vector<secs_t> pivots) override;
     bool splitClipsAtSilences(const ClipKeyList& clipKeyList) override;
     bool splitRangeSelectionAtSilences(const TrackIdList& tracksIds, secs_t begin, secs_t end) override;

--- a/src/trackedit/internal/trackeditoperationcontroller.cpp
+++ b/src/trackedit/internal/trackeditoperationcontroller.cpp
@@ -257,9 +257,9 @@ bool TrackeditOperationController::moveClips(secs_t timePositionOffset, int trac
     return success;
 }
 
-void TrackeditOperationController::cancelClipEdit()
+void TrackeditOperationController::cancelClipDragEdit()
 {
-    trackAndClipOperations()->cancelClipEdit();
+    trackAndClipOperations()->cancelClipDragEdit();
     projectHistory()->rollbackState();
     globalContext()->currentTrackeditProject()->reload();
 }

--- a/src/trackedit/internal/trackeditoperationcontroller.cpp
+++ b/src/trackedit/internal/trackeditoperationcontroller.cpp
@@ -257,6 +257,13 @@ bool TrackeditOperationController::moveClips(secs_t timePositionOffset, int trac
     return success;
 }
 
+void TrackeditOperationController::cancelClipEdit()
+{
+    trackAndClipOperations()->cancelClipEdit();
+    projectHistory()->rollbackState();
+    globalContext()->currentTrackeditProject()->reload();
+}
+
 bool TrackeditOperationController::splitTracksAt(const TrackIdList& tracksIds, std::vector<secs_t> pivots)
 {
     if (trackAndClipOperations()->splitTracksAt(tracksIds, pivots)) {

--- a/src/trackedit/internal/trackeditoperationcontroller.cpp
+++ b/src/trackedit/internal/trackeditoperationcontroller.cpp
@@ -534,6 +534,16 @@ bool TrackeditOperationController::undoRedoToIndex(size_t index)
     return m_undoManager->undoRedoToIndex(index);
 }
 
+void TrackeditOperationController::notifyAboutCancelDragEdit()
+{
+    m_cancelDragEditRequested.notify();
+}
+
+muse::async::Notification TrackeditOperationController::cancelDragEditRequested() const
+{
+    return m_cancelDragEditRequested;
+}
+
 bool TrackeditOperationController::insertSilence(const TrackIdList& trackIds, secs_t begin, secs_t end, secs_t duration)
 {
     if (trackAndClipOperations()->insertSilence(trackIds, begin, end, duration)) {

--- a/src/trackedit/internal/trackeditoperationcontroller.cpp
+++ b/src/trackedit/internal/trackeditoperationcontroller.cpp
@@ -259,6 +259,9 @@ bool TrackeditOperationController::moveClips(secs_t timePositionOffset, int trac
 
 void TrackeditOperationController::cancelClipDragEdit()
 {
+    if (!projectHistory()->interactionOngoing()) {
+        return;
+    }
     trackAndClipOperations()->cancelClipDragEdit();
     projectHistory()->rollbackState();
     globalContext()->currentTrackeditProject()->reload();

--- a/src/trackedit/internal/trackeditoperationcontroller.h
+++ b/src/trackedit/internal/trackeditoperationcontroller.h
@@ -54,7 +54,7 @@ public:
     bool removeClips(const ClipKeyList& clipKeyList, bool moveClips) override;
     bool removeTracksData(const TrackIdList& tracksIds, secs_t begin, secs_t end, bool moveClips) override;
     bool moveClips(secs_t timePositionOffset, int trackPositionOffset, bool completed, bool& clipsMovedToOtherTrack) override;
-    void cancelClipEdit() override;
+    void cancelClipDragEdit() override;
     bool splitTracksAt(const TrackIdList& tracksIds, std::vector<secs_t> pivots) override;
     bool splitClipsAtSilences(const ClipKeyList& clipKeyList) override;
     bool splitRangeSelectionAtSilences(const TrackIdList& tracksIds, secs_t begin, secs_t end) override;

--- a/src/trackedit/internal/trackeditoperationcontroller.h
+++ b/src/trackedit/internal/trackeditoperationcontroller.h
@@ -54,6 +54,7 @@ public:
     bool removeClips(const ClipKeyList& clipKeyList, bool moveClips) override;
     bool removeTracksData(const TrackIdList& tracksIds, secs_t begin, secs_t end, bool moveClips) override;
     bool moveClips(secs_t timePositionOffset, int trackPositionOffset, bool completed, bool& clipsMovedToOtherTrack) override;
+    void cancelClipEdit() override;
     bool splitTracksAt(const TrackIdList& tracksIds, std::vector<secs_t> pivots) override;
     bool splitClipsAtSilences(const ClipKeyList& clipKeyList) override;
     bool splitRangeSelectionAtSilences(const TrackIdList& tracksIds, secs_t begin, secs_t end) override;

--- a/src/trackedit/internal/trackeditoperationcontroller.h
+++ b/src/trackedit/internal/trackeditoperationcontroller.h
@@ -93,6 +93,9 @@ public:
     bool canRedo() override;
     bool undoRedoToIndex(size_t index) override;
 
+    void notifyAboutCancelDragEdit() override;
+    muse::async::Notification cancelDragEditRequested() const override;
+
     bool insertSilence(const TrackIdList& trackIds, secs_t begin, secs_t end, secs_t duration) override;
 
     bool toggleStretchToMatchProjectTempo(const ClipKey& clipKey) override;
@@ -121,5 +124,6 @@ private:
     void pushProjectHistoryDeleteState(secs_t start, secs_t duration);
 
     const std::unique_ptr<IUndoManager> m_undoManager;
+    muse::async::Notification m_cancelDragEditRequested;
 };
 }

--- a/src/trackedit/iprojecthistory.h
+++ b/src/trackedit/iprojecthistory.h
@@ -59,7 +59,7 @@ public:
     /**
      * @ref startUserInteraction()
      */
-    virtual void endUserInteraction() = 0;
+    virtual void endUserInteraction(bool modifyState = false) = 0;
 
     virtual bool interactionOngoing() const = 0;
 };

--- a/src/trackedit/iprojecthistory.h
+++ b/src/trackedit/iprojecthistory.h
@@ -60,6 +60,8 @@ public:
      * @ref startUserInteraction()
      */
     virtual void endUserInteraction() = 0;
+
+    virtual bool interactionOngoing() const = 0;
 };
 
 using IProjectHistoryPtr = std::shared_ptr<IProjectHistory>;

--- a/src/trackedit/iprojecthistory.h
+++ b/src/trackedit/iprojecthistory.h
@@ -10,6 +10,8 @@
 #include "global/types/translatablestring.h"
 #include "trackedittypes.h"
 
+#include <typeindex>
+
 namespace au::trackedit {
 class IProjectHistory : MODULE_EXPORT_INTERFACE
 {
@@ -39,7 +41,16 @@ public:
     virtual muse::async::Notification historyChanged() const = 0;
 
     virtual void rollbackState() = 0;
+
     virtual void modifyState(bool autoSave = false) = 0;
+    /**
+     * @brief Modify state wrt a particular restorer only.
+     * Doesn't have an option for auto-save but may be added if needed.
+     *
+     * @param undoStateExtensionTypeIndex obtained by `typeid(<your undo state extension class>)`
+     */
+    virtual void modifyState(const std::type_index& undoStateExtensionTypeIndex) = 0;
+
     virtual void markUnsaved() = 0;
 
     /**

--- a/src/trackedit/itrackandclipoperations.h
+++ b/src/trackedit/itrackandclipoperations.h
@@ -53,7 +53,7 @@ public:
     virtual bool removeClips(const ClipKeyList& clipKeyList, bool moveClips) = 0;
     virtual bool removeTracksData(const TrackIdList& tracksIds, secs_t begin, secs_t end, bool moveClips) = 0;
     virtual bool moveClips(secs_t timePositionOffset, int trackPositionOffset, bool completed, bool& clipsMovedToOtherTracks) = 0;
-    virtual void cancelClipEdit() = 0;
+    virtual void cancelClipDragEdit() = 0;
     virtual bool splitTracksAt(const TrackIdList& tracksIds, std::vector<secs_t> pivots) = 0;
     virtual bool splitClipsAtSilences(const ClipKeyList& clipKeyList) = 0;
     virtual bool splitRangeSelectionAtSilences(const TrackIdList& tracksIds, secs_t begin, secs_t end) = 0;

--- a/src/trackedit/itrackandclipoperations.h
+++ b/src/trackedit/itrackandclipoperations.h
@@ -53,6 +53,7 @@ public:
     virtual bool removeClips(const ClipKeyList& clipKeyList, bool moveClips) = 0;
     virtual bool removeTracksData(const TrackIdList& tracksIds, secs_t begin, secs_t end, bool moveClips) = 0;
     virtual bool moveClips(secs_t timePositionOffset, int trackPositionOffset, bool completed, bool& clipsMovedToOtherTracks) = 0;
+    virtual void cancelClipEdit() = 0;
     virtual bool splitTracksAt(const TrackIdList& tracksIds, std::vector<secs_t> pivots) = 0;
     virtual bool splitClipsAtSilences(const ClipKeyList& clipKeyList) = 0;
     virtual bool splitRangeSelectionAtSilences(const TrackIdList& tracksIds, secs_t begin, secs_t end) = 0;

--- a/src/trackedit/itrackeditinteraction.h
+++ b/src/trackedit/itrackeditinteraction.h
@@ -53,6 +53,7 @@ public:
     virtual bool removeClips(const ClipKeyList& clipKeyList, bool moveClips) = 0;
     virtual bool removeTracksData(const TrackIdList& tracksIds, secs_t begin, secs_t end, bool moveClips) = 0;
     virtual bool moveClips(secs_t timePositionOffset, int trackPositionOffset, bool completed, bool& clipsMovedToOtherTrack) = 0;
+    virtual void cancelClipEdit() = 0;
     virtual bool splitTracksAt(const TrackIdList& tracksIds, std::vector<secs_t> pivots) = 0;
     virtual bool splitClipsAtSilences(const ClipKeyList& clipKeyList) = 0;
     virtual bool splitRangeSelectionAtSilences(const TrackIdList& tracksIds, secs_t begin, secs_t end) = 0;

--- a/src/trackedit/itrackeditinteraction.h
+++ b/src/trackedit/itrackeditinteraction.h
@@ -1,10 +1,11 @@
 #pragma once
 
 #include "dom/track.h"
-#include "modularity/imoduleinterface.h"
 
+#include "global/modularity/imoduleinterface.h"
 #include "global/types/string.h"
 #include "global/async/channel.h"
+#include "global/async/notification.h"
 #include "global/progress.h"
 
 #include "trackedittypes.h"
@@ -91,6 +92,9 @@ public:
     virtual bool redo() = 0;
     virtual bool canRedo() = 0;
     virtual bool undoRedoToIndex(size_t index) = 0;
+
+    virtual void notifyAboutCancelDragEdit() = 0;
+    virtual muse::async::Notification cancelDragEditRequested() const = 0;
 
     virtual bool insertSilence(const TrackIdList& trackIds, secs_t begin, secs_t end, secs_t duration) = 0;
 

--- a/src/trackedit/itrackeditinteraction.h
+++ b/src/trackedit/itrackeditinteraction.h
@@ -54,7 +54,7 @@ public:
     virtual bool removeClips(const ClipKeyList& clipKeyList, bool moveClips) = 0;
     virtual bool removeTracksData(const TrackIdList& tracksIds, secs_t begin, secs_t end, bool moveClips) = 0;
     virtual bool moveClips(secs_t timePositionOffset, int trackPositionOffset, bool completed, bool& clipsMovedToOtherTrack) = 0;
-    virtual void cancelClipEdit() = 0;
+    virtual void cancelClipDragEdit() = 0;
     virtual bool splitTracksAt(const TrackIdList& tracksIds, std::vector<secs_t> pivots) = 0;
     virtual bool splitClipsAtSilences(const ClipKeyList& clipKeyList) = 0;
     virtual bool splitRangeSelectionAtSilences(const TrackIdList& tracksIds, secs_t begin, secs_t end) = 0;


### PR DESCRIPTION
Resolves: #8747
Resolves: #8529
Resolves: probably most other tickets that are related to Ctrl+Alt while dragging some clip, if there's more of them.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:
All the following actions are canceled when either pressing escape or changing focus to another app, and if any of these actions started auto-scroll, auto scroll should automatically stop and the viewport should be replace to where it was at drag start:

- [x] Left/Right Trim/Stretch
- [x] Dragging a clip on one same track
- [x] Dragging a clip on another track
- [x] Same but for multiple clips at a time (if applicable)

Besides:
- [x] Snipping tool still works
- [ ] Doesn't re-introduce #9604, #9519, #9491 or #9631

Besides, the usual:
- [ ] Autobot test cases have been run
