### PR TITLE
9697 Add setting to configure whether clicking on ruler should trigger playback

### DIFF
--- a/src/projectscene/internal/projectsceneactionscontroller.cpp
+++ b/src/projectscene/internal/projectsceneactionscontroller.cpp
@@ -15,6 +15,7 @@ static const ActionCode CLIPPING_IN_WAVEFORM_CODE("toggle-clipping-in-waveform")
 static const ActionCode MINUTES_SECONDS_RULER("minutes-seconds-ruler");
 static const ActionCode BEATS_MEASURES_RULER("beats-measures-ruler");
 static const ActionCode CLIP_PITCH_AND_SPEED_CODE("clip-pitch-speed");
+static const ActionCode TOGGLE_PLAYBACK_ON_RULER_CLICK_ENABLED_CODE("toggle-playback-on-ruler-click-enabled");
 
 void ProjectSceneActionsController::init()
 {
@@ -26,6 +27,8 @@ void ProjectSceneActionsController::init()
     dispatcher()->reg(this, "update-display-while-playing", this, &ProjectSceneActionsController::updateDisplayWhilePlaying);
     dispatcher()->reg(this, "pinned-play-head", this, &ProjectSceneActionsController::pinnedPlayHead);
     dispatcher()->reg(this, CLIP_PITCH_AND_SPEED_CODE, this, &ProjectSceneActionsController::openClipPitchAndSpeedEdit);
+    dispatcher()->reg(this, TOGGLE_PLAYBACK_ON_RULER_CLICK_ENABLED_CODE, this,
+                      &ProjectSceneActionsController::togglePlaybackOnRulerClickEnabled);
 }
 
 void ProjectSceneActionsController::notifyActionCheckedChanged(const ActionCode& actionCode)
@@ -105,6 +108,13 @@ void ProjectSceneActionsController::openClipPitchAndSpeedEdit(const ActionData& 
     interactive()->open(query);
 }
 
+void ProjectSceneActionsController::togglePlaybackOnRulerClickEnabled()
+{
+    bool isEnabled = configuration()->playbackOnRulerClickEnabled();
+    configuration()->setPlaybackOnRulerClickEnabled(!isEnabled);
+    notifyActionCheckedChanged(TOGGLE_PLAYBACK_ON_RULER_CLICK_ENABLED_CODE);
+}
+
 bool ProjectSceneActionsController::actionChecked(const ActionCode& actionCode) const
 {
     QMap<std::string, bool> isChecked {
@@ -112,7 +122,8 @@ bool ProjectSceneActionsController::actionChecked(const ActionCode& actionCode) 
         { RMS_IN_WAVEFORM_CODE, configuration()->isRMSInWaveformVisible() },
         { CLIPPING_IN_WAVEFORM_CODE, configuration()->isClippingInWaveformVisible() },
         { MINUTES_SECONDS_RULER, configuration()->timelineRulerMode() == TimelineRulerMode::MINUTES_AND_SECONDS },
-        { BEATS_MEASURES_RULER, configuration()->timelineRulerMode() == TimelineRulerMode::BEATS_AND_MEASURES }
+        { BEATS_MEASURES_RULER, configuration()->timelineRulerMode() == TimelineRulerMode::BEATS_AND_MEASURES },
+        { TOGGLE_PLAYBACK_ON_RULER_CLICK_ENABLED_CODE, configuration()->playbackOnRulerClickEnabled() }
     };
 
     return isChecked[actionCode];

--- a/src/projectscene/internal/projectsceneactionscontroller.h
+++ b/src/projectscene/internal/projectsceneactionscontroller.h
@@ -39,6 +39,7 @@ private:
     void toggleClippingInWaveform();
     void updateDisplayWhilePlaying();
     void pinnedPlayHead();
+    void togglePlaybackOnRulerClickEnabled();
 
     void openClipPitchAndSpeedEdit(const muse::actions::ActionData& args);
 

--- a/src/projectscene/internal/projectsceneconfiguration.cpp
+++ b/src/projectscene/internal/projectsceneconfiguration.cpp
@@ -31,6 +31,8 @@ static const muse::Settings::Key CLIP_STYLE(moduleName, "projectscene/clipStyle"
 static const muse::Settings::Key STEREO_HEIGHTS_PREF(moduleName, "projectscene/asymmetricStereoHeights");
 static const muse::Settings::Key ASYMMETRIC_STEREO_HEIGHTS_WORKSPACES(moduleName, "projectscene/asymmetricStereoHeightsWorkspaces");
 static const muse::Settings::Key SELECTION_TIMECODE_FORMAT(moduleName, "projectscene/selectionTimecodeFormat");
+static const muse::Settings::Key PLAYBACK_ON_RULER_CLICK_ENABLED(moduleName, "projectscene/playbackOnRulerClickEnabled");
+static const bool DEFAULT_PLAYBACK_ON_RULER_CLICK_ENABLED = false;
 
 void ProjectSceneConfiguration::init()
 {
@@ -69,6 +71,11 @@ void ProjectSceneConfiguration::init()
     muse::settings()->valueChanged(SELECTION_TIMECODE_FORMAT).onReceive(nullptr, [this](const muse::Val& val) {
         UNUSED(val);
         m_selectionTimecodeFormatChanged.notify();
+    });
+
+    muse::settings()->setDefaultValue(PLAYBACK_ON_RULER_CLICK_ENABLED, muse::Val(DEFAULT_PLAYBACK_ON_RULER_CLICK_ENABLED));
+    muse::settings()->valueChanged(PLAYBACK_ON_RULER_CLICK_ENABLED).onReceive(nullptr, [this](const muse::Val&) {
+        m_playbackOnRulerClickEnabledChanged.notify();
     });
 }
 
@@ -263,4 +270,19 @@ void ProjectSceneConfiguration::setSelectionTimecodeFormat(int format)
 muse::async::Notification ProjectSceneConfiguration::selectionTimecodeFormatChanged() const
 {
     return m_selectionTimecodeFormatChanged;
+}
+
+bool ProjectSceneConfiguration::playbackOnRulerClickEnabled() const
+{
+    return muse::settings()->value(PLAYBACK_ON_RULER_CLICK_ENABLED).toBool();
+}
+
+void ProjectSceneConfiguration::setPlaybackOnRulerClickEnabled(bool enabled)
+{
+    muse::settings()->setSharedValue(PLAYBACK_ON_RULER_CLICK_ENABLED, muse::Val(enabled));
+}
+
+muse::async::Notification ProjectSceneConfiguration::playbackOnRulerClickEnabledChanged() const
+{
+    return m_playbackOnRulerClickEnabledChanged;
 }

--- a/src/projectscene/internal/projectsceneconfiguration.h
+++ b/src/projectscene/internal/projectsceneconfiguration.h
@@ -65,6 +65,10 @@ public:
     void setSelectionTimecodeFormat(int format) override;
     muse::async::Notification selectionTimecodeFormatChanged() const override;
 
+    bool playbackOnRulerClickEnabled() const override;
+    void setPlaybackOnRulerClickEnabled(bool enabled) override;
+    muse::async::Notification playbackOnRulerClickEnabledChanged() const override;
+
 private:
     muse::async::Channel<bool> m_isVerticalRulersVisibleChanged;
     muse::async::Channel<bool> m_isRMSInWaveformVisibleChanged;
@@ -74,5 +78,6 @@ private:
     muse::async::Notification m_asymmetricStereoHeightsChanged;
     muse::async::Notification m_asymmetricStereoHeightsWorkspacesChanged;
     muse::async::Notification m_selectionTimecodeFormatChanged;
+    muse::async::Notification m_playbackOnRulerClickEnabledChanged;
 };
 }

--- a/src/projectscene/internal/projectsceneuiactions.cpp
+++ b/src/projectscene/internal/projectsceneuiactions.cpp
@@ -135,6 +135,13 @@ static UiActionList STATIC_ACTIONS = {
              TranslatableString("action", "Pinned play head"),
              Checkable::Yes
              ),
+    UiAction("toggle-playback-on-ruler-click-enabled",
+             au::context::UiCtxAny,
+             au::context::CTX_ANY,
+             TranslatableString("action", "Click ruler to start playback"),
+             TranslatableString("action", "Click ruler to start playback"),
+             Checkable::Yes
+             ),
     // clip
     UiAction("clip-properties",
              au::context::UiCtxUnknown,

--- a/src/projectscene/iprojectsceneconfiguration.h
+++ b/src/projectscene/iprojectsceneconfiguration.h
@@ -55,5 +55,9 @@ public:
     virtual int selectionTimecodeFormat() const = 0;
     virtual void setSelectionTimecodeFormat(int) = 0;
     virtual muse::async::Notification selectionTimecodeFormatChanged() const = 0;
+
+    virtual bool playbackOnRulerClickEnabled() const = 0;
+    virtual void setPlaybackOnRulerClickEnabled(bool enabled) = 0;
+    virtual muse::async::Notification playbackOnRulerClickEnabledChanged() const = 0;
 };
 }

