### PR TITLE
Warn the user, and convert the project from AUP3 to AUP4 file format

### DIFF
--- a/src/appshell/internal/applicationactioncontroller.cpp
+++ b/src/appshell/internal/applicationactioncontroller.cpp
@@ -155,20 +155,20 @@ bool ApplicationActionController::eventFilter(QObject* watched, QEvent* event)
         return true;
     }
 
-    // if (event->type() == QEvent::FileOpen && watched == qApp) {
-    //     const QFileOpenEvent* openEvent = static_cast<const QFileOpenEvent*>(event);
-    //     const QUrl url = openEvent->url();
+    if (event->type() == QEvent::FileOpen && watched == qApp) {
+        const QFileOpenEvent* openEvent = static_cast<const QFileOpenEvent*>(event);
+        const QUrl url = openEvent->url();
 
-    //     if (projectFilesController()->isUrlSupported(url)) {
-    //         if (startupScenario()->startupCompleted()) {
-    //             dispatcher()->dispatch("file-open", ActionData::make_arg1<QUrl>(url));
-    //         } else {
-    //             startupScenario()->setStartupScoreFile(project::ProjectFile { url });
-    //         }
+        if (projectFilesController()->isUrlSupported(url)) {
+            if (startupScenario()->startupCompleted()) {
+                dispatcher()->dispatch("file-open", ActionData::make_arg1<QUrl>(url));
+            } else {
+                startupScenario()->setStartupScoreFile(project::ProjectFile { url });
+            }
 
-    //         return true;
-    //     }
-    // }
+            return true;
+        }
+    }
 
     return QObject::eventFilter(watched, event);
 }

--- a/src/appshell/internal/applicationactioncontroller.h
+++ b/src/appshell/internal/applicationactioncontroller.h
@@ -35,6 +35,7 @@
 #include "iinteractive.h"
 #include "iappshellconfiguration.h"
 #include "iapplication.h"
+#include "startupscenario.h"
 #include "project/iprojectfilescontroller.h"
 #include "record/irecordcontroller.h"
 
