### PR TITLE
Change focus border for light theme

### DIFF
--- a/src/projectscene/qml/Audacity/ProjectScene/clipsview/ClipItem.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/clipsview/ClipItem.qml
@@ -134,21 +134,19 @@ Rectangle {
     NavigationFocusBorder {
         id: focusBorder
 
-        padding: -1
-
         navigationCtrl: navCtrl
 
         border.color: ui.theme.fontPrimaryColor
         border.width: 2
-        radius: 4
+        radius: isContrastFocusBorderEnabled ? 0 : 4
 
-        visible: navigationCtrl ? navigationCtrl.highlight : false
+        visible: clipSelected || (navigationCtrl ? navigationCtrl.highlight : false)
     }
 
     NavigationFocusBorder {
         id: contrastFocusBorder
 
-        padding: focusBorder.padding + focusBorder.border.width
+        padding: focusBorder.border.width
 
         navigationCtrl: navCtrl
 
@@ -156,7 +154,7 @@ Rectangle {
         border.width: 2
         radius: 4
 
-        visible: isContrastFocusBorderEnabled && navigationCtrl ? navigationCtrl.highlight : false
+        visible: isContrastFocusBorderEnabled && ((navigationCtrl ? navigationCtrl.highlight : false) || root.clipSelected)
     }
 
     QtObject {
@@ -803,16 +801,6 @@ Rectangle {
                     waveView.onWaveViewPositionChanged(hoverArea.mouseX, hoverArea.mouseY - header.height)
                 }
             }
-        }
-
-        RoundedRectangle {
-            id: clipBorder
-            anchors.fill: parent
-            border.width: 1
-            border.color: root.clipSelected ? "white" : "black"
-            color: "transparent"
-            radius: root.radius
-            z: 2
         }
     }
 