--- a/src/projectscene/qml/Audacity/ProjectScene/clipsview/TracksClipsView.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/clipsview/TracksClipsView.qml
@@ -245,7 +245,7 @@ Rectangle {
 
                 onClicked: function (e) {
                     if (!prv.playRegionActivated) {
-                        playCursorController.seekToX(e.x, true /* triggerPlay */)
+                        playCursorController.seekToX(e.x, timeline.context.playbackOnRulerClickEnabled)
                     }
                     prv.playRegionActivated = false
                 }

--- a/src/projectscene/tests/mocks/projectsceneconfigurationmock.h
+++ b/src/projectscene/tests/mocks/projectsceneconfigurationmock.h
@@ -54,5 +54,9 @@ public:
     MOCK_METHOD(int, selectionTimecodeFormat, (), (const, override));
     MOCK_METHOD(void, setSelectionTimecodeFormat, (int precision), (override));
     MOCK_METHOD(muse::async::Notification, selectionTimecodeFormatChanged, (), (const, override));
+
+    MOCK_METHOD(bool, playbackOnRulerClickEnabled, (), (const, override));
+    MOCK_METHOD(void, setPlaybackOnRulerClickEnabled, (bool enabled), (override));
+    MOCK_METHOD(muse::async::Notification, playbackOnRulerClickEnabledChanged, (), (const, override));
 };
 }

--- a/src/projectscene/view/timeline/timelinecontext.cpp
+++ b/src/projectscene/view/timeline/timelinecontext.cpp
@@ -126,6 +126,10 @@ void TimelineContext::init(double frameWidth)
     dispatcher()->reg(this, "zoom-to-selection", this, &TimelineContext::fitSelectionToWidth);
     dispatcher()->reg(this, "zoom-to-fit-project", this, &TimelineContext::fitProjectToWidth);
 
+    configuration()->playbackOnRulerClickEnabledChanged().onNotify(this, [this]() {
+        emit playbackOnRulerClickEnabledChanged();
+    });
+
     onProjectChanged();
 
     emit horizontalScrollChanged();
@@ -970,4 +974,9 @@ void TimelineContext::setStartVerticalScrollPosition(qreal position)
 au::context::IPlaybackStatePtr TimelineContext::playbackState() const
 {
     return globalContext()->playbackState();
+}
+
+bool TimelineContext::playbackOnRulerClickEnabled() const
+{
+    return configuration()->playbackOnRulerClickEnabled();
 }

--- a/src/projectscene/view/timeline/timelinecontext.h
+++ b/src/projectscene/view/timeline/timelinecontext.h
@@ -53,6 +53,8 @@ class TimelineContext : public QObject, public muse::async::Asyncable, public mu
         qreal startVerticalScrollPosition READ startVerticalScrollPosition WRITE setStartVerticalScrollPosition NOTIFY verticalScrollChanged)
     Q_PROPERTY(qreal verticalScrollbarSize READ verticalScrollbarSize NOTIFY verticalScrollChanged)
 
+    Q_PROPERTY(bool playbackOnRulerClickEnabled READ playbackOnRulerClickEnabled NOTIFY playbackOnRulerClickEnabledChanged FINAL)
+
     muse::Inject<muse::actions::IActionsDispatcher> dispatcher;
     muse::Inject<context::IGlobalContext> globalContext;
     muse::Inject<trackedit::ISelectionController> selectionController;
@@ -129,6 +131,8 @@ public:
 
     void updateSelectedClipTime();
 
+    bool playbackOnRulerClickEnabled() const;
+
 signals:
 
     void frameStartTimeChanged();
@@ -156,6 +160,8 @@ signals:
 
     void horizontalScrollChanged();
     void verticalScrollChanged();
+
+    void playbackOnRulerClickEnabledChanged();
 
 private:
     trackedit::ITrackeditProjectPtr trackEditProject() const;

--- a/src/projectscene/view/timeline/timelinecontextmenumodel.cpp
+++ b/src/projectscene/view/timeline/timelinecontextmenumodel.cpp
@@ -27,6 +27,7 @@ MenuItemList TimelineContextMenuModel::makeRulerItems()
         makeSeparator(),
         makeMenuItem("update-display-while-playing"),
         makeMenuItem("pinned-play-head"),
+        makeMenuItem("toggle-playback-on-ruler-click-enabled"),
         makeSeparator(),
         makeMenuItem("toggle-loop-region"),
         makeMenuItem("clear-loop-region"),


### PR DESCRIPTION
Resolves: #9697 

Add setting on the timeline context menu to configure whether clicking on the timeline should trigger playback.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Autobot test cases have been run
