### PR TITLE
Fix #9491: track clip view mouse behavior is broken after clip deletion

### DIFF
--- a/src/projectscene/qml/Audacity/ProjectScene/clipsview/ClipItem.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/clipsview/ClipItem.qml
@@ -256,6 +256,7 @@ Rectangle {
         waveView.isStemPlot = false
         root.leftTrimContainsMouse = false
         root.rightTrimContainsMouse = false
+        headerHovered = false
     }
 
     MouseArea {


### PR DESCRIPTION
Resolves: #9491

Clip header hovered state was not reset on clip deletion

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Autobot test cases have been run
