### PR TITLE
8924 Enable project button if project not null

### DIFF
--- a/src/appshell/view/internal/maintoolbarmodel.cpp
+++ b/src/appshell/view/internal/maintoolbarmodel.cpp
@@ -92,7 +92,7 @@ void MainToolBarModel::load()
 
     m_items.clear();
     m_items << buildItem(muse::qtrc("appshell", "Home"), HOME_PAGE, true);
-    m_items << buildItem(muse::qtrc("appshell", "Project"), PROJECT_PAGE, true);
+    m_items << buildItem(muse::qtrc("appshell", "Project"), PROJECT_PAGE, false);
     m_items << buildItem(muse::qtrc("appshell", "Publish"), PUBLISH_PAGE, false);
 
     if (globalConfiguration()->devModeEnabled()) {
@@ -113,10 +113,11 @@ void MainToolBarModel::updateNotationPageItem()
         QVariantMap& item = m_items[i];
 
         if (item[URI_KEY] == PROJECT_PAGE) {
+            item[ENABLED_KEY] = context()->currentProject() != nullptr;
             item[IS_TITLE_BOLD_KEY] = context()->currentProject() != nullptr;
 
             QModelIndex modelIndex = index(i);
-            emit dataChanged(modelIndex, modelIndex, { IsTitleBoldRole });
+            emit dataChanged(modelIndex, modelIndex, { IsTitleBoldRole, EnabledRole });
 
             break;
         }


### PR DESCRIPTION
Resolves: #8924 

Project button is enabled if current project is not null

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [ ] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Autobot test cases have been run
