### PR TITLE
Effects are not accessible on the first start after scanned #9512

### DIFF
--- a/src/au3audio/audiomodule.cpp
+++ b/src/au3audio/audiomodule.cpp
@@ -46,7 +46,7 @@ void AudioModule::onInit(const muse::IApplication::RunMode&)
 
     //! NOTE At the moment this is needed for VST plugins
     //! and everything is done in the main thread.
-    m_audioThreadSecurer->setupWorkerThread();
+    m_audioThreadSecurer->setupAudioEngineThread();
 }
 
 void AudioModule::onDeinit()

--- a/src/au3audio/internal/audiothreadsecurer.cpp
+++ b/src/au3audio/internal/audiothreadsecurer.cpp
@@ -10,9 +10,9 @@ void AudioThreadSecurer::setupMainThread()
     m_mainThreadID = std::this_thread::get_id();
 }
 
-void AudioThreadSecurer::setupWorkerThread()
+void AudioThreadSecurer::setupAudioEngineThread()
 {
-    m_workerThreadID = std::this_thread::get_id();
+    m_audioEngineThreadID = std::this_thread::get_id();
 }
 
 bool AudioThreadSecurer::isMainThread() const
@@ -25,12 +25,12 @@ std::thread::id AudioThreadSecurer::mainThreadId() const
     return m_mainThreadID;
 }
 
-bool AudioThreadSecurer::isAudioWorkerThread() const
+bool AudioThreadSecurer::isAudioEngineThread() const
 {
-    return m_workerThreadID == std::this_thread::get_id();
+    return m_audioEngineThreadID == std::this_thread::get_id();
 }
 
-std::thread::id AudioThreadSecurer::workerThreadId() const
+std::thread::id AudioThreadSecurer::audioEngineThreadId() const
 {
-    return m_workerThreadID;
+    return m_audioEngineThreadID;
 }

--- a/src/au3audio/internal/audiothreadsecurer.h
+++ b/src/au3audio/internal/audiothreadsecurer.h
@@ -16,15 +16,15 @@ public:
 
     bool isMainThread() const override;
     std::thread::id mainThreadId() const override;
-    bool isAudioWorkerThread() const override;
-    std::thread::id workerThreadId() const override;
+    bool isAudioEngineThread() const override;
+    std::thread::id audioEngineThreadId() const override;
 
     void setupMainThread();
-    void setupWorkerThread();
+    void setupAudioEngineThread();
 
 private:
 
     std::thread::id m_mainThreadID;
-    std::thread::id m_workerThreadID;
+    std::thread::id m_audioEngineThreadID;
 };
 }