@@ -48,15 +49,16 @@ namespace au::appshell {
 class ApplicationActionController : public QObject, public IApplicationActionController, public muse::actions::Actionable,
     public muse::async::Asyncable
 {
-    INJECT(muse::actions::IActionsDispatcher, dispatcher)
-    INJECT(muse::ui::IUiActionsRegister, actionsRegister)
-    INJECT(muse::ui::IMainWindow, mainWindow)
+    muse::Inject<muse::actions::IActionsDispatcher> dispatcher;
+    muse::Inject<muse::ui::IUiActionsRegister> actionsRegister;
+    muse::Inject<muse::ui::IMainWindow> mainWindow;
+    muse::Inject<appshell::IStartupScenario> startupScenario;
 
-    INJECT(muse::IInteractive, interactive)
-    INJECT(muse::IApplication, application)
-    INJECT(IAppShellConfiguration, configuration)
-    INJECT(project::IProjectFilesController, projectFilesController)
-    INJECT(record::IRecordController, recordController)
+    muse::Inject<muse::IInteractive> interactive;
+    muse::Inject<muse::IApplication> application;
+    muse::Inject<IAppShellConfiguration> configuration;
+    muse::Inject<project::IProjectFilesController> projectFilesController;
+    muse::Inject<record::IRecordController> recordController;
 //! TODO AU4
     // INJECT(languages::ILanguagesService, languagesService)
     // INJECT(mi::IMultiInstancesProvider, multiInstancesProvider)

--- a/src/project/internal/iopensaveprojectscenario.h
+++ b/src/project/internal/iopensaveprojectscenario.h
@@ -41,6 +41,8 @@ public:
     virtual muse::RetVal<CloudProjectInfo> askPublishLocation(IAudacityProjectPtr project) const = 0;
     virtual muse::RetVal<CloudAudioInfo> askShareAudioLocation(IAudacityProjectPtr project) const = 0;
 
+    virtual muse::RetVal<muse::io::path_t> resolveLegacyProjectFormat(const muse::io::path_t& path) const = 0;
+
     virtual bool warnBeforeSavingToExistingPubliclyVisibleCloudProject() const = 0;
 
     static constexpr int RET_CODE_CONFLICT_RESPONSE_SAVE_AS = 1235;

--- a/src/project/internal/opensaveprojectscenario.h
+++ b/src/project/internal/opensaveprojectscenario.h
@@ -28,6 +28,7 @@
 #include "modularity/ioc.h"
 #include "iprojectconfiguration.h"
 #include "iprojectfilescontroller.h"
+#include "global/io/ifilesystem.h"
 #include "global/iinteractive.h"
 
 #include "cloud/musescorecom/imusescorecomservice.h"
@@ -40,6 +41,7 @@ class OpenSaveProjectScenario : public IOpenSaveProjectScenario
     muse::Inject<IProjectConfiguration> configuration;
     muse::Inject<IProjectFilesController> projectFilesController;
     muse::Inject<muse::IInteractive> interactive;
+    muse::Inject<muse::io::IFileSystem> fileSystem;
     muse::Inject<muse::cloud::IMuseScoreComService> museScoreComService;
     muse::Inject<muse::cloud::IAudioComService> audioComService;
 
@@ -53,6 +55,8 @@ public:
     muse::RetVal<CloudProjectInfo> askCloudLocation(IAudacityProjectPtr project, SaveMode mode) const override;
     muse::RetVal<CloudProjectInfo> askPublishLocation(IAudacityProjectPtr project) const override;
     muse::RetVal<CloudAudioInfo> askShareAudioLocation(IAudacityProjectPtr project) const override;
+
+    muse::RetVal<muse::io::path_t> resolveLegacyProjectFormat(const muse::io::path_t& path) const override;
 
     bool warnBeforeSavingToExistingPubliclyVisibleCloudProject() const override;
 

--- a/src/project/internal/projectactionscontroller.cpp
+++ b/src/project/internal/projectactionscontroller.cpp
@@ -7,6 +7,7 @@
 #include "audacityproject.h"
 #include "projecterrors.h"
 
+#include "project/types/projecttypes.h"
 #include "au3wrap/au3types.h"
 
 #include "log.h"
@@ -21,7 +22,7 @@ static const muse::Uri NEW_PROJECT_URI("audacity://project/new");
 static const muse::Uri EXPORT_URI("audacity://project/export");
 static const muse::Uri CUSTOM_FFMPEG_OPTIONS("audacity://project/export/ffmpeg");
 
-static const QString AUDACITY_URL_SCHEME("AUDACITY");
+static const QString AUDACITY_URL_SCHEME("audacity");
 static const QString OPEN_PROJECT_URL_HOSTNAME("open-project");
 
 static const muse::actions::ActionCode OPEN_CUSTOM_FFMPEG_OPTIONS("open-custom-ffmpeg-options");
@@ -181,15 +182,27 @@ void ProjectActionsController::importFile()
     project->import(askedPath);
 }
 
-bool ProjectActionsController::isUrlSupported([[maybe_unused]] const QUrl& url) const
+bool ProjectActionsController::isUrlSupported(const QUrl& url) const
 {
-    //! TODO AU4
+    if (url.isLocalFile()) {
+        return isFileSupported(muse::io::path_t(url));
+    }
+
+    if (url.scheme() == AUDACITY_URL_SCHEME) {
+        if (url.host() == OPEN_PROJECT_URL_HOSTNAME) {
+            return true;
+        }
+    }
+
     return false;
 }
 
-bool ProjectActionsController::isFileSupported([[maybe_unused]] const muse::io::path_t& path) const
+bool ProjectActionsController::isFileSupported(const muse::io::path_t& path) const
 {
-    //! TODO AU4
+    if (au::project::isAudacityFile(path)) {
+        return true;
+    }
+
     return false;
 }
 

--- a/src/project/internal/projectactionscontroller.cpp
+++ b/src/project/internal/projectactionscontroller.cpp
@@ -178,6 +178,9 @@ void ProjectActionsController::openProject(const muse::actions::ActionData& args
     const QString displayNameOverride = args.count() >= 2 ? args.arg<QString>(1) : QString();
 
     Ret ret = openProject(ProjectFile(url, displayNameOverride));
+    if (!ret) {
+        openPageIfNeed(HOME_PAGE_URI);
+    }
 }
 
 void ProjectActionsController::importFile()

--- a/src/project/types/projecttypes.h
+++ b/src/project/types/projecttypes.h
@@ -279,6 +279,39 @@ public:
 };
 
 using GenerateAudioTimePeriodType = GenerateAudioTimePeriod::Type;
+
+static const std::string AUP3 = "aup3";
+static const std::string AUP4 = "aup4";
+
+inline bool isAudacity3File(const muse::io::path_t& filename)
+{
+    return muse::io::suffix(filename) == AUP3;
+}
+
+inline bool isAudacity3FileType(const std::string_view ext)
+{
+    return ext == AUP3;
+}
+
+inline bool isAudacity4File(const muse::io::path_t& filename)
+{
+    return muse::io::suffix(filename) == AUP4;
+}
+
+inline bool isAudacity4FileType(const std::string_view ext)
+{
+    return ext == AUP4;
+}
+
+inline bool isAudacityFile(const muse::io::path_t& filename)
+{
+    return isAudacity3File(filename) || isAudacity4File(filename);
+}
+
+inline bool isAudacityFileType(const std::string_view ext)
+{
+    return isAudacity3FileType(ext) || isAudacity4FileType(ext);
+}
 }
 
 #endif // AU_PROJECT_PROJECTTYPES_H


### PR DESCRIPTION
Resolves: #9505

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [x] When opening a project via "File\Open" the warning dialog appears when opening aup3 file
- [x] When opening a project via Explorer\Finder the warning dialog appears  when opening aup3 file. **Make sure, that you open with the correct version, not the previously installed** 
- [x] The dialog does not appear for aup4 files
- [x] When the copy is created and there is an existing file with the same name, a number is added to the copy name
- [x] It is working the same on all platforms