### PR TITLE
Create loop region only when control key is pressed

### DIFF
--- a/src/projectscene/qml/Audacity/ProjectScene/clipsview/TracksClipsView.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/clipsview/TracksClipsView.qml
@@ -227,6 +227,58 @@ Rectangle {
             }
         }
 
+        MouseArea {
+            id: timelineMouseArea
+            anchors.fill: parent
+            hoverEnabled: true
+
+            property bool playRegionActivated: false
+
+            function convertToTimelinePosition(e) {
+                let position = mapToItem(timeline, Qt.point(e.x, e.y))
+                position.x = Math.max(0, position.x)
+                position.y = Math.max(0, position.y)
+                return position
+            }
+
+            onPositionChanged: function (e) {
+                let position = convertToTimelinePosition(e)
+                timeline.updateCursorPosition(position.x, position.y)
+                playRegionController.updatePosition(position.x)
+            }
+
+            onPressed: function (e) {
+                let position = convertToTimelinePosition(e)
+                if (timeline.isMajorSection(position.y)) {
+                    playRegionController.startInteraction(position.x, root.ctrlPressed)
+                    playRegionActivated = true
+                }
+            }
+
+            onReleased: function (e) {
+                let position = convertToTimelinePosition(e)
+                playRegionController.finishInteraction(position.x)
+            }
+
+            onClicked: function (e) {
+                let position = convertToTimelinePosition(e)
+                if (!playRegionActivated) {
+                    playCursorController.seekToX(position.x, timeline.context.playbackOnRulerClickEnabled)
+                }
+                playRegionActivated = false
+            }
+
+            Connections {
+                target: root
+
+                function onCtrlPressedChanged() {
+                    if (!root.ctrlPressed) {
+                        playRegionController.finishInteraction(timelineMouseArea.mouseX)
+                    }
+                }
+            }
+        }
+
         Timeline {
             id: timeline
 
@@ -240,45 +292,6 @@ Rectangle {
                 lineCursor.x = x
                 timeline.context.updateMousePositionTime(x)
                 tracksViewState.setMouseY(Math.max(0, Math.min(y, mainMouseArea.height)))
-            }
-
-            MouseArea {
-                id: timelineMouseArea
-                anchors.fill: parent
-                hoverEnabled: true
-
-                onPositionChanged: function (e) {
-                    timeline.updateCursorPosition(e.x, e.y)
-                    playRegionController.updatePosition(e.x)
-                }
-
-                onPressed: function (e) {
-                    if (timeline.isMajorSection(e.y)) {
-                        playRegionController.startInteraction(e.x, root.ctrlPressed)
-                        prv.playRegionActivated = true
-                    }
-                }
-
-                onReleased: function (e) {
-                    playRegionController.finishInteraction(e.x)
-                }
-
-                onClicked: function (e) {
-                    if (!prv.playRegionActivated) {
-                        playCursorController.seekToX(e.x, timeline.context.playbackOnRulerClickEnabled)
-                    }
-                    prv.playRegionActivated = false
-                }
-
-                Connections {
-                    target: root
-
-                    function onCtrlPressedChanged() {
-                        if (!root.ctrlPressed) {
-                            playRegionController.finishInteraction(timelineMouseArea.mouseX)
-                        }
-                    }
-                }
             }
 
             Rectangle {

--- a/src/projectscene/qml/Audacity/ProjectScene/clipsview/TracksClipsView.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/clipsview/TracksClipsView.qml
@@ -249,18 +249,18 @@ Rectangle {
 
                 onPositionChanged: function (e) {
                     timeline.updateCursorPosition(e.x, e.y)
-                    playRegionController.mouseMove(e.x)
+                    playRegionController.updatePosition(e.x)
                 }
 
                 onPressed: function (e) {
                     if (timeline.isMajorSection(e.y)) {
-                        playRegionController.mouseDown(e.x)
+                        playRegionController.startInteraction(e.x, root.ctrlPressed)
                         prv.playRegionActivated = true
                     }
                 }
 
                 onReleased: function (e) {
-                    playRegionController.mouseUp(e.x)
+                    playRegionController.finishInteraction(e.x)
                 }
 
                 onClicked: function (e) {
@@ -268,6 +268,16 @@ Rectangle {
                         playCursorController.seekToX(e.x, timeline.context.playbackOnRulerClickEnabled)
                     }
                     prv.playRegionActivated = false
+                }
+
+                Connections {
+                    target: root
+
+                    function onCtrlPressedChanged() {
+                        if (!root.ctrlPressed) {
+                            playRegionController.finishInteraction(timelineMouseArea.mouseX)
+                        }
+                    }
                 }
             }
 

--- a/src/projectscene/view/timeline/playregioncontroller.cpp
+++ b/src/projectscene/view/timeline/playregioncontroller.cpp
@@ -5,7 +5,6 @@
 #include "playregioncontroller.h"
 
 #include <cmath>
-#include <qguiapplication.h>
 
 #include "log.h"
 
@@ -36,8 +35,8 @@ void PlayRegionController::startInteraction(double pos, bool ctrlPressed)
     m_lastPos = m_dragStartPos;
     updateSnapGuideline(m_dragStartPos);
 
-    if (playback()->player()->isLoopRegionClear() && ctrlPressed) {
-        m_action = UserInputAction::CreateRegion;
+    if (playback()->player()->isLoopRegionClear()) {
+        m_action = ctrlPressed ? UserInputAction::CreateRegion : UserInputAction::None;
     } else if (std::abs(startPos() - pos) < RESIZE_AREA_WIDTH_PX) {
         m_action = UserInputAction::ResizeStart;
     } else if (std::abs(endPos() - pos) < RESIZE_AREA_WIDTH_PX) {

--- a/src/projectscene/view/timeline/playregioncontroller.cpp
+++ b/src/projectscene/view/timeline/playregioncontroller.cpp
@@ -5,6 +5,7 @@
 #include "playregioncontroller.h"
 
 #include <cmath>
+#include <qguiapplication.h>
 
 #include "log.h"
 
@@ -23,7 +24,7 @@ void PlayRegionController::init()
     updateIsActive();
 }
 
-void PlayRegionController::mouseDown(double pos)
+void PlayRegionController::startInteraction(double pos, bool ctrlPressed)
 {
     if (!m_isActive) {
         return;
@@ -35,21 +36,22 @@ void PlayRegionController::mouseDown(double pos)
     m_lastPos = m_dragStartPos;
     updateSnapGuideline(m_dragStartPos);
 
-    if (playback()->player()->isLoopRegionClear()) {
+    if (playback()->player()->isLoopRegionClear() && ctrlPressed) {
         m_action = UserInputAction::CreateRegion;
-        QGuiApplication::setOverrideCursor(QCursor(Qt::SizeHorCursor));
     } else if (std::abs(startPos() - pos) < RESIZE_AREA_WIDTH_PX) {
         m_action = UserInputAction::ResizeStart;
-        QGuiApplication::setOverrideCursor(QCursor(Qt::SizeHorCursor));
     } else if (std::abs(endPos() - pos) < RESIZE_AREA_WIDTH_PX) {
         m_action = UserInputAction::ResizeEnd;
-        QGuiApplication::setOverrideCursor(QCursor(Qt::SizeHorCursor));
     } else if (pos > startPos() && pos < endPos()) {
         m_action = UserInputAction::Drag;
-        QGuiApplication::setOverrideCursor(QCursor(Qt::ClosedHandCursor));
-    } else {
-        m_action = UserInputAction::CreateRegion;
+    }
+
+    if (m_action == UserInputAction::CreateRegion
+        || m_action == UserInputAction::ResizeStart
+        || m_action == UserInputAction::ResizeEnd) {
         QGuiApplication::setOverrideCursor(QCursor(Qt::SizeHorCursor));
+    } else if (m_action == UserInputAction::Drag) {
+        QGuiApplication::setOverrideCursor(QCursor(Qt::ClosedHandCursor));
     }
 
     if (m_action != UserInputAction::None) {
@@ -58,16 +60,16 @@ void PlayRegionController::mouseDown(double pos)
 
     connect(qApp, &QApplication::applicationStateChanged, this, [this](Qt::ApplicationState state){
         if (state != Qt::ApplicationActive) {
-            mouseUp(m_dragStartPos);
+            finishInteraction(m_dragStartPos);
         }
     });
 
     uicontextResolver()->currentUiContextChanged().onNotify(this, [this]() {
-        mouseUp(m_dragStartPos);
+        finishInteraction(m_dragStartPos);
     });
 }
 
-void PlayRegionController::mouseMove(double pos)
+void PlayRegionController::updatePosition(double pos)
 {
     if (!m_isActive) {
         return;
@@ -162,11 +164,15 @@ void au::projectscene::PlayRegionController::handleDrag(double pos)
     player->setLoopRegion({ ctx->positionToTime(snappedStart), ctx->positionToTime(snappedEnd) });
 }
 
-void PlayRegionController::mouseUp(double pos)
+void PlayRegionController::finishInteraction(double pos)
 {
     UNUSED(pos);
 
     if (!m_isActive) {
+        return;
+    }
+
+    if (m_action == UserInputAction::None) {
         return;
     }
 

--- a/src/projectscene/view/timeline/playregioncontroller.h
+++ b/src/projectscene/view/timeline/playregioncontroller.h
@@ -88,7 +88,7 @@ private:
     double m_snapGuidelinePos = 0;
 
     bool m_dragStarted = false;
-    UserInputAction m_action;
+    UserInputAction m_action = UserInputAction::None;
 
     bool m_isActive = false;
 };

--- a/src/projectscene/view/timeline/playregioncontroller.h
+++ b/src/projectscene/view/timeline/playregioncontroller.h
@@ -39,9 +39,9 @@ public:
 
     Q_INVOKABLE void init();
 
-    Q_INVOKABLE void mouseDown(double pos);
-    Q_INVOKABLE void mouseUp(double pos);
-    Q_INVOKABLE void mouseMove(double pos);
+    Q_INVOKABLE void startInteraction(double pos, bool ctrlPressed);
+    Q_INVOKABLE void finishInteraction(double pos);
+    Q_INVOKABLE void updatePosition(double pos);
 
     Q_INVOKABLE void beginPreview();
     Q_INVOKABLE void setPreviewStartTime(double time);


### PR DESCRIPTION
Resolves: #9672 

Following the new design, only create the loop region if control key is pressed.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Autobot test cases have been run
