### PR TITLE
9647 Playback Cannot be Resumed

### DIFF
--- a/src/record/internal/au3/au3audioinput.cpp
+++ b/src/record/internal/au3/au3audioinput.cpp
@@ -44,7 +44,9 @@ Au3AudioInput::Au3AudioInput()
         });
 
         playbackController()->isPlayingChanged().onNotify(this, [this]() {
-            restartMonitoring();
+            if (playbackController()->isStopped()) {
+                restartMonitoring();
+            }
         });
 
         audioDevicesProvider()->inputChannelsChanged().onNotify(this, [this]() {


### PR DESCRIPTION
Resolves: #9647 Playback Cannot be Resumed

revert part of the changes introduced in 281802c583ccc390023fcba31c729c0fa1db000d

to only restart monitoring when stopped

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Autobot test cases have been run
