### PR TITLE
9441 smoother playhead

### DIFF
--- a/au3/libraries/lib-audio-devices/AudioIOBase.cpp
+++ b/au3/libraries/lib-audio-devices/AudioIOBase.cpp
@@ -310,10 +310,10 @@ int AudioIOBase::GetHostIndex(const std::string& hostName)
 void AudioIOBase::StartMeters()
 {
     if (auto pInputMeter = mInputMeter.lock()) {
-        pInputMeter->start();
+        pInputMeter->start(mRate);
     }
     if (auto pOutputMeter = mOutputMeter.lock()) {
-        pOutputMeter->start();
+        pOutputMeter->start(mRate);
     }
 }
 
@@ -331,16 +331,6 @@ void AudioIOBase::ResetMeters()
 {
     mInputMeter.reset();
     mOutputMeter.reset();
-}
-
-void AudioIOBase::UpdateMetersRate(const double rate)
-{
-    if (auto pInputMeter = mInputMeter.lock()) {
-        pInputMeter->setSampleRate(rate);
-    }
-    if (auto pOutputMeter = mOutputMeter.lock()) {
-        pOutputMeter->setSampleRate(rate);
-    }
 }
 
 void AudioIOBase::SetCaptureMeter(

--- a/au3/libraries/lib-audio-devices/AudioIOBase.h
+++ b/au3/libraries/lib-audio-devices/AudioIOBase.h
@@ -128,11 +128,6 @@ public:
      */
     void ResetMeters();
 
-    /**
-     * \brief Update the sample rate of the current VU meters
-     */
-    void UpdateMetersRate(const double rate);
-
     void SetCaptureMeter(
         const std::shared_ptr<AudacityProject>& project, const std::weak_ptr<IMeterSender>& meter);
     void SetPlaybackMeter(

--- a/au3/libraries/lib-audio-devices/AudioIOBase.h
+++ b/au3/libraries/lib-audio-devices/AudioIOBase.h
@@ -321,6 +321,8 @@ public:
      */
     void SetMixer(int inputSource);
 
+    double GetPlaybackSampleRate() const { return mRate; }
+
 protected:
     static std::unique_ptr<AudioIOBase> ugAudioIO;
     static wxString DeviceName(const PaDeviceInfo* info);

--- a/au3/libraries/lib-audio-devices/IMeterSender.h
+++ b/au3/libraries/lib-audio-devices/IMeterSender.h
@@ -10,10 +10,25 @@ class AUDIO_DEVICES_API IMeterSender
 public:
     struct InterleavedSampleData
     {
+        InterleavedSampleData(
+            const float* const buf,
+            size_t frm,
+            size_t nCh,
+            double firstTs,
+            std::chrono::steady_clock::time_point when_)
+            : buffer(buf)
+            , frames(frm)
+            , nChannels(nCh)
+            , firstSampleTimestamp(firstTs)
+            , when(when_)
+        {
+        }
+
         const float* const buffer;
         const size_t frames;
         const size_t nChannels;
         const double firstSampleTimestamp;
+        const std::chrono::steady_clock::time_point when;
     };
 
     struct TrackId {
@@ -24,9 +39,10 @@ public:
         bool operator<(const TrackId& other) const { return value < other.value; }
     };
 
+    using OptionalTimePoint = std::optional<std::chrono::steady_clock::time_point>;
+
     virtual ~IMeterSender() = default;
     virtual void push(uint8_t channel, const InterleavedSampleData& sampleData, TrackId = TrackId { MASTER_TRACK_ID }) = 0;
-    virtual void start() = 0;
+    virtual void start(double sampleRate) = 0;
     virtual void stop() = 0;
-    virtual void setSampleRate(double rate) = 0;
 };

--- a/au3/libraries/lib-audio-devices/IMeterSender.h
+++ b/au3/libraries/lib-audio-devices/IMeterSender.h
@@ -4,31 +4,30 @@
 #pragma once
 
 constexpr int64_t MASTER_TRACK_ID = -2;
+using TimePoint = std::chrono::steady_clock::time_point;
 
 class AUDIO_DEVICES_API IMeterSender
 {
 public:
+
     struct InterleavedSampleData
     {
         InterleavedSampleData(
             const float* const buf,
             size_t frm,
             size_t nCh,
-            double firstTs,
-            std::chrono::steady_clock::time_point when_)
+            TimePoint dacTime)
             : buffer(buf)
             , frames(frm)
             , nChannels(nCh)
-            , firstSampleTimestamp(firstTs)
-            , when(when_)
+            , dacTime(std::move(dacTime))
         {
         }
 
         const float* const buffer;
         const size_t frames;
         const size_t nChannels;
-        const double firstSampleTimestamp;
-        const std::chrono::steady_clock::time_point when;
+        const TimePoint dacTime;
     };
 
     struct TrackId {
@@ -39,10 +38,12 @@ public:
         bool operator<(const TrackId& other) const { return value < other.value; }
     };
 
-    using OptionalTimePoint = std::optional<std::chrono::steady_clock::time_point>;
+    using OptionalTimePoint = std::optional<TimePoint>;
 
     virtual ~IMeterSender() = default;
     virtual void push(uint8_t channel, const InterleavedSampleData& sampleData, TrackId = TrackId { MASTER_TRACK_ID }) = 0;
     virtual void start(double sampleRate) = 0;
     virtual void stop() = 0;
 };
+
+using IMeterSenderPtr = std::shared_ptr<IMeterSender>;

--- a/au3/libraries/lib-audio-io/AudioIO.cpp
+++ b/au3/libraries/lib-audio-io/AudioIO.cpp
@@ -2742,7 +2742,7 @@ bool AudioIoCallback::FillOutputBuffers(
                 using namespace std::chrono;
                 const auto now = steady_clock::now();
                 const auto adcTime = now + milliseconds(static_cast<int>(mHardwarePlaybackLatencyFrames * 1000.0 / mRate));
-                mAudioDeliveryQueue.Put({ adcTime, static_cast<int>(numberOfRetrievedFrames) });
+                mAudioCallbackInfoQueue.Put({ adcTime, static_cast<int>(numberOfRetrievedFrames) });
             }
 
             // Output volume emulation: possibly copy meter samples, then

--- a/au3/libraries/lib-audio-io/AudioIO.cpp
+++ b/au3/libraries/lib-audio-io/AudioIO.cpp
@@ -3035,7 +3035,7 @@ void AudioIoCallback::SendVuOutputMeterData(const float* outputMeterFloats, unsi
         return;
     }
 
-    PushMainMeterValues(outputMeter, outputMeterFloats, mNumPlaybackChannels, framesPerBuffer, dacTime);
+    PushMasterOutputMeterValues(outputMeter, outputMeterFloats, mNumPlaybackChannels, framesPerBuffer, dacTime);
     PushTrackMeterValues(outputMeter, framesPerBuffer, dacTime);
 }
 
@@ -3082,8 +3082,9 @@ void AudioIoCallback::PushInputMeterValues(const IMeterSenderPtr& sender, const 
     }
 }
 
