### PR TITLE
9577 preview dialog freeze fix

### DIFF
--- a/au3/libraries/lib-audio-devices/AudioIOBase.h
+++ b/au3/libraries/lib-audio-devices/AudioIOBase.h
@@ -38,8 +38,6 @@ class BoundedEnvelope;
 class Meter;
 using PRCrossfadeData = std::vector< std::vector < float > >;
 
-#define BAD_STREAM_TIME (-DBL_MAX)
-
 class PlaybackPolicy;
 
 // To avoid growing the argument list of StartStream, add fields here

--- a/au3/libraries/lib-audio-io/AudioIO.cpp
+++ b/au3/libraries/lib-audio-io/AudioIO.cpp
@@ -1831,11 +1831,6 @@ double AudioIO::GetBestRate(bool capturing, bool playing, double sampleRate)
 double AudioIO::GetStreamTime()
 {
     // Sequence time readout for the main thread
-
-    if (!IsStreamActive()) {
-        return BAD_STREAM_TIME;
-    }
-
     return mPlaybackSchedule.GetSequenceTime();
 }
 

--- a/au3/libraries/lib-audio-io/AudioIO.h
+++ b/au3/libraries/lib-audio-io/AudioIO.h
@@ -398,7 +398,12 @@ protected:
     //! Holds some state for duration of playback or recording
     std::unique_ptr<TransportState> mpTransportState;
 
-    AudioCallbackInfoQueue mAudioCallbackInfoQueue { 16 };
+    // In a jitter-free world, the size of this queue only has to be `ceil(producerRate / consumerRate)`.
+    // If we assume a minimum of 30fps for the consumer (this is supposed to be read by a entity occupied with
+    // smooth rendering of the playback cursor), and a callback pushing maybe as little as 10 samples per
+    // callback (I've just seen 14 samples per callback, on MacOS with a requested buffer size of 10ms),
+    // we get ceil(96000 / 10 / 30) = 360. The rounding to the next power of two should accommodate jitter.
+    AudioCallbackInfoQueue mAudioCallbackInfoQueue { 512 };
 
 private:
     /*!

--- a/au3/libraries/lib-wave-track/WaveTrack.h
+++ b/au3/libraries/lib-wave-track/WaveTrack.h
@@ -367,7 +367,7 @@ public:
     Holder EmptyCopy(const SampleBlockFactoryPtr& pFactory = {})
     const;
 
-    Track::Holder TrackEmptyCopy() const;
+    Track::Holder TrackEmptyCopy() const override;
 
     //! Simply discard any right channel
     void MakeMono();

--- a/src/effects/audio_unit/internal/audiounitviewlauncher.cpp
+++ b/src/effects/audio_unit/internal/audiounitviewlauncher.cpp
@@ -3,14 +3,9 @@
 */
 #include "audiounitviewlauncher.h"
 
-#include "log.h"
-
 muse::Ret au::effects::AudioUnitViewLauncher::showEffect(const EffectInstanceId& instanceId) const
 {
-    muse::UriQuery uri(EFFECT_VIEWER_URI);
-    uri.addParam("instanceId", muse::Val(instanceId));
-    uri.addParam("effectFamily", muse::Val(EffectFamily::AudioUnit));
-    return interactive()->openSync(uri).ret;
+    return doShowEffect(instanceId, EffectFamily::AudioUnit);
 }
 
 void au::effects::AudioUnitViewLauncher::showRealtimeEffect(const RealtimeEffectStatePtr& state) const

--- a/src/effects/audio_unit/qml/Audacity/AudioUnit/AudioUnitViewer.qml
+++ b/src/effects/audio_unit/qml/Audacity/AudioUnit/AudioUnitViewer.qml
@@ -22,6 +22,7 @@ Rectangle {
 
     // out
     property alias title: model.title
+    property alias isPreviewing: model.isPreviewing
 
     color: ui.theme.backgroundPrimaryColor
 
@@ -39,11 +40,11 @@ Rectangle {
     }
 
     Component.onDestruction: {
-        model.deinit();
+        model.deinit()
     }
 
-    function preview() {
-        model.preview()
+    function togglePreview() {
+        model.togglePreview()
     }
 
     function manage(parent) {

--- a/src/effects/audio_unit/qml/Audacity/AudioUnit/AudioUnitViewer.qml
+++ b/src/effects/audio_unit/qml/Audacity/AudioUnit/AudioUnitViewer.qml
@@ -41,8 +41,12 @@ Rectangle {
         model.deinit()
     }
 
-    function togglePreview() {
-        model.togglePreview()
+    function startPreview() {
+        model.startPreview()
+    }
+
+    function stopPreview() {
+        model.stopPreview()
     }
 
     function manage(parent) {

--- a/src/effects/audio_unit/qml/Audacity/AudioUnit/AudioUnitViewer.qml
+++ b/src/effects/audio_unit/qml/Audacity/AudioUnit/AudioUnitViewer.qml
@@ -10,7 +10,6 @@ import Audacity.Effects 1.0
 import Audacity.AudioUnit 1.0
 
 Rectangle {
-
     id: root
 
     // in
@@ -31,7 +30,6 @@ Rectangle {
 
     implicitWidth: view.implicitWidth
     implicitHeight: view.implicitHeight
-
 
     Component.onCompleted: {
         model.init()
@@ -63,7 +61,7 @@ Rectangle {
     ContextMenuLoader {
         id: menuLoader
 
-        onHandleMenuItem: function(itemId) {
+        onHandleMenuItem: function (itemId) {
             manageMenuModel.handleMenuItem(itemId)
         }
     }

--- a/src/effects/audio_unit/qml/Audacity/AudioUnit/AudioUnitViewer.qml
+++ b/src/effects/audio_unit/qml/Audacity/AudioUnit/AudioUnitViewer.qml
@@ -13,7 +13,7 @@ Rectangle {
     id: root
 
     // in
-    property alias instanceId: view.instanceId
+    property alias instanceId: model.instanceId
     property alias sidePadding: view.sidePadding
     property alias topPadding: view.topPadding
     property alias bottomPadding: view.bottomPadding
@@ -59,7 +59,7 @@ Rectangle {
 
     EffectManageMenu {
         id: manageMenuModel
-        instanceId: view.instanceId
+        instanceId: model.instanceId
     }
 
     ContextMenuLoader {
@@ -72,10 +72,10 @@ Rectangle {
 
     AudioUnitViewModel {
         id: model
-        instanceId: view.instanceId
     }
 
     AudioUnitView {
         id: view
+        instanceId: model.instanceId
     }
 }

--- a/src/effects/audio_unit/view/audiounitviewmodel.cpp
+++ b/src/effects/audio_unit/view/audiounitviewmodel.cpp
@@ -17,7 +17,7 @@
 
 namespace au::effects {
 AudioUnitViewModel::AudioUnitViewModel(QObject* parent)
-    : QObject(parent)
+    : AbstractEffectViewModel(parent)
 {}
 
 AudioUnitViewModel::~AudioUnitViewModel()
@@ -25,21 +25,21 @@ AudioUnitViewModel::~AudioUnitViewModel()
     checkSettingChangesFromUi();
 }
 
-void AudioUnitViewModel::init()
+void AudioUnitViewModel::doInit()
 {
-    IF_ASSERT_FAILED(m_instanceId >= 0) {
+    IF_ASSERT_FAILED(instanceId() >= 0) {
         return;
     }
 
-    m_instance = std::dynamic_pointer_cast<AudioUnitInstance>(instancesRegister()->instanceById(m_instanceId));
+    m_instance = std::dynamic_pointer_cast<AudioUnitInstance>(instancesRegister()->instanceById(instanceId()));
     IF_ASSERT_FAILED(m_instance) {
         return;
     }
 
-    instancesRegister()->settingsChanged(m_instanceId).onNotify(this, [this]() {
+    instancesRegister()->settingsChanged(instanceId()).onNotify(this, [this]() {
         settingsToView();
     });
-    instancesRegister()->updateSettingsRequested(m_instanceId).onNotify(this, [this]() {
+    instancesRegister()->updateSettingsRequested(instanceId()).onNotify(this, [this]() {
         settingsFromView();
     });
     realtimeEffectService()->effectSettingsChanged().onNotify(this, [this]() {
@@ -48,19 +48,19 @@ void AudioUnitViewModel::init()
 
     m_eventListenerRef = MakeListener();
 
-    const EffectSettings* settings = instancesRegister()->settingsById(m_instanceId);
+    const EffectSettings* settings = instancesRegister()->settingsById(instanceId());
     IF_ASSERT_FAILED(settings) {
         return;
     }
 
-    const EffectId id = instancesRegister()->effectIdByInstanceId(m_instanceId);
+    const EffectId id = instancesRegister()->effectIdByInstanceId(instanceId());
     const AudioUnitEffectBase* const effect = dynamic_cast<AudioUnitEffectBase*>(EffectManager::Get().GetEffect(id.toStdString()));
 
     IF_ASSERT_FAILED(effect) {
         return;
     }
 
-    m_settingsAccess = instancesRegister()->settingsAccessById(m_instanceId);
+    m_settingsAccess = instancesRegister()->settingsAccessById(instanceId());
     IF_ASSERT_FAILED(m_settingsAccess) {
         return;
     }
@@ -76,7 +76,7 @@ void AudioUnitViewModel::init()
     m_settingsTimer.start(100);
 }
 
-void au::effects::AudioUnitViewModel::preview()
+void au::effects::AudioUnitViewModel::doStartPreview()
 {
     IF_ASSERT_FAILED(m_settingsAccess) {
         return;
@@ -251,19 +251,5 @@ void AudioUnitViewModel::setTitle(const QString& newTitle)
     }
     m_title = newTitle;
     emit titleChanged();
-}
-
-int AudioUnitViewModel::instanceId() const
-{
-    return m_instanceId;
-}
-
-void AudioUnitViewModel::setInstanceId(int newInstanceId)
-{
-    if (m_instanceId == newInstanceId) {
-        return;
-    }
-    m_instanceId = newInstanceId;
-    emit instanceIdChanged();
 }
 }

--- a/src/effects/builtin/common/builtineffectmodel.cpp
+++ b/src/effects/builtin/common/builtineffectmodel.cpp
@@ -10,7 +10,7 @@
 using namespace au::effects;
 
 BuiltinEffectModel::BuiltinEffectModel(QObject* parent)
-    : AbstractEffectViewModel(parent), m_instanceId(BuiltinEffectViewLoader::initializationInstanceId())
+    : AbstractEffectViewModel(parent)
 {
     assert(m_instanceId != -1);
 }
@@ -47,11 +47,6 @@ const EffectSettings& BuiltinEffectModel::settings() const
 EffectSettingsAccessPtr BuiltinEffectModel::settingsAccess() const
 {
     return instancesRegister()->settingsAccessById(m_instanceId);
-}
-
-EffectInstanceId BuiltinEffectModel::instanceId() const
-{
-    return m_instanceId;
 }
 
 void BuiltinEffectModel::doStartPreview()

--- a/src/effects/builtin/common/builtineffectmodel.cpp
+++ b/src/effects/builtin/common/builtineffectmodel.cpp
@@ -10,12 +10,12 @@
 using namespace au::effects;
 
 BuiltinEffectModel::BuiltinEffectModel(QObject* parent)
-    : QObject(parent), m_instanceId(BuiltinEffectViewLoader::initializationInstanceId())
+    : AbstractEffectViewModel(parent), m_instanceId(BuiltinEffectViewLoader::initializationInstanceId())
 {
     assert(m_instanceId != -1);
 }
 
-void BuiltinEffectModel::componentComplete()
+void BuiltinEffectModel::doInit()
 {
     instancesRegister()->settingsChanged(m_instanceId).onNotify(this, [this]() {
         doReload();
@@ -54,7 +54,7 @@ EffectInstanceId BuiltinEffectModel::instanceId() const
     return m_instanceId;
 }
 
-void BuiltinEffectModel::preview()
+void BuiltinEffectModel::doStartPreview()
 {
     if (const EffectSettingsAccessPtr access = this->settingsAccess()) {
         access->ModifySettings([this](EffectSettings& settings) {

--- a/src/effects/builtin/common/builtineffectmodel.h
+++ b/src/effects/builtin/common/builtineffectmodel.h
@@ -8,16 +8,13 @@
 #include "libraries/lib-components/EffectInterface.h"
 
 #include "modularity/ioc.h"
-#include "effects/effects_base/ieffectinstancesregister.h"
-#include "effects/effects_base/ieffectexecutionscenario.h"
 #include "effects/effects_base/ieffectsprovider.h"
 #include "effects/effects_base/irealtimeeffectservice.h"
+#include "effects/effects_base/view/abstracteffectviewmodel.h"
 #include "trackedit/iprojecthistory.h"
 
-#include "global/async/asyncable.h"
-
 namespace au::effects {
-class BuiltinEffectModel : public QObject, public QQmlParserStatus, public muse::async::Asyncable
+class BuiltinEffectModel : public AbstractEffectViewModel
 {
     Q_OBJECT
     Q_PROPERTY(int instanceId READ instanceId CONSTANT FINAL)
@@ -26,8 +23,6 @@ class BuiltinEffectModel : public QObject, public QQmlParserStatus, public muse:
     Q_PROPERTY(bool usesPresets READ usesPresets CONSTANT FINAL)
 
 public:
-    muse::Inject<IEffectInstancesRegister> instancesRegister;
-    muse::Inject<IEffectExecutionScenario> executionScenario;
     muse::Inject<IRealtimeEffectService> realtimeEffectService;
     muse::Inject<trackedit::IProjectHistory> projectHistory;
     muse::Inject<IEffectsProvider> effectsProvider;
@@ -38,7 +33,6 @@ public:
     int instanceId() const;
     QString effectId() const;
 
-    Q_INVOKABLE void preview();
     Q_INVOKABLE void commitSettings();
 
     virtual bool usesPresets() const { return true; }
@@ -81,8 +75,8 @@ protected:
     }
 
 private:
-    void classBegin() override {}
-    void componentComplete() override;
+    void doInit() override;
+    void doStartPreview() override;
 
     EffectSettingsAccessPtr settingsAccess() const;
     const int m_instanceId;

--- a/src/effects/builtin/common/builtineffectmodel.h
+++ b/src/effects/builtin/common/builtineffectmodel.h
@@ -17,8 +17,6 @@ namespace au::effects {
 class BuiltinEffectModel : public AbstractEffectViewModel
 {
     Q_OBJECT
-    Q_PROPERTY(int instanceId READ instanceId CONSTANT FINAL)
-
     Q_PROPERTY(QString effectId READ effectId NOTIFY effectIdChanged FINAL)
     Q_PROPERTY(bool usesPresets READ usesPresets CONSTANT FINAL)
 
@@ -30,7 +28,6 @@ public:
 public:
     BuiltinEffectModel(QObject* parent = nullptr);
 
-    int instanceId() const;
     QString effectId() const;
 
     Q_INVOKABLE void commitSettings();
@@ -79,6 +76,5 @@ private:
     void doStartPreview() override;
 
     EffectSettingsAccessPtr settingsAccess() const;
-    const int m_instanceId;
 };
 }

--- a/src/effects/builtin/dynamics/compressor/CompressorView.qml
+++ b/src/effects/builtin/dynamics/compressor/CompressorView.qml
@@ -31,21 +31,34 @@ DynamicsEffectBase {
     Column {
         id: rootColumn
 
-        DynamicsPanel {
-            width: root.width
-            visible: !root.usedDestructively
+        Component {
+            id: dynamicsPanel
 
-            instanceId: compressor.instanceId
-            playState: root.playState
+            DynamicsPanel {
+                width: root.width
 
-            showInputDbModel: CompressorSettingModel {
-                paramId: "showInput"
+                instanceId: compressor.instanceId
+                playState: root.playState
+
+                showInputDbModel: CompressorSettingModel {
+                    paramId: "showInput"
+                }
+                showOutputDbModel: CompressorSettingModel {
+                    paramId: "showOutput"
+                }
+                showCompressionDbModel: CompressorSettingModel {
+                    paramId: "showActual"
+                }
             }
-            showOutputDbModel: CompressorSettingModel {
-                paramId: "showOutput"
-            }
-            showCompressionDbModel: CompressorSettingModel {
-                paramId: "showActual"
+        }
+
+        Loader {
+            id: dynamicsPanelLoader
+
+            Component.onCompleted: {
+                if (!root.usedDestructively) {
+                    sourceComponent = dynamicsPanel
+                }
             }
         }
 

--- a/src/effects/builtin/dynamics/limiter/LimiterView.qml
+++ b/src/effects/builtin/dynamics/limiter/LimiterView.qml
@@ -28,29 +28,43 @@ DynamicsEffectBase {
     Column {
         id: rootColumn
 
-        DynamicsPanel {
-            width: root.width
-            visible: !root.usedDestructively
+        Component {
+            id: dynamicsPanel
 
-            instanceId: limiter.instanceId
-            playState: root.playState
+            DynamicsPanel {
+                width: root.width
+                visible: !root.usedDestructively
 
-            showInputDbModel: LimiterSettingModel {
-                paramId: "showInput"
-            }
-            showOutputDbModel: LimiterSettingModel {
-                paramId: "showOutput"
-            }
-            showCompressionDbModel: LimiterSettingModel {
-                paramId: "showActual"
-            }
+                instanceId: limiter.instanceId
+                playState: root.playState
 
-            // Specific to limiter
-            dbMin: -12
-            dbStep: 3
-            duration: 2
-            timelineHeight: knobRow.height
-            needsClipIndicator: false // Clipping with the limiter is impossible.
+                showInputDbModel: LimiterSettingModel {
+                    paramId: "showInput"
+                }
+                showOutputDbModel: LimiterSettingModel {
+                    paramId: "showOutput"
+                }
+                showCompressionDbModel: LimiterSettingModel {
+                    paramId: "showActual"
+                }
+
+                // Specific to limiter
+                dbMin: -12
+                dbStep: 3
+                duration: 2
+                timelineHeight: knobRow.height
+                needsClipIndicator: false // Clipping with the limiter is impossible.
+            }
+        }
+
+        Loader {
+            id: dynamicsPanelLoader
+
+            Component.onCompleted: {
+                if (!root.usedDestructively) {
+                    sourceComponent = dynamicsPanel
+                }
+            }
         }
 
         Rectangle {

--- a/src/effects/builtin/internal/builtinviewlauncher.cpp
+++ b/src/effects/builtin/internal/builtinviewlauncher.cpp
@@ -3,21 +3,11 @@
 */
 #include "builtinviewlauncher.h"
 
-#include "libraries/lib-effects/EffectManager.h"
-#include "libraries/lib-effects/Effect.h"
-
-#include "au3wrap/internal/wxtypes_convert.h"
-
-#include "log.h"
-
 using namespace au::effects;
 
 muse::Ret BuiltinViewLauncher::showEffect(const EffectInstanceId& instanceId) const
 {
-    muse::UriQuery uri(EFFECT_VIEWER_URI);
-    uri.addParam("instanceId", muse::Val(instanceId));
-    uri.addParam("effectFamily", muse::Val(EffectFamily::Builtin));
-    return interactive()->openSync(uri).ret;
+    return doShowEffect(instanceId, EffectFamily::Builtin);
 }
 
 void BuiltinViewLauncher::showRealtimeEffect(const RealtimeEffectStatePtr& state) const

--- a/src/effects/builtin/qml/Audacity/BuiltinEffects/BuiltinEffectBase.qml
+++ b/src/effects/builtin/qml/Audacity/BuiltinEffects/BuiltinEffectBase.qml
@@ -13,11 +13,16 @@ Rectangle {
 
     property BuiltinEffectModel model: null
     property bool usesPresets: model ? model.usesPresets : true
+    property bool isPreviewing: model ? model.isPreviewing : false
     property bool usedDestructively: true
 
     color: ui.theme.backgroundPrimaryColor
 
-    function preview() {
-        root.model.preview()
+    function init() {
+        root.model.init()
+    }
+
+    function togglePreview() {
+        root.model.togglePreview()
     }
 }

--- a/src/effects/builtin/qml/Audacity/BuiltinEffects/BuiltinEffectBase.qml
+++ b/src/effects/builtin/qml/Audacity/BuiltinEffects/BuiltinEffectBase.qml
@@ -22,7 +22,11 @@ Rectangle {
         root.model.init()
     }
 
-    function togglePreview() {
-        root.model.togglePreview()
+    function startPreview() {
+        root.model.startPreview()
+    }
+
+    function stopPreview() {
+        root.model.stopPreview()
     }
 }

--- a/src/effects/builtin/qml/Audacity/BuiltinEffects/BuiltinEffectViewer.qml
+++ b/src/effects/builtin/qml/Audacity/BuiltinEffects/BuiltinEffectViewer.qml
@@ -38,9 +38,15 @@ Rectangle {
         }
     }
 
-    function togglePreview() {
+    function startPreview() {
         if (builder.contentItem) {
-            builder.contentItem.togglePreview()
+            builder.contentItem.startPreview()
+        }
+    }
+
+    function stopPreview() {
+        if (builder.contentItem) {
+            builder.contentItem.stopPreview()
         }
     }
 

--- a/src/effects/builtin/qml/Audacity/BuiltinEffects/BuiltinEffectViewer.qml
+++ b/src/effects/builtin/qml/Audacity/BuiltinEffects/BuiltinEffectViewer.qml
@@ -6,7 +6,6 @@ import QtQuick
 import Audacity.BuiltinEffects
 
 Rectangle {
-
     id: root
 
     property string instanceId: ""
@@ -18,7 +17,7 @@ Rectangle {
     property bool isPreviewing: builder.contentItem ? builder.contentItem.isPreviewing : false
     property bool usesPresets: builder.contentItem ? builder.contentItem.usesPresets : false
 
-    signal closeRequested()
+    signal closeRequested
 
     color: ui.theme.backgroundPrimaryColor
 

--- a/src/effects/builtin/qml/Audacity/BuiltinEffects/BuiltinEffectViewer.qml
+++ b/src/effects/builtin/qml/Audacity/BuiltinEffects/BuiltinEffectViewer.qml
@@ -8,7 +8,7 @@ import Audacity.BuiltinEffects
 Rectangle {
     id: root
 
-    property string instanceId: ""
+    property alias instanceId: builder.instanceId
     property var dialogView: null
     required property bool usedDestructively
 
@@ -28,7 +28,7 @@ Rectangle {
     height: implicitHeight
 
     Component.onCompleted: {
-        builder.load(root.instanceId, root, dialogView, usedDestructively)
+        builder.load(root, dialogView, usedDestructively)
         builder.contentItem.init()
     }
 

--- a/src/effects/builtin/qml/Audacity/BuiltinEffects/BuiltinEffectViewer.qml
+++ b/src/effects/builtin/qml/Audacity/BuiltinEffects/BuiltinEffectViewer.qml
@@ -15,6 +15,7 @@ Rectangle {
 
     property string title: builder.contentItem ? builder.contentItem.title : ""
     property bool isApplyAllowed: builder.contentItem ? builder.contentItem.isApplyAllowed : false
+    property bool isPreviewing: builder.contentItem ? builder.contentItem.isPreviewing : false
     property bool usesPresets: builder.contentItem ? builder.contentItem.usesPresets : false
 
     signal closeRequested()
@@ -29,6 +30,7 @@ Rectangle {
 
     Component.onCompleted: {
         builder.load(root.instanceId, root, dialogView, usedDestructively)
+        builder.contentItem.init()
     }
 
     function manage(parent) {
@@ -37,9 +39,9 @@ Rectangle {
         }
     }
 
-    function preview() {
+    function togglePreview() {
         if (builder.contentItem) {
-            builder.contentItem.preview()
+            builder.contentItem.togglePreview()
         }
     }
 

--- a/src/effects/builtin/view/builtineffectviewloader.h
+++ b/src/effects/builtin/view/builtineffectviewloader.h
@@ -21,6 +21,7 @@ class BuiltinEffectViewLoader : public QObject, public muse::async::Asyncable
 {
     Q_OBJECT
 
+    Q_PROPERTY(int instanceId READ instanceId CONSTANT FINAL)
     Q_PROPERTY(QQuickItem * contentItem READ contentItem NOTIFY contentItemChanged FINAL)
 
     muse::Inject<IEffectsViewRegister> viewRegister;
@@ -33,9 +34,9 @@ public:
 
     QQuickItem* contentItem() const;
 
-    Q_INVOKABLE void load(const QString& instanceId, QObject* itemParent, QObject* dialogView, bool usedDestructively);
+    Q_INVOKABLE void load(QObject* itemParent, QObject* dialogView, bool usedDestructively);
 
-    static int initializationInstanceId();
+    int instanceId() const { return m_instanceId; }
 
 signals:
     void titleChanged();
@@ -44,6 +45,7 @@ signals:
     void closeRequested();
 
 private:
+    const int m_instanceId;
     QQuickItem* m_contentItem = nullptr;
 };
 }

--- a/src/effects/effects_base/CMakeLists.txt
+++ b/src/effects/effects_base/CMakeLists.txt
@@ -64,6 +64,8 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/internal/effectviewlaunchregister.h
 
     # view
+    ${CMAKE_CURRENT_LIST_DIR}/view/abstracteffectviewmodel.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/view/abstracteffectviewmodel.h
     ${CMAKE_CURRENT_LIST_DIR}/view/effectmanagemenu.cpp
     ${CMAKE_CURRENT_LIST_DIR}/view/effectmanagemenu.h
     ${CMAKE_CURRENT_LIST_DIR}/view/effectsuiengine.cpp

--- a/src/effects/effects_base/effects_base.qrc
+++ b/src/effects/effects_base/effects_base.qrc
@@ -2,6 +2,7 @@
     <qresource prefix="/">
         <file>qml/Audacity/Effects/qmldir</file>
         <file>qml/Audacity/Effects/BypassEffectButton.qml</file>
+        <file>qml/Audacity/Effects/EffectControlsDisablingOverlay.qml</file>
         <file>qml/Audacity/Effects/EffectPresetsBar.qml</file>
         <file>qml/Audacity/Effects/EffectsViewerDialog.qml</file>
         <file>qml/Audacity/Effects/EffectStyledDialogView.qml</file>

--- a/src/effects/effects_base/effectstypes.h
+++ b/src/effects/effects_base/effectstypes.h
@@ -107,7 +107,7 @@ const std::string EFFECT_OPEN_ACTION = "action://effects/open?effectId=%1";
 const std::string REALTIME_EFFECT_ADD_ACTION = "action://effects/realtime-add?effectId=%1";
 const std::string REALTIME_EFFECT_REPLACE_ACTION = "action://effects/realtime-replace?effectId=%1";
 
-const std::string EFFECT_VIEWER_URI = "audacity://effects/effect_viewer?instanceId=%1&effectFamily=%2";
+const std::string EFFECT_VIEWER_URI = "audacity://effects/effect_viewer?effectFamily=%1";
 
 inline std::string makeEffectAction(const std::string& action, const EffectId& id)
 {

--- a/src/effects/effects_base/ieffectsconfiguration.h
+++ b/src/effects/effects_base/ieffectsconfiguration.h
@@ -22,5 +22,8 @@ public:
     virtual EffectMenuOrganization effectMenuOrganization() const = 0;
     virtual void setEffectMenuOrganization(EffectMenuOrganization) = 0;
     virtual muse::async::Notification effectMenuOrganizationChanged() const = 0;
+
+    virtual double previewMaxDuration() const = 0;
+    virtual void setPreviewMaxDuration(double value) = 0;
 };
 }

--- a/src/effects/effects_base/ieffectsprovider.h
+++ b/src/effects/effects_base/ieffectsprovider.h
@@ -42,6 +42,6 @@ public:
     virtual muse::Ret performEffect(au3::Au3Project& project, Effect* effect, std::shared_ptr<EffectInstance> effectInstance,
                                     EffectSettings& settings) = 0;
 
-    virtual muse::Ret previewEffect(au3::Au3Project& project, Effect* effect, EffectSettings& settings) = 0;
+    virtual muse::Ret previewEffect(const EffectId& effectId, EffectSettings& settings) = 0;
 };
 }

--- a/src/effects/effects_base/internal/abstractviewlauncher.h
+++ b/src/effects/effects_base/internal/abstractviewlauncher.h
@@ -10,10 +10,14 @@
 namespace au::effects {
 class AbstractViewLauncher : public IEffectViewLauncher
 {
+public:
+    static int initializationInstanceId();
+
 protected:
     muse::Inject<muse::IInteractive> interactive;
     muse::Inject<IEffectInstancesRegister> instancesRegister;
 
+    muse::Ret doShowEffect(int instanceId, EffectFamily) const;
     void doShowRealtimeEffect(const RealtimeEffectStatePtr& state) const;
 
 private:

--- a/src/effects/effects_base/internal/effectexecutionscenario.cpp
+++ b/src/effects/effects_base/internal/effectexecutionscenario.cpp
@@ -465,8 +465,6 @@ muse::async::Channel<EffectId> EffectExecutionScenario::lastProcessorIdChanged()
 
 muse::Ret EffectExecutionScenario::previewEffect(const EffectInstanceId& effectInstanceId, EffectSettings& settings)
 {
-    au3::Au3Project& project = projectRef();
     EffectId effectId = effectInstancesRegister()->effectIdByInstanceId(effectInstanceId);
-    Effect* effect = effectsProvider()->effect(effectId);
-    return effectsProvider()->previewEffect(project, effect, settings);
+    return effectsProvider()->previewEffect(effectId, settings);
 }

--- a/src/effects/effects_base/internal/effectsconfiguration.cpp
+++ b/src/effects/effects_base/internal/effectsconfiguration.cpp
@@ -10,6 +10,7 @@ using namespace au::effects;
 static const std::string moduleName("effects");
 static const muse::Settings::Key APPLY_EFFECT_TO_ALL_AUDIO(moduleName, "effects/applyEffectToAllAudio");
 static const muse::Settings::Key EFFECT_MENU_ORGANIZATION(moduleName, "effects/effectMenuOrganization");
+static const muse::Settings::Key PREVIEW_MAX_DURATION(moduleName, "effects/previewMaxDuration");
 
 void EffectsConfiguration::init()
 {
@@ -22,6 +23,8 @@ void EffectsConfiguration::init()
     muse::settings()->valueChanged(EFFECT_MENU_ORGANIZATION).onReceive(nullptr, [this](const muse::Val&) {
         m_effectMenuOrganizationChanged.notify();
     });
+
+    muse::settings()->setDefaultValue(PREVIEW_MAX_DURATION, muse::Val(60.0));
 }
 
 bool EffectsConfiguration::applyEffectToAllAudio() const
@@ -56,4 +59,14 @@ void EffectsConfiguration::setEffectMenuOrganization(EffectMenuOrganization orga
 muse::async::Notification EffectsConfiguration::effectMenuOrganizationChanged() const
 {
     return m_effectMenuOrganizationChanged;
+}
+
+double EffectsConfiguration::previewMaxDuration() const
+{
+    return muse::settings()->value(PREVIEW_MAX_DURATION).toDouble();
+}
+
+void EffectsConfiguration::setPreviewMaxDuration(double value)
+{
+    muse::settings()->setSharedValue(PREVIEW_MAX_DURATION, muse::Val(value));
 }

--- a/src/effects/effects_base/internal/effectsconfiguration.h
+++ b/src/effects/effects_base/internal/effectsconfiguration.h
@@ -26,6 +26,9 @@ public:
     void setEffectMenuOrganization(EffectMenuOrganization) override;
     muse::async::Notification effectMenuOrganizationChanged() const override;
 
+    double previewMaxDuration() const override;
+    void setPreviewMaxDuration(double value) override;
+
 private:
     muse::async::Notification m_applyEffectToAllAudioChanged;
     muse::async::Notification m_effectMenuOrganizationChanged;

--- a/src/effects/effects_base/internal/effectsprovider.cpp
+++ b/src/effects/effects_base/internal/effectsprovider.cpp
@@ -448,12 +448,12 @@ muse::Ret EffectsProvider::doEffectPreview(EffectBase& effect, EffectSettings& s
     if (effect.PreviewsFullSelection()) {
         newCtx.t1 = originCtx.t1;
     } else {
-        // Limit preview time to 1mn. We need to pre-render the audio,
-        // which would take a long time and lots of memory for long selections.
+        // Limit preview time:
+        // We need to pre-render the audio, which would take a long time and lots of memory for long selections.
         // On the other hand, preview isn't typically something users would listen to for more than a few seconds.
         // (Au3 used to read `previewLen` from the `/AudioIO/EffectsPreviewLen` setting.
         // There is no plan at the moment to reintroduce it in Au4.)
-        constexpr double maxPreviewLen = 60.0;
+        const double maxPreviewLen = configuration()->previewMaxDuration();
         const double previewLen = std::min(originCtx.t1 - originCtx.t0, maxPreviewLen);
         double previewDuration = 0.0;
         if (isNyquist && isGenerator) {

--- a/src/effects/effects_base/internal/effectsprovider.cpp
+++ b/src/effects/effects_base/internal/effectsprovider.cpp
@@ -389,8 +389,14 @@ void restoreEffectStateHack(EffectBase& effect)
 }
 }
 
-muse::Ret EffectsProvider::doEffectPreview(EffectBase& effect, EffectSettings& settings)
+muse::Ret EffectsProvider::previewEffect(const EffectId& effectId, EffectSettings& settings)
 {
+    ::EffectBase* pEffect = this->effect(effectId);
+    if (!pEffect) {
+        return muse::make_ret(muse::Ret::Code::InternalError);
+    }
+    auto& effect = *pEffect;
+
     const bool isNyquist = effect.GetFamily() == NYQUISTEFFECTS_FAMILY;
     const bool isGenerator = effect.GetType() == EffectTypeGenerate;
 
@@ -598,9 +604,4 @@ muse::Ret EffectsProvider::doEffectPreview(EffectBase& effect, EffectSettings& s
     }
 
     return muse::make_ok();
-}
-
-muse::Ret EffectsProvider::previewEffect(au3::Au3Project&, Effect* effect, EffectSettings& settings)
-{
-    return doEffectPreview(*effect, settings);
 }

--- a/src/effects/effects_base/internal/effectsprovider.cpp
+++ b/src/effects/effects_base/internal/effectsprovider.cpp
@@ -590,7 +590,9 @@ muse::Ret EffectsProvider::doEffectPreview(EffectBase& effect, EffectSettings& s
 
         while (player->isRunning()) {
             using namespace std::chrono;
-            std::this_thread::sleep_for(10ms);
+            // A fast update rate is necessary if we want a smooth play-cursor animation
+            // whether the user interacts with the dialog during preview or not.
+            std::this_thread::sleep_for(1ms);
             QCoreApplication::processEvents();
         }
     }

--- a/src/effects/effects_base/internal/effectsprovider.cpp
+++ b/src/effects/effects_base/internal/effectsprovider.cpp
@@ -570,25 +570,10 @@ muse::Ret EffectsProvider::doEffectPreview(EffectBase& effect, EffectSettings& s
             return ret;
         }
 
-        using namespace BasicUI;
-
-        // The progress dialog must be deleted before stopping the stream
-        // to allow events to flow to the app during StopStream processing.
-        // The progress dialog blocks these events.
-        {
-            auto progress = MakeProgress(effect.GetName(), XO("Previewing"), ProgressShowStop);
-            while (player->isRunning()) {
-                using namespace std::chrono;
-                std::this_thread::sleep_for(100ms);
-                muse::secs_t playPos = player->playbackPosition() - startOffset;
-                auto previewing = progress->Poll(playPos, newCtx.t1);
-
-                if (previewing != BasicUI::ProgressResult::Success || player->reachedEnd().val) {
-                    break;
-                }
-            }
-
-            player->stop();
+        while (player->isRunning()) {
+            using namespace std::chrono;
+            std::this_thread::sleep_for(10ms);
+            QCoreApplication::processEvents();
         }
     }
 

--- a/src/effects/effects_base/internal/effectsprovider.h
+++ b/src/effects/effects_base/internal/effectsprovider.h
@@ -61,7 +61,7 @@ public:
     muse::Ret performEffect(au3::Au3Project& project, Effect* effect, std::shared_ptr<EffectInstance> effectInstance,
                             EffectSettings& settings) override;
 
-    muse::Ret previewEffect(au3::Au3Project& project, Effect* effect, EffectSettings& settings) override;
+    muse::Ret previewEffect(const EffectId& effectId, EffectSettings& settings) override;
 
 private:
 

--- a/src/effects/effects_base/internal/effectsprovider.h
+++ b/src/effects/effects_base/internal/effectsprovider.h
@@ -21,6 +21,11 @@
 
 class EffectBase;
 class EffectSettingsAccess;
+
+namespace BasicUI {
+class ProgressDialog;
+}
+
 namespace au::effects {
 class EffectsProvider : public IEffectsProvider, public muse::async::Asyncable
 {
@@ -64,6 +69,20 @@ public:
     muse::Ret previewEffect(const EffectId& effectId, EffectSettings& settings) override;
 
 private:
+    struct EffectContext {
+        double t0 = 0.0;
+        double t1 = 0.0;
+        std::shared_ptr<TrackList> tracks;
+        BasicUI::ProgressDialog* preparingPreviewProgress = nullptr;
+        bool isPreview = false;
+    };
+
+    struct EffectPreviewState {
+        EffectPreviewState(const EffectContext& originContext, const std::shared_ptr<TrackList>& previewTracks)
+            : originContext(originContext), previewTracks(previewTracks) {}
+        const EffectContext originContext;
+        const std::shared_ptr<TrackList> previewTracks;
+    };
 
     bool isVstSupported() const;
     bool isNyquistSupported() const;
@@ -74,5 +93,6 @@ private:
 
     mutable EffectMetaList m_effects;
     muse::async::Notification m_effectsChanged;
+    std::optional<EffectPreviewState> m_effectPreviewState;
 };
 }

--- a/src/effects/effects_base/qml/Audacity/Effects/EffectControlsDisablingOverlay.qml
+++ b/src/effects/effects_base/qml/Audacity/Effects/EffectControlsDisablingOverlay.qml
@@ -1,0 +1,36 @@
+import QtQuick
+import Audacity.Effects
+
+/**
+ * For third-part effects, the only way we can safely block interaction with the UI is by placing an overlay window.
+ *
+ * With Qt 6.9.1, this doesn't work on Windows for built-in effects, who use QML-drawn controls. The reason is unknown at the time of writing.
+ * We therefore use a simple rectangle component instead.
+ */
+Item {
+    id: root
+
+    required property int effectFamily
+
+    WindowContainer {
+        visible: root.visible && root.effectFamily !== EffectFamily.Builtin
+        anchors.fill: parent
+
+        window: Window {
+            color: "#55555555"
+        }
+    }
+
+    Rectangle {
+        visible: root.visible && root.effectFamily === EffectFamily.Builtin
+        anchors.fill: parent
+
+        color: "#55555555"
+
+        MouseArea {
+            id: interceptingMouseArea
+            anchors.fill: parent
+            hoverEnabled: true
+        }
+    }
+}

--- a/src/effects/effects_base/qml/Audacity/Effects/EffectPresetsBar.qml
+++ b/src/effects/effects_base/qml/Audacity/Effects/EffectPresetsBar.qml
@@ -12,7 +12,7 @@ import Audacity.Effects
 RowLayout {
     id: root
 
-    property var instanceId
+    required property var instanceId
     property int navigationOrder: 0
     property var navigationPanel: null
 
@@ -70,8 +70,7 @@ RowLayout {
 
         onActivated: function (index, value) {
             manageMenuModel.preset = value
-            currentIndex = manageMenuModel.presets.findIndex(
-                        preset => preset.id === value)
+            currentIndex = manageMenuModel.presets.findIndex(preset => preset.id === value)
         }
     }
 

--- a/src/effects/effects_base/qml/Audacity/Effects/EffectsViewerDialog.qml
+++ b/src/effects/effects_base/qml/Audacity/Effects/EffectsViewerDialog.qml
@@ -31,9 +31,7 @@ EffectStyledDialogView {
         property int separatorHeight: effectFamily == EffectFamily.Builtin ? separator.height + prv.panelMargins : 0
 
         function closeWindow(accept) {
-            if (prv.viewer.isPreviewing) {
-                prv.viewer.togglePreview()
-            }
+            prv.viewer.stopPreview()
             // Call later because the preview calls `QCoreApplication::processEvents()`,
             // and we must make sure it doesn't do this after we've closed the dialog, or we'll be getting that Qt exception
             // "Object %p destroyed while one of its QML signal handlers is in progress."
@@ -201,7 +199,7 @@ EffectStyledDialogView {
                             buttonId: ButtonBoxModel.CustomButton + 2
                             enabled: prv.isApplyAllowed
 
-                            onClicked: prv.viewer.togglePreview()
+                            onClicked: prv.viewer.isPreviewing ? prv.viewer.stopPreview() : prv.viewer.startPreview()
                         }
 
                         FlatButton {

--- a/src/effects/effects_base/qml/Audacity/Effects/EffectsViewerDialog.qml
+++ b/src/effects/effects_base/qml/Audacity/Effects/EffectsViewerDialog.qml
@@ -16,7 +16,6 @@ import Audacity.AudioUnit
 EffectStyledDialogView {
     id: root
 
-    property alias instanceId: viewerModel.instanceId
     property int effectFamily: EffectFamily.Unknown
 
     QtObject {
@@ -116,7 +115,7 @@ EffectStyledDialogView {
 
                         enabled: !prv.viewer.isPreviewing
                         parentWindow: root.window
-                        instanceId: root.instanceId
+                        instanceId: Boolean(prv.viewer) ? prv.viewer.instanceId : -1
                     }
                 }
 
@@ -250,7 +249,6 @@ EffectStyledDialogView {
     Component {
         id: builtinViewerComp
         BuiltinEffectViewer {
-            instanceId: root.instanceId
             dialogView: root
             usedDestructively: true
         }
@@ -259,7 +257,6 @@ EffectStyledDialogView {
     Component {
         id: lv2ViewerComp
         Lv2Viewer {
-            instanceId: root.instanceId
             title: root.title
         }
     }
@@ -267,7 +264,6 @@ EffectStyledDialogView {
     Component {
         id: audioUnitViewerComp
         AudioUnitViewer {
-            instanceId: root.instanceId
             height: implicitHeight
             topPadding: topPanel.height
             bottomPadding: bbox.implicitHeight + prv.panelMargins * 2
@@ -279,7 +275,6 @@ EffectStyledDialogView {
     Component {
         id: vstViewerComp
         VstViewer {
-            instanceId: root.instanceId
             height: implicitHeight
             topPadding: topPanel.height
             bottomPadding: bbox.implicitHeight + prv.panelMargins * 2

--- a/src/effects/effects_base/qml/Audacity/Effects/EffectsViewerDialog.qml
+++ b/src/effects/effects_base/qml/Audacity/Effects/EffectsViewerDialog.qml
@@ -35,12 +35,8 @@ EffectStyledDialogView {
             // Call later because the preview calls `QCoreApplication::processEvents()`,
             // and we must make sure it doesn't do this after we've closed the dialog, or we'll be getting that Qt exception
             // "Object %p destroyed while one of its QML signal handlers is in progress."
-            Qt.callLater(function () {
-                if (accept) {
-                    root.accept()
-                } else {
-                    root.reject()
-                }
+            Qt.callLater(() => {
+                accept ? root.accept() : root.reject()
             })
         }
     }
@@ -48,11 +44,8 @@ EffectStyledDialogView {
     Connections {
         target: root.window
         function onClosing(event) {
-            prv.closeWindow(false)
-            // Prevent immediate close so preview/cleanup can finish
-            if (event && event.accept !== undefined) {
-                event.accept = false
-            }
+            // Stop preview before closing, for the same reason as in closeWindow()
+            prv.viewer.stopPreview()
         }
     }
 
@@ -194,7 +187,12 @@ EffectStyledDialogView {
                             minWidth: 80
                             isLeftSide: true
 
-                            text: prv.viewer.isPreviewing ? qsTrc("effects", "Stop preview") : qsTrc("effects", "Preview")
+                            text: prv.viewer.isPreviewing ?
+                            //: Shown on a button that stops effect preview
+                            qsTrc("effects", "Stop preview") :
+                            //: Shown on a button that starts effect preview
+                            qsTrc("effects", "Preview")
+
                             buttonRole: ButtonBoxModel.CustomRole
                             buttonId: ButtonBoxModel.CustomButton + 2
                             enabled: prv.isApplyAllowed

--- a/src/effects/effects_base/qml/Audacity/Effects/RealtimeEffectViewerDialog.qml
+++ b/src/effects/effects_base/qml/Audacity/Effects/RealtimeEffectViewerDialog.qml
@@ -16,7 +16,6 @@ import Audacity.AudioUnit
 EffectStyledDialogView {
     id: root
 
-    property string instanceId
     property alias effectState: viewerModel.effectState
 
     title: viewerModel.title + " - " + viewerModel.trackName
@@ -64,8 +63,6 @@ EffectStyledDialogView {
     Component {
         id: audioUnitViewerComponent
         AudioUnitViewer {
-            id: view
-            instanceId: root.instanceId
             topPadding: headerBar.y + headerBar.height + prv.padding
             minimumWidth: prv.minimumWidth
         }
@@ -74,8 +71,6 @@ EffectStyledDialogView {
     Component {
         id: lv2ViewerComponent
         Lv2Viewer {
-            id: view
-            instanceId: root.instanceId
             effectState: root.effectState
             title: root.title
         }
@@ -84,8 +79,6 @@ EffectStyledDialogView {
     Component {
         id: vstViewerComponent
         VstViewer {
-            id: view
-            instanceId: root.instanceId
             topPadding: headerBar.y + headerBar.height + prv.padding
             minimumWidth: prv.minimumWidth
         }
@@ -99,9 +92,10 @@ EffectStyledDialogView {
             rightPadding: prv.padding
             bottomPadding: prv.padding
 
+            property alias instanceId: viewer.instanceId
+
             BuiltinEffectViewer {
-                id: view
-                instanceId: root.instanceId
+                id: viewer
                 usedDestructively: false
             }
         }
@@ -115,7 +109,6 @@ EffectStyledDialogView {
             Layout.fillWidth: true
 
             window: Window {
-
                 id: win
 
                 color: ui.theme.backgroundPrimaryColor
@@ -148,7 +141,7 @@ EffectStyledDialogView {
                         parentWindow: root.window
                         navigationPanel: root.navigationPanel
                         navigationOrder: 1
-                        instanceId: root.instanceId
+                        instanceId: Boolean(prv.viewItem) ? prv.viewItem.instanceId : -1
                         Layout.fillWidth: true
                     }
                 }

--- a/src/effects/effects_base/qml/Audacity/Effects/qmldir
+++ b/src/effects/effects_base/qml/Audacity/Effects/qmldir
@@ -1,4 +1,5 @@
 module Audacity.Effects
 BypassEffectButton 1.0 BypassEffectButton.qml
+EffectControlsDisablingOverlay 1.0 EffectControlsDisablingOverlay.qml
 EffectPresetsBar 1.0 EffectPresetsBar.qml
 EffectStyledDialogView 1.0 EffectStyledDialogView.qml

--- a/src/effects/effects_base/view/abstracteffectviewmodel.cpp
+++ b/src/effects/effects_base/view/abstracteffectviewmodel.cpp
@@ -3,11 +3,13 @@
 */
 #include "abstracteffectviewmodel.h"
 
+#include "effects/effects_base/internal/abstractviewlauncher.h"
+
 #include "playback/iplayer.h"
 
 namespace au::effects {
 AbstractEffectViewModel::AbstractEffectViewModel(QObject* parent)
-    : QObject(parent)
+    : QObject(parent), m_instanceId{AbstractViewLauncher::initializationInstanceId()}
 {
 }
 
@@ -46,14 +48,5 @@ void AbstractEffectViewModel::stopPreview()
 EffectInstanceId AbstractEffectViewModel::instanceId() const
 {
     return m_instanceId;
-}
-
-void AbstractEffectViewModel::setInstanceId(EffectInstanceId newInstanceId)
-{
-    if (m_instanceId == newInstanceId) {
-        return;
-    }
-    m_instanceId = newInstanceId;
-    emit instanceIdChanged();
 }
 }

--- a/src/effects/effects_base/view/abstracteffectviewmodel.cpp
+++ b/src/effects/effects_base/view/abstracteffectviewmodel.cpp
@@ -33,13 +33,14 @@ bool AbstractEffectViewModel::isPreviewing() const
     return player->playbackStatus() == playback::PlaybackStatus::Running;
 }
 
-void AbstractEffectViewModel::togglePreview()
+void AbstractEffectViewModel::startPreview()
 {
-    if (isPreviewing()) {
-        playback()->player()->stop();
-    } else {
-        doStartPreview();
-    }
+    doStartPreview();
+}
+
+void AbstractEffectViewModel::stopPreview()
+{
+    playback()->player()->stop();
 }
 
 EffectInstanceId AbstractEffectViewModel::instanceId() const

--- a/src/effects/effects_base/view/abstracteffectviewmodel.cpp
+++ b/src/effects/effects_base/view/abstracteffectviewmodel.cpp
@@ -11,6 +11,7 @@ namespace au::effects {
 AbstractEffectViewModel::AbstractEffectViewModel(QObject* parent)
     : QObject(parent), m_instanceId{AbstractViewLauncher::initializationInstanceId()}
 {
+    assert(m_instanceId != -1);
 }
 
 void AbstractEffectViewModel::init()

--- a/src/effects/effects_base/view/abstracteffectviewmodel.cpp
+++ b/src/effects/effects_base/view/abstracteffectviewmodel.cpp
@@ -1,0 +1,58 @@
+/*
+* Audacity: A Digital Audio Editor
+*/
+#include "abstracteffectviewmodel.h"
+
+#include "playback/iplayer.h"
+
+namespace au::effects {
+AbstractEffectViewModel::AbstractEffectViewModel(QObject* parent)
+    : QObject(parent)
+{
+}
+
+void AbstractEffectViewModel::init()
+{
+    const auto player = playback()->player();
+    IF_ASSERT_FAILED(player) {
+        return;
+    }
+    player->playbackStatusChanged().onReceive(this, [this](auto) {
+        emit isPreviewingChanged();
+    });
+
+    doInit();
+}
+
+bool AbstractEffectViewModel::isPreviewing() const
+{
+    const auto player = playback()->player();
+    IF_ASSERT_FAILED(player) {
+        return false;
+    }
+    return player->playbackStatus() == playback::PlaybackStatus::Running;
+}
+
+void AbstractEffectViewModel::togglePreview()
+{
+    if (isPreviewing()) {
+        playback()->player()->stop();
+    } else {
+        doStartPreview();
+    }
+}
+
+EffectInstanceId AbstractEffectViewModel::instanceId() const
+{
+    return m_instanceId;
+}
+
+void AbstractEffectViewModel::setInstanceId(EffectInstanceId newInstanceId)
+{
+    if (m_instanceId == newInstanceId) {
+        return;
+    }
+    m_instanceId = newInstanceId;
+    emit instanceIdChanged();
+}
+}

--- a/src/effects/effects_base/view/abstracteffectviewmodel.h
+++ b/src/effects/effects_base/view/abstracteffectviewmodel.h
@@ -1,0 +1,49 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+#pragma once
+
+#include "effects/effects_base/ieffectinstancesregister.h"
+#include "effects/effects_base/ieffectexecutionscenario.h"
+#include "playback/iplayback.h"
+
+#include "framework/global/async/asyncable.h"
+#include "framework/global/modularity/ioc.h"
+
+#include <QObject>
+
+namespace au::effects {
+class AbstractEffectViewModel : public QObject, public muse::async::Asyncable
+{
+    Q_OBJECT
+    Q_PROPERTY(EffectInstanceId instanceId READ instanceId WRITE setInstanceId NOTIFY instanceIdChanged FINAL)
+    Q_PROPERTY(bool isPreviewing READ isPreviewing NOTIFY isPreviewingChanged FINAL)
+
+protected:
+    muse::Inject<IEffectInstancesRegister> instancesRegister;
+    muse::Inject<IEffectExecutionScenario> executionScenario;
+    muse::Inject<au::playback::IPlayback> playback;
+
+public:
+    AbstractEffectViewModel(QObject* parent = nullptr);
+    ~AbstractEffectViewModel() override = default;
+
+    Q_INVOKABLE void init();
+    Q_INVOKABLE void togglePreview();
+
+    EffectInstanceId instanceId() const;
+    void setInstanceId(EffectInstanceId newInstanceId);
+
+    bool isPreviewing() const;
+
+signals:
+    void instanceIdChanged();
+    void isPreviewingChanged();
+
+private:
+    virtual void doInit() = 0;
+    virtual void doStartPreview() = 0;
+
+    EffectInstanceId m_instanceId = -1;
+};
+}

--- a/src/effects/effects_base/view/abstracteffectviewmodel.h
+++ b/src/effects/effects_base/view/abstracteffectviewmodel.h
@@ -16,7 +16,7 @@ namespace au::effects {
 class AbstractEffectViewModel : public QObject, public muse::async::Asyncable
 {
     Q_OBJECT
-    Q_PROPERTY(EffectInstanceId instanceId READ instanceId WRITE setInstanceId NOTIFY instanceIdChanged FINAL)
+    Q_PROPERTY(EffectInstanceId instanceId READ instanceId CONSTANT FINAL)
     Q_PROPERTY(bool isPreviewing READ isPreviewing NOTIFY isPreviewingChanged FINAL)
 
 protected:
@@ -33,18 +33,16 @@ public:
     Q_INVOKABLE void stopPreview();
 
     EffectInstanceId instanceId() const;
-    void setInstanceId(EffectInstanceId newInstanceId);
-
     bool isPreviewing() const;
 
 signals:
-    void instanceIdChanged();
     void isPreviewingChanged();
+
+protected:
+    const EffectInstanceId m_instanceId;
 
 private:
     virtual void doInit() = 0;
     virtual void doStartPreview() = 0;
-
-    EffectInstanceId m_instanceId = -1;
 };
 }

--- a/src/effects/effects_base/view/abstracteffectviewmodel.h
+++ b/src/effects/effects_base/view/abstracteffectviewmodel.h
@@ -29,7 +29,8 @@ public:
     ~AbstractEffectViewModel() override = default;
 
     Q_INVOKABLE void init();
-    Q_INVOKABLE void togglePreview();
+    Q_INVOKABLE void startPreview();
+    Q_INVOKABLE void stopPreview();
 
     EffectInstanceId instanceId() const;
     void setInstanceId(EffectInstanceId newInstanceId);

--- a/src/effects/effects_base/view/effectmanagemenu.cpp
+++ b/src/effects/effects_base/view/effectmanagemenu.cpp
@@ -12,19 +12,18 @@ void EffectManageMenu::load()
 {
     AbstractMenuModel::load();
 
-    const EffectInstanceId instanceId = m_instanceId.toULongLong();
-    const EffectId effectId = instancesRegister()->effectIdByInstanceId(instanceId);
+    const EffectId effectId = instancesRegister()->effectIdByInstanceId(m_instanceId);
 
     // subscribe on user presets change
-    presetsController()->userPresetsChanged().onReceive(this, [this, effectId, instanceId](const EffectId& eid) {
+    presetsController()->userPresetsChanged().onReceive(this, [this, effectId](const EffectId& eid) {
         if (effectId != eid) {
             return;
         }
 
-        reload(effectId, instanceId);
+        reload(effectId, m_instanceId);
     });
 
-    reload(effectId, instanceId);
+    reload(effectId, m_instanceId);
 }
 
 void EffectManageMenu::reload(const EffectId& effectId, const EffectInstanceId& instanceId)
@@ -143,12 +142,12 @@ void EffectManageMenu::reload(const EffectId& effectId, const EffectInstanceId& 
     emit presetsChanged();
 }
 
-QString EffectManageMenu::instanceId_prop() const
+int EffectManageMenu::instanceId_prop() const
 {
     return m_instanceId;
 }
 
-void EffectManageMenu::setInstanceId_prop(const QString& newInstanceId)
+void EffectManageMenu::setInstanceId_prop(int newInstanceId)
 {
     if (m_instanceId == newInstanceId) {
         return;
@@ -181,18 +180,16 @@ bool EffectManageMenu::enabled() const
 
 void EffectManageMenu::resetPreset()
 {
-    const EffectInstanceId instanceId = m_instanceId.toULongLong();
     ActionQuery q("action://effects/presets/apply");
-    q.addParam("instanceId", Val(instanceId));
+    q.addParam("instanceId", Val(m_instanceId));
     q.addParam("presetId", Val(m_currentPreset.toStdString()));
     dispatcher()->dispatch(q);
 }
 
 void EffectManageMenu::savePresetAs()
 {
-    const EffectInstanceId instanceId = m_instanceId.toULongLong();
     ActionQuery q("action://effects/presets/save");
-    q.addParam("instanceId", Val(instanceId));
+    q.addParam("instanceId", Val(m_instanceId));
     dispatcher()->dispatch(q);
     emit presetsChanged();
     emit presetChanged();

--- a/src/effects/effects_base/view/effectmanagemenu.h
+++ b/src/effects/effects_base/view/effectmanagemenu.h
@@ -10,7 +10,7 @@ namespace au::effects {
 class EffectManageMenu : public muse::uicomponents::AbstractMenuModel
 {
     Q_OBJECT
-    Q_PROPERTY(QString instanceId READ instanceId_prop WRITE setInstanceId_prop NOTIFY instanceIdChanged FINAL)
+    Q_PROPERTY(int instanceId READ instanceId_prop WRITE setInstanceId_prop NOTIFY instanceIdChanged FINAL)
     Q_PROPERTY(QVariantList presets READ presets NOTIFY presetsChanged FINAL)
     Q_PROPERTY(QString preset READ preset WRITE setPreset NOTIFY presetChanged FINAL)
     Q_PROPERTY(bool enabled READ enabled NOTIFY presetsChanged FINAL)
@@ -21,8 +21,8 @@ class EffectManageMenu : public muse::uicomponents::AbstractMenuModel
 
 public:
 
-    QString instanceId_prop() const;
-    void setInstanceId_prop(const QString& newInstanceId);
+    int instanceId_prop() const;
+    void setInstanceId_prop(int newInstanceId);
     QVariantList presets();
     QString preset() const;
     void setPreset(QString presetId);
@@ -42,7 +42,7 @@ private:
 
     void reload(const EffectId& effectId, const EffectInstanceId& instanceId);
 
-    QString m_instanceId;
+    int m_instanceId = -1;
     QString m_currentPreset;
     QVariantList m_presets;
 };

--- a/src/effects/lv2/internal/lv2viewlauncher.cpp
+++ b/src/effects/lv2/internal/lv2viewlauncher.cpp
@@ -6,17 +6,11 @@
 #include "libraries/lib-components/EffectInterface.h"
 #include "libraries/lib-realtime-effects/RealtimeEffectState.h"
 
-#include "au3wrap/internal/wxtypes_convert.h"
-#include "log.h"
-
 using namespace au::effects;
 
 muse::Ret Lv2ViewLauncher::showEffect(const EffectInstanceId& instanceId) const
 {
-    muse::UriQuery uri(EFFECT_VIEWER_URI);
-    uri.addParam("instanceId", muse::Val(instanceId));
-    uri.addParam("effectFamily", muse::Val(EffectFamily::LV2));
-    return interactive()->openSync(uri).ret;
+    return doShowEffect(instanceId, EffectFamily::LV2);
 }
 
 void Lv2ViewLauncher::showRealtimeEffect(const RealtimeEffectStatePtr& state) const

--- a/src/effects/lv2/qml/Audacity/Lv2/Lv2Viewer.qml
+++ b/src/effects/lv2/qml/Audacity/Lv2/Lv2Viewer.qml
@@ -17,6 +17,7 @@ Rectangle {
     property alias instanceId: model.instanceId
     property alias effectState: model.effectState
     property alias title: model.title
+    property alias isPreviewing: model.isPreviewing
 
     implicitWidth: textItem.width
     implicitHeight: textItem.height
@@ -31,8 +32,8 @@ Rectangle {
         model.deinit()
     }
 
-    function preview() {
-       model.preview()
+    function togglePreview() {
+        model.togglePreview()
     }
 
     function manage(parent) {

--- a/src/effects/lv2/qml/Audacity/Lv2/Lv2Viewer.qml
+++ b/src/effects/lv2/qml/Audacity/Lv2/Lv2Viewer.qml
@@ -10,7 +10,6 @@ import Audacity.Effects
 import Audacity.Lv2
 
 Rectangle {
-
     id: root
 
     // in
@@ -52,7 +51,7 @@ Rectangle {
     ContextMenuLoader {
         id: menuLoader
 
-        onHandleMenuItem: function(itemId) {
+        onHandleMenuItem: function (itemId) {
             manageMenuModel.handleMenuItem(itemId)
         }
     }

--- a/src/effects/lv2/qml/Audacity/Lv2/Lv2Viewer.qml
+++ b/src/effects/lv2/qml/Audacity/Lv2/Lv2Viewer.qml
@@ -31,8 +31,12 @@ Rectangle {
         model.deinit()
     }
 
-    function togglePreview() {
-        model.togglePreview()
+    function startPreview() {
+        model.startPreview()
+    }
+
+    function stopPreview() {
+        model.stopPreview()
     }
 
     function manage(parent) {

--- a/src/effects/lv2/view/lv2viewmodel.cpp
+++ b/src/effects/lv2/view/lv2viewmodel.cpp
@@ -489,9 +489,7 @@ void Lv2ViewModel::onSuilPortWrite(uint32_t port_index, uint32_t buffer_size, ui
                     // Is there a robust way of preventing the user from interacting with the UI
                     // while previewing is active?
                     // In the meantime, we just stop the preview.
-                    if (isPreviewing()) {
-                        togglePreview();
-                    }
+                    stopPreview();
                 }
                 return nullptr;
             });

--- a/src/effects/lv2/view/lv2viewmodel.h
+++ b/src/effects/lv2/view/lv2viewmodel.h
@@ -5,9 +5,7 @@
 
 #include "lv2uihandler.h"
 
-#include "effects/effects_base/ieffectinstancesregister.h"
-#include "effects/effects_base/ieffectexecutionscenario.h"
-#include "playback/iplayback.h"
+#include "effects/effects_base/view/abstracteffectviewmodel.h"
 #include "trackedit/iprojecthistory.h"
 
 #include "libraries/lib-lv2/LV2UIFeaturesList.h"
@@ -27,29 +25,20 @@ typedef unsigned long XID;
 
 namespace au::effects {
 class ILv2IdleUi;
-class Lv2ViewModel : public QObject
+class Lv2ViewModel : public AbstractEffectViewModel
 {
     Q_OBJECT
-    Q_PROPERTY(int instanceId READ instanceId WRITE setInstanceId NOTIFY instanceIdChanged FINAL)
     Q_PROPERTY(QString title READ title WRITE setTitle NOTIFY titleChanged FINAL)
     Q_PROPERTY(QString effectState READ effectState WRITE setEffectState NOTIFY effectStateChanged FINAL)
     Q_PROPERTY(QString unsupportedUiReason READ unsupportedUiReason NOTIFY unsupportedUiReasonChanged FINAL)
 
-    muse::Inject<IEffectInstancesRegister> instancesRegister;
-    muse::Inject<IEffectExecutionScenario> executionScenario;
-    muse::Inject<au::playback::IPlayback> playback;
     muse::Inject<trackedit::IProjectHistory> projectHistory;
 
 public:
     Lv2ViewModel(QObject* parent = nullptr);
     ~Lv2ViewModel() override;
 
-    Q_INVOKABLE void init();
     Q_INVOKABLE void deinit();
-    Q_INVOKABLE void preview();
-
-    int instanceId() const;
-    void setInstanceId(int newInstanceId);
 
     QString effectState() const;
     void setEffectState(const QString& state);
@@ -60,7 +49,6 @@ public:
     void setTitle(const QString& title);
 
 signals:
-    void instanceIdChanged();
     void titleChanged();
     void externalUiClosed();
     void effectStateChanged();
@@ -68,6 +56,8 @@ signals:
 
 private:
     friend class Lv2UiHandler;
+    void doInit() override;
+    void doStartPreview() override;
     int onResizeUi(int width, int height);
     void onUiClosed();
     void onKeyPressed(Qt::Key);
@@ -90,7 +80,6 @@ private:
 
     Lv2UiHandler m_handler;
 
-    int m_instanceId = -1;
     int m_minimumWidth = 0;
     QString m_title;
     RealtimeEffectStatePtr m_effectState;

--- a/src/effects/vst/internal/vst3viewlauncher.cpp
+++ b/src/effects/vst/internal/vst3viewlauncher.cpp
@@ -47,13 +47,7 @@ muse::Ret Vst3ViewLauncher::showEffect(const EffectInstanceId& instanceId) const
         return muse::make_ret(muse::Ret::Code::InternalError);
     }
 
-    muse::UriQuery uri(EFFECT_VIEWER_URI);
-    uri.addParam("instanceId", muse::Val(instanceId));
-    uri.addParam("effectFamily", muse::Val(EffectFamily::VST3));
-
-    muse::Ret ret = interactive()->openSync(uri).ret;
-
-    return ret;
+    return doShowEffect(instanceId, EffectFamily::VST3);
 }
 
 void Vst3ViewLauncher::showRealtimeEffect(const RealtimeEffectStatePtr& state) const

--- a/src/effects/vst/qml/Audacity/Vst/VstViewer.qml
+++ b/src/effects/vst/qml/Audacity/Vst/VstViewer.qml
@@ -31,7 +31,6 @@ Rectangle {
     id: root
 
     // in
-    property alias instanceId: view.instanceId
     property alias sidePadding: view.sidePadding
     property alias topPadding: view.topPadding
     property alias bottomPadding: view.bottomPadding
@@ -39,6 +38,7 @@ Rectangle {
 
     // out
     property alias title: view.title
+    property alias instanceId: viewModel.instanceId
     property alias isPreviewing: viewModel.isPreviewing
 
     color: ui.theme.backgroundPrimaryColor
@@ -83,10 +83,10 @@ Rectangle {
 
     VstViewModel {
         id: viewModel
-        instanceId: view.instanceId
     }
 
     VstView {
         id: view
+        instanceId: viewModel.instanceId
     }
 }

--- a/src/effects/vst/qml/Audacity/Vst/VstViewer.qml
+++ b/src/effects/vst/qml/Audacity/Vst/VstViewer.qml
@@ -52,8 +52,12 @@ Rectangle {
         Qt.callLater(manageMenuModel.load)
     }
 
-    function togglePreview() {
-        viewModel.togglePreview()
+    function startPreview() {
+        viewModel.startPreview()
+    }
+
+    function stopPreview() {
+        viewModel.stopPreview()
     }
 
     function manage(parent) {

--- a/src/effects/vst/qml/Audacity/Vst/VstViewer.qml
+++ b/src/effects/vst/qml/Audacity/Vst/VstViewer.qml
@@ -39,6 +39,7 @@ Rectangle {
 
     // out
     property alias title: view.title
+    property alias isPreviewing: viewModel.isPreviewing
 
     color: ui.theme.backgroundPrimaryColor
 
@@ -51,8 +52,8 @@ Rectangle {
         Qt.callLater(manageMenuModel.load)
     }
 
-    function preview() {
-        viewModel.preview()
+    function togglePreview() {
+        viewModel.togglePreview()
     }
 
     function manage(parent) {

--- a/src/effects/vst/view/vstviewmodel.cpp
+++ b/src/effects/vst/view/vstviewmodel.cpp
@@ -20,7 +20,7 @@ VstViewModel::~VstViewModel()
     checkSettingChangesFromUi(true);
 }
 
-void VstViewModel::init()
+void VstViewModel::doInit()
 {
     EffectInstanceId id = this->instanceId();
     IF_ASSERT_FAILED(id != 0) {
@@ -117,7 +117,7 @@ void VstViewModel::settingsFromView()
     });
 }
 
-void VstViewModel::preview()
+void VstViewModel::doStartPreview()
 {
     IF_ASSERT_FAILED(m_settingsAccess) {
         return;
@@ -129,18 +129,4 @@ void VstViewModel::preview()
         executionScenario()->previewEffect(instanceId(), settings);
         return nullptr;
     });
-}
-
-int VstViewModel::instanceId() const
-{
-    return m_instanceId;
-}
-
-void VstViewModel::setInstanceId(int newInstanceId)
-{
-    if (m_instanceId == newInstanceId) {
-        return;
-    }
-    m_instanceId = newInstanceId;
-    emit instanceIdChanged();
 }

--- a/src/effects/vst/view/vstviewmodel.h
+++ b/src/effects/vst/view/vstviewmodel.h
@@ -5,27 +5,20 @@
 
 #include <QObject>
 
-#include "global/async/asyncable.h"
-
 #include "modularity/ioc.h"
 #include "trackedit/iprojecthistory.h"
-#include "effects/effects_base/ieffectinstancesregister.h"
-#include "effects/effects_base/ieffectexecutionscenario.h"
 #include "effects/effects_base/irealtimeeffectservice.h"
-
 #include "effects/effects_base/effectstypes.h"
+#include "effects/effects_base/view/abstracteffectviewmodel.h"
 
 class VST3Instance;
 class EffectSettingsAccess;
 namespace au::effects {
-class VstViewModel : public QObject, public muse::async::Asyncable
+class VstViewModel : public AbstractEffectViewModel
 {
     Q_OBJECT
-    Q_PROPERTY(int instanceId READ instanceId WRITE setInstanceId NOTIFY instanceIdChanged FINAL)
 
 public:
-    muse::Inject<IEffectInstancesRegister> instancesRegister;
-    muse::Inject<IEffectExecutionScenario> executionScenario;
     muse::Inject<IRealtimeEffectService> realtimeEffectService;
     muse::Inject<trackedit::IProjectHistory> projectHistory;
 
@@ -33,16 +26,9 @@ public:
     VstViewModel() = default;
     ~VstViewModel() override;
 
-    int instanceId() const;
-    void setInstanceId(int newInstanceId);
-
-    Q_INVOKABLE void init();
-    Q_INVOKABLE void preview();
-
-signals:
-    void instanceIdChanged();
-
 private:
+    void doInit() override;
+    void doStartPreview() override;
 
     std::shared_ptr<EffectSettingsAccess> settingsAccess() const;
     void settingsToView();
@@ -50,7 +36,6 @@ private:
     void checkSettingChangesFromUiWhileIdle();
     void checkSettingChangesFromUi(bool forceCommitting);
 
-    EffectInstanceId m_instanceId = -1;
     std::shared_ptr<VST3Instance> m_auVst3Instance;
     std::shared_ptr<EffectSettingsAccess> m_settingsAccess;
     QTimer m_settingUpdateTimer;

--- a/src/playback/internal/au3/au3player.cpp
+++ b/src/playback/internal/au3/au3player.cpp
@@ -488,7 +488,15 @@ void Au3Player::updatePlaybackPosition()
         const auto targetConsumedSamples = static_cast<unsigned long long>(newCallback.numSamples)
                                            + (m_currentTarget ? m_currentTarget->consumedSamples : 0);
         const nanoseconds payloadDuration{ static_cast<long>(newCallback.numSamples * 1e9 / sampleRate + .5) };
-        const auto targetTime = newCallback.dacTime + payloadDuration;
+
+        auto dacTime = newCallback.dacTime;
+        if (m_currentTarget && m_currentTarget->time > newCallback.dacTime) {
+            // Jitter was observed in the hardware-thread callbacks on a macbook device: 4096 samples at 44.1kHz is 93ms, yet it
+            // was called 10 times with 85ms intervals, then one time with 170ms, over and over again.
+            dacTime = m_currentTarget->time;
+        }
+
+        const auto targetTime = dacTime + payloadDuration;
         m_currentTarget.emplace(targetTime, targetConsumedSamples);
     }
 

--- a/src/playback/internal/au3/au3player.cpp
+++ b/src/playback/internal/au3/au3player.cpp
@@ -27,6 +27,12 @@ using namespace au::au3;
 
 Au3Player::Au3Player()
 {
+    m_playbackStatus.ch.onReceive(this, [this](PlaybackStatus st) {
+        if (st == PlaybackStatus::Running) {
+            m_reachedEnd.val = false;
+        }
+    });
+
     globalContext()->currentProjectChanged().onNotify(this, [this]() {
         auto project = globalContext()->currentTrackeditProject();
         if (!project) {
@@ -450,14 +456,14 @@ void Au3Player::updatePlaybackState()
 {
     int token = ProjectAudioIO::Get(projectRef()).GetAudioIOToken();
     bool isActive = AudioIO::Get()->IsStreamActive(token);
-    double time = AudioIO::Get()->GetStreamTime() + m_startOffset;
+    const double time = std::max(0.0, AudioIO::Get()->GetStreamTime() + m_startOffset);
+
+    if (!muse::is_equal(time, m_playbackPosition.val.raw())) {
+        m_playbackPosition.set(time);
+    }
 
     if (isActive) {
         m_reachedEnd.val = false;
-        const auto newTime = std::max(0.0, time);
-        if (!muse::is_equal(newTime, m_playbackPosition.val.raw())) {
-            m_playbackPosition.set(newTime);
-        }
     } else {
         if (playbackStatus() == PlaybackStatus::Running && !m_reachedEnd.val) {
             m_reachedEnd.val = true;

--- a/src/playback/internal/au3/au3player.cpp
+++ b/src/playback/internal/au3/au3player.cpp
@@ -29,6 +29,8 @@ Au3Player::Au3Player()
 {
     m_playbackStatus.ch.onReceive(this, [this](PlaybackStatus st) {
         if (st == PlaybackStatus::Running) {
+            m_currentTarget.reset();
+            m_consumedSamplesSoFar = 0;
             m_reachedEnd.val = false;
         }
     });
@@ -261,9 +263,6 @@ void Au3Player::stop()
     if (captureMeter) {
         captureMeter->stop();
     }
-
-    m_consumedSamplesSoFar = 0;
-    m_currentTarget.reset();
 }
 
 void Au3Player::pause()
@@ -506,7 +505,7 @@ void Au3Player::updatePlaybackPosition()
 
     const auto timeDiff = duration_cast<milliseconds>(steady_clock::now() - m_currentTarget->time).count() / 1000.0;
     if (timeDiff > 0) {
-        // Hardware buffer was drained an no new data was put in there.
+        // We are past the target time, stop consuming until new data is available.
         return;
     }
 

--- a/src/playback/internal/au3/au3player.cpp
+++ b/src/playback/internal/au3/au3player.cpp
@@ -504,14 +504,12 @@ void Au3Player::updatePlaybackPosition()
     }
 
     const auto timeDiff = duration_cast<milliseconds>(steady_clock::now() - m_currentTarget->time).count() / 1000.0;
-    if (timeDiff > 0) {
-        // We are past the target time, stop consuming until new data is available.
-        return;
-    }
+    const auto extrapolation = static_cast<long long>(m_currentTarget->consumedSamples + timeDiff * sampleRate);
+    // Never progress by more samples than really have been output.
+    const auto expectedConsumedNow = std::min(static_cast<long long>(m_currentTarget->consumedSamples), extrapolation);
 
-    const auto expectedConsumedNow = static_cast<long long>(m_currentTarget->consumedSamples + timeDiff * sampleRate);
     if (static_cast<long long>(m_consumedSamplesSoFar) >= expectedConsumedNow) {
-        // User isn't hearing audio yet - wait some more.
+        // User isn't hearing audio yet - wait some more. (`expectedConsumedNow` can be negative.)
         return;
     }
 

--- a/src/projectscene/view/clipsview/au3/WaveformScale.cpp
+++ b/src/projectscene/view/clipsview/au3/WaveformScale.cpp
@@ -33,8 +33,3 @@ auto WaveformScale::Clone() const -> PointerType
 {
     return std::make_unique<WaveformScale>(*this);
 }
-
-int WaveformScale::ZeroLevelYCoordinate(wxRect rect) const
-{
-    return rect.GetTop() + (int)((mDisplayMax / (mDisplayMax - mDisplayMin)) * rect.height);
-}

--- a/src/projectscene/view/clipsview/au3/WaveformScale.h
+++ b/src/projectscene/view/clipsview/au3/WaveformScale.h
@@ -29,8 +29,6 @@ public:
     ~WaveformScale() override = default;
     PointerType Clone() const override;
 
-    int ZeroLevelYCoordinate(wxRect rect) const;
-
     void GetDisplayBounds(float& min, float& max) const
     { min = mDisplayMin; max = mDisplayMax; }
 

--- a/src/projectscene/view/trackspanel/realtimeeffectlistitemmenumodel.cpp
+++ b/src/projectscene/view/trackspanel/realtimeeffectlistitemmenumodel.cpp
@@ -26,7 +26,7 @@ void RealtimeEffectListItemMenuModel::doPopulateMenu()
 {
     MenuItemList items;
 
-    items << makeMenuItem("realtimeeffect-remove", muse::TranslatableString("projectscene", "No effect")) << makeSeparator();
+    items << makeMenuItem("realtimeeffect-remove", muse::TranslatableString("projectscene", "Remove effect")) << makeSeparator();
 
     const auto effectMenus = this->effectMenus();
     if (!effectMenus.empty()) {


### PR DESCRIPTION
Resolves: #9577
Resolves: #7877
Resolves: #9698
Resolves: #9738

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:
The following should work for all effect types: VST, LV2, AudioUnit, built-in effects and built-in generators

- [x] Built-in, VST and AudioUnit effects: UI and presets are disabled during preview
- [x] LV2 effects: modifying a control during playback interrupts preview
- [x] "Cancel", pressing Esc or closing  the window during preview close the dialog without applying the effect.
- [x] "Apply" during preview closes the dialog and applies the effect.
- [x] Only the select portion of Audio gets played back
- [x] Please smoke-test all combinations of effect dialogs with respect to destructive/realtime and effect-family (built-in, VST, AudioUnit and LV2). Only just opening one of them should suffice.
- [x] Preview region is dissociated from loop region (e.g. have a small loop region, loop enabled, select a region that's not the same as the loop region: preview should play the selected region, not the loop region)
- [x] Preview duration is limited to 1mn. (Tip: you may go in DevTools, look for "preview" and reduce the max preview duration to speed up testing this.)

Besides:
- [ ] Autobot test cases have been run
