### PR TITLE
Add middle-mouse drag panning to TrackPanel

### DIFF
--- a/libraries/lib-viewport/Viewport.cpp
+++ b/libraries/lib-viewport/Viewport.cpp
@@ -218,6 +218,24 @@ void Viewport::SetHorizontalThumb(double scrollto, bool doScroll)
       DoScroll();
 }
 
+void Viewport::ScrollHorizontalByPixels(int deltaPixels)
+{
+    if (!mpCallbacks)
+        return;
+    int current = mpCallbacks->GetHorizontalThumbPosition();
+    int max = mpCallbacks->GetHorizontalRange() -
+              mpCallbacks->GetHorizontalThumbSize();
+    int newPos = std::clamp(current - deltaPixels, 0, max);
+    sbarH += deltaPixels;
+    sbarH = std::clamp<wxInt64>(
+        sbarH,
+        -PixelWidthBeforeTime(0.0),
+        std::max(sbarTotal - PixelWidthBeforeTime(0.0) - sbarScreen, 0.)
+    );
+    mpCallbacks->SetHorizontalThumbPosition(newPos);
+    DoScroll();
+}
+
 bool Viewport::ScrollUpDown(int delta)
 {
    int oldPos = mpCallbacks ? mpCallbacks->GetVerticalThumbPosition() : 0;

--- a/libraries/lib-viewport/Viewport.h
+++ b/libraries/lib-viewport/Viewport.h
@@ -129,6 +129,8 @@ public:
 
    void SetHorizontalThumb(double scrollto, bool doScroll = true);
 
+   void ScrollHorizontalByPixels(int deltaPixels);
+
    //! Set timeline magnification; unchanged left edge time
    void Zoom(double pixelsPerSecond);
 

--- a/src/TrackPanel.cpp
+++ b/src/TrackPanel.cpp
@@ -741,6 +741,21 @@ void TrackPanel::OnMouseEvent(wxMouseEvent & event)
       mTimer.Start(std::chrono::milliseconds{kTimerInterval}.count(), FALSE);
    }
 
+   if (event.MiddleDown()) {
+      mIsPanning = true;
+      mLastPanX = event.GetX();
+      CaptureMouse();
+   }
+   else if (event.MiddleUp()) {
+      mIsPanning = false;
+      ReleaseMouse();
+   }
+   else if (event.Dragging() && mIsPanning) {
+      int dx = event.GetX() - mLastPanX;
+      mLastPanX = event.GetX();
+
+      Viewport::Get(*GetProject()).ScrollHorizontalByPixels(-dx);
+   }
 
    if (event.ButtonUp()) {
       //ShowTrack should be called after processing the up-click.

--- a/src/TrackPanel.h
+++ b/src/TrackPanel.h
@@ -214,6 +214,9 @@ protected:
 
    bool mRefreshBacking;
 
+   bool mIsPanning;
+   int mLastPanX;
+
 
 protected:
 


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/693

Implemented smooth horizontal panning in the TrackPanel using the middle mouse button.  
- Pressing and holding the middle button allows dragging the waveform left/right.  
- Scrollbar and viewport update in sync for natural movement.

![untitled](https://github.com/user-attachments/assets/046d72f3-25c7-49a5-a4b1-b404d3702f4e)

While this feature is planned for 4.0, adding it to the 3.x branch improves usability and addresses a longstanding frustration of mine. The behavior matches other creative tools like GIMP, Inkscape, Kdenlive, and Blender, helping frequent Audacity users work more naturally until 4.0 is released.

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Autobot test cases have been run