-void AudioIoCallback::PushMainMeterValues(const IMeterSenderPtr& sender, const float* values, uint8_t channels, unsigned long frames,
-                                          const TimePoint& dacTime)
+void AudioIoCallback::PushMasterOutputMeterValues(const IMeterSenderPtr& sender, const float* values, uint8_t channels,
+                                                  unsigned long frames,
+                                                  const TimePoint& dacTime)
 {
     auto sptr = values;
     for (size_t ch = 0; ch < channels; ++ch) {

--- a/au3/libraries/lib-audio-io/AudioIO.h
+++ b/au3/libraries/lib-audio-io/AudioIO.h
@@ -188,7 +188,7 @@ public:
     void SetListener(const std::shared_ptr< AudioIOListener >& listener);
 
     struct AudioDelivery {
-        std::chrono::steady_clock::time_point startTime;
+        TimePoint dacTime;
         int numSamples = 0;
     };
     using AudioDeliveryQueue = LockFreeQueue<AudioDelivery>;
@@ -220,17 +220,12 @@ public:
         unsigned long framesPerBuffer);
     void DoPlaythrough(
         constSamplePtr inputBuffer, float* outputBuffer, unsigned long framesPerBuffer, float* outputMeterFloats);
-    void SendVuInputMeterData(const float* inputSamples, unsigned long framesPerBuffer, const PaStreamCallbackTimeInfo* timeInfo,
-                              const std::chrono::steady_clock::time_point& when);
-    void SendVuOutputMeterData(
-        const float* outputMeterFloats, unsigned long framesPerBuffer, const PaStreamCallbackTimeInfo* timeInfo,
-        const std::chrono::steady_clock::time_point& when);
-    void PushMainMeterValues(const std::shared_ptr<IMeterSender>& sender, const float* values, uint8_t channels, unsigned long frames,
-                             const PaStreamCallbackTimeInfo* timeInfo, const std::chrono::steady_clock::time_point& when);
-    void PushTrackMeterValues(const std::shared_ptr<IMeterSender>& sender, unsigned long frames, const PaStreamCallbackTimeInfo* timeInfo,
-                              const std::chrono::steady_clock::time_point& when);
-    void PushInputMeterValues(const std::shared_ptr<IMeterSender>& sender, const float* values, unsigned long frames,
-                              const PaStreamCallbackTimeInfo* timeInfo, const std::chrono::steady_clock::time_point& when);
+    void SendVuInputMeterData(const float* inputSamples, unsigned long framesPerBuffer, const TimePoint& dacTime);
+    void SendVuOutputMeterData(const float* outputMeterFloats, unsigned long framesPerBuffer, const TimePoint& dacTime);
+    void PushMainMeterValues(const IMeterSenderPtr& sender, const float* values, uint8_t channels, unsigned long frames,
+                             const TimePoint& dacTime);
+    void PushTrackMeterValues(const IMeterSenderPtr& sender, unsigned long frames, const TimePoint& dacTime);
+    void PushInputMeterValues(const IMeterSenderPtr& sender, const float* values, unsigned long frames, const TimePoint& dacTime);
 
     /** \brief Get the number of audio samples ready in all of the playback
     * buffers.

--- a/au3/libraries/lib-audio-io/AudioIO.h
+++ b/au3/libraries/lib-audio-io/AudioIO.h
@@ -187,13 +187,13 @@ public:
     { return mListener.lock(); }
     void SetListener(const std::shared_ptr< AudioIOListener >& listener);
 
-    struct AudioDelivery {
+    struct AudioCallbackInfo {
         TimePoint dacTime;
         int numSamples = 0;
     };
-    using AudioDeliveryQueue = LockFreeQueue<AudioDelivery>;
+    using AudioCallbackInfoQueue = LockFreeQueue<AudioCallbackInfo>;
 
-    AudioDeliveryQueue& GetAudioDeliveryQueue() { return mAudioDeliveryQueue; }
+    AudioCallbackInfoQueue& GetAudioCallbackInfoQueue() { return mAudioCallbackInfoQueue; }
 
     // Part of the callback
     int CallbackDoSeek();
@@ -397,7 +397,7 @@ protected:
     //! Holds some state for duration of playback or recording
     std::unique_ptr<TransportState> mpTransportState;
 
-    AudioDeliveryQueue mAudioDeliveryQueue { 16 };
+    AudioCallbackInfoQueue mAudioCallbackInfoQueue { 16 };
 
 private:
     /*!

--- a/au3/libraries/lib-audio-io/AudioIO.h
+++ b/au3/libraries/lib-audio-io/AudioIO.h
@@ -280,7 +280,8 @@ public:
     /// Preferred batch size for replenishing the playback RingBuffer
     size_t mPlaybackSamplesToCopy;
     /// Hardware output latency in frames
-    size_t mHardwarePlaybackLatencyFrames {};
+    size_t mHardwarePlaybackLatencyFrames { 0u };
+    double mHardwarePlaybackLatencyMs{ 0 };
     /// Occupancy of the queue we try to maintain, with bigger batches if needed
     size_t mPlaybackQueueMinimum;
 

--- a/au3/libraries/lib-audio-io/AudioIO.h
+++ b/au3/libraries/lib-audio-io/AudioIO.h
@@ -138,7 +138,7 @@ public:
                         : audioIO.mAudioIOExt.begin()}
         {}
         AudioIOExtIterator& operator ++() { ++mIterator; return *this; }
-        auto operator *() const -> AudioIOExt &;
+        auto operator *() const -> AudioIOExt&;
         friend inline bool operator ==(
             const AudioIOExtIterator& xx, const AudioIOExtIterator& yy)
         {
@@ -185,6 +185,8 @@ public:
     std::shared_ptr< AudioIOListener > GetListener() const
     { return mListener.lock(); }
     void SetListener(const std::shared_ptr< AudioIOListener >& listener);
+
+    bool ProjectSamplesReachedDeviceThread() const;
 
     // Part of the callback
     int CallbackDoSeek();
@@ -389,6 +391,8 @@ protected:
     struct TransportState;
     //! Holds some state for duration of playback or recording
     std::unique_ptr<TransportState> mpTransportState;
+
+    std::atomic<bool> mProjectSamplesReachedDeviceThread { false };
 
 private:
     /*!

--- a/au3/libraries/lib-audio-io/AudioIO.h
+++ b/au3/libraries/lib-audio-io/AudioIO.h
@@ -138,7 +138,7 @@ public:
                         : audioIO.mAudioIOExt.begin()}
         {}
         AudioIOExtIterator& operator ++() { ++mIterator; return *this; }
-        auto operator *() const -> AudioIOExt&;
+        auto operator *() const -> AudioIOExt &;
         friend inline bool operator ==(
             const AudioIOExtIterator& xx, const AudioIOExtIterator& yy)
         {
@@ -186,7 +186,7 @@ public:
     { return mListener.lock(); }
     void SetListener(const std::shared_ptr< AudioIOListener >& listener);
 
-    bool ProjectSamplesReachedDeviceThread() const;
+    std::optional<std::chrono::steady_clock::time_point> UserStartsHearingAudioTimePoint() const;
 
     // Part of the callback
     int CallbackDoSeek();
@@ -392,7 +392,7 @@ protected:
     //! Holds some state for duration of playback or recording
     std::unique_ptr<TransportState> mpTransportState;
 
-    std::atomic<bool> mProjectSamplesReachedDeviceThread { false };
+    std::atomic<std::optional<std::chrono::steady_clock::time_point>> mUserStartsHearingAudioTimePoint;
 
 private:
     /*!

--- a/au3/libraries/lib-audio-io/AudioIO.h
+++ b/au3/libraries/lib-audio-io/AudioIO.h
@@ -222,7 +222,7 @@ public:
         constSamplePtr inputBuffer, float* outputBuffer, unsigned long framesPerBuffer, float* outputMeterFloats);
     void SendVuInputMeterData(const float* inputSamples, unsigned long framesPerBuffer, const TimePoint& dacTime);
     void SendVuOutputMeterData(const float* outputMeterFloats, unsigned long framesPerBuffer, const TimePoint& dacTime);
-    void PushMainMeterValues(const IMeterSenderPtr& sender, const float* values, uint8_t channels, unsigned long frames,
+    void PushMasterOutputMeterValues(const IMeterSenderPtr& sender, const float* values, uint8_t channels, unsigned long frames,
                              const TimePoint& dacTime);
     void PushTrackMeterValues(const IMeterSenderPtr& sender, unsigned long frames, const TimePoint& dacTime);
     void PushInputMeterValues(const IMeterSenderPtr& sender, const float* values, unsigned long frames, const TimePoint& dacTime);

--- a/au3/libraries/lib-audio-io/AudioIO.h
+++ b/au3/libraries/lib-audio-io/AudioIO.h
@@ -187,8 +187,6 @@ public:
     { return mListener.lock(); }
     void SetListener(const std::shared_ptr< AudioIOListener >& listener);
 
-    std::optional<std::chrono::steady_clock::time_point> UserStartsHearingAudioTimePoint() const;
-
     struct AudioDelivery {
         std::chrono::steady_clock::time_point startTime;
         int numSamples = 0;
@@ -222,14 +220,17 @@ public:
         unsigned long framesPerBuffer);
     void DoPlaythrough(
         constSamplePtr inputBuffer, float* outputBuffer, unsigned long framesPerBuffer, float* outputMeterFloats);
-    void SendVuInputMeterData(const float* inputSamples, unsigned long framesPerBuffer, const PaStreamCallbackTimeInfo* timeInfo);
+    void SendVuInputMeterData(const float* inputSamples, unsigned long framesPerBuffer, const PaStreamCallbackTimeInfo* timeInfo,
+                              const std::chrono::steady_clock::time_point& when);
     void SendVuOutputMeterData(
-        const float* outputMeterFloats, unsigned long framesPerBuffer, const PaStreamCallbackTimeInfo* timeInfo);
+        const float* outputMeterFloats, unsigned long framesPerBuffer, const PaStreamCallbackTimeInfo* timeInfo,
+        const std::chrono::steady_clock::time_point& when);
     void PushMainMeterValues(const std::shared_ptr<IMeterSender>& sender, const float* values, uint8_t channels, unsigned long frames,
-                             const PaStreamCallbackTimeInfo* timeInfo);
-    void PushTrackMeterValues(const std::shared_ptr<IMeterSender>& sender, unsigned long frames, const PaStreamCallbackTimeInfo* timeInfo);
+                             const PaStreamCallbackTimeInfo* timeInfo, const std::chrono::steady_clock::time_point& when);
+    void PushTrackMeterValues(const std::shared_ptr<IMeterSender>& sender, unsigned long frames, const PaStreamCallbackTimeInfo* timeInfo,
+                              const std::chrono::steady_clock::time_point& when);
     void PushInputMeterValues(const std::shared_ptr<IMeterSender>& sender, const float* values, unsigned long frames,
-                              const PaStreamCallbackTimeInfo* timeInfo);
+                              const PaStreamCallbackTimeInfo* timeInfo, const std::chrono::steady_clock::time_point& when);
 
     /** \brief Get the number of audio samples ready in all of the playback
     * buffers.
@@ -402,7 +403,6 @@ protected:
     std::unique_ptr<TransportState> mpTransportState;
 
     AudioDeliveryQueue mAudioDeliveryQueue { 16 };
-    std::atomic<std::optional<std::chrono::steady_clock::time_point> > mUserStartsHearingAudioTimePoint;
 
 private:
     /*!

--- a/au3/libraries/lib-audio-io/PlaybackSchedule.h
+++ b/au3/libraries/lib-audio-io/PlaybackSchedule.h
@@ -24,7 +24,9 @@ struct AudioIOStartStreamOptions;
 class BoundedEnvelope;
 using PRCrossfadeData = std::vector< std::vector < float > >;
 
-constexpr size_t TimeQueueGrainSize = 2000;
+// This can become a bottleneck to the update rate of the play cursor position.
+// Let's set this to 10ms at 48kHz. Even at 16kHz, that'd be a refresh rate of 33fps.
+constexpr size_t TimeQueueGrainSize = 480;
 
 struct RecordingSchedule {
     double mPreRoll{};

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -31,6 +31,7 @@ endif()
 
 add_subdirectory(au3wrap)
 
+add_subdirectory(auaudio)
 add_subdirectory(context)
 add_subdirectory(project)
 

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -85,6 +85,7 @@ set(LINK_LIB
 
     appshell
     au3wrap
+    auaudio
     context
     effects_audio_unit
     effects_lv2

--- a/src/au3wrap/CMakeLists.txt
+++ b/src/au3wrap/CMakeLists.txt
@@ -29,6 +29,8 @@ set(MODULE_SRC
 
     ${CMAKE_CURRENT_LIST_DIR}/internal/au3audiometer.cpp
     ${CMAKE_CURRENT_LIST_DIR}/internal/au3audiometer.h
+    ${CMAKE_CURRENT_LIST_DIR}/internal/au3audiometerfactory.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/internal/au3audiometerfactory.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/wxtypes_convert.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/wxlogwrap.cpp
     ${CMAKE_CURRENT_LIST_DIR}/internal/wxlogwrap.h

--- a/src/au3wrap/CMakeLists.txt
+++ b/src/au3wrap/CMakeLists.txt
@@ -823,7 +823,7 @@ add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/thirdparty/portmixer au3-portmixer)
 set(MODULE_INCLUDE ${AU3_INCLUDE})
 set(MODULE_DEF ${AU3_DEF})
 set(MODULE_SRC ${MODULE_SRC} ${AU3_SRC})
-set(MODULE_LINK ${AU3_LINK} project)
+set(MODULE_LINK ${AU3_LINK} project auaudio)
 
 set(MODULE_USE_PCH OFF)
 set(MODULE_USE_UNITY OFF)

--- a/src/au3wrap/internal/au3audiometer.cpp
+++ b/src/au3wrap/internal/au3audiometer.cpp
@@ -56,6 +56,7 @@ Meter::Meter()
     });
 
     m_meterUpdateTimer.setInterval(static_cast<int>(updatePeriod * 1000));
+    m_meterUpdateTimer.setTimerType(Qt::PreciseTimer);
 
     m_meterUpdateTimer.callOnTimeout([this]() {
         for (auto& [_, trackData] : m_trackData) {

--- a/src/au3wrap/internal/au3audiometer.cpp
+++ b/src/au3wrap/internal/au3audiometer.cpp
@@ -42,23 +42,22 @@ void Meter::maybeBumpUp(LevelState& level, float newLinValue, int hangover)
     }
 }
 
-Meter::Meter()
+Meter::Meter(std::unique_ptr<ITimer> meterUpdateTimer, std::unique_ptr<ITimer> stopTimer)
+    : m_meterUpdateTimer{std::move(meterUpdateTimer)}, m_stopTimer{std::move(stopTimer)}
 {
     constexpr int letRingMs = -1000 * leastDb / decayDbPerSecond;
     static_assert(letRingMs > 0);
-    m_stopTimer.setSingleShot(true);
-    m_stopTimer.setInterval(letRingMs);
-    m_stopTimer.callOnTimeout([this]() {
-        m_meterUpdateTimer.stop();
+    m_stopTimer->setSingleShot(true);
+    m_stopTimer->setInterval(std::chrono::milliseconds { letRingMs });
+    m_stopTimer->setCallback([this]() {
+        m_meterUpdateTimer->stop();
         for (auto& [_, trackData] : m_trackData) {
             trackData.channelLevels.clear();
         }
     });
 
-    m_meterUpdateTimer.setInterval(static_cast<int>(updatePeriod * 1000));
-    m_meterUpdateTimer.setTimerType(Qt::PreciseTimer);
-
-    m_meterUpdateTimer.callOnTimeout([this]() {
+    m_meterUpdateTimer->setInterval(std::chrono::milliseconds { static_cast<int>(updatePeriod * 1000) });
+    m_meterUpdateTimer->setCallback([this]() {
         for (auto& [_, trackData] : m_trackData) {
             for (auto& [_, levels] : trackData.channelLevels) {
                 decay(levels.peak);
@@ -118,10 +117,8 @@ void Meter::push(uint8_t channel, const IMeterSender::InterleavedSampleData& sam
 
 void Meter::start()
 {
-    if (!m_meterUpdateTimer.isActive()) {
-        m_meterUpdateTimer.start();
-    }
-    m_stopTimer.stop();
+    m_meterUpdateTimer->start();
+    m_stopTimer->stop();
     m_running.store(true);
     m_maxFramesPerPush = 0;
 }

--- a/src/au3wrap/internal/au3audiometer.cpp
+++ b/src/au3wrap/internal/au3audiometer.cpp
@@ -71,7 +71,7 @@ Meter::Meter(std::unique_ptr<ITimer> meterUpdateTimer, std::unique_ptr<ITimer> s
         }
 
         const auto now = std::chrono::steady_clock::now();
-        while (!m_mainThreadQueue.empty() && now >= m_mainThreadQueue.front().when) {
+        while (!m_mainThreadQueue.empty() && now >= m_mainThreadQueue.front().dacTime) {
             const QueueItem& item = m_mainThreadQueue.front();
             auto& levels = m_trackData[item.trackId].channelLevels[item.channel];
             maybeBumpUp(levels.peak, item.sample.peak, m_hangoverCount.load());
@@ -121,7 +121,7 @@ void Meter::push(uint8_t channel, const IMeterSender::InterleavedSampleData& sam
         m_hangoverCount.store(std::ceil(hangoverTime / updatePeriod));
     }
     const QueueSample value = getSamplesMaxValue(sampleData.buffer, sampleData.frames, sampleData.nChannels);
-    m_lockFreeQueue.Put(QueueItem { trackId, channel, value, sampleData.when });
+    m_lockFreeQueue.Put(QueueItem { trackId, channel, value, sampleData.dacTime });
 }
 
 void Meter::start(double sampleRate)

--- a/src/au3wrap/internal/au3audiometer.h
+++ b/src/au3wrap/internal/au3audiometer.h
@@ -48,7 +48,7 @@ private:
         TrackId trackId;
         audio::audioch_t channel;
         QueueSample sample;
-        std::chrono::steady_clock::time_point when;
+        TimePoint dacTime;
     };
 
     static constexpr auto leastDb = -100.0f;

--- a/src/au3wrap/internal/au3audiometer.h
+++ b/src/au3wrap/internal/au3audiometer.h
@@ -28,7 +28,12 @@ namespace au::au3 {
 class Meter : public IMeterSender, public muse::async::Asyncable
 {
 public:
-    Meter(std::unique_ptr<ITimer> meterUpdateTimer, std::unique_ptr<ITimer> stopTimer);
+    /**
+     * @param playingTimer For the update of the meters. Called very frequently and needs high precision to maximize smoothness of meter animation.
+     * @param stoppingTimer After pressing stop, `playingTimer` will continue running for a while until the meters have decayed and become invisible.
+     * The `stoppingTimer` will tell when `playingTimer` can definitely stop. May be very coarse.
+     */
+    Meter(std::unique_ptr<ITimer> playingTimer, std::unique_ptr<ITimer> stoppingTimer);
 
     void push(uint8_t channel, const IMeterSender::InterleavedSampleData& sampleData, TrackId) override;
     void start(double sampleRate) override;
@@ -81,8 +86,8 @@ private:
     LockFreeQueue<QueueItem> m_lockFreeQueue{ 1024 };
     std::queue<QueueItem> m_mainThreadQueue;
     std::map<TrackId, TrackData> m_trackData;
-    const std::unique_ptr<ITimer> m_meterUpdateTimer;
-    const std::unique_ptr<ITimer> m_stopTimer;
+    const std::unique_ptr<ITimer> m_playingTimer;
+    const std::unique_ptr<ITimer> m_stoppingTimer;
     std::atomic<bool> m_running { false };
     bool m_stopPending = true;
     bool m_warningIssued = false;

--- a/src/au3wrap/internal/au3audiometerfactory.cpp
+++ b/src/au3wrap/internal/au3audiometerfactory.cpp
@@ -1,0 +1,10 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+#include "au3audiometerfactory.h"
+#include "auaudio/internal/auqttimer.h"
+
+std::shared_ptr<au::au3::Meter> au::au3::createAudioMeter()
+{
+    return std::make_shared<au3::Meter>(std::make_unique<AuQtTimer>(Qt::PreciseTimer), std::make_unique<AuQtTimer>());
+}

--- a/src/au3wrap/internal/au3audiometerfactory.cpp
+++ b/src/au3wrap/internal/au3audiometerfactory.cpp
@@ -6,5 +6,7 @@
 
 std::shared_ptr<au::au3::Meter> au::au3::createAudioMeter()
 {
-    return std::make_shared<au3::Meter>(std::make_unique<AuQtTimer>(Qt::PreciseTimer), std::make_unique<AuQtTimer>());
+    auto playingTimer = std::make_unique<AuQtTimer>(Qt::PreciseTimer);
+    auto stoppingTimer = std::make_unique<AuQtTimer>(Qt::VeryCoarseTimer);
+    return std::make_shared<au3::Meter>(std::move(playingTimer), std::move(stoppingTimer));
 }

--- a/src/au3wrap/internal/au3audiometerfactory.h
+++ b/src/au3wrap/internal/au3audiometerfactory.h
@@ -1,0 +1,11 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+#pragma once
+
+#include "au3audiometer.h"
+#include <memory>
+
+namespace au::au3 {
+std::shared_ptr<Meter> createAudioMeter();
+}

--- a/src/auaudio/CMakeLists.txt
+++ b/src/auaudio/CMakeLists.txt
@@ -1,0 +1,16 @@
+#
+# Audacity: A Digital Audio Editor
+#
+
+declare_module(auaudio)
+
+set(MODULE_SRC
+    ${CMAKE_CURRENT_LIST_DIR}/auaudiomodule.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/auaudiomodule.h
+
+    ${CMAKE_CURRENT_LIST_DIR}/internal/auqttimer.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/internal/auqttimer.h
+    ${CMAKE_CURRENT_LIST_DIR}/internal/itimer.h
+)
+
+setup_module()

--- a/src/auaudio/auaudiomodule.cpp
+++ b/src/auaudio/auaudiomodule.cpp
@@ -1,0 +1,11 @@
+/*
+* Audacity: A Digital Audio Editor
+*/
+#include "auaudiomodule.h"
+
+namespace au::auaudio {
+std::string AuAudioModule::moduleName() const
+{
+    return "auaudio";
+}
+}

--- a/src/auaudio/auaudiomodule.h
+++ b/src/auaudio/auaudiomodule.h
@@ -1,0 +1,16 @@
+/*
+* Audacity: A Digital Audio Editor
+*/
+#pragma once
+
+#include <memory>
+
+#include "modularity/imodulesetup.h"
+
+namespace au::auaudio {
+class AuAudioModule : public muse::modularity::IModuleSetup
+{
+public:
+    std::string moduleName() const override;
+};
+}

--- a/src/auaudio/internal/auqttimer.cpp
+++ b/src/auaudio/internal/auqttimer.cpp
@@ -1,0 +1,38 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+#include "auqttimer.h"
+
+namespace au {
+AuQtTimer::AuQtTimer(std::optional<Qt::TimerType> timerType)
+{
+    if (timerType.has_value()) {
+        m_timer.setTimerType(*timerType);
+    }
+}
+
+void AuQtTimer::setCallback(std::function<void()> callback)
+{
+    m_timer.callOnTimeout(std::move(callback));
+}
+
+void AuQtTimer::setInterval(const std::chrono::milliseconds& interval)
+{
+    m_timer.setInterval(interval);
+}
+
+void AuQtTimer::setSingleShot(bool singleShot)
+{
+    m_timer.setSingleShot(singleShot);
+}
+
+void AuQtTimer::start()
+{
+    m_timer.start();
+}
+
+void AuQtTimer::stop()
+{
+    m_timer.stop();
+}
+}

--- a/src/auaudio/internal/auqttimer.h
+++ b/src/auaudio/internal/auqttimer.h
@@ -1,0 +1,24 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+#pragma once
+
+#include "itimer.h"
+#include <QTimer>
+
+namespace au {
+class AuQtTimer : public ITimer
+{
+public:
+    AuQtTimer(std::optional<Qt::TimerType> = {});
+    ~AuQtTimer() override = default;
+
+    void setCallback(std::function<void()>) override;
+    void setInterval(const std::chrono::milliseconds&) override;
+    void setSingleShot(bool) override;
+    void start() override;
+    void stop() override;
+private:
+    QTimer m_timer;
+};
+}

--- a/src/auaudio/internal/itimer.h
+++ b/src/auaudio/internal/itimer.h
@@ -1,0 +1,21 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+#pragma once
+
+#include <chrono>
+#include <functional>
+
+namespace au {
+class ITimer
+{
+public:
+    virtual ~ITimer() = default;
+
+    virtual void setCallback(std::function<void()>) = 0;
+    virtual void setInterval(const std::chrono::milliseconds&) = 0;
+    virtual void setSingleShot(bool) = 0;
+    virtual void start() = 0;
+    virtual void stop() = 0;
+};
+}

--- a/src/context/internal/playbackstate.cpp
+++ b/src/context/internal/playbackstate.cpp
@@ -7,7 +7,7 @@ void PlaybackState::setPlayer(playback::IPlayerPtr player)
 {
     if (m_player) {
         m_player->playbackStatusChanged().resetOnReceive(this);
-        m_player->playbackPositionChangedMainThreadOnly().resetOnReceive(this);
+        m_player->playbackPositionChanged().resetOnReceive(this);
     }
 
     m_player = player;
@@ -17,7 +17,7 @@ void PlaybackState::setPlayer(playback::IPlayerPtr player)
         m_playbackStatusChanged.send(st);
     });
 
-    m_player->playbackPositionChangedMainThreadOnly().onReceive(this, [this](muse::secs_t pos) {
+    m_player->playbackPositionChanged().onReceive(this, [this](muse::secs_t pos) {
         m_playbackPositionChanged.send(pos);
     });
 }

--- a/src/context/internal/playbackstate.cpp
+++ b/src/context/internal/playbackstate.cpp
@@ -7,7 +7,7 @@ void PlaybackState::setPlayer(playback::IPlayerPtr player)
 {
     if (m_player) {
         m_player->playbackStatusChanged().resetOnReceive(this);
-        m_player->playbackPositionChanged().resetOnReceive(this);
+        m_player->playbackPositionChangedMainThreadOnly().resetOnReceive(this);
     }
 
     m_player = player;
@@ -17,7 +17,7 @@ void PlaybackState::setPlayer(playback::IPlayerPtr player)
         m_playbackStatusChanged.send(st);
     });
 
-    m_player->playbackPositionChanged().onReceive(this, [this](muse::secs_t pos) {
+    m_player->playbackPositionChangedMainThreadOnly().onReceive(this, [this](muse::secs_t pos) {
         m_playbackPositionChanged.send(pos);
     });
 }

--- a/src/context/internal/playbackstate.h
+++ b/src/context/internal/playbackstate.h
@@ -3,7 +3,8 @@
 */
 #pragma once
 
-#include "global/async/asyncable.h"
+#include "framework/global/async/asyncable.h"
+#include "framework/global/modularity/ioc.h"
 
 #include "context/iplaybackstate.h"
 #include "playback/iplayer.h"

--- a/src/context/internal/uicontextresolver.cpp
+++ b/src/context/internal/uicontextresolver.cpp
@@ -190,8 +190,5 @@ bool UiContextResolver::isShortcutContextAllowed(const std::string& scContext) c
         return !matchWithCurrent(context::UiCtxProjectFocused);
     }
 