--- a/src/au3wrap/internal/progressdialog.cpp
+++ b/src/au3wrap/internal/progressdialog.cpp
@@ -27,7 +27,7 @@ void ProgressDialog::SetDialogTitle(const TranslatableString& title)
 ProgressResult ProgressDialog::Poll(unsigned long long numerator, unsigned long long denominator, const TranslatableString& message)
 {
     if (!m_progress.isStarted()) {
-        interactive()->showProgress(std::string(), &m_progress);
+        interactive()->showProgress(std::string(), m_progress);
 
         m_progress.canceled().onNotify(this, [this]() {
             m_cancelled = true;

--- a/src/effects/effects_base/effectsmodule.cpp
+++ b/src/effects/effects_base/effectsmodule.cpp
@@ -89,6 +89,7 @@ void EffectsModule::onInit(const muse::IApplication::RunMode&)
     m_configuration->init();
     m_actionsController->init();
     m_realtimeEffectService->init();
+    m_provider->init();
 
     //! --- Diagnostics ---
     auto pr = ioc()->resolve<muse::diagnostics::IDiagnosticsPathsRegister>(moduleName());

--- a/src/effects/effects_base/internal/effectsprovider.cpp
+++ b/src/effects/effects_base/internal/effectsprovider.cpp
@@ -33,6 +33,13 @@
 using namespace muse;
 using namespace au::effects;
 
+void EffectsProvider::init()
+{
+    knownPluginsRegister()->pluginInfoListChanged().onNotify(this, [this]() {
+        reloadEffects();
+    });
+}
+
 bool EffectsProvider::isVstSupported() const
 {
     return vstEffectsRepository() ? true : false;

--- a/src/effects/effects_base/internal/effectsprovider.h
+++ b/src/effects/effects_base/internal/effectsprovider.h
@@ -13,6 +13,7 @@
 #include "effects/vst/ivsteffectsrepository.h"
 #include "effects/nyquist/inyquisteffectsrepository.h"
 #include "effects/audio_unit/iaudiouniteffectsrepository.h"
+#include "audioplugins/iknownaudiopluginsregister.h"
 #include "../ieffectsconfiguration.h"
 #include "../ieffectviewlaunchregister.h"
 
@@ -33,8 +34,11 @@ class EffectsProvider : public IEffectsProvider, public muse::async::Asyncable
     muse::Inject<muse::IInteractive> interactive;
     muse::Inject<playback::IPlayback> playback;
     muse::Inject<IEffectViewLaunchRegister> viewLaunchRegister;
+    muse::Inject<muse::audioplugins::IKnownAudioPluginsRegister> knownPluginsRegister;
 
 public:
+    void init();
+
     void reloadEffects();
 
     EffectMetaList effectMetaList() const override;

--- a/src/trackedit/internal/au3/au3interaction.cpp
+++ b/src/trackedit/internal/au3/au3interaction.cpp
@@ -2537,11 +2537,11 @@ bool Au3Interaction::changeTracksFormat(const TrackIdList& tracksIds, trackedit:
     });
     size_t convertedSamples = 0;
 
-    progress()->start();
+    progress().start();
 
     muse::ProgressResult result;
     DEFER {
-        progress()->finish(result);
+        progress().finish(result);
     };
 
     try {
@@ -2569,12 +2569,12 @@ bool Au3Interaction::changeTracksFormat(const TrackIdList& tracksIds, trackedit:
 
             if (!(waveTrack->GetSampleFormat() == newFormat)) {
                 waveTrack->ConvertToSampleFormat(newFormat,  [&](size_t sampleCnt) {
-                    if (progress()->isCanceled()) {
+                    if (progress().isCanceled()) {
                         throw UserException();
                     }
 
                     convertedSamples += sampleCnt;
-                    progress()->progress(convertedSamples, totalSamples, "");
+                    progress().progress(convertedSamples, totalSamples, "");
                 });
 
                 trackedit::ITrackeditProjectPtr prj = globalContext()->currentTrackeditProject();
@@ -2849,11 +2849,11 @@ bool Au3Interaction::resampleTracks(const TrackIdList& tracksIds, int rate)
         return sum + WaveTrackUtilities::GetSequenceSamplesCount(*waveTrack).as_size_t();
     });
 
-    progress()->start();
+    progress().start();
 
     muse::ProgressResult result;
     DEFER {
-        progress()->finish(result);
+        progress().finish(result);
     };
 
     try {
@@ -2864,12 +2864,12 @@ bool Au3Interaction::resampleTracks(const TrackIdList& tracksIds, int rate)
             }
 
             waveTrack->Resample(rate, [&](size_t sampleCnt) {
-                if (progress()->isCanceled()) {
+                if (progress().isCanceled()) {
                     throw UserException();
                 }
 
                 convertedSamples += sampleCnt;
-                progress()->progress(convertedSamples, totalSamples, "");
+                progress().progress(convertedSamples, totalSamples, "");
             });
             trackedit::ITrackeditProjectPtr prj = globalContext()->currentTrackeditProject();
             prj->notifyAboutTrackChanged(DomConverter::track(waveTrack));
@@ -2883,9 +2883,9 @@ bool Au3Interaction::resampleTracks(const TrackIdList& tracksIds, int rate)
     return true;
 }
 
-muse::ProgressPtr Au3Interaction::progress() const
+muse::Progress Au3Interaction::progress() const
 {
-    return m_progress;
+    return *m_progress;
 }
 
 bool Au3Interaction::doChangeClipSpeed(const ClipKey& clipKey, double speed)

--- a/src/trackedit/internal/au3/au3interaction.h
+++ b/src/trackedit/internal/au3/au3interaction.h
@@ -108,7 +108,7 @@ public:
     bool makeStereoTrack(const TrackId left, const TrackId right) override;
     bool resampleTracks(const TrackIdList& tracksIds, int rate) override;
 
-    muse::ProgressPtr progress() const override;
+    muse::Progress progress() const override;
 
 private:
     friend class Au3InteractionTests;

--- a/src/trackedit/internal/au3/au3interactionutils.cpp
+++ b/src/trackedit/internal/au3/au3interactionutils.cpp
@@ -246,7 +246,7 @@ muse::Ret au::trackedit::utils::withProgress(muse::IInteractive& interactive, co
                                                                                                                                  CancelCb)>& action)
 {
     muse::Progress progress;
-    interactive.showProgress(title, &progress);
+    interactive.showProgress(title, progress);
     progress.started();
 
     ProgressCb progressCb = [&](double progressFraction)

--- a/src/trackedit/internal/trackeditactionscontroller.cpp
+++ b/src/trackedit/internal/trackeditactionscontroller.cpp
@@ -1255,7 +1255,7 @@ void TrackeditActionsController::renderClipPitchAndSpeed(const muse::actions::Ac
         return;
     }
 
-    interactive()->showProgress(muse::trc("trackedit", "Applying"), trackeditInteraction()->progress().get());
+    interactive()->showProgress(muse::trc("trackedit", "Applying"), trackeditInteraction()->progress());
 
     trackeditInteraction()->renderClipPitchAndSpeed(clipKey);
 }

--- a/src/trackedit/internal/trackeditinteraction.cpp
+++ b/src/trackedit/internal/trackeditinteraction.cpp
@@ -402,7 +402,7 @@ bool TrackeditInteraction::resampleTracks(const TrackIdList& tracksIds, int rate
     });
 }
 
-muse::ProgressPtr TrackeditInteraction::progress() const
+muse::Progress TrackeditInteraction::progress() const
 {
     return m_interaction->progress();
 }

--- a/src/trackedit/internal/trackeditinteraction.h
+++ b/src/trackedit/internal/trackeditinteraction.h
@@ -101,7 +101,7 @@ private:
     bool makeStereoTrack(const TrackId left, const TrackId right) override;
     bool resampleTracks(const TrackIdList& tracksIds, int rate) override;
 
-    muse::ProgressPtr progress() const override;
+    muse::Progress progress() const override;
 
 private:
     template<typename Func, typename ... Args>
@@ -118,11 +118,11 @@ private:
     muse::Ret withProgress(Func&& method, Args&&... args) const
     {
         auto progressDialog = std::make_unique<ProgressDialog>();
-        progress()->progressChanged().onReceive(progressDialog.get(),
-                                                [&](int64_t current, int64_t total, const std::string&) {
+        progress().progressChanged().onReceive(progressDialog.get(),
+                                               [&](int64_t current, int64_t total, const std::string&) {
             const auto result = progressDialog->Poll(current, total);
             if (result == ProgressResult::Cancelled) {
-                progress()->cancel();
+                progress().cancel();
             }
         });
 

--- a/src/trackedit/internal/trackeditoperationcontroller.cpp
+++ b/src/trackedit/internal/trackeditoperationcontroller.cpp
@@ -626,7 +626,7 @@ bool TrackeditOperationController::resampleTracks(const TrackIdList& tracksIds, 
     return false;
 }
 
-muse::ProgressPtr TrackeditOperationController::progress() const
+muse::Progress TrackeditOperationController::progress() const
 {
     return trackAndClipOperations()->progress();
 }

--- a/src/trackedit/internal/trackeditoperationcontroller.h
+++ b/src/trackedit/internal/trackeditoperationcontroller.h
@@ -110,7 +110,7 @@ public:
     bool makeStereoTrack(const TrackId left, const TrackId right) override;
     bool resampleTracks(const TrackIdList& tracksIds, int rate) override;
 
-    muse::ProgressPtr progress() const override;
+    muse::Progress progress() const override;
 
 private:
     void pushProjectHistoryJoinState(secs_t start, secs_t duration);

--- a/src/trackedit/itrackandclipoperations.h
+++ b/src/trackedit/itrackandclipoperations.h
@@ -103,6 +103,6 @@ public:
     virtual bool makeStereoTrack(const TrackId left, const TrackId right) = 0;
     virtual bool resampleTracks(const TrackIdList& tracksIds, int rate) = 0;
 
-    virtual muse::ProgressPtr progress() const = 0;
+    virtual muse::Progress progress() const = 0;
 };
 }

--- a/src/trackedit/itrackeditinteraction.h
+++ b/src/trackedit/itrackeditinteraction.h
@@ -109,6 +109,6 @@ public:
     virtual bool makeStereoTrack(const TrackId left, const TrackId right) = 0;
     virtual bool resampleTracks(const TrackIdList& tracksIds, int rate) = 0;
 
-    virtual muse::ProgressPtr progress() const = 0;
+    virtual muse::Progress progress() const = 0;
 };
 }


### PR DESCRIPTION
Resolves: Effects are not accessible on the first start after scanned #9512

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Autobot test cases have been run
