### PR TITLE
returned match ui context  playback - projectfocused logic

### DIFF
--- a/src/context/internal/uicontextresolver.cpp
+++ b/src/context/internal/uicontextresolver.cpp
@@ -138,8 +138,9 @@ bool UiContextResolver::match(const ui::UiContext& currentCtx, const ui::UiConte
         return true;
     }
 
+    //! SEE There's a problem here, see https://github.com/audacity/audacity/pull/9662#issuecomment-3405088750
     //! NOTE If the current context is `UiCtxProjectPlayback`, then we allow `UiCtxProjectFocused` too
-    if (currentCtx == context::UiCtxProjectPlayback && actCtx == context::UiCtxProjectFocused) {
+    if (currentCtx == context::UiCtxProjectFocused && actCtx == context::UiCtxProjectPlayback) {
         return true;
     }
 


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/9655

I've returned the logic for comparing the "Project-Playback" and "Project-Focus" ui contexts to as was. It doesn't match the comments and doesn't match how it should be. 