### PR TITLE
Do not restart monitoring if playback is paused

### DIFF
--- a/au3/libraries/lib-audio-io/AudioIO.cpp
+++ b/au3/libraries/lib-audio-io/AudioIO.cpp
@@ -1906,6 +1906,11 @@ void AudioIO::AudioThread(std::atomic<bool>& finish)
                 gAudioIO->mAudioThreadAcknowledge.store(Acknowledge::eStop,
                                                         std::memory_order::memory_order_release);
             }
+            else if (lastState == State::eDoNothing) {
+                //Avoid multiple stops in a row
+                gAudioIO->mAudioThreadAcknowledge.store(Acknowledge::eStop,
+                                                        std::memory_order::memory_order_release);
+            }
             lastState = State::eDoNothing;
 
             if (gAudioIO->IsMonitoring()) {

--- a/src/record/internal/au3/au3audioinput.cpp
+++ b/src/record/internal/au3/au3audioinput.cpp
@@ -232,7 +232,7 @@ int Au3AudioInput::getFocusedTrackChannels() const
 
 void Au3AudioInput::restartMonitoring()
 {
-    if (controller()->isRecording() || playbackController()->isPlaying()) {
+    if (controller()->isRecording() || !playbackController()->isStopped()) {
         return;
     }
 


### PR DESCRIPTION
Resolves: #9647 

Do not restart monitoring if playback is paused.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Autobot test cases have been run
