### PR TITLE
Fix data format sent through meter channel

### DIFF
--- a/src/au3wrap/internal/au3audiometer.cpp
+++ b/src/au3wrap/internal/au3audiometer.cpp
@@ -83,7 +83,9 @@ Meter::Meter(std::unique_ptr<ITimer> playingTimer, std::unique_ptr<ITimer> stopp
             auto& trackData = entry.second;
             for (const std::pair<const audio::audioch_t, Levels>& entry : trackData.channelLevels) {
                 const auto& [channel, levels] = entry;
-                trackData.notificationChannel.send(channel, audio::MeterSignal { levels.peak.db, levels.rms.db });
+                trackData.notificationChannel.send(channel, audio::MeterSignal {
+                        { muse::db_to_linear(levels.peak.db), levels.peak.db },
+                        { muse::db_to_linear(levels.rms.db), levels.rms.db } });
             }
         }
     });


### PR DESCRIPTION
Resolves: #9763 

`MeterSignal` is composed by two `AudioSignalVal` values (peak, rms) and this struct is formed by two fields (amplitude, pressure)
The current code is incorrectly setting just the peak value.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Autobot test cases have been run
