### PR TITLE
Fix string conversion in EffectsProvider

### DIFF
--- a/src/effects/effects_base/internal/effectsprovider.cpp
+++ b/src/effects/effects_base/internal/effectsprovider.cpp
@@ -333,7 +333,7 @@ muse::Ret EffectsProvider::performEffect(au3::Au3Project& project, Effect* effec
             const std::string title
                 = (effect->GetType()
                    == EffectTypeGenerate ? muse::qtrc("effects", "Generating %1...") : muse::qtrc("effects", "Applying %1...")).arg(
-                      name.Translation().ToStdString()).toStdString();
+                      QString::fromUtf8(name.Translation().ToUTF8().data())).toStdString();
 
             ::ProgressDialog progress{ title };
             auto vr = valueRestorer<BasicUI::ProgressDialog*>(effect->mProgress, &progress);


### PR DESCRIPTION
Resolves: Building under GCC 14.2

```
audacity/src/effects/effects_base/internal/effectsprovider.cpp:335:132: error: no matching function for call to ‘QString::arg(std::string)’
      = (effect->GetType()                   
         == EffectTypeGenerate ? muse::qtrc("effects", "Generating %1...") : muse::qtrc("effects", "Applying %1...")).arg(
            name.Translation().ToStdString()).toStdString();
```

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Autobot test cases have been run