-    IF_ASSERT_FAILED(CTX_ANY == scContext) {
-        return true;
-    }
     return true;
 }

--- a/src/playback/CMakeLists.txt
+++ b/src/playback/CMakeLists.txt
@@ -52,6 +52,8 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/view/common/playbackstatemodel.h
     ${CMAKE_CURRENT_LIST_DIR}/view/common/playbackmetermodel.cpp
     ${CMAKE_CURRENT_LIST_DIR}/view/common/playbackmetermodel.h
+    ${CMAKE_CURRENT_LIST_DIR}/view/common/playbackpositiontimer.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/view/common/playbackpositiontimer.h
     ${CMAKE_CURRENT_LIST_DIR}/view/common/metermodel.cpp
     ${CMAKE_CURRENT_LIST_DIR}/view/common/metermodel.h
 

--- a/src/playback/internal/au3/au3audiooutput.cpp
+++ b/src/playback/internal/au3/au3audiooutput.cpp
@@ -12,6 +12,7 @@
 #include "libraries/lib-project-rate/ProjectRate.h"
 
 #include "au3wrap/au3types.h"
+#include "au3wrap/internal/au3audiometerfactory.h"
 
 #include "au3audio/audiotypes.h"
 
@@ -23,7 +24,7 @@ using namespace au::playback;
 using namespace au::au3;
 
 Au3AudioOutput::Au3AudioOutput()
