### PR TITLE
Allow track range selection using shift enter

### DIFF
--- a/src/app/configs/data/shortcuts.xml
+++ b/src/app/configs/data/shortcuts.xml
@@ -63,6 +63,11 @@
         <seq>Enter</seq>
     </SC>
     <SC>
+        <key>track-range-selection</key>
+        <seq>Shift+Enter</seq>
+        <seq>Shift+Return</seq>
+    </SC>
+    <SC>
         <key>nav-up</key>
         <seq>Up</seq>
     </SC>

--- a/src/projectscene/internal/projectsceneuiactions.cpp
+++ b/src/projectscene/internal/projectsceneuiactions.cpp
@@ -194,6 +194,12 @@ static UiActionList STATIC_ACTIONS = {
              TranslatableString("action", "Select track"),
              TranslatableString("action", "Select track")
              ),
+    UiAction("track-range-selection",
+             au::context::UiCtxProjectOpened,
+             muse::shortcuts::CTX_PROJECT_OPENED,
+             TranslatableString("action", "Track range selection"),
+             TranslatableString("action", "Track range selection")
+             ),
     UiAction("focus-prev-track",
              au::context::UiCtxProjectOpened,
              muse::shortcuts::CTX_PROJECT_OPENED,

--- a/src/trackedit/internal/itracknavigationcontroller.h
+++ b/src/trackedit/internal/itracknavigationcontroller.h
@@ -17,6 +17,7 @@ public:
     virtual void focusNextTrack() = 0;
     virtual void navigateUp(const muse::actions::ActionData& args) = 0;
     virtual void navigateDown(const muse::actions::ActionData& args) = 0;
+    virtual void trackRangeSelection() = 0;
     virtual void toggleSelectionOnFocusedTrack() = 0;
     virtual void multiSelectionUp() = 0;
     virtual void multiSelectionDown() = 0;

--- a/src/trackedit/internal/tracknavigationcontroller.h
+++ b/src/trackedit/internal/tracknavigationcontroller.h
@@ -34,6 +34,7 @@ public:
     void navigateUp(const muse::actions::ActionData& args) override;
     void navigateDown(const muse::actions::ActionData& args) override;
     void toggleSelectionOnFocusedTrack() override;
+    void trackRangeSelection() override;
     void multiSelectionUp() override;
     void multiSelectionDown() override;
 
@@ -42,5 +43,6 @@ private:
     void updateTrackSelection(TrackIdList& selectedTracks, const TrackId& previousFocusedTrack);
 
     std::optional<TrackId> m_selectionStart;
+    std::optional<TrackId> m_lastSelectedTrack;
 };
 }


### PR DESCRIPTION
Resolves: #9361

Allow track range selection using shift + enter.

If a mouse selects the first track, it is used as the base of the range selection.
If the mouse selects more than one track to simplify, ignore the previous selection once to determine which track is the base track, which can have many corner cases.

For selection with the keyboard, on the other hand, we pick the last selected track as the base and clear the selection from tracks that are not within the range between the base and the endpoint of the range selection.
If we have multiple selected tracks and the last action is to deselect a track, the range selection will ignore the selected tracks. This seems to be coherent with what we can see on Linux file explorer for example.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Autobot test cases have been run
