### PR TITLE
Zix: Add compile definition for Linux builds

### DIFF
--- a/src/au3wrap/lv2sdk/CMakeLists.txt
+++ b/src/au3wrap/lv2sdk/CMakeLists.txt
@@ -192,4 +192,5 @@ setup_module()
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     target_compile_definitions(${MODULE} PRIVATE _GNU_SOURCE)
 endif()
+
 target_no_warning(${MODULE} -w)


### PR DESCRIPTION
Without `_GNU_SOURCE` being defined `copy_file_range()` won't be available.

I don't know if this is the preferred place to put this, but the module now builds without having to do any additional setup steps.

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Autobot test cases have been run