-    : m_outputMeter{std::make_shared<au::au3::Meter>()}
+    : m_outputMeter{au::au3::createAudioMeter()}
 {
     globalContext()->currentProjectChanged().onNotify(this, [this](){
         auto currentProject = globalContext()->currentProject();

--- a/src/playback/internal/au3/au3audiooutput.cpp
+++ b/src/playback/internal/au3/au3audiooutput.cpp
@@ -23,9 +23,8 @@ using namespace au::playback;
 using namespace au::au3;
 
 Au3AudioOutput::Au3AudioOutput()
+    : m_outputMeter{std::make_shared<au::au3::Meter>()}
 {
-    m_outputMeter = std::make_shared<au::au3::Meter>();
-
     globalContext()->currentProjectChanged().onNotify(this, [this](){
         auto currentProject = globalContext()->currentProject();
         if (!currentProject) {

--- a/src/playback/internal/au3/au3audiooutput.h
+++ b/src/playback/internal/au3/au3audiooutput.h
@@ -14,6 +14,8 @@
 #include "au3wrap/au3types.h"
 #include "au3wrap/internal/au3audiometer.h"
 
+#include "libraries/lib-utility/LockFreeQueue.h"
+
 namespace au::playback {
 class Au3AudioOutput : public IAudioOutput, public muse::async::Asyncable
 {
@@ -39,9 +41,9 @@ private:
 
     void notifyAboutSampleRateChanged();
 
-    mutable muse::async::Channel<float> m_playbackVolumeChanged;
-    mutable muse::async::Channel<audio::sample_rate_t> m_sampleRateChanged;
+    muse::async::Channel<float> m_playbackVolumeChanged;
+    muse::async::Channel<audio::sample_rate_t> m_sampleRateChanged;
 
-    std::shared_ptr<au::au3::Meter> m_outputMeter;
+    const std::shared_ptr<au::au3::Meter> m_outputMeter;
 };
 }

--- a/src/playback/internal/au3/au3player.cpp
+++ b/src/playback/internal/au3/au3player.cpp
@@ -482,12 +482,12 @@ void Au3Player::updatePlaybackPosition()
 
     auto& audioIO = *AudioIO::Get();
     const double sampleRate = audioIO.GetPlaybackSampleRate();
-    AudioIoCallback::AudioDelivery newDelivery;
-    while (audioIO.GetAudioDeliveryQueue().Get(newDelivery)) {
-        const auto targetConsumedSamples = static_cast<unsigned long long>(newDelivery.numSamples)
+    AudioIoCallback::AudioCallbackInfo newCallback;
+    while (audioIO.GetAudioCallbackInfoQueue().Get(newCallback)) {
+        const auto targetConsumedSamples = static_cast<unsigned long long>(newCallback.numSamples)
                                            + (m_currentTarget ? m_currentTarget->consumedSamples : 0);
-        const nanoseconds newDeliveryDuration{ static_cast<long>(newDelivery.numSamples * 1e6 / sampleRate + .5) };
-        const auto targetTime = newDelivery.dacTime + newDeliveryDuration;
+        const nanoseconds payloadDuration{ static_cast<long>(newCallback.numSamples * 1e6 / sampleRate + .5) };
+        const auto targetTime = newCallback.dacTime + payloadDuration;
         m_currentTarget.emplace(targetTime, targetConsumedSamples);
     }
 

--- a/src/playback/internal/au3/au3player.cpp
+++ b/src/playback/internal/au3/au3player.cpp
@@ -3,8 +3,8 @@
 */
 #include "au3player.h"
 
-#include "global/types/number.h"
-#include "global/defer.h"
+#include "framework/global/types/number.h"
+#include "framework/global/defer.h"
 
 #include "libraries/lib-time-frequency-selection/SelectedRegion.h"
 #include "libraries/lib-track/Track.h"

--- a/src/playback/internal/au3/au3player.cpp
+++ b/src/playback/internal/au3/au3player.cpp
@@ -451,7 +451,7 @@ muse::async::Notification Au3Player::loopRegionChanged() const
     return m_loopRegionChanged;
 }
 
-void Au3Player::updatePlaybackStateTimeCritical()
+void Au3Player::updatePlaybackState()
 {
     int token = ProjectAudioIO::Get(projectRef()).GetAudioIOToken();
     bool isActive = AudioIO::Get()->IsStreamActive(token);
@@ -509,7 +509,7 @@ void Au3Player::updatePlaybackPosition()
 
     audioIO.UpdateTimePosition(expectedConsumedNow - m_consumedSamplesSoFar);
     m_consumedSamplesSoFar = expectedConsumedNow;
-    updatePlaybackStateTimeCritical();
+    updatePlaybackState();
 }
 
 muse::async::Channel<muse::secs_t> Au3Player::playbackPositionChanged() const

--- a/src/playback/internal/au3/au3player.cpp
+++ b/src/playback/internal/au3/au3player.cpp
@@ -487,7 +487,7 @@ void Au3Player::updatePlaybackPosition()
         const auto targetConsumedSamples = static_cast<unsigned long long>(newDelivery.numSamples)
                                            + (m_currentTarget ? m_currentTarget->consumedSamples : 0);
         const nanoseconds newDeliveryDuration{ static_cast<long>(newDelivery.numSamples * 1e6 / sampleRate + .5) };
-        const auto targetTime = newDelivery.startTime + newDeliveryDuration;
+        const auto targetTime = newDelivery.dacTime + newDeliveryDuration;
         m_currentTarget.emplace(targetTime, targetConsumedSamples);
     }
 

--- a/src/playback/internal/au3/au3player.cpp
+++ b/src/playback/internal/au3/au3player.cpp
@@ -486,7 +486,7 @@ void Au3Player::updatePlaybackPosition()
     while (audioIO.GetAudioCallbackInfoQueue().Get(newCallback)) {
         const auto targetConsumedSamples = static_cast<unsigned long long>(newCallback.numSamples)
                                            + (m_currentTarget ? m_currentTarget->consumedSamples : 0);
-        const nanoseconds payloadDuration{ static_cast<long>(newCallback.numSamples * 1e6 / sampleRate + .5) };
+        const nanoseconds payloadDuration{ static_cast<long>(newCallback.numSamples * 1e9 / sampleRate + .5) };
         const auto targetTime = newCallback.dacTime + payloadDuration;
         m_currentTarget.emplace(targetTime, targetConsumedSamples);
     }

--- a/src/playback/internal/au3/au3player.h
+++ b/src/playback/internal/au3/au3player.h
@@ -76,7 +76,7 @@ private:
 
     muse::Ret doPlayTracks(TrackList& trackList, double startTime, double endTime, const PlayTracksOptions& options = {});
 
-    void updatePlaybackStateTimeCritical();
+    void updatePlaybackState();
 
     muse::async::Notification m_loopRegionChanged;
 

--- a/src/playback/internal/au3/au3player.h
+++ b/src/playback/internal/au3/au3player.h
@@ -87,6 +87,5 @@ private:
     double m_startOffset = 0.0;
 
     unsigned long long m_elapsedSamplesAtLastReport = 0;
-    std::optional<std::chrono::steady_clock::time_point> m_startTime;
 };
 }

--- a/src/playback/internal/au3/au3player.h
+++ b/src/playback/internal/au3/au3player.h
@@ -62,8 +62,8 @@ public:
     void setLoopRegionActive(const bool active) override;
 
     muse::secs_t playbackPosition() const override;
-    void updatePlaybackPositionTimeCritical() override;
-    muse::async::Channel<muse::secs_t> playbackPositionChangedMainThreadOnly() const override;
+    void updatePlaybackPosition() override;
+    muse::async::Channel<muse::secs_t> playbackPositionChanged() const override;
 
     muse::Ret playTracks(TrackList& trackList, double startTime, double endTime, const PlayTracksOptions& options = {}) override;
 
@@ -83,7 +83,7 @@ private:
     muse::ValCh<PlaybackStatus> m_playbackStatus;
     muse::ValNt<bool> m_reachedEnd;
 
-    muse::ValCh<muse::secs_t> m_playbackPositionMainThreadOnly;
+    muse::ValCh<muse::secs_t> m_playbackPosition;
     double m_startOffset = 0.0;
 
     unsigned long long m_elapsedSamplesAtLastReport = 0;

--- a/src/playback/internal/au3/au3player.h
+++ b/src/playback/internal/au3/au3player.h
@@ -86,6 +86,14 @@ private:
     muse::ValCh<muse::secs_t> m_playbackPosition;
     double m_startOffset = 0.0;
 
-    unsigned long long m_elapsedSamplesAtLastReport = 0;
+    struct TargetPoint {
+        TargetPoint(const std::chrono::steady_clock::time_point time, const unsigned long long consumedSamples)
+            : time{time}, consumedSamples{consumedSamples} {}
+        const std::chrono::steady_clock::time_point time;
+        const unsigned long long consumedSamples;
+    };
+
+    std::optional<TargetPoint> m_currentTarget;
+    unsigned long long m_consumedSamplesSoFar = 0;
 };
 }

--- a/src/playback/internal/playbackcontroller.cpp
+++ b/src/playback/internal/playbackcontroller.cpp
@@ -65,7 +65,7 @@ void PlaybackController::init()
     });
 
     // No need to assert that we're on the main thread here: this is the init method of a controller...
