### PR TITLE
9051 Fix channel splitter drawing

### DIFF
--- a/src/projectscene/qml/Audacity/ProjectScene/clipsview/ChannelSplitter.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/clipsview/ChannelSplitter.qml
@@ -16,6 +16,8 @@ Item {
     Rectangle {
         id: splitter
 
+        y: Math.round(root.channelHeightRatio * root.height) - 1
+
         height: 1
         width: root.width
     }
@@ -26,7 +28,6 @@ Item {
         anchors.fill: splitter
         anchors.margins: -2
 
-        drag.target: splitter
         drag.axis: Drag.YAxis
         drag.threshold: 0
 
@@ -35,19 +36,8 @@ Item {
         enabled: asymmetricStereoHeightsPossible
 
         onPositionChanged: {
-            root.positionChangeRequested(splitter.y)
-        }
-    }
-
-    Binding {
-        target: splitter
-        property: "y"
-        value: {
-            if (root.height <= 0) {
-                return 0
-            }
-
-            return Math.round(root.channelHeightRatio * root.height) - 1
+            var newY = mapToItem(root, mouse.x, mouse.y).y
+            root.positionChangeRequested(newY)
         }
     }
 }

--- a/src/projectscene/view/clipsview/au3/minmaxrmspainter.cpp
+++ b/src/projectscene/view/clipsview/au3/minmaxrmspainter.cpp
@@ -89,7 +89,7 @@ void MinMaxRMSPainter::paint(QPainter& painter, const trackedit::ClipKey& clipKe
         _metrics.fromTime += waveClip->GetTrimLeft();
         _metrics.toTime += waveClip->GetTrimLeft();
 
-        metrics.top += metrics.height;
+        metrics.top += static_cast<int>(metrics.height);
 
         waveformPainter.Draw(index, painter, paintParameters, _metrics);
     }


### PR DESCRIPTION
Resolves: #9051

Sometimes a white line appears if the height is not rounded.
Also the splitter position should only be defined by the root.height or channelHeightRatio change.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Autobot test cases have been run
