### PR TITLE
Opening AUP3 files and saving it immediately makes the project corrupted

### DIFF
--- a/au3/libraries/lib-wave-track/WaveClip.cpp
+++ b/au3/libraries/lib-wave-track/WaveClip.cpp
@@ -1237,13 +1237,19 @@ void WaveClip::WriteXML(size_t ii, XMLWriter& xmlFile) const
     xmlFile.WriteAttr(CentShiftAttr, mCentShift);
     xmlFile.WriteAttr(PitchAndSpeedPreset_attr,
                       static_cast<long>(mPitchAndSpeedPreset));
-    xmlFile.WriteAttr(RawAudioTempo_attr, mRawAudioTempo.value_or(0.), 8);
     xmlFile.WriteAttr(ClipStretchRatio_attr, mClipStretchRatio, 8);
     xmlFile.WriteAttr(ClipStretchToMatchTempo_attr, mStretchToMatchProjectTempo);
-    xmlFile.WriteAttr(ClipTempo_attr, mClipTempo.value_or(0.), 8);
     xmlFile.WriteAttr(Name_attr, mName);
     xmlFile.WriteAttr(GroupId_attr, static_cast<long>(mGroupId));
     xmlFile.WriteAttr(Color_attr, mColor);
+
+    if (mClipTempo) {
+        xmlFile.WriteAttr(ClipTempo_attr, *mClipTempo, 8);
+    }
+    if (mRawAudioTempo) {
+        xmlFile.WriteAttr(RawAudioTempo_attr, *mRawAudioTempo, 8);
+    }
+
     Attachments::ForEach([&](const WaveClipListener& listener){
         listener.WriteXMLAttributes(xmlFile);
     });


### PR DESCRIPTION
Resolves: #9608

Opening AUP3 files and saving it immediately makes the project corrupted. Do not save invalid clip tempo.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Autobot test cases have been run
