### PR TITLE
9536 Fix unsaved file restoration discarded

### DIFF
--- a/src/au3wrap/internal/au3project.cpp
+++ b/src/au3wrap/internal/au3project.cpp
@@ -69,10 +69,8 @@ muse::Ret Au3ProjectCreator::removeUnsavedData(const muse::io::path_t& projectPa
         if (tempProject->isTemporary()) {
             tempProject->close();
             ret = fileSystem()->remove(projectPath);
-        } else if (tempProject->hasAutosaveData()) {
-            ret = tempProject->removeAutosaveData();
-            tempProject->close();
         } else {
+            ret = tempProject->removeAutosaveData();
             tempProject->close();
         }
     }


### PR DESCRIPTION
Resolves: Fix unsaved file restoration discarded #9536 

after the changes from https://github.com/audacity/audacity/pull/9485 the file was now loaded in normal state not recovered to the checks that relied on the recovered state to delete the autosaved data where no longer making the deletion of the autosaved data happening

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Autobot test cases have been run
