### PR TITLE
Force to clear channels when stopping timer

### DIFF
--- a/src/au3wrap/internal/au3audiometer.cpp
+++ b/src/au3wrap/internal/au3audiometer.cpp
@@ -7,15 +7,8 @@
 
 #include "au3audiometer.h"
 
-#include "global/async/async.h"
 #include "global/log.h"
-
-#include "libraries/lib-utility/MathApprox.h"
-#include "libraries/lib-utility/MemoryX.h"
-
 #include "global/types/ratio.h" // muse::linear_to_db
-
-#include <cmath> // std::ceil
 
 namespace au::au3 {
 namespace {
@@ -127,6 +120,10 @@ void Meter::push(uint8_t channel, const IMeterSender::InterleavedSampleData& sam
 void Meter::start(double sampleRate)
 {
     m_stoppingTimer->stop();
+    for (auto& [trackId, trackData] : m_trackData) {
+        trackData.channelLevels.clear();
+    }
+
     m_playingTimer->start();
     m_sampleRate = sampleRate;
     m_running.store(true);

--- a/src/au3wrap/internal/au3audiometer.h
+++ b/src/au3wrap/internal/au3audiometer.h
@@ -89,7 +89,6 @@ private:
     const std::unique_ptr<ITimer> m_playingTimer;
     const std::unique_ptr<ITimer> m_stoppingTimer;
     std::atomic<bool> m_running { false };
-    bool m_stopPending = true;
     bool m_warningIssued = false;
 };
 }


### PR DESCRIPTION
Resolves: #9722 

When executing `Meter::start`, `m_stoppingTimer` may already be running.
In that case, `channelLevels` are not cleared and the lowest value after the decay is always sent to the meter.

The fix is to ensure `channelLevels` are correctly cleared.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Autobot test cases have been run