--- a/src/projectscene/qml/Audacity/ProjectScene/clipsview/ClipItem.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/clipsview/ClipItem.qml
@@ -104,6 +104,9 @@ Rectangle {
     property bool rightTrimContainsMouse: false
     property alias leftTrimPressedButtons: leftTrimStretchEdgeHover.pressedButtons
     property alias rightTrimPressedButtons: rightTrimStretchEdgeHover.pressedButtons
+    property bool enableFocusBorder: (navCtrl ? navCtrl.highlight : false) || root.clipSelected
+    property bool enableDefaultBorder: !isContrastFocusBorderEnabled && enableFocusBorder
+    property bool enableContrastBorder: isContrastFocusBorderEnabled && enableFocusBorder
 
     PlaybackStateModel {
         id: playbackState
@@ -131,6 +134,17 @@ Rectangle {
         }
     }
 
+    Rectangle {
+        id: borderRect
+
+        anchors.fill: parent
+        color: "transparent"
+        border.width: root.enableContrastBorder ?  2 : 1
+        border.color: "#000000"
+        radius: root.enableContrastBorder ? 0 : 4
+        z: root.parent.z + 1
+    }
+
     NavigationFocusBorder {
         id: focusBorder
 
@@ -138,15 +152,13 @@ Rectangle {
 
         border.color: ui.theme.fontPrimaryColor
         border.width: 2
-        radius: isContrastFocusBorderEnabled ? 0 : 4
+        radius: 4
 
-        visible: clipSelected || (navigationCtrl ? navigationCtrl.highlight : false)
+        visible: root.enableDefaultBorder
     }
 
     NavigationFocusBorder {
         id: contrastFocusBorder
-
-        padding: focusBorder.border.width
 
         navigationCtrl: navCtrl
 
@@ -154,7 +166,7 @@ Rectangle {
         border.width: 2
         radius: 4
 
-        visible: isContrastFocusBorderEnabled && ((navigationCtrl ? navigationCtrl.highlight : false) || root.clipSelected)
+        visible: root.enableContrastBorder
     }
 
     QtObject {

--- a/src/projectscene/qml/Audacity/ProjectScene/clipsview/ClipItem.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/clipsview/ClipItem.qml
@@ -39,6 +39,7 @@ Rectangle {
     property real selectionWidth: 0
     property bool selectionInProgress: false
     property bool enableCursorInteraction: !selectionInProgress && !isBrush
+    property bool isContrastFocusBorderEnabled: false
 
     property real distanceToLeftNeighbor: -1
     property real distanceToRightNeighbor: -1
@@ -118,6 +119,8 @@ Rectangle {
         accessible.name: root.name
 
         onActiveChanged: function (active) {
+            // Make sure the focus navigation border is visible on top of other clips
+            root.parent.z = active ? 1 : 0
             if (active) {
                 root.forceActiveFocus()
             }
@@ -129,7 +132,31 @@ Rectangle {
     }
 
     NavigationFocusBorder {
+        id: focusBorder
+
+        padding: -1
+
         navigationCtrl: navCtrl
+
+        border.color: ui.theme.fontPrimaryColor
+        border.width: 2
+        radius: 4
+
+        visible: navigationCtrl ? navigationCtrl.highlight : false
+    }
+
+    NavigationFocusBorder {
+        id: contrastFocusBorder
+
+        padding: focusBorder.padding + focusBorder.border.width
+
+        navigationCtrl: navCtrl
+
+        border.color: "white"
+        border.width: 2
+        radius: 4
+
+        visible: isContrastFocusBorderEnabled && navigationCtrl ? navigationCtrl.highlight : false
     }
 
     QtObject {

--- a/src/projectscene/qml/Audacity/ProjectScene/clipsview/TrackClipsItem.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/clipsview/TrackClipsItem.qml
@@ -289,6 +289,7 @@ Item {
                 altPressed: root.altPressed
                 selectionInProgress: root.selectionInProgress || root.selectionEditInProgress
                 asymmetricStereoHeightsPossible: clipsModel.asymmetricStereoHeightsPossible
+                isContrastFocusBorderEnabled: clipsModel.isContrastFocusBorderEnabled
 
                 //! NOTE: use the same integer rounding as in WaveBitmapCache
                 selectionStart: root.context.selectionStartPosition < clipItem.x ? 0 : Math.floor(root.context.selectionStartPosition - clipItem.x + 0.5)

--- a/src/projectscene/view/clipsview/clipslistmodel.cpp
+++ b/src/projectscene/view/clipsview/clipslistmodel.cpp
@@ -76,6 +76,10 @@ void ClipsListModel::init()
 
     dispatcher()->reg(this, "rename-clip", this, &ClipsListModel::requestClipTitleChange);
 
+    uiConfiguration()->currentThemeChanged().onNotify(this, [this]() {
+        emit isContrastFocusBorderEnabledChanged();
+    });
+
     reload();
 }
 
@@ -655,6 +659,11 @@ bool ClipsListModel::asymmetricStereoHeightsPossible() const
     }
 
     return false;
+}
+
+bool ClipsListModel::isContrastFocusBorderEnabled() const
+{
+    return !uiConfiguration()->isDarkMode();
 }
 
 au::projectscene::ClipKey ClipsListModel::updateClipTrack(ClipKey clipKey) const

--- a/src/projectscene/view/clipsview/clipslistmodel.h
+++ b/src/projectscene/view/clipsview/clipslistmodel.h
@@ -11,6 +11,7 @@
 #include "context/iglobalcontext.h"
 #include "global/iinteractive.h"
 #include "global/async/asyncable.h"
+#include "ui/iuiconfiguration.h"
 #include "workspace/iworkspacemanager.h"
 
 #include "trackedit/iselectioncontroller.h"
@@ -32,6 +33,7 @@ class ClipsListModel : public QAbstractListModel, public muse::async::Asyncable,
     Q_PROPERTY(ClipStyles::Style clipStyle READ clipStyle NOTIFY clipStyleChanged FINAL)
     Q_PROPERTY(
         bool asymmetricStereoHeightsPossible READ asymmetricStereoHeightsPossible NOTIFY asymmetricStereoHeightsPossibleChanged)
+    Q_PROPERTY(bool isContrastFocusBorderEnabled READ isContrastFocusBorderEnabled NOTIFY isContrastFocusBorderEnabledChanged FINAL)
 
     Q_PROPERTY(int cacheBufferPx READ cacheBufferPx CONSTANT)
 
@@ -43,6 +45,7 @@ class ClipsListModel : public QAbstractListModel, public muse::async::Asyncable,
     muse::Inject<projectscene::IProjectSceneConfiguration> projectSceneConfiguration;
     muse::Inject<muse::workspace::IWorkspaceManager> workspacesManager;
     muse::Inject<trackedit::IProjectHistory> projectHistory;
+    muse::Inject<muse::ui::IUiConfiguration> uiConfiguration;
 
 public:
     explicit ClipsListModel(QObject* parent = nullptr);
@@ -87,6 +90,7 @@ public:
     Q_INVOKABLE projectscene::ClipKey updateClipTrack(ClipKey clipKey) const;
 
     bool asymmetricStereoHeightsPossible() const;
+    bool isContrastFocusBorderEnabled() const;
 
     int rowCount(const QModelIndex& parent) const override;
     QHash<int, QByteArray> roleNames() const override;
@@ -101,6 +105,7 @@ signals:
     void isStereoChanged();
     void clipStyleChanged();
     void asymmetricStereoHeightsPossibleChanged();
+    void isContrastFocusBorderEnabledChanged();
 
     void requestClipTitleEdit(int index);
 


### PR DESCRIPTION
Resolves: #9357 

Add a white border external to the black border on the light theme to enhance contrast.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Autobot test cases have been run