-    m_player->playbackPositionChangedMainThreadOnly().onReceive(this, [this](const muse::secs_t&) {
+    m_player->playbackPositionChanged().onReceive(this, [this](const muse::secs_t&) {
         if (isPlaybackPositionOnTheEndOfProject() || isPlaybackPositionOnTheEndOfPlaybackRegion()) {
             //! NOTE: just stop, without seek
             player()->stop();

--- a/src/playback/internal/playbackcontroller.cpp
+++ b/src/playback/internal/playbackcontroller.cpp
@@ -64,7 +64,8 @@ void PlaybackController::init()
         m_isPlayingChanged.notify();
     });
 
-    m_player->playbackPositionChanged().onReceive(this, [this](const muse::secs_t&) {
+    // No need to assert that we're on the main thread here: this is the init method of a controller...
+    m_player->playbackPositionChangedMainThreadOnly().onReceive(this, [this](const muse::secs_t&) {
         if (isPlaybackPositionOnTheEndOfProject() || isPlaybackPositionOnTheEndOfPlaybackRegion()) {
             //! NOTE: just stop, without seek
             player()->stop();

--- a/src/playback/iplayer.h
+++ b/src/playback/iplayer.h
@@ -54,10 +54,10 @@ public:
      * Beside consuming from a lock-free queue, the implementation also ensures that it does not involve locks elsewhere, making
      * it suitable for time-critical contexts.
      */
-    virtual void updatePlaybackPositionTimeCritical() = 0;
+    virtual void updatePlaybackPosition() = 0;
 
     virtual muse::secs_t playbackPosition() const = 0;
-    virtual muse::async::Channel<muse::secs_t> playbackPositionChangedMainThreadOnly() const = 0;
+    virtual muse::async::Channel<muse::secs_t> playbackPositionChanged() const = 0;
 
     // tracks
     virtual muse::Ret playTracks(TrackList& trackList, double startTime, double endTime, const PlayTracksOptions& options = {}) = 0;

--- a/src/playback/iplayer.h
+++ b/src/playback/iplayer.h
@@ -48,8 +48,16 @@ public:
     virtual void setLoopRegionActive(const bool active) = 0;
     virtual bool isLoopRegionActive() const = 0;
 
+    /*!
+     * \brief Consumer side of a single-producer/single-consumer lock-free queue.
+     * In other words, implementation assumes a single caller to this method on a single thread, whatever thread this might be.
+     * Beside consuming from a lock-free queue, the implementation also ensures that it does not involve locks elsewhere, making
+     * it suitable for time-critical contexts.
+     */
+    virtual void updatePlaybackPositionTimeCritical() = 0;
+
     virtual muse::secs_t playbackPosition() const = 0;
-    virtual muse::async::Channel<muse::secs_t> playbackPositionChanged() const = 0;
+    virtual muse::async::Channel<muse::secs_t> playbackPositionChangedMainThreadOnly() const = 0;
 
     // tracks
     virtual muse::Ret playTracks(TrackList& trackList, double startTime, double endTime, const PlayTracksOptions& options = {}) = 0;

--- a/src/playback/playbackmodule.cpp
+++ b/src/playback/playbackmodule.cpp
@@ -16,6 +16,7 @@
 
 #include "view/common/playbackstatemodel.h"
 #include "view/common/playbackmetermodel.h"
+#include "view/common/playbackpositiontimer.h"
 #include "view/common/metermodel.h"
 #include "view/toolbars/components/timecodemodeselector.h"
 #include "view/toolbars/components/timecodemodel.h"
@@ -80,6 +81,7 @@ void PlaybackModule::registerUiTypes()
     qmlRegisterType<BPMModel>("Audacity.Playback", 1, 0, "BPMModel");
     qmlRegisterType<PlaybackMeterPanelModel>("Audacity.Playback", 1, 0, "PlaybackMeterPanelModel");
     qmlRegisterType<PlaybackMeterModel>("Audacity.Playback", 1, 0, "PlaybackMeterModel");
+    qmlRegisterType<PlaybackPositionTimer>("Audacity.Playback", 1, 0, "PlaybackPositionTimer");
     qmlRegisterType<MeterModel>("Audacity.Playback", 1, 0, "MeterModel");
     qmlRegisterUncreatableType<TracksBehaviors>("Audacity.Playback", 1, 0, "SoloBehavior", "Not creatable from QML");
     qmlRegisterUncreatableType<PlaybackQualityPrefs>("Audacity.Playback", 1, 0, "PlaybackQuality", "Not creatable from QML");

--- a/src/playback/tests/mocks/playermock.h
+++ b/src/playback/tests/mocks/playermock.h
@@ -43,7 +43,8 @@ public:
     MOCK_METHOD(bool, isLoopRegionActive, (), (const, override));
 
     MOCK_METHOD(muse::secs_t, playbackPosition, (), (const, override));
-    MOCK_METHOD(muse::async::Channel<muse::secs_t>, playbackPositionChanged, (), (const, override));
+    MOCK_METHOD(void, updatePlaybackPositionTimeCritical, (), (override));
+    MOCK_METHOD(muse::async::Channel<muse::secs_t>, playbackPositionChangedMainThreadOnly, (), (const, override));
 
     MOCK_METHOD(muse::Ret, playTracks, (TrackList&, double, double, const PlayTracksOptions&), (override));
 };

--- a/src/playback/tests/mocks/playermock.h
+++ b/src/playback/tests/mocks/playermock.h
@@ -43,8 +43,8 @@ public:
     MOCK_METHOD(bool, isLoopRegionActive, (), (const, override));
 
     MOCK_METHOD(muse::secs_t, playbackPosition, (), (const, override));
-    MOCK_METHOD(void, updatePlaybackPositionTimeCritical, (), (override));
-    MOCK_METHOD(muse::async::Channel<muse::secs_t>, playbackPositionChangedMainThreadOnly, (), (const, override));
+    MOCK_METHOD(void, updatePlaybackPosition, (), (override));
+    MOCK_METHOD(muse::async::Channel<muse::secs_t>, playbackPositionChanged, (), (const, override));
 
     MOCK_METHOD(muse::Ret, playTracks, (TrackList&, double, double, const PlayTracksOptions&), (override));
 };

--- a/src/playback/view/common/playbackpositiontimer.cpp
+++ b/src/playback/view/common/playbackpositiontimer.cpp
@@ -1,0 +1,51 @@
+#include "playbackpositiontimer.h"
+
+#include "playback/iplayer.h"
+#include "global/log.h"
+
+#include <QQuickWindow>
+
+namespace au::playback {
+PlaybackPositionTimer::PlaybackPositionTimer(QQuickItem* parent)
+    : QQuickItem(parent)
+{
+    setFlag(ItemHasContents, true);
+}
+
+PlaybackPositionTimer::~PlaybackPositionTimer()
+{
+    disconnect(m_beforeSynchronizingConnection);
+    m_beforeSynchronizingConnection = {};
+}
+
+void PlaybackPositionTimer::itemChange(ItemChange change, const ItemChangeData& value)
+{
+    QQuickItem::itemChange(change, value);
+    if (change == ItemSceneChange) {
+        if (value.window) {
+            // Ensuring a direct connection, as per recommendation of the Qt documentation on `beforeSynchronizing`:
+            // > Warning: This signal is emitted from the scene graph rendering thread.
+            // > If your slot function needs to finish before execution continues, you must make sure that
+            // > the connection is direct (see Qt::ConnectionType).
+            m_beforeSynchronizingConnection = connect(value.window, &QQuickWindow::beforeSynchronizing, this,
+                                                      &PlaybackPositionTimer::doBeforeSynchronizing, Qt::DirectConnection);
+        } else {
+            disconnect(m_beforeSynchronizingConnection);
+            m_beforeSynchronizingConnection = {};
+        }
+    }
+}
+
+void PlaybackPositionTimer::doBeforeSynchronizing()
+{
+    const auto playback = this->playback();
+    if (!playback) {
+        return;
+    }
+    const auto player = playback->player();
+    if (!player) {
+        return;
+    }
+    player->updatePlaybackPositionTimeCritical();
+}
+}

--- a/src/playback/view/common/playbackpositiontimer.cpp
+++ b/src/playback/view/common/playbackpositiontimer.cpp
@@ -68,7 +68,7 @@ void PlaybackPositionTimer::doBeforeSynchronizing()
 {
     const auto player = this->player();
     if (player && player->playbackStatus() == PlaybackStatus::Running) {
-        player->updatePlaybackPositionTimeCritical();
+        player->updatePlaybackPosition();
     }
 }
 

--- a/src/playback/view/common/playbackpositiontimer.cpp
+++ b/src/playback/view/common/playbackpositiontimer.cpp
@@ -38,7 +38,7 @@ void PlaybackPositionTimer::componentComplete()
         return;
     }
     player->playbackStatusChanged().onReceive(this, [this](PlaybackStatus status) {
-        if (status == PlaybackStatus::Running) {
+        if (status != PlaybackStatus::Stopped) {
             m_timer.start();
         } else {
             m_timer.stop();
@@ -67,7 +67,7 @@ void PlaybackPositionTimer::itemChange(ItemChange change, const ItemChangeData& 
 void PlaybackPositionTimer::doBeforeSynchronizing()
 {
     const auto player = this->player();
-    if (player && player->playbackStatus() == PlaybackStatus::Running) {
+    if (player && player->playbackStatus() != PlaybackStatus::Stopped) {
         player->updatePlaybackPosition();
     }
 }

--- a/src/playback/view/common/playbackpositiontimer.h
+++ b/src/playback/view/common/playbackpositiontimer.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "playback/iplayback.h"
+
+#include "framework/global/modularity/ioc.h"
+
+#include <QQuickItem>
+
+namespace au::playback {
+class PlaybackPositionTimer : public QQuickItem
+{
+    muse::Inject<IPlayback> playback;
+
+public:
+    explicit PlaybackPositionTimer(QQuickItem* parent = nullptr);
+    ~PlaybackPositionTimer();
+
+private:
+    void itemChange(ItemChange change, const ItemChangeData& value) override;
+    void doBeforeSynchronizing();
+
+    QMetaObject::Connection m_beforeSynchronizingConnection{};
+};
+}

--- a/src/playback/view/common/playbackpositiontimer.h
+++ b/src/playback/view/common/playbackpositiontimer.h
@@ -2,12 +2,14 @@
 
 #include "playback/iplayback.h"
 
+#include "framework/global/async/asyncable.h"
 #include "framework/global/modularity/ioc.h"
 
 #include <QQuickItem>
+#include <QTimer>
 
 namespace au::playback {
-class PlaybackPositionTimer : public QQuickItem
+class PlaybackPositionTimer : public QQuickItem, public muse::async::Asyncable
 {
     muse::Inject<IPlayback> playback;
 
@@ -18,7 +20,10 @@ public:
 private:
     void itemChange(ItemChange change, const ItemChangeData& value) override;
     void doBeforeSynchronizing();
+    void componentComplete() override;
+    std::shared_ptr<IPlayer> player() const;
 
     QMetaObject::Connection m_beforeSynchronizingConnection{};
+    QTimer m_timer;
 };
 }

--- a/src/projectscene/qml/Audacity/ProjectScene/clipsview/PlayCursorHead.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/clipsview/PlayCursorHead.qml
@@ -2,7 +2,6 @@ import QtQuick
 import Muse.Ui
 import Muse.UiComponents
 
-
 Item {
     id: playCursorHead
 
@@ -10,6 +9,8 @@ Item {
 
     signal setPlaybackPosition(real x)
     signal playCursorMousePositionChanged(real x)
+
+    antialiasing: true
 
     StyledIconLabel {
         id: playheadIcon
@@ -38,7 +39,7 @@ Item {
             hoverEnabled: true
             cursorShape: pressed || timelinePressed ? Qt.ClosedHandCursor : Qt.OpenHandCursor
 
-            onPositionChanged: function(e) {
+            onPositionChanged: function (e) {
                 var ix = mapToItem(content, e.x, e.y).x
                 if (pressed) {
                     setPlaybackPosition(ix)

--- a/src/projectscene/qml/Audacity/ProjectScene/clipsview/PlayCursorHead.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/clipsview/PlayCursorHead.qml
@@ -15,7 +15,8 @@ Item {
     StyledIconLabel {
         id: playheadIcon
 
-        x: -(playheadIcon.width) / 2 - 0.5
+        x: -(playheadIcon.width) / 2
+        y: -1 // offset up to avoid too much cropping
 
         iconCode: IconCode.PLAYHEAD_FILLED
 
@@ -25,13 +26,43 @@ Item {
         StyledIconLabel {
             id: playheadFill
 
-            x: 1.1
-            y: 0.9
+            // inset the Fill Icon by 1px X,Y
+            x: 1
+            y: 1
 
             iconCode: IconCode.PLAYHEAD_FILLED
 
             font.pixelSize: 15
             color: "white"
+        }
+
+        // we do some pixel trickery to hide the aliased bottom part and "connect" to the PlayCursorLine
+        Rectangle {
+            // this is to remove the aliased part in the bottom of the Icon
+            id: playheadBottomCenterDot
+            width: 1
+            height: 2
+            x: parent.width / 2
+            y: 15
+            color: "white"
+        }
+        Rectangle {
+            // this is to remove the aliased part in the bottom of the Icon
+            id: playheadBottomCenterDotLeft
+            width: 1
+            height: 1
+            x: (parent.width / 2) - 1
+            y: 16
+            color: "black"
+        }
+        Rectangle {
+            // this is to remove the aliased part in the bottom of the Icon
+            id: playheadBottomCenterDotRight
+            width: 1
+            height: 1
+            x: (parent.width / 2) + 1
+            y: 16
+            color: "black"
         }
 
         MouseArea {

--- a/src/projectscene/qml/Audacity/ProjectScene/clipsview/PlayCursorLine.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/clipsview/PlayCursorLine.qml
@@ -3,12 +3,13 @@ import Muse.Ui
 import Muse.UiComponents
 
 Rectangle {
-
     id: root
 
     property color borderColor: "#000000"
     property int borderWidth: 1
     property bool timelinePressed: false
+
+    antialiasing: true
 
     Rectangle {
         id: cursor
@@ -17,7 +18,6 @@ Rectangle {
         width: 3
         height: root.height
         color: "#ffffff"
-
 
         // draw borders without top one
         Rectangle {

--- a/src/projectscene/qml/Audacity/ProjectScene/clipsview/PlayCursorLine.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/clipsview/PlayCursorLine.qml
@@ -14,8 +14,8 @@ Rectangle {
     Rectangle {
         id: cursor
 
-        x: -width / 2
-        width: 3
+        x: -1 // offset to align center line
+        width: 3 // 1px border, 1px center line, 1px border
         height: root.height
         color: "#ffffff"
 

--- a/src/projectscene/qml/Audacity/ProjectScene/clipsview/TracksClipsView.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/clipsview/TracksClipsView.qml
@@ -332,7 +332,7 @@ Rectangle {
                 }
 
                 onPlayCursorMousePositionChanged: function (ix) {
-                    timeline.updateCursorPosition(ix, -1)
+                     timeline.updateCursorPosition(ix, 0)
                 }
             }
         }

--- a/src/projectscene/qml/Audacity/ProjectScene/clipsview/TracksClipsView.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/clipsview/TracksClipsView.qml
@@ -834,6 +834,8 @@ Rectangle {
             width: timeline.context.selectionEndPosition - x
         }
 
+        PlaybackPositionTimer {}
+
         PlayCursorLine {
             id: playCursor
 

--- a/src/record/internal/au3/au3audioinput.cpp
+++ b/src/record/internal/au3/au3audioinput.cpp
@@ -10,6 +10,7 @@
 #include "libraries/lib-audio-io/ProjectAudioIO.h"
 
 #include "au3wrap/au3types.h"
+#include "au3wrap/internal/au3audiometerfactory.h"
 
 #include "au3audio/audiotypes.h"
 
@@ -20,9 +21,8 @@ using namespace au::playback;
 using namespace au::au3;
 
 Au3AudioInput::Au3AudioInput()
+    : m_inputMeter{au::au3::createAudioMeter()}
 {
-    m_inputMeter = std::make_shared<au::au3::Meter>();
-
     globalContext()->currentProjectChanged().onNotify(this, [this](){
         auto currentProject = globalContext()->currentProject();
         if (!currentProject) {

--- a/src/record/internal/au3/au3audioinput.h
+++ b/src/record/internal/au3/au3audioinput.h
@@ -56,7 +56,7 @@ private:
     bool audioEngineShouldBeMonitoring() const;
 
     mutable muse::async::Channel<float> m_recordVolumeChanged;
-    std::shared_ptr<au::au3::Meter> m_inputMeter;
+    const std::shared_ptr<au::au3::Meter> m_inputMeter;
     int m_inputChannelsCount{};
     int m_focusedTrackChannels{};
 };


### PR DESCRIPTION
Resolves: #9441

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:
- [x] Position of cursor is well synchronized with what is played through the speakers (tip: import a rhythm track from Audacity 3)
- [x] Buffer length in Audio settings can be set to a very large value (e.g. 999ms) and the cursor is still well synchronized.
- [x] Robust when pausing/playing/pausing/... in quick successions
- [x] Also works for stereo meters
- [x] Works for different device types (MME, Wasapi, CoreAudio, etc.)
- [ ] Autobot test cases have been run
