### PR TITLE
Add note about installing Qt Shader Tools in setup instructions

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -23,6 +23,9 @@ As large parts of Audacity 4 are based on MuseScore Studio, the general setup st
 1. [Set up a developer environment](https://github.com/musescore/MuseScore/wiki/Set-up-developer-environment)
 2. [Install Qt and Qt Creator](https://github.com/musescore/MuseScore/wiki/Install-Qt-and-Qt-Creator)
 
+> [!IMPORTANT]  
+> You will also need to install `QT Shader Tools` under `Additional Libraries`
+
 ### Get the Audacity source and its submodules
 
 To get the source and submodules in one command, `git clone --recurse-submodules https://github.com/audacity/audacity.git` in the folder of your choice. See the [Github help](https://docs.github.com/en/get-started/getting-started-with-git/about-remote-repositories) for more information. 


### PR DESCRIPTION
Resolves: ***Not sure if needed. If I need to create an issue, please let me know.***

Found that the build fails on Windows 11 if `Qt Shader Tools` isn't installed. Added a note to the setup guide to clarify this requirement. As it deviates from the linked MuseScore Studio requirements.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [ ] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR