### PR TITLE
Refactoring: use effect view model factories

### DIFF
--- a/au3/libraries/lib-audio-devices/AudioIOBase.h
+++ b/au3/libraries/lib-audio-devices/AudioIOBase.h
@@ -38,8 +38,6 @@ class BoundedEnvelope;
 class Meter;
 using PRCrossfadeData = std::vector< std::vector < float > >;
 
-#define BAD_STREAM_TIME (-DBL_MAX)
-
 class PlaybackPolicy;
 
 // To avoid growing the argument list of StartStream, add fields here

--- a/au3/libraries/lib-audio-io/AudioIO.cpp
+++ b/au3/libraries/lib-audio-io/AudioIO.cpp
@@ -1831,11 +1831,6 @@ double AudioIO::GetBestRate(bool capturing, bool playing, double sampleRate)
 double AudioIO::GetStreamTime()
 {
     // Sequence time readout for the main thread
-
-    if (!IsStreamActive()) {
-        return BAD_STREAM_TIME;
-    }
-
     return mPlaybackSchedule.GetSequenceTime();
 }
 

--- a/au3/libraries/lib-audio-io/AudioIO.h
+++ b/au3/libraries/lib-audio-io/AudioIO.h
@@ -388,7 +388,12 @@ protected:
     //! Holds some state for duration of playback or recording
     std::unique_ptr<TransportState> mpTransportState;
 
-    AudioCallbackInfoQueue mAudioCallbackInfoQueue { 16 };
+    // In a jitter-free world, the size of this queue only has to be `ceil(producerRate / consumerRate)`.
+    // If we assume a minimum of 30fps for the consumer (this is supposed to be read by a entity occupied with
+    // smooth rendering of the playback cursor), and a callback pushing maybe as little as 10 samples per
+    // callback (I've just seen 14 samples per callback, on MacOS with a requested buffer size of 10ms),
+    // we get ceil(96000 / 10 / 30) = 360. The rounding to the next power of two should accommodate jitter.
+    AudioCallbackInfoQueue mAudioCallbackInfoQueue { 512 };
 
 private:
     /*!

--- a/src/au3wrap/internal/waveformscale.h
+++ b/src/au3wrap/internal/waveformscale.h
@@ -29,8 +29,6 @@ public:
     ~WaveformScale() override = default;
     PointerType Clone() const override;
 
-    int ZeroLevelYCoordinate(wxRect rect) const;
-
     void GetDisplayBounds(float& min, float& max) const
     { min = mDisplayMin; max = mDisplayMax; }
 

--- a/src/effects/audio_unit/audiouniteffectsmodule.cpp
+++ b/src/effects/audio_unit/audiouniteffectsmodule.cpp
@@ -7,6 +7,7 @@
 #include "audioplugins/iaudiopluginmetareaderregister.h"
 
 #include "effects/effects_base/ieffectviewlaunchregister.h"
+#include "effects/effects_base/view/effectsviewutils.h"
 
 #include "internal/audiouniteffectsrepository.h"
 #include "internal/audiounitpluginsscanner.h"
@@ -60,7 +61,7 @@ void au::effects::AudioUnitEffectsModule::resolveImports()
 void au::effects::AudioUnitEffectsModule::registerUiTypes()
 {
     qmlRegisterType<au::effects::AudioUnitView>("Audacity.AudioUnit", 1, 0, "AudioUnitView");
-    qmlRegisterType<au::effects::AudioUnitViewModel>("Audacity.AudioUnit", 1, 0, "AudioUnitViewModel");
+    REGISTER_AUDACITY_EFFECTS_SINGLETON_TYPE(AudioUnitViewModelFactory);
 }
 
 void au::effects::AudioUnitEffectsModule::onInit(const muse::IApplication::RunMode& mode)

--- a/src/effects/audio_unit/internal/audiounitviewlauncher.cpp
+++ b/src/effects/audio_unit/internal/audiounitviewlauncher.cpp
@@ -3,14 +3,9 @@
 */
 #include "audiounitviewlauncher.h"
 
-#include "log.h"
-
 muse::Ret au::effects::AudioUnitViewLauncher::showEffect(const EffectInstanceId& instanceId) const
 {
-    muse::UriQuery uri(EFFECT_VIEWER_URI);
-    uri.addParam("instanceId", muse::Val(instanceId));
-    uri.addParam("effectFamily", muse::Val(EffectFamily::AudioUnit));
-    return interactive()->openSync(uri).ret;
+    return doShowEffect(instanceId, EffectFamily::AudioUnit);
 }
 
 void au::effects::AudioUnitViewLauncher::showRealtimeEffect(const RealtimeEffectStatePtr& state) const

--- a/src/effects/audio_unit/qml/Audacity/AudioUnit/AudioUnitViewer.qml
+++ b/src/effects/audio_unit/qml/Audacity/AudioUnit/AudioUnitViewer.qml
@@ -22,6 +22,7 @@ Rectangle {
 
     // out
     property alias title: model.title
+    property alias isPreviewing: model.isPreviewing
 
     color: ui.theme.backgroundPrimaryColor
 
@@ -39,11 +40,11 @@ Rectangle {
     }
 
     Component.onDestruction: {
-        model.deinit();
+        model.deinit()
     }
 
-    function preview() {
-        model.preview()
+    function togglePreview() {
+        model.togglePreview()
     }
 
     function manage(parent) {

--- a/src/effects/audio_unit/qml/Audacity/AudioUnit/AudioUnitViewer.qml
+++ b/src/effects/audio_unit/qml/Audacity/AudioUnit/AudioUnitViewer.qml
@@ -41,8 +41,12 @@ Rectangle {
         model.deinit()
     }
 
-    function togglePreview() {
-        model.togglePreview()
+    function startPreview() {
+        model.startPreview()
+    }
+
+    function stopPreview() {
+        model.stopPreview()
     }
 
     function manage(parent) {

--- a/src/effects/audio_unit/qml/Audacity/AudioUnit/AudioUnitViewer.qml
+++ b/src/effects/audio_unit/qml/Audacity/AudioUnit/AudioUnitViewer.qml
@@ -13,15 +13,17 @@ Rectangle {
     id: root
 
     // in
-    property alias instanceId: model.instanceId
+    required property int instanceId
     property alias sidePadding: view.sidePadding
     property alias topPadding: view.topPadding
     property alias bottomPadding: view.bottomPadding
     property alias minimumWidth: view.minimumWidth
 
     // out
-    property alias title: model.title
-    property alias isPreviewing: model.isPreviewing
+    property bool title: model.title
+    property bool isPreviewing: model.isPreviewing
+
+    readonly property var model: AudioUnitViewModelFactory.createModel(root, root.instanceId)
 
     color: ui.theme.backgroundPrimaryColor
 
@@ -68,10 +70,6 @@ Rectangle {
         onHandleMenuItem: function (itemId) {
             manageMenuModel.handleMenuItem(itemId)
         }
-    }
-
-    AudioUnitViewModel {
-        id: model
     }
 
     AudioUnitView {

--- a/src/effects/audio_unit/qml/Audacity/AudioUnit/AudioUnitViewer.qml
+++ b/src/effects/audio_unit/qml/Audacity/AudioUnit/AudioUnitViewer.qml
@@ -10,7 +10,6 @@ import Audacity.Effects 1.0
 import Audacity.AudioUnit 1.0
 
 Rectangle {
-
     id: root
 
     // in
@@ -31,7 +30,6 @@ Rectangle {
 
     implicitWidth: view.implicitWidth
     implicitHeight: view.implicitHeight
-
 
     Component.onCompleted: {
         model.init()
@@ -63,7 +61,7 @@ Rectangle {
     ContextMenuLoader {
         id: menuLoader
 
-        onHandleMenuItem: function(itemId) {
+        onHandleMenuItem: function (itemId) {
             manageMenuModel.handleMenuItem(itemId)
         }
     }

--- a/src/effects/audio_unit/qml/Audacity/AudioUnit/AudioUnitViewer.qml
+++ b/src/effects/audio_unit/qml/Audacity/AudioUnit/AudioUnitViewer.qml
@@ -13,7 +13,7 @@ Rectangle {
     id: root
 
     // in
-    property alias instanceId: view.instanceId
+    property alias instanceId: model.instanceId
     property alias sidePadding: view.sidePadding
     property alias topPadding: view.topPadding
     property alias bottomPadding: view.bottomPadding
@@ -59,7 +59,7 @@ Rectangle {
 
     EffectManageMenu {
         id: manageMenuModel
-        instanceId: view.instanceId
+        instanceId: model.instanceId
     }
 
     ContextMenuLoader {
@@ -72,10 +72,10 @@ Rectangle {
 
     AudioUnitViewModel {
         id: model
-        instanceId: view.instanceId
     }
 
     AudioUnitView {
         id: view
+        instanceId: model.instanceId
     }
 }

--- a/src/effects/audio_unit/view/audiounitviewmodel.cpp
+++ b/src/effects/audio_unit/view/audiounitviewmodel.cpp
@@ -17,7 +17,7 @@
 
 namespace au::effects {
 AudioUnitViewModel::AudioUnitViewModel(QObject* parent)
-    : QObject(parent)
+    : AbstractEffectViewModel(parent)
 {}
 
 AudioUnitViewModel::~AudioUnitViewModel()
@@ -25,21 +25,21 @@ AudioUnitViewModel::~AudioUnitViewModel()
     checkSettingChangesFromUi();
 }
 
-void AudioUnitViewModel::init()
+void AudioUnitViewModel::doInit()
 {
-    IF_ASSERT_FAILED(m_instanceId >= 0) {
+    IF_ASSERT_FAILED(instanceId() >= 0) {
         return;
     }
 
-    m_instance = std::dynamic_pointer_cast<AudioUnitInstance>(instancesRegister()->instanceById(m_instanceId));
+    m_instance = std::dynamic_pointer_cast<AudioUnitInstance>(instancesRegister()->instanceById(instanceId()));
     IF_ASSERT_FAILED(m_instance) {
         return;
     }
 
-    instancesRegister()->settingsChanged(m_instanceId).onNotify(this, [this]() {
+    instancesRegister()->settingsChanged(instanceId()).onNotify(this, [this]() {
         settingsToView();
     });
-    instancesRegister()->updateSettingsRequested(m_instanceId).onNotify(this, [this]() {
+    instancesRegister()->updateSettingsRequested(instanceId()).onNotify(this, [this]() {
         settingsFromView();
     });
     realtimeEffectService()->effectSettingsChanged().onNotify(this, [this]() {
@@ -48,19 +48,19 @@ void AudioUnitViewModel::init()
 
     m_eventListenerRef = MakeListener();
 
-    const EffectSettings* settings = instancesRegister()->settingsById(m_instanceId);
+    const EffectSettings* settings = instancesRegister()->settingsById(instanceId());
     IF_ASSERT_FAILED(settings) {
         return;
     }
 
-    const EffectId id = instancesRegister()->effectIdByInstanceId(m_instanceId);
+    const EffectId id = instancesRegister()->effectIdByInstanceId(instanceId());
     const AudioUnitEffectBase* const effect = dynamic_cast<AudioUnitEffectBase*>(EffectManager::Get().GetEffect(id.toStdString()));
 
     IF_ASSERT_FAILED(effect) {
         return;
     }
 
-    m_settingsAccess = instancesRegister()->settingsAccessById(m_instanceId);
+    m_settingsAccess = instancesRegister()->settingsAccessById(instanceId());
     IF_ASSERT_FAILED(m_settingsAccess) {
         return;
     }
@@ -76,7 +76,7 @@ void AudioUnitViewModel::init()
     m_settingsTimer.start(100);
 }
 
-void au::effects::AudioUnitViewModel::preview()
+void au::effects::AudioUnitViewModel::doStartPreview()
 {
     IF_ASSERT_FAILED(m_settingsAccess) {
         return;
@@ -251,19 +251,5 @@ void AudioUnitViewModel::setTitle(const QString& newTitle)
     }
     m_title = newTitle;
     emit titleChanged();
-}
-
-int AudioUnitViewModel::instanceId() const
-{
-    return m_instanceId;
-}
-
-void AudioUnitViewModel::setInstanceId(int newInstanceId)
-{
-    if (m_instanceId == newInstanceId) {
-        return;
-    }
-    m_instanceId = newInstanceId;
-    emit instanceIdChanged();
 }
 }

--- a/src/effects/audio_unit/view/audiounitviewmodel.cpp
+++ b/src/effects/audio_unit/view/audiounitviewmodel.cpp
@@ -16,8 +16,8 @@
 #include "log.h"
 
 namespace au::effects {
-AudioUnitViewModel::AudioUnitViewModel(QObject* parent)
-    : AbstractEffectViewModel(parent)
+AudioUnitViewModel::AudioUnitViewModel(QObject* parent, int instanceId)
+    : AbstractEffectViewModel(parent, instanceId)
 {}
 
 AudioUnitViewModel::~AudioUnitViewModel()

--- a/src/effects/audio_unit/view/audiounitviewmodel.h
+++ b/src/effects/audio_unit/view/audiounitviewmodel.h
@@ -29,7 +29,7 @@ class AudioUnitViewModel : public AbstractEffectViewModel
     muse::Inject<trackedit::IProjectHistory> projectHistory;
 
 public:
-    AudioUnitViewModel(QObject* parent = nullptr);
+    AudioUnitViewModel(QObject* parent, int instanceId);
     ~AudioUnitViewModel() override;
 
     Q_INVOKABLE void deinit();
@@ -63,5 +63,9 @@ private:
 
     QString m_title;
     QTimer m_settingsTimer;
+};
+
+class AudioUnitViewModelFactory : public EffectViewModelFactory<AudioUnitViewModel>
+{
 };
 }

--- a/src/effects/builtin/amplify/AmplifyView.qml
+++ b/src/effects/builtin/amplify/AmplifyView.qml
@@ -7,18 +7,19 @@ BuiltinEffectBase {
     id: root
 
     property string title: amplify.effectTitle
-    property alias isApplyAllowed: amplify.isApplyAllowed
+    property bool isApplyAllowed: amplify.isApplyAllowed
 
     width: 320
     implicitHeight: column.height
 
-    model: amplify
-
-    AmplifyViewModel {
-        id: amplify
-
-        onAmpValueChanged: ampSlider.value = ampValue
+    builtinEffectModel: {
+        var model = AmplifyViewModelFactory.createModel(root, root.instanceId)
+        model.ampValueChanged.connect(function () {
+            ampSlider.value = model.ampValue
+        })
+        return model
     }
+    property alias amplify: root.builtinEffectModel
 
     Component.onCompleted: {
         ampSlider.value = amplify.ampValue

--- a/src/effects/builtin/amplify/amplifyviewmodel.cpp
+++ b/src/effects/builtin/amplify/amplifyviewmodel.cpp
@@ -10,6 +10,11 @@
 
 using namespace au::effects;
 
+AmplifyViewModel::AmplifyViewModel(QObject* parent, int instanceId)
+    : BuiltinEffectModel(parent, instanceId)
+{
+}
+
 void AmplifyViewModel::doReload()
 {
     auto& ae = effect<AmplifyEffect>();

--- a/src/effects/builtin/amplify/amplifyviewmodel.h
+++ b/src/effects/builtin/amplify/amplifyviewmodel.h
@@ -36,7 +36,8 @@ class AmplifyViewModel : public BuiltinEffectModel
     Q_PROPERTY(bool isApplyAllowed READ isApplyAllowed NOTIFY isApplyAllowedChanged FINAL)
 
 public:
-    AmplifyViewModel() = default;
+    AmplifyViewModel(QObject* parent, int instanceId);
+    ~AmplifyViewModel() override = default;
 
     QString effectTitle() const;
 
@@ -80,5 +81,9 @@ private:
     db_t m_newPeak = 0.0f;
     bool m_canClip = false;
     bool m_isApplyAllowed = false;
+};
+
+class AmplifyViewModelFactory : public EffectViewModelFactory<AmplifyViewModel>
+{
 };
 }

--- a/src/effects/builtin/clickremoval/ClickRemovalView.qml
+++ b/src/effects/builtin/clickremoval/ClickRemovalView.qml
@@ -12,11 +12,8 @@ BuiltinEffectBase {
     width: 328
     implicitHeight: column.height
 
-    model: clickRemoval
-
-    ClickRemovalViewModel {
-        id: clickRemoval
-    }
+    builtinEffectModel: ClickRemovalViewModelFactory.createModel(root, root.instanceId)
+    property alias clickRemoval: root.builtinEffectModel
 
     Column {
         id: column

--- a/src/effects/builtin/clickremoval/clickremovalviewmodel.cpp
+++ b/src/effects/builtin/clickremoval/clickremovalviewmodel.cpp
@@ -8,6 +8,11 @@
 #include "global/translation.h"
 
 namespace au::effects {
+ClickRemovalViewModel::ClickRemovalViewModel(QObject* parent, int instanceId)
+    : BuiltinEffectModel(parent, instanceId)
+{
+}
+
 QString ClickRemovalViewModel::effectTitle() const
 {
     return muse::qtrc("effects/clickremoval", "Click removal");

--- a/src/effects/builtin/clickremoval/clickremovalviewmodel.h
+++ b/src/effects/builtin/clickremoval/clickremovalviewmodel.h
@@ -28,7 +28,7 @@ class ClickRemovalViewModel : public BuiltinEffectModel
     Q_PROPERTY(int widthDecimals READ widthDecimals CONSTANT FINAL)
 
 public:
-    ClickRemovalViewModel() = default;
+    ClickRemovalViewModel(QObject* parent, int instanceId);
 
     QString effectTitle() const;
 
@@ -54,5 +54,9 @@ signals:
 
 private:
     void doReload() override;
+};
+
+class ClickRemovalViewModelFactory : public EffectViewModelFactory<ClickRemovalViewModel>
+{
 };
 }

--- a/src/effects/builtin/common/builtineffectmodel.cpp
+++ b/src/effects/builtin/common/builtineffectmodel.cpp
@@ -10,7 +10,7 @@
 using namespace au::effects;
 
 BuiltinEffectModel::BuiltinEffectModel(QObject* parent)
-    : AbstractEffectViewModel(parent), m_instanceId(BuiltinEffectViewLoader::initializationInstanceId())
+    : AbstractEffectViewModel(parent)
 {
     assert(m_instanceId != -1);
 }
@@ -47,11 +47,6 @@ const EffectSettings& BuiltinEffectModel::settings() const
 EffectSettingsAccessPtr BuiltinEffectModel::settingsAccess() const
 {
     return instancesRegister()->settingsAccessById(m_instanceId);
-}
-
-EffectInstanceId BuiltinEffectModel::instanceId() const
-{
-    return m_instanceId;
 }
 
 void BuiltinEffectModel::doStartPreview()

--- a/src/effects/builtin/common/builtineffectmodel.cpp
+++ b/src/effects/builtin/common/builtineffectmodel.cpp
@@ -9,8 +9,8 @@
 
 using namespace au::effects;
 
-BuiltinEffectModel::BuiltinEffectModel(QObject* parent)
-    : AbstractEffectViewModel(parent)
+BuiltinEffectModel::BuiltinEffectModel(QObject* parent, int instanceId)
+    : AbstractEffectViewModel(parent, instanceId)
 {
     assert(m_instanceId != -1);
 }

--- a/src/effects/builtin/common/builtineffectmodel.cpp
+++ b/src/effects/builtin/common/builtineffectmodel.cpp
@@ -10,12 +10,12 @@
 using namespace au::effects;
 
 BuiltinEffectModel::BuiltinEffectModel(QObject* parent)
-    : QObject(parent), m_instanceId(BuiltinEffectViewLoader::initializationInstanceId())
+    : AbstractEffectViewModel(parent), m_instanceId(BuiltinEffectViewLoader::initializationInstanceId())
 {
     assert(m_instanceId != -1);
 }
 
-void BuiltinEffectModel::componentComplete()
+void BuiltinEffectModel::doInit()
 {
     instancesRegister()->settingsChanged(m_instanceId).onNotify(this, [this]() {
         doReload();
@@ -54,7 +54,7 @@ EffectInstanceId BuiltinEffectModel::instanceId() const
     return m_instanceId;
 }
 
-void BuiltinEffectModel::preview()
+void BuiltinEffectModel::doStartPreview()
 {
     if (const EffectSettingsAccessPtr access = this->settingsAccess()) {
         access->ModifySettings([this](EffectSettings& settings) {

--- a/src/effects/builtin/common/builtineffectmodel.h
+++ b/src/effects/builtin/common/builtineffectmodel.h
@@ -8,16 +8,13 @@
 #include "libraries/lib-components/EffectInterface.h"
 
 #include "modularity/ioc.h"
-#include "effects/effects_base/ieffectinstancesregister.h"
-#include "effects/effects_base/ieffectexecutionscenario.h"
 #include "effects/effects_base/ieffectsprovider.h"
 #include "effects/effects_base/irealtimeeffectservice.h"
+#include "effects/effects_base/view/abstracteffectviewmodel.h"
 #include "trackedit/iprojecthistory.h"
 
-#include "global/async/asyncable.h"
-
 namespace au::effects {
-class BuiltinEffectModel : public QObject, public QQmlParserStatus, public muse::async::Asyncable
+class BuiltinEffectModel : public AbstractEffectViewModel
 {
     Q_OBJECT
     Q_PROPERTY(int instanceId READ instanceId CONSTANT FINAL)
@@ -26,8 +23,6 @@ class BuiltinEffectModel : public QObject, public QQmlParserStatus, public muse:
     Q_PROPERTY(bool usesPresets READ usesPresets CONSTANT FINAL)
 
 public:
-    muse::Inject<IEffectInstancesRegister> instancesRegister;
-    muse::Inject<IEffectExecutionScenario> executionScenario;
     muse::Inject<IRealtimeEffectService> realtimeEffectService;
     muse::Inject<trackedit::IProjectHistory> projectHistory;
     muse::Inject<IEffectsProvider> effectsProvider;
@@ -38,7 +33,6 @@ public:
     int instanceId() const;
     QString effectId() const;
 
-    Q_INVOKABLE void preview();
     Q_INVOKABLE void commitSettings();
 
     virtual bool usesPresets() const { return true; }
@@ -81,8 +75,8 @@ protected:
     }
 
 private:
-    void classBegin() override {}
-    void componentComplete() override;
+    void doInit() override;
+    void doStartPreview() override;
 
     EffectSettingsAccessPtr settingsAccess() const;
     const int m_instanceId;

--- a/src/effects/builtin/common/builtineffectmodel.h
+++ b/src/effects/builtin/common/builtineffectmodel.h
@@ -26,7 +26,7 @@ public:
     muse::Inject<IEffectsProvider> effectsProvider;
 
 public:
-    BuiltinEffectModel(QObject* parent = nullptr);
+    BuiltinEffectModel(QObject* parent, int instanceId);
 
     QString effectId() const;
 

--- a/src/effects/builtin/common/builtineffectmodel.h
+++ b/src/effects/builtin/common/builtineffectmodel.h
@@ -17,8 +17,6 @@ namespace au::effects {
 class BuiltinEffectModel : public AbstractEffectViewModel
 {
     Q_OBJECT
-    Q_PROPERTY(int instanceId READ instanceId CONSTANT FINAL)
-
     Q_PROPERTY(QString effectId READ effectId NOTIFY effectIdChanged FINAL)
     Q_PROPERTY(bool usesPresets READ usesPresets CONSTANT FINAL)
 
@@ -30,7 +28,6 @@ public:
 public:
     BuiltinEffectModel(QObject* parent = nullptr);
 
-    int instanceId() const;
     QString effectId() const;
 
     Q_INVOKABLE void commitSettings();
@@ -79,6 +76,5 @@ private:
     void doStartPreview() override;
 
     EffectSettingsAccessPtr settingsAccess() const;
-    const int m_instanceId;
 };
 }

--- a/src/effects/builtin/common/builtineffectsettingmodel.cpp
+++ b/src/effects/builtin/common/builtineffectsettingmodel.cpp
@@ -4,8 +4,8 @@
 #include "builtineffectsettingmodel.h"
 
 namespace au::effects {
-BuiltinEffectSettingModel::BuiltinEffectSettingModel(QObject* parent)
-    : BuiltinEffectModel{parent} {}
+BuiltinEffectSettingModel::BuiltinEffectSettingModel(QObject* parent, int instanceId)
+    : BuiltinEffectModel{parent, instanceId} {}
 
 QString BuiltinEffectSettingModel::paramId() const
 {

--- a/src/effects/builtin/common/builtineffectsettingmodel.h
+++ b/src/effects/builtin/common/builtineffectsettingmodel.h
@@ -20,7 +20,7 @@ class BuiltinEffectSettingModel : public BuiltinEffectModel
     Q_PROPERTY(QString unit READ unit CONSTANT FINAL)
 
 public:
-    BuiltinEffectSettingModel(QObject* parent);
+    BuiltinEffectSettingModel(QObject* parent, int instanceId);
     ~BuiltinEffectSettingModel() override = default;
 
     QString paramId() const;
@@ -46,5 +46,34 @@ protected:
 private:
     void doReload() override;
     void doUpdateSettings() override;
+};
+
+class AbstractBuiltinEffectSettingModelFactory : public QObject
+{
+    Q_OBJECT
+public:
+    virtual ~AbstractBuiltinEffectSettingModelFactory() = default;
+
+    Q_INVOKABLE BuiltinEffectSettingModel* createModel(QObject* parent, int instanceId, const QString& paramId) const
+    {
+        BuiltinEffectSettingModel* model = doCreateModel(parent, instanceId);
+        model->setParamId(paramId);
+        return model;
+    }
+
+private:
+    virtual BuiltinEffectSettingModel* doCreateModel(QObject* parent, int instanceId) const = 0;
+};
+
+template<typename T>
+class BuiltinEffectSettingModelFactory : public AbstractBuiltinEffectSettingModelFactory
+{
+public:
+    ~BuiltinEffectSettingModelFactory() override = default;
+
+    BuiltinEffectSettingModel* doCreateModel(QObject* parent, int instanceId) const override
+    {
+        return new T(parent, instanceId);
+    }
 };
 }

--- a/src/effects/builtin/common/effectsettingmodelimpl.h
+++ b/src/effects/builtin/common/effectsettingmodelimpl.h
@@ -26,8 +26,8 @@ public:
 
     using LabelMap = std::unordered_map<QString /*param ID*/, Labels>;
 
-    EffectSettingModelImpl(QObject* parent, LabelMap labelMap, ParamGetter<EffectType> getter)
-        : BuiltinEffectSettingModel{parent}, m_labelMap{std::move(labelMap)}, m_getter{std::move(getter)} {}
+    EffectSettingModelImpl(QObject* parent, int instanceId, LabelMap labelMap, ParamGetter<EffectType> getter)
+        : BuiltinEffectSettingModel{parent, instanceId}, m_labelMap{std::move(labelMap)}, m_getter{std::move(getter)} {}
 
     double value() const final override
     {

--- a/src/effects/builtin/common/generatoreffectmodel.cpp
+++ b/src/effects/builtin/common/generatoreffectmodel.cpp
@@ -10,6 +10,11 @@
 
 using namespace au::effects;
 
+GeneratorEffectModel::GeneratorEffectModel(QObject* parent, int instanceId)
+    : BuiltinEffectModel{parent, instanceId}
+{
+}
+
 void GeneratorEffectModel::doReload()
 {
     auto& ge = effect<GeneratorEffect>();

--- a/src/effects/builtin/common/generatoreffectmodel.h
+++ b/src/effects/builtin/common/generatoreffectmodel.h
@@ -21,6 +21,7 @@ class GeneratorEffectModel : public BuiltinEffectModel
     Q_PROPERTY(bool isApplyAllowed READ isApplyAllowed NOTIFY isApplyAllowedChanged FINAL)
 
 public:
+    GeneratorEffectModel(QObject* parent, int instanceId);
 
     double duration() const;
     void prop_setDuration(double newDuration);

--- a/src/effects/builtin/dtmfgen/DtmfView.qml
+++ b/src/effects/builtin/dtmfgen/DtmfView.qml
@@ -13,24 +13,19 @@ import Preferences
 BuiltinEffectBase {
     id: root
 
-    property alias instanceId: dtmf.instanceId
-
     property string title: qsTrc("effects/dtmf", "DTMF tones")
-    property alias isApplyAllowed: dtmf.isApplyAllowed
+    property bool isApplyAllowed: dtmf.isApplyAllowed
 
     width: 550
     implicitHeight: row.height
 
-    model: dtmf
+    builtinEffectModel: DtmfViewModelFactory.createModel(root, root.instanceId)
+    property alias dtmf: root.builtinEffectModel
 
     QtObject {
         id: prv
 
         readonly property int spacing: 16
-    }
-
-    DtmfViewModel {
-        id: dtmf
     }
 
     RowLayout {

--- a/src/effects/builtin/dtmfgen/dtmfviewmodel.cpp
+++ b/src/effects/builtin/dtmfgen/dtmfviewmodel.cpp
@@ -6,7 +6,8 @@
 
 using namespace au::effects;
 
-DtmfViewModel::DtmfViewModel()
+DtmfViewModel::DtmfViewModel(QObject* parent, int instanceId)
+    : GeneratorEffectModel(parent, instanceId)
 {
     connect(this, &DtmfViewModel::durationChanged, this, &DtmfViewModel::recalculateDurations);
 }

--- a/src/effects/builtin/dtmfgen/dtmfviewmodel.h
+++ b/src/effects/builtin/dtmfgen/dtmfviewmodel.h
@@ -17,7 +17,7 @@ class DtmfViewModel : public GeneratorEffectModel
     Q_PROPERTY(double silenceDuration READ silenceDuration NOTIFY silenceDurationChanged)
 
 public:
-    DtmfViewModel();
+    DtmfViewModel(QObject* parent, int instanceId);
     virtual ~DtmfViewModel();
 
     bool isApplyAllowed() const override;
@@ -46,5 +46,9 @@ private:
     void doEmitSignals() override;
 
     void recalculateDurations();
+};
+
+class DtmfViewModelFactory : public EffectViewModelFactory<DtmfViewModel>
+{
 };
 }

--- a/src/effects/builtin/dynamics/compressor/CompressorView.qml
+++ b/src/effects/builtin/dynamics/compressor/CompressorView.qml
@@ -31,21 +31,34 @@ DynamicsEffectBase {
     Column {
         id: rootColumn
 
-        DynamicsPanel {
-            width: root.width
-            visible: !root.usedDestructively
+        Component {
+            id: dynamicsPanel
 
-            instanceId: compressor.instanceId
-            playState: root.playState
+            DynamicsPanel {
+                width: root.width
 
-            showInputDbModel: CompressorSettingModel {
-                paramId: "showInput"
+                instanceId: compressor.instanceId
+                playState: root.playState
+
+                showInputDbModel: CompressorSettingModel {
+                    paramId: "showInput"
+                }
+                showOutputDbModel: CompressorSettingModel {
+                    paramId: "showOutput"
+                }
+                showCompressionDbModel: CompressorSettingModel {
+                    paramId: "showActual"
+                }
             }
-            showOutputDbModel: CompressorSettingModel {
-                paramId: "showOutput"
-            }
-            showCompressionDbModel: CompressorSettingModel {
-                paramId: "showActual"
+        }
+
+        Loader {
+            id: dynamicsPanelLoader
+
+            Component.onCompleted: {
+                if (!root.usedDestructively) {
+                    sourceComponent = dynamicsPanel
+                }
             }
         }
 

--- a/src/effects/builtin/dynamics/compressor/CompressorView.qml
+++ b/src/effects/builtin/dynamics/compressor/CompressorView.qml
@@ -18,15 +18,12 @@ DynamicsEffectBase {
     width: rootColumn.width
     implicitHeight: rootColumn.height
 
-    model: compressor
-
-    CompressorViewModel {
-        id: compressor
-
-        onCompressionCurveChanged: {
-            compressionCurve.requestPaint()
-        }
+    builtinEffectModel: {
+        var model = CompressorViewModelFactory.createModel(root, root.instanceId)
+        model.onCompressionCurveChanged.connect(compressionCurve.requestPaint)
+        return model
     }
+    property alias compressor: root.builtinEffectModel
 
     Column {
         id: rootColumn
@@ -40,15 +37,9 @@ DynamicsEffectBase {
                 instanceId: compressor.instanceId
                 playState: root.playState
 
-                showInputDbModel: CompressorSettingModel {
-                    paramId: "showInput"
-                }
-                showOutputDbModel: CompressorSettingModel {
-                    paramId: "showOutput"
-                }
-                showCompressionDbModel: CompressorSettingModel {
-                    paramId: "showActual"
-                }
+                showInputDbModel: CompressorSettingModelFactory.createModel(root, root.instanceId, "showInput")
+                showOutputDbModel: CompressorSettingModelFactory.createModel(root, root.instanceId, "showOutput")
+                showCompressionDbModel: CompressorSettingModelFactory.createModel(root, root.instanceId, "showActual")
             }
         }
 
@@ -91,9 +82,7 @@ DynamicsEffectBase {
                             isVertical: true
                             knobFirst: false
                             warp: true
-                            model: CompressorSettingModel {
-                                paramId: modelData
-                            }
+                            model: CompressorSettingModelFactory.createModel(root, root.instanceId, modelData)
                         }
                     }
                 }
@@ -117,11 +106,12 @@ DynamicsEffectBase {
                             isVertical: true
                             knobFirst: false
                             warp: true
-                            model: CompressorSettingModel {
-                                paramId: modelData
-                                onValueChanged: {
+                            model: {
+                                var model = CompressorSettingModelFactory.createModel(root, root.instanceId, modelData)
+                                model.onValueChanged.connect(function () {
                                     compressionCurve.requestPaint()
-                                }
+                                })
+                                return model
                             }
                         }
                     }

--- a/src/effects/builtin/dynamics/compressor/compressorsettingmodel.cpp
+++ b/src/effects/builtin/dynamics/compressor/compressorsettingmodel.cpp
@@ -21,8 +21,8 @@ const CompressorSettingModel::LabelMap labelMap = {
 };
 }
 
-CompressorSettingModel::CompressorSettingModel(QObject* parent)
-    : EffectSettingModelImpl<CompressorEffect>(parent, labelMap, [this](const CompressorEffect& effect) {
+CompressorSettingModel::CompressorSettingModel(QObject* parent, int instanceId)
+    : EffectSettingModelImpl<CompressorEffect>(parent, instanceId, labelMap, [this](const CompressorEffect& effect) {
     if (m_paramId == "thresholdDb") {
         return effect.thresholdDb;
     } else if (m_paramId == "makeupGainDb") {

--- a/src/effects/builtin/dynamics/compressor/compressorsettingmodel.h
+++ b/src/effects/builtin/dynamics/compressor/compressorsettingmodel.h
@@ -10,6 +10,10 @@ namespace au::effects {
 class CompressorSettingModel : public EffectSettingModelImpl<CompressorEffect>
 {
 public:
-    CompressorSettingModel(QObject* parent = nullptr);
+    CompressorSettingModel(QObject* parent, int instanceId);
+};
+
+class CompressorSettingModelFactory : public BuiltinEffectSettingModelFactory<CompressorSettingModel>
+{
 };
 }

--- a/src/effects/builtin/dynamics/compressor/compressorviewmodel.cpp
+++ b/src/effects/builtin/dynamics/compressor/compressorviewmodel.cpp
@@ -8,8 +8,8 @@
 #include "log.h"
 
 namespace au::effects {
-CompressorViewModel::CompressorViewModel(QObject* parent)
-    : BuiltinEffectModel{parent}
+CompressorViewModel::CompressorViewModel(QObject* parent, int instanceId)
+    : BuiltinEffectModel{parent, instanceId}
 {
 }
 

--- a/src/effects/builtin/dynamics/compressor/compressorviewmodel.h
+++ b/src/effects/builtin/dynamics/compressor/compressorviewmodel.h
@@ -11,7 +11,7 @@ class CompressorViewModel : public BuiltinEffectModel
     Q_OBJECT
 
 public:
-    CompressorViewModel(QObject* parent = nullptr);
+    CompressorViewModel(QObject* parent, int instanceId);
 
     Q_INVOKABLE QList<QVariantMap> compressionCurve(int from, int to, int count) const;
 
@@ -20,5 +20,9 @@ signals:
 
 private:
     void doReload() override;
+};
+
+class CompressorViewModelFactory : public EffectViewModelFactory<CompressorViewModel>
+{
 };
 }

--- a/src/effects/builtin/dynamics/limiter/LimiterView.qml
+++ b/src/effects/builtin/dynamics/limiter/LimiterView.qml
@@ -19,11 +19,8 @@ DynamicsEffectBase {
     width: rootColumn.width
     implicitHeight: rootColumn.height
 
-    model: limiter
-
-    LimiterViewModel {
-        id: limiter
-    }
+    builtinEffectModel: LimiterViewModelFactory.createModel(root, root.instanceId)
+    property alias limiter: root.builtinEffectModel
 
     Column {
         id: rootColumn
@@ -38,15 +35,9 @@ DynamicsEffectBase {
                 instanceId: limiter.instanceId
                 playState: root.playState
 
-                showInputDbModel: LimiterSettingModel {
-                    paramId: "showInput"
-                }
-                showOutputDbModel: LimiterSettingModel {
-                    paramId: "showOutput"
-                }
-                showCompressionDbModel: LimiterSettingModel {
-                    paramId: "showActual"
-                }
+                showInputDbModel: LimiterSettingModelFactory.createModel(root, root.instanceId, "showInput")
+                showOutputDbModel: LimiterSettingModelFactory.createModel(root, root.instanceId, "showOutput")
+                showCompressionDbModel: LimiterSettingModelFactory.createModel(root, root.instanceId, "showActual")
 
                 // Specific to limiter
                 dbMin: -12
@@ -93,9 +84,7 @@ DynamicsEffectBase {
                         isVertical: true
                         radius: 24
                         warp: true
-                        model: LimiterSettingModel {
-                            paramId: "thresholdDb"
-                        }
+                        model: LimiterSettingModelFactory.createModel(root, root.instanceId, "thresholdDb")
                     }
                 }
 
@@ -109,9 +98,7 @@ DynamicsEffectBase {
                         isVertical: true
                         radius: 24
                         warp: true
-                        model: LimiterSettingModel {
-                            paramId: "makeupTargetDb"
-                        }
+                        model: LimiterSettingModelFactory.createModel(root, root.instanceId, "makeupTargetDb")
                     }
                 }
 
@@ -132,9 +119,7 @@ DynamicsEffectBase {
                         knobFirst: false
                         radius: 16
                         warp: true
-                        model: LimiterSettingModel {
-                            paramId: modelData
-                        }
+                        model: LimiterSettingModelFactory.createModel(root, root.instanceId, modelData)
                     }
                 }
             }

--- a/src/effects/builtin/dynamics/limiter/LimiterView.qml
+++ b/src/effects/builtin/dynamics/limiter/LimiterView.qml
@@ -28,29 +28,43 @@ DynamicsEffectBase {
     Column {
         id: rootColumn
 
-        DynamicsPanel {
-            width: root.width
-            visible: !root.usedDestructively
+        Component {
+            id: dynamicsPanel
 
-            instanceId: limiter.instanceId
-            playState: root.playState
+            DynamicsPanel {
+                width: root.width
+                visible: !root.usedDestructively
 
-            showInputDbModel: LimiterSettingModel {
-                paramId: "showInput"
-            }
-            showOutputDbModel: LimiterSettingModel {
-                paramId: "showOutput"
-            }
-            showCompressionDbModel: LimiterSettingModel {
-                paramId: "showActual"
-            }
+                instanceId: limiter.instanceId
+                playState: root.playState
 
-            // Specific to limiter
-            dbMin: -12
-            dbStep: 3
-            duration: 2
-            timelineHeight: knobRow.height
-            needsClipIndicator: false // Clipping with the limiter is impossible.
+                showInputDbModel: LimiterSettingModel {
+                    paramId: "showInput"
+                }
+                showOutputDbModel: LimiterSettingModel {
+                    paramId: "showOutput"
+                }
+                showCompressionDbModel: LimiterSettingModel {
+                    paramId: "showActual"
+                }
+
+                // Specific to limiter
+                dbMin: -12
+                dbStep: 3
+                duration: 2
+                timelineHeight: knobRow.height
+                needsClipIndicator: false // Clipping with the limiter is impossible.
+            }
+        }
+
+        Loader {
+            id: dynamicsPanelLoader
+
+            Component.onCompleted: {
+                if (!root.usedDestructively) {
+                    sourceComponent = dynamicsPanel
+                }
+            }
         }
 
         Rectangle {

--- a/src/effects/builtin/dynamics/limiter/limitersettingmodel.cpp
+++ b/src/effects/builtin/dynamics/limiter/limitersettingmodel.cpp
@@ -20,8 +20,8 @@ const LimiterSettingModel::LabelMap labelMap = {
 };
 }
 
-LimiterSettingModel::LimiterSettingModel(QObject* parent)
-    : EffectSettingModelImpl<LimiterEffect>(parent, labelMap, [this](const LimiterEffect& effect) {
+LimiterSettingModel::LimiterSettingModel(QObject* parent, int instanceId)
+    : EffectSettingModelImpl<LimiterEffect>(parent, instanceId, labelMap, [this](const LimiterEffect& effect) {
     if (m_paramId == "thresholdDb") {
         return effect.thresholdDb;
     } else if (m_paramId == "makeupTargetDb") {

--- a/src/effects/builtin/dynamics/limiter/limitersettingmodel.h
+++ b/src/effects/builtin/dynamics/limiter/limitersettingmodel.h
@@ -10,6 +10,10 @@ namespace au::effects {
 class LimiterSettingModel : public EffectSettingModelImpl<LimiterEffect>
 {
 public:
-    LimiterSettingModel(QObject* parent = nullptr);
+    LimiterSettingModel(QObject* parent, int instanceId);
+};
+
+class LimiterSettingModelFactory : public BuiltinEffectSettingModelFactory<LimiterSettingModel>
+{
 };
 }

--- a/src/effects/builtin/dynamics/limiter/limiterviewmodel.cpp
+++ b/src/effects/builtin/dynamics/limiter/limiterviewmodel.cpp
@@ -6,8 +6,8 @@
 #include "log.h"
 
 namespace au::effects {
-LimiterViewModel::LimiterViewModel(QObject* parent)
-    : BuiltinEffectModel{parent}
+LimiterViewModel::LimiterViewModel(QObject* parent, int instanceId)
+    : BuiltinEffectModel{parent, instanceId}
 {
 }
 

--- a/src/effects/builtin/dynamics/limiter/limiterviewmodel.h
+++ b/src/effects/builtin/dynamics/limiter/limiterviewmodel.h
@@ -11,9 +11,13 @@ class LimiterViewModel : public BuiltinEffectModel
     Q_OBJECT
 
 public:
-    LimiterViewModel(QObject* parent = nullptr);
+    LimiterViewModel(QObject* parent, int instanceId);
 
 private:
     void doReload() override;
+};
+
+class LimiterViewModelFactory : public EffectViewModelFactory<LimiterViewModel>
+{
 };
 }

--- a/src/effects/builtin/graphiceq/GraphicEqView.qml
+++ b/src/effects/builtin/graphiceq/GraphicEqView.qml
@@ -14,11 +14,8 @@ BuiltinEffectBase {
     width: boardRectangle.width
     implicitHeight: boardRectangle.height
 
-    model: graphicEq
-
-    GraphicEqViewModel {
-        id: graphicEq
-    }
+    builtinEffectModel: GraphicEqViewModelFactory.createModel(root, root.instanceId)
+    property alias graphicEq: root.builtinEffectModel
 
     Rectangle {
         id: boardRectangle

--- a/src/effects/builtin/graphiceq/graphiceqviewmodel.cpp
+++ b/src/effects/builtin/graphiceq/graphiceqviewmodel.cpp
@@ -9,8 +9,8 @@
 #include "log.h"
 
 namespace au::effects {
-GraphicEqViewModel::GraphicEqViewModel()
-    : mBandsModel(new GraphicEqBandsModel(this, effect<GraphicEq>()))
+GraphicEqViewModel::GraphicEqViewModel(QObject* parent, int instanceId)
+    : BuiltinEffectModel{parent, instanceId}, mBandsModel(new GraphicEqBandsModel(this, effect<GraphicEq>()))
 {
 }
 

--- a/src/effects/builtin/graphiceq/graphiceqviewmodel.h
+++ b/src/effects/builtin/graphiceq/graphiceqviewmodel.h
@@ -17,7 +17,7 @@ class GraphicEqViewModel : public BuiltinEffectModel
     Q_PROPERTY(double maxDbGain READ maxDbGain CONSTANT FINAL)
 
 public:
-    GraphicEqViewModel();
+    GraphicEqViewModel(QObject* parent, int instanceId);
 
     GraphicEqBandsModel* bandsModel() const;
     double minDbGain() const;
@@ -30,5 +30,9 @@ private:
     void doReload() override;
 
     GraphicEqBandsModel* const mBandsModel;
+};
+
+class GraphicEqViewModelFactory : public EffectViewModelFactory<GraphicEqViewModel>
+{
 };
 }

--- a/src/effects/builtin/internal/builtineffectsrepository.cpp
+++ b/src/effects/builtin/internal/builtineffectsrepository.cpp
@@ -256,7 +256,7 @@ void BuiltinEffectsRepository::updateEffectMetaList()
                     true
                     );
         } else if (symbol == TruncateSilenceEffect::Symbol) {
-            qmlRegisterType<TruncateSilenceViewModel>("Audacity.Effects", 1, 0, "TruncateSilenceViewModel");
+            REGISTER_AUDACITY_EFFECTS_SINGLETON_TYPE(TruncateSilenceViewModelFactory);
             regView(TruncateSilenceEffect::Symbol, u"qrc:/truncatesilence/TruncateSilenceView.qml");
             regMeta(desc,
                     muse::mtrc("effects", "Truncate Silence"),

--- a/src/effects/builtin/internal/builtineffectsrepository.cpp
+++ b/src/effects/builtin/internal/builtineffectsrepository.cpp
@@ -17,6 +17,7 @@
 
 #include "effects/effects_base/effectstypes.h"
 #include "effects/effects_base/internal/effectsutils.h"
+#include "effects/effects_base/view/effectsviewutils.h"
 
 #include "amplify/amplifyeffect.h"
 #include "amplify/amplifyviewmodel.h"
@@ -152,7 +153,7 @@ void BuiltinEffectsRepository::updateEffectMetaList()
     for (const PluginDescriptor& desc : PluginManager::Get().PluginsOfType(PluginTypeEffect)) {
         const auto& symbol = desc.GetSymbol();
         if (symbol == AmplifyEffect::Symbol) {
-            qmlRegisterType<AmplifyViewModel>("Audacity.Effects", 1, 0, "AmplifyViewModel");
+            REGISTER_AUDACITY_EFFECTS_SINGLETON_TYPE(AmplifyViewModelFactory);
             regView(AmplifyEffect::Symbol, u"qrc:/amplify/AmplifyView.qml");
             regMeta(desc,
                     muse::mtrc("effects", "Amplify"),
@@ -161,7 +162,7 @@ void BuiltinEffectsRepository::updateEffectMetaList()
                     false
                     );
         } else if (symbol == NormalizeLoudnessEffect::Symbol) {
-            qmlRegisterType<NormalizeLoudnessViewModel>("Audacity.Effects", 1, 0, "NormalizeLoudnessViewModel");
+            REGISTER_AUDACITY_EFFECTS_SINGLETON_TYPE(NormalizeLoudnessViewModelFactory);
             regView(NormalizeLoudnessEffect::Symbol, u"qrc:/loudness/NormalizeLoudnessView.qml");
             regMeta(desc,
                     muse::mtrc("effects", "Loudness normalization"),
@@ -170,7 +171,7 @@ void BuiltinEffectsRepository::updateEffectMetaList()
                     true
                     );
         } else if (symbol == GraphicEq::Symbol) {
-            qmlRegisterType<GraphicEqViewModel>("Audacity.Effects", 1, 0, "GraphicEqViewModel");
+            REGISTER_AUDACITY_EFFECTS_SINGLETON_TYPE(GraphicEqViewModelFactory);
             qmlRegisterType<GraphicEqBandsModel>("Audacity.Effects", 1, 0, "GraphicEqBandsModel");
             regView(GraphicEq::Symbol, u"qrc:/graphiceq/GraphicEqView.qml");
             regMeta(desc,
@@ -180,7 +181,7 @@ void BuiltinEffectsRepository::updateEffectMetaList()
                     true
                     );
         } else if (symbol == ClickRemovalEffect::Symbol) {
-            qmlRegisterType<ClickRemovalViewModel>("Audacity.Effects", 1, 0, "ClickRemovalViewModel");
+            REGISTER_AUDACITY_EFFECTS_SINGLETON_TYPE(ClickRemovalViewModelFactory);
             regView(ClickRemovalEffect::Symbol, u"qrc:/clickremoval/ClickRemovalView.qml");
             regMeta(desc,
                     muse::mtrc("effects", "Click Removal"),
@@ -190,8 +191,8 @@ void BuiltinEffectsRepository::updateEffectMetaList()
                     );
         } else if (symbol == CompressorEffect::Symbol) {
             hasDynamicRangeProcessor = true;
-            qmlRegisterType<CompressorViewModel>("Audacity.Effects", 1, 0, "CompressorViewModel");
-            qmlRegisterType<CompressorSettingModel>("Audacity.Effects", 1, 0, "CompressorSettingModel");
+            REGISTER_AUDACITY_EFFECTS_SINGLETON_TYPE(CompressorViewModelFactory);
+            REGISTER_AUDACITY_EFFECTS_SINGLETON_TYPE(CompressorSettingModelFactory);
             regView(CompressorEffect::Symbol, u"qrc:/dynamics/compressor/CompressorView.qml");
             regMeta(desc,
                     muse::mtrc("effects", "Compressor"),
@@ -201,8 +202,8 @@ void BuiltinEffectsRepository::updateEffectMetaList()
                     );
         } else if (symbol == LimiterEffect::Symbol) {
             hasDynamicRangeProcessor = true;
-            qmlRegisterType<LimiterViewModel>("Audacity.Effects", 1, 0, "LimiterViewModel");
-            qmlRegisterType<LimiterSettingModel>("Audacity.Effects", 1, 0, "LimiterSettingModel");
+            REGISTER_AUDACITY_EFFECTS_SINGLETON_TYPE(LimiterViewModelFactory);
+            REGISTER_AUDACITY_EFFECTS_SINGLETON_TYPE(LimiterSettingModelFactory);
             regView(LimiterEffect::Symbol, u"qrc:/dynamics/limiter/LimiterView.qml");
             regMeta(desc,
                     muse::mtrc("effects", "Limiter"),
@@ -211,7 +212,7 @@ void BuiltinEffectsRepository::updateEffectMetaList()
                     true
                     );
         } else if (symbol == NormalizeEffect::Symbol) {
-            qmlRegisterType<NormalizeViewModel>("Audacity.Effects", 1, 0, "NormalizeViewModel");
+            REGISTER_AUDACITY_EFFECTS_SINGLETON_TYPE(NormalizeViewModelFactory);
             regView(NormalizeEffect::Symbol, u"qrc:/normalize/NormalizeView.qml");
             regMeta(desc,
                     muse::mtrc("effects", "Normalize"),
@@ -285,7 +286,7 @@ void BuiltinEffectsRepository::updateEffectMetaList()
                     false
                     );
         } else if (symbol == ToneEffect::Symbol) {
-            qmlRegisterType<ToneViewModel>("Audacity.Effects", 1, 0, "ToneViewModel");
+            REGISTER_AUDACITY_EFFECTS_SINGLETON_TYPE(ToneViewModelFactory);
             regView(ToneEffect::Symbol, u"qrc:/tonegen/ToneView.qml");
             regMeta(desc,
                     muse::mtrc("effects", "Tone"),
@@ -294,7 +295,7 @@ void BuiltinEffectsRepository::updateEffectMetaList()
                     false
                     );
         } else if (symbol == ReverbEffect::Symbol) {
-            qmlRegisterType<ReverbViewModel>("Audacity.Effects", 1, 0, "ReverbViewModel");
+            REGISTER_AUDACITY_EFFECTS_SINGLETON_TYPE(ReverbViewModelFactory);
             regView(ReverbEffect::Symbol, u"qrc:/reverb/ReverbView.qml");
             regMeta(desc,
                     muse::mtrc("effects", "Reverb"),
@@ -303,7 +304,7 @@ void BuiltinEffectsRepository::updateEffectMetaList()
                     true
                     );
         } else if (symbol == NoiseGenerator::Symbol) {
-            qmlRegisterType<NoiseViewModel>("Audacity.Effects", 1, 0, "NoiseViewModel");
+            REGISTER_AUDACITY_EFFECTS_SINGLETON_TYPE(NoiseViewModelFactory);
             regView(NoiseGenerator::Symbol, u"qrc:/noisegen/NoiseView.qml");
             regMeta(desc,
                     muse::mtrc("effects/noise", "Noise"),
@@ -312,7 +313,7 @@ void BuiltinEffectsRepository::updateEffectMetaList()
                     false
                     );
         } else if (symbol == NoiseReductionEffect::Symbol) {
-            qmlRegisterType<NoiseReductionViewModel>("Audacity.Effects", 1, 0, "NoiseReductionViewModel");
+            REGISTER_AUDACITY_EFFECTS_SINGLETON_TYPE(NoiseReductionViewModelFactory);
             regView(NoiseReductionEffect::Symbol, u"qrc:/noisereduction/NoiseReductionView.qml");
             regMeta(desc,
                     muse::mtrc("effects/noisereduction", "Noise Reduction"),
@@ -321,7 +322,7 @@ void BuiltinEffectsRepository::updateEffectMetaList()
                     false
                     );
         } else if (symbol == DtmfGenerator::Symbol) {
-            qmlRegisterType<DtmfViewModel>("Audacity.Effects", 1, 0, "DtmfViewModel");
+            REGISTER_AUDACITY_EFFECTS_SINGLETON_TYPE(DtmfViewModelFactory);
             regView(DtmfGenerator::Symbol, u"qrc:/dtmfgen/DtmfView.qml");
             regMeta(desc,
                     muse::mtrc("effects/dtmf", "DTMF tones"),
@@ -330,7 +331,7 @@ void BuiltinEffectsRepository::updateEffectMetaList()
                     false
                     );
         } else if (symbol == SilenceGenerator::Symbol) {
-            qmlRegisterType<SilenceViewModel>("Audacity.Effects", 1, 0, "SilenceViewModel");
+            REGISTER_AUDACITY_EFFECTS_SINGLETON_TYPE(SilenceViewModelFactory);
             regView(SilenceGenerator::Symbol, u"qrc:/silencegen/SilenceView.qml");
             regMeta(desc,
                     muse::mtrc("effects/silence", "Silence"),

--- a/src/effects/builtin/internal/builtinviewlauncher.cpp
+++ b/src/effects/builtin/internal/builtinviewlauncher.cpp
@@ -3,21 +3,11 @@
 */
 #include "builtinviewlauncher.h"
 
-#include "libraries/lib-effects/EffectManager.h"
-#include "libraries/lib-effects/Effect.h"
-
-#include "au3wrap/internal/wxtypes_convert.h"
-
-#include "log.h"
-
 using namespace au::effects;
 
 muse::Ret BuiltinViewLauncher::showEffect(const EffectInstanceId& instanceId) const
 {
-    muse::UriQuery uri(EFFECT_VIEWER_URI);
-    uri.addParam("instanceId", muse::Val(instanceId));
-    uri.addParam("effectFamily", muse::Val(EffectFamily::Builtin));
-    return interactive()->openSync(uri).ret;
+    return doShowEffect(instanceId, EffectFamily::Builtin);
 }
 
 void BuiltinViewLauncher::showRealtimeEffect(const RealtimeEffectStatePtr& state) const

--- a/src/effects/builtin/loudness/NormalizeLoudnessView.qml
+++ b/src/effects/builtin/loudness/NormalizeLoudnessView.qml
@@ -12,11 +12,8 @@ BuiltinEffectBase {
     width: 400
     implicitHeight: column.height
 
-    model: normalizeLoudness
-
-    NormalizeLoudnessViewModel {
-        id: normalizeLoudness
-    }
+    builtinEffectModel: NormalizeLoudnessViewModelFactory.createModel(root, root.instanceId)
+    property alias normalizeLoudness: root.builtinEffectModel
 
     Column {
         id: column
@@ -39,9 +36,9 @@ BuiltinEffectBase {
                 anchors.verticalCenter: parent.verticalCenter
 
                 model: normalizeLoudness.algorithmOptions
-                currentIndex: root.model.useRmsAlgorithm ? 0 : 1
+                currentIndex: normalizeLoudness.useRmsAlgorithm ? 0 : 1
                 onActivated: function (index) {
-                    root.model.useRmsAlgorithm = index === 0
+                    normalizeLoudness.useRmsAlgorithm = index === 0
                 }
             }
 
@@ -57,14 +54,14 @@ BuiltinEffectBase {
                 measureUnitsSymbol: normalizeLoudness.currentMeasureUnitsSymbol
                 step: normalizeLoudness.targetStep
                 decimals: normalizeLoudness.targetDecimals
-                minValue: root.model.targetMin
-                maxValue: root.model.targetMax
-                currentValue: root.model.useRmsAlgorithm ? root.model.rmsTarget : root.model.perceivedLoudnessTarget
+                minValue: normalizeLoudness.targetMin
+                maxValue: normalizeLoudness.targetMax
+                currentValue: normalizeLoudness.useRmsAlgorithm ? normalizeLoudness.rmsTarget : normalizeLoudness.perceivedLoudnessTarget
                 onValueEdited: function (newValue) {
-                    if (root.model.useRmsAlgorithm) {
-                        root.model.rmsTarget = newValue
+                    if (normalizeLoudness.useRmsAlgorithm) {
+                        normalizeLoudness.rmsTarget = newValue
                     } else {
-                        root.model.perceivedLoudnessTarget = newValue
+                        normalizeLoudness.perceivedLoudnessTarget = newValue
                     }
                 }
             }
@@ -74,9 +71,9 @@ BuiltinEffectBase {
             spacing: 8
 
             CheckBox {
-                checked: root.model.normalizeStereoChannelsIndependently
+                checked: normalizeLoudness.normalizeStereoChannelsIndependently
                 onClicked: {
-                    root.model.normalizeStereoChannelsIndependently = !checked
+                    normalizeLoudness.normalizeStereoChannelsIndependently = !checked
                 }
             }
 
@@ -90,10 +87,10 @@ BuiltinEffectBase {
             spacing: 8
 
             CheckBox {
-                enabled: !root.model.useRmsAlgorithm
-                checked: root.model.useDualMono
+                enabled: !normalizeLoudness.useRmsAlgorithm
+                checked: normalizeLoudness.useDualMono
                 onClicked: {
-                    root.model.useDualMono = !checked
+                    normalizeLoudness.useDualMono = !checked
                 }
             }
 

--- a/src/effects/builtin/loudness/normalizeloudnessviewmodel.cpp
+++ b/src/effects/builtin/loudness/normalizeloudnessviewmodel.cpp
@@ -8,6 +8,11 @@
 #include "global/translation.h"
 
 namespace au::effects {
+NormalizeLoudnessViewModel::NormalizeLoudnessViewModel(QObject* parent, int instanceId)
+    : BuiltinEffectModel(parent, instanceId)
+{
+}
+
 void NormalizeLoudnessViewModel::doReload()
 {
     emit useRmsAlgorithmChanged();

--- a/src/effects/builtin/loudness/normalizeloudnessviewmodel.h
+++ b/src/effects/builtin/loudness/normalizeloudnessviewmodel.h
@@ -31,7 +31,7 @@ class NormalizeLoudnessViewModel : public BuiltinEffectModel
     Q_PROPERTY(bool useDualMono READ useDualMono WRITE setUseDualMono NOTIFY useDualMonoChanged FINAL)
 
 public:
-    NormalizeLoudnessViewModel() = default;
+    NormalizeLoudnessViewModel(QObject* parent, int instanceId);
 
     QString effectTitle() const;
 
@@ -71,5 +71,9 @@ signals:
 
 private:
     void doReload() override;
+};
+
+class NormalizeLoudnessViewModelFactory : public EffectViewModelFactory<NormalizeLoudnessViewModel>
+{
 };
 }

--- a/src/effects/builtin/noisegen/NoiseView.qml
+++ b/src/effects/builtin/noisegen/NoiseView.qml
@@ -13,16 +13,13 @@ BuiltinEffectBase {
     id: root
 
     property string title: qsTrc("effects", "Noise")
-    property alias isApplyAllowed: noise.isApplyAllowed
+    property bool isApplyAllowed: noise.isApplyAllowed
 
     width: 300
     implicitHeight: column.height
 
-    model: noise
-
-    NoiseViewModel {
-        id: noise
-    }
+    builtinEffectModel: NoiseViewModelFactory.createModel(root, root.instanceId)
+    property alias noise: root.builtinEffectModel
 
     Column {
         id: column

--- a/src/effects/builtin/noisegen/noiseviewmodel.cpp
+++ b/src/effects/builtin/noisegen/noiseviewmodel.cpp
@@ -8,6 +8,11 @@
 
 using namespace au::effects;
 
+NoiseViewModel::NoiseViewModel(QObject* parent, int instanceId)
+    : GeneratorEffectModel(parent, instanceId)
+{
+}
+
 bool NoiseViewModel::isApplyAllowed() const
 {
     return settings<NoiseSettings>().isApplyAllowed() && GeneratorEffectModel::isApplyAllowed();

--- a/src/effects/builtin/noisegen/noiseviewmodel.h
+++ b/src/effects/builtin/noisegen/noiseviewmodel.h
@@ -17,6 +17,8 @@ class NoiseViewModel : public GeneratorEffectModel
     Q_PROPERTY(QVariantList types READ types CONSTANT)
 
 public:
+    NoiseViewModel(QObject* parent, int instanceId);
+
     bool isApplyAllowed() const override;
 
     QVariantList types() const;
@@ -34,5 +36,9 @@ signals:
 private:
 
     void doEmitSignals() override;
+};
+
+class NoiseViewModelFactory : public EffectViewModelFactory<NoiseViewModel>
+{
 };
 }

--- a/src/effects/builtin/noisereduction/NoiseReductionView.qml
+++ b/src/effects/builtin/noisereduction/NoiseReductionView.qml
@@ -15,11 +15,8 @@ BuiltinEffectBase {
     implicitHeight: column.implicitHeight
     implicitWidth: row.implicitWidth
 
-    model: noiseReduction
-
-    NoiseReductionViewModel {
-        id: noiseReduction
-    }
+    builtinEffectModel: NoiseReductionViewModelFactory.createModel(root, root.instanceId)
+    property alias noiseReduction: root.builtinEffectModel
 
     Column {
         id: column

--- a/src/effects/builtin/noisereduction/noisereductionviewmodel.cpp
+++ b/src/effects/builtin/noisereduction/noisereductionviewmodel.cpp
@@ -8,6 +8,11 @@
 
 using namespace au::effects;
 
+NoiseReductionViewModel::NoiseReductionViewModel(QObject* parent, int instanceId)
+    : BuiltinEffectModel{parent, instanceId}
+{
+}
+
 void NoiseReductionViewModel::doReload()
 {
     emit isApplyAllowedChanged();

--- a/src/effects/builtin/noisereduction/noisereductionviewmodel.h
+++ b/src/effects/builtin/noisereduction/noisereductionviewmodel.h
@@ -34,7 +34,7 @@ class NoiseReductionViewModel : public BuiltinEffectModel
     muse::Inject<muse::IInteractive> interactive;
 
 public:
-    NoiseReductionViewModel() = default;
+    NoiseReductionViewModel(QObject* parent, int instanceId);
 
     bool isApplyAllowed() const;
     void setIsApplyAllowed(bool isApplyAllowed);
@@ -69,5 +69,9 @@ signals:
 private:
     void doReload() override;
     bool usesPresets() const override { return false; }
+};
+
+class NoiseReductionViewModelFactory : public EffectViewModelFactory<NoiseReductionViewModel>
+{
 };
 }

--- a/src/effects/builtin/normalize/NormalizeView.qml
+++ b/src/effects/builtin/normalize/NormalizeView.qml
@@ -13,11 +13,8 @@ BuiltinEffectBase {
     width: 400
     implicitHeight: column.height
 
-    model: normalize
-
-    NormalizeViewModel {
-        id: normalize
-    }
+    builtinEffectModel: NormalizeViewModelFactory.createModel(root, root.instanceId)
+    property alias normalize: root.builtinEffectModel
 
     Column {
         id: column

--- a/src/effects/builtin/normalize/normalizeviewmodel.cpp
+++ b/src/effects/builtin/normalize/normalizeviewmodel.cpp
@@ -8,6 +8,11 @@
 #include "log.h"
 
 namespace au::effects {
+NormalizeViewModel::NormalizeViewModel(QObject* parent, int instanceId)
+    : BuiltinEffectModel(parent, instanceId)
+{
+}
+
 bool NormalizeViewModel::removeDC() const
 {
     const auto& fx = effect<NormalizeEffect>();

--- a/src/effects/builtin/normalize/normalizeviewmodel.h
+++ b/src/effects/builtin/normalize/normalizeviewmodel.h
@@ -19,7 +19,7 @@ class NormalizeViewModel : public BuiltinEffectModel
     Q_PROPERTY(double peakAmplitudeTarget READ peakAmplitudeTarget WRITE setPeakAmplitudeTarget NOTIFY peakAmplitudeTargetChanged FINAL)
 
 public:
-    NormalizeViewModel() = default;
+    NormalizeViewModel(QObject* parent, int instanceId);
 
     bool removeDC() const;
     void setRemoveDC(bool removeDC);
@@ -41,5 +41,9 @@ signals:
 
 private:
     void doReload() override;
+};
+
+class NormalizeViewModelFactory : public EffectViewModelFactory<NormalizeViewModel>
+{
 };
 }

--- a/src/effects/builtin/qml/Audacity/BuiltinEffects/BuiltinEffectBase.qml
+++ b/src/effects/builtin/qml/Audacity/BuiltinEffects/BuiltinEffectBase.qml
@@ -13,11 +13,16 @@ Rectangle {
 
     property BuiltinEffectModel model: null
     property bool usesPresets: model ? model.usesPresets : true
+    property bool isPreviewing: model ? model.isPreviewing : false
     property bool usedDestructively: true
 
     color: ui.theme.backgroundPrimaryColor
 
-    function preview() {
-        root.model.preview()
+    function init() {
+        root.model.init()
+    }
+
+    function togglePreview() {
+        root.model.togglePreview()
     }
 }

--- a/src/effects/builtin/qml/Audacity/BuiltinEffects/BuiltinEffectBase.qml
+++ b/src/effects/builtin/qml/Audacity/BuiltinEffects/BuiltinEffectBase.qml
@@ -22,7 +22,11 @@ Rectangle {
         root.model.init()
     }
 
-    function togglePreview() {
-        root.model.togglePreview()
+    function startPreview() {
+        root.model.startPreview()
+    }
+
+    function stopPreview() {
+        root.model.stopPreview()
     }
 }

--- a/src/effects/builtin/qml/Audacity/BuiltinEffects/BuiltinEffectBase.qml
+++ b/src/effects/builtin/qml/Audacity/BuiltinEffects/BuiltinEffectBase.qml
@@ -11,22 +11,23 @@ Rectangle {
 
     property var dialogView: null
 
-    property BuiltinEffectModel model: null
-    property bool usesPresets: model ? model.usesPresets : true
-    property bool isPreviewing: model ? model.isPreviewing : false
+    required property int instanceId
+    required property BuiltinEffectModel builtinEffectModel
+    property bool usesPresets: builtinEffectModel.usesPresets
+    property bool isPreviewing: builtinEffectModel.isPreviewing
     property bool usedDestructively: true
 
     color: ui.theme.backgroundPrimaryColor
 
     function init() {
-        root.model.init()
+        root.builtinEffectModel.init()
     }
 
     function startPreview() {
-        root.model.startPreview()
+        root.builtinEffectModel.startPreview()
     }
 
     function stopPreview() {
-        root.model.stopPreview()
+        root.builtinEffectModel.stopPreview()
     }
 }

--- a/src/effects/builtin/qml/Audacity/BuiltinEffects/BuiltinEffectViewer.qml
+++ b/src/effects/builtin/qml/Audacity/BuiltinEffects/BuiltinEffectViewer.qml
@@ -38,9 +38,15 @@ Rectangle {
         }
     }
 
-    function togglePreview() {
+    function startPreview() {
         if (builder.contentItem) {
-            builder.contentItem.togglePreview()
+            builder.contentItem.startPreview()
+        }
+    }
+
+    function stopPreview() {
+        if (builder.contentItem) {
+            builder.contentItem.stopPreview()
         }
     }
 

--- a/src/effects/builtin/qml/Audacity/BuiltinEffects/BuiltinEffectViewer.qml
+++ b/src/effects/builtin/qml/Audacity/BuiltinEffects/BuiltinEffectViewer.qml
@@ -6,7 +6,6 @@ import QtQuick
 import Audacity.BuiltinEffects
 
 Rectangle {
-
     id: root
 
     property string instanceId: ""
@@ -18,7 +17,7 @@ Rectangle {
     property bool isPreviewing: builder.contentItem ? builder.contentItem.isPreviewing : false
     property bool usesPresets: builder.contentItem ? builder.contentItem.usesPresets : false
 
-    signal closeRequested()
+    signal closeRequested
 
     color: ui.theme.backgroundPrimaryColor
 

--- a/src/effects/builtin/qml/Audacity/BuiltinEffects/BuiltinEffectViewer.qml
+++ b/src/effects/builtin/qml/Audacity/BuiltinEffects/BuiltinEffectViewer.qml
@@ -8,7 +8,7 @@ import Audacity.BuiltinEffects
 Rectangle {
     id: root
 
-    property alias instanceId: builder.instanceId
+    required property int instanceId
     property var dialogView: null
     required property bool usedDestructively
 
@@ -28,7 +28,7 @@ Rectangle {
     height: implicitHeight
 
     Component.onCompleted: {
-        builder.load(root, dialogView, usedDestructively)
+        builder.load(instanceId, root, dialogView, usedDestructively)
         builder.contentItem.init()
     }
 

--- a/src/effects/builtin/qml/Audacity/BuiltinEffects/BuiltinEffectViewer.qml
+++ b/src/effects/builtin/qml/Audacity/BuiltinEffects/BuiltinEffectViewer.qml
@@ -8,7 +8,7 @@ import Audacity.BuiltinEffects
 Rectangle {
     id: root
 
-    property string instanceId: ""
+    property alias instanceId: builder.instanceId
     property var dialogView: null
     required property bool usedDestructively
 
@@ -28,7 +28,7 @@ Rectangle {
     height: implicitHeight
 
     Component.onCompleted: {
-        builder.load(root.instanceId, root, dialogView, usedDestructively)
+        builder.load(root, dialogView, usedDestructively)
         builder.contentItem.init()
     }
 

--- a/src/effects/builtin/qml/Audacity/BuiltinEffects/BuiltinEffectViewer.qml
+++ b/src/effects/builtin/qml/Audacity/BuiltinEffects/BuiltinEffectViewer.qml
@@ -15,6 +15,7 @@ Rectangle {
 
     property string title: builder.contentItem ? builder.contentItem.title : ""
     property bool isApplyAllowed: builder.contentItem ? builder.contentItem.isApplyAllowed : false
+    property bool isPreviewing: builder.contentItem ? builder.contentItem.isPreviewing : false
     property bool usesPresets: builder.contentItem ? builder.contentItem.usesPresets : false
 
     signal closeRequested()
@@ -29,6 +30,7 @@ Rectangle {
 
     Component.onCompleted: {
         builder.load(root.instanceId, root, dialogView, usedDestructively)
+        builder.contentItem.init()
     }
 
     function manage(parent) {
@@ -37,9 +39,9 @@ Rectangle {
         }
     }
 
-    function preview() {
+    function togglePreview() {
         if (builder.contentItem) {
-            builder.contentItem.preview()
+            builder.contentItem.togglePreview()
         }
     }
 

--- a/src/effects/builtin/reverb/ReverbView.qml
+++ b/src/effects/builtin/reverb/ReverbView.qml
@@ -15,7 +15,8 @@ BuiltinEffectBase {
     implicitHeight: row.height
     width: 560
 
-    model: reverb
+    builtinEffectModel: ReverbViewModelFactory.createModel(root, root.instanceId)
+    property alias reverb: root.builtinEffectModel
 
     QtObject {
         id: prv
@@ -23,10 +24,6 @@ BuiltinEffectBase {
         readonly property int narrowRowSpacing: 16
         readonly property int rowSpacing: 24
         readonly property int columnSpacing: 32
-    }
-
-    ReverbViewModel {
-        id: reverb
     }
 
     function newParameterValueRequested(key, value) {

--- a/src/effects/builtin/reverb/reverbviewmodel.cpp
+++ b/src/effects/builtin/reverb/reverbviewmodel.cpp
@@ -8,7 +8,8 @@
 
 using namespace au::effects;
 
-ReverbViewModel::ReverbViewModel()
+ReverbViewModel::ReverbViewModel(QObject* parent, int instanceId)
+    : BuiltinEffectModel(parent, instanceId)
 {
 }
 

--- a/src/effects/builtin/reverb/reverbviewmodel.h
+++ b/src/effects/builtin/reverb/reverbviewmodel.h
@@ -13,7 +13,7 @@ class ReverbViewModel : public BuiltinEffectModel
     Q_PROPERTY(bool wetOnly READ wetOnly WRITE setWetOnly NOTIFY wetOnlyChanged FINAL)
 
 public:
-    ReverbViewModel();
+    ReverbViewModel(QObject* parent, int instanceId);
 
     QVariantMap paramsList() const;
 
@@ -38,5 +38,9 @@ private:
 
     QVariantMap m_paramsList;
     QMap<QString, Setter> m_setters;
+};
+
+class ReverbViewModelFactory : public EffectViewModelFactory<ReverbViewModel>
+{
 };
 }

--- a/src/effects/builtin/silencegen/SilenceView.qml
+++ b/src/effects/builtin/silencegen/SilenceView.qml
@@ -10,16 +10,13 @@ BuiltinEffectBase {
     id: root
 
     property string title: qsTrc("projectscene/silence", "Silence")
-    property alias isApplyAllowed: silence.isApplyAllowed
+    property bool isApplyAllowed: silence.isApplyAllowed
 
     implicitWidth: 300
     implicitHeight: column.implicitHeight
 
-    model: silence
-
-    SilenceViewModel {
-        id: silence
-    }
+    builtinEffectModel: SilenceViewModelFactory.createModel(root, root.instanceId)
+    property alias silence: root.builtinEffectModel
 
     Column {
         id: column

--- a/src/effects/builtin/silencegen/silenceviewmodel.h
+++ b/src/effects/builtin/silencegen/silenceviewmodel.h
@@ -13,11 +13,16 @@ class SilenceViewModel : public GeneratorEffectModel
     Q_OBJECT
 
 public:
-    SilenceViewModel() = default;
+    SilenceViewModel(QObject* parent, int instanceId)
+        : GeneratorEffectModel(parent, instanceId) {}
     ~SilenceViewModel() override = default;
 
 private:
     void doEmitSignals() override {}
     bool usesPresets() const override { return false; }
+};
+
+class SilenceViewModelFactory : public EffectViewModelFactory<SilenceViewModel>
+{
 };
 }

--- a/src/effects/builtin/tonegen/ChirpView.qml
+++ b/src/effects/builtin/tonegen/ChirpView.qml
@@ -14,12 +14,13 @@ BuiltinEffectBase {
     id: root
 
     property string title: qsTrc("effects", "Chirp")
-    property alias isApplyAllowed: chirp.isApplyAllowed
+    property bool isApplyAllowed: chirp.isApplyAllowed
 
     width: 370
     implicitHeight: column.height
 
-    model: chirp
+    builtinEffectModel: ToneViewModelFactory.createModel(root, root.instanceId)
+    property alias chirp: root.builtinEffectModel
 
     QtObject {
         id: prv
@@ -28,10 +29,6 @@ BuiltinEffectBase {
         readonly property int padding: 32
         readonly property int interpolationLinear: 0
         readonly property int interpolationLogarithmic: 1
-    }
-
-    ToneViewModel {
-        id: chirp
     }
 
     ColumnLayout {

--- a/src/effects/builtin/tonegen/ToneView.qml
+++ b/src/effects/builtin/tonegen/ToneView.qml
@@ -13,12 +13,13 @@ BuiltinEffectBase {
     id: root
 
     property string title: qsTrc("effects/tone", "Tone")
-    property alias isApplyAllowed: tone.isApplyAllowed
+    property bool isApplyAllowed: tone.isApplyAllowed
 
     width: 360
     implicitHeight: column.height
 
-    model: tone
+    builtinEffectModel: ToneViewModelFactory.createModel(root, root.instanceId)
+    property alias tone: root.builtinEffectModel
 
     QtObject {
         id: prv
@@ -26,10 +27,6 @@ BuiltinEffectBase {
         readonly property int spacing: 16
         readonly property int interpolationLinear: 0
         readonly property int interpolationLogarithmic: 1
-    }
-
-    ToneViewModel {
-        id: tone
     }
 
     Column {

--- a/src/effects/builtin/tonegen/toneviewmodel.cpp
+++ b/src/effects/builtin/tonegen/toneviewmodel.cpp
@@ -11,6 +11,11 @@
 
 using namespace au::effects;
 
+ToneViewModel::ToneViewModel(QObject* parent, int instanceId)
+    : GeneratorEffectModel(parent, instanceId)
+{
+}
+
 void ToneViewModel::doEmitSignals()
 {
     emit amplitudeStartChanged();

--- a/src/effects/builtin/tonegen/toneviewmodel.h
+++ b/src/effects/builtin/tonegen/toneviewmodel.h
@@ -24,6 +24,8 @@ class ToneViewModel : public GeneratorEffectModel
     muse::Inject<IEffectsProvider> effectsProvider;
 
 public:
+    ToneViewModel(QObject* parent, int instanceId);
+
     bool isApplyAllowed() const override;
     QList<QString> waveforms() const;
     QList<QString> interpolationTypes() const;
@@ -52,5 +54,9 @@ private:
     void doEmitSignals() override;
 
     ToneEffect* effect() const;
+};
+
+class ToneViewModelFactory : public EffectViewModelFactory<ToneViewModel>
+{
 };
 }

--- a/src/effects/builtin/truncatesilence/TruncateSilenceView.qml
+++ b/src/effects/builtin/truncatesilence/TruncateSilenceView.qml
@@ -17,11 +17,8 @@ BuiltinEffectBase {
     property string title: truncateSilence.effectTitle()
     property bool isApplyAllowed: true
 
-    model: truncateSilence
-
-    TruncateSilenceViewModel {
-        id: truncateSilence
-    }
+    builtinEffectModel: TruncateSilenceViewModelFactory.createModel(root, root.instanceId)
+    property alias truncateSilence: root.builtinEffectModel
 
     QtObject {
         id: prv

--- a/src/effects/builtin/truncatesilence/truncatesilenceviewmodel.cpp
+++ b/src/effects/builtin/truncatesilence/truncatesilenceviewmodel.cpp
@@ -10,6 +10,11 @@
 #include "framework/global/translation.h"
 
 namespace au::effects {
+TruncateSilenceViewModel::TruncateSilenceViewModel(QObject* parent, int instanceId)
+    : BuiltinEffectModel(parent, instanceId)
+{
+}
+
 QString TruncateSilenceViewModel::effectTitle() const
 {
     return muse::qtrc("effects/truncatesilence", "Truncate silence");

--- a/src/effects/builtin/truncatesilence/truncatesilenceviewmodel.h
+++ b/src/effects/builtin/truncatesilence/truncatesilenceviewmodel.h
@@ -20,7 +20,8 @@ class TruncateSilenceViewModel : public BuiltinEffectModel
     Q_PROPERTY(bool independentValue READ independentValue WRITE setIndependentValue NOTIFY independentValueChanged FINAL)
 
 public:
-    TruncateSilenceViewModel() = default;
+    TruncateSilenceViewModel(QObject* parent, int instanceId);
+    ~TruncateSilenceViewModel() override = default;
 
     double thresholdValue() const;
     void setThresholdValue(double newThreshold);
@@ -92,5 +93,9 @@ signals:
 
 private:
     void doReload() override;
+};
+
+class TruncateSilenceViewModelFactory : public EffectViewModelFactory<TruncateSilenceViewModel>
+{
 };
 }

--- a/src/effects/builtin/view/builtineffectviewloader.cpp
+++ b/src/effects/builtin/view/builtineffectviewloader.cpp
@@ -34,12 +34,6 @@
 
 using namespace au::effects;
 
-BuiltinEffectViewLoader::BuiltinEffectViewLoader(QObject* parent)
-    : QObject(parent), m_instanceId{AbstractViewLauncher::initializationInstanceId()}
-{
-    assert(m_instanceId != -1);
-}
-
 BuiltinEffectViewLoader::~BuiltinEffectViewLoader()
 {
     if (m_contentItem) {
@@ -48,14 +42,14 @@ BuiltinEffectViewLoader::~BuiltinEffectViewLoader()
     }
 }
 
-void BuiltinEffectViewLoader::load(QObject* itemParent, QObject* dialogView, bool usedDestructively)
+void BuiltinEffectViewLoader::load(int instanceId, QObject* itemParent, QObject* dialogView, bool usedDestructively)
 {
     // TODO: could instancesRegister have a `typeByInstanceId` method?
-    const auto effectId = instancesRegister()->effectIdByInstanceId(m_instanceId).toStdString();
+    const auto effectId = instancesRegister()->effectIdByInstanceId(instanceId).toStdString();
 
     const auto effect = dynamic_cast<Effect*>(EffectManager::Get().GetEffect(effectId));
     IF_ASSERT_FAILED(effect) {
-        LOGE() << "effect not available, instanceId: " << m_instanceId << ", effectId: " << effectId;
+        LOGE() << "effect not available, instanceId: " << instanceId << ", effectId: " << effectId;
         return;
     }
 
@@ -82,6 +76,7 @@ void BuiltinEffectViewLoader::load(QObject* itemParent, QObject* dialogView, boo
     QObject* obj = component.createWithInitialProperties(
     {
         { "parent", QVariant::fromValue(itemParent) },
+        { "instanceId", instanceId },
         { "dialogView", QVariant::fromValue(dialogView) },
         { "usedDestructively", usedDestructively }
     });

--- a/src/effects/builtin/view/builtineffectviewloader.h
+++ b/src/effects/builtin/view/builtineffectviewloader.h
@@ -21,6 +21,7 @@ class BuiltinEffectViewLoader : public QObject, public muse::async::Asyncable
 {
     Q_OBJECT
 
+    Q_PROPERTY(int instanceId READ instanceId CONSTANT FINAL)
     Q_PROPERTY(QQuickItem * contentItem READ contentItem NOTIFY contentItemChanged FINAL)
 
     muse::Inject<IEffectsViewRegister> viewRegister;
@@ -33,9 +34,9 @@ public:
 
     QQuickItem* contentItem() const;
 
-    Q_INVOKABLE void load(const QString& instanceId, QObject* itemParent, QObject* dialogView, bool usedDestructively);
+    Q_INVOKABLE void load(QObject* itemParent, QObject* dialogView, bool usedDestructively);
 
-    static int initializationInstanceId();
+    int instanceId() const { return m_instanceId; }
 
 signals:
     void titleChanged();
@@ -44,6 +45,7 @@ signals:
     void closeRequested();
 
 private:
+    const int m_instanceId;
     QQuickItem* m_contentItem = nullptr;
 };
 }

--- a/src/effects/builtin/view/builtineffectviewloader.h
+++ b/src/effects/builtin/view/builtineffectviewloader.h
@@ -21,7 +21,6 @@ class BuiltinEffectViewLoader : public QObject, public muse::async::Asyncable
 {
     Q_OBJECT
 
-    Q_PROPERTY(int instanceId READ instanceId CONSTANT FINAL)
     Q_PROPERTY(QQuickItem * contentItem READ contentItem NOTIFY contentItemChanged FINAL)
 
     muse::Inject<IEffectsViewRegister> viewRegister;
@@ -29,14 +28,11 @@ class BuiltinEffectViewLoader : public QObject, public muse::async::Asyncable
     muse::Inject<IEffectInstancesRegister> instancesRegister;
 
 public:
-    BuiltinEffectViewLoader(QObject* parent = nullptr);
     ~BuiltinEffectViewLoader() override;
 
     QQuickItem* contentItem() const;
 
-    Q_INVOKABLE void load(QObject* itemParent, QObject* dialogView, bool usedDestructively);
-
-    int instanceId() const { return m_instanceId; }
+    Q_INVOKABLE void load(int instanceId, QObject* itemParent, QObject* dialogView, bool usedDestructively);
 
 signals:
     void titleChanged();
@@ -45,7 +41,6 @@ signals:
     void closeRequested();
 
 private:
-    const int m_instanceId;
     QQuickItem* m_contentItem = nullptr;
 };
 }

--- a/src/effects/effects_base/CMakeLists.txt
+++ b/src/effects/effects_base/CMakeLists.txt
@@ -64,6 +64,8 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/internal/effectviewlaunchregister.h
 
     # view
+    ${CMAKE_CURRENT_LIST_DIR}/view/abstracteffectviewmodel.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/view/abstracteffectviewmodel.h
     ${CMAKE_CURRENT_LIST_DIR}/view/effectmanagemenu.cpp
     ${CMAKE_CURRENT_LIST_DIR}/view/effectmanagemenu.h
     ${CMAKE_CURRENT_LIST_DIR}/view/effectsuiengine.cpp

--- a/src/effects/effects_base/CMakeLists.txt
+++ b/src/effects/effects_base/CMakeLists.txt
@@ -70,6 +70,7 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/view/effectmanagemenu.h
     ${CMAKE_CURRENT_LIST_DIR}/view/effectsuiengine.cpp
     ${CMAKE_CURRENT_LIST_DIR}/view/effectsuiengine.h
+    ${CMAKE_CURRENT_LIST_DIR}/view/effectsviewutils.h
     ${CMAKE_CURRENT_LIST_DIR}/view/effectviewerdialogmodel.cpp
     ${CMAKE_CURRENT_LIST_DIR}/view/effectviewerdialogmodel.h
     ${CMAKE_CURRENT_LIST_DIR}/view/realtimeeffectviewerdialogmodel.cpp

--- a/src/effects/effects_base/effects_base.qrc
+++ b/src/effects/effects_base/effects_base.qrc
@@ -2,6 +2,7 @@
     <qresource prefix="/">
         <file>qml/Audacity/Effects/qmldir</file>
         <file>qml/Audacity/Effects/BypassEffectButton.qml</file>
+        <file>qml/Audacity/Effects/EffectControlsDisablingOverlay.qml</file>
         <file>qml/Audacity/Effects/EffectPresetsBar.qml</file>
         <file>qml/Audacity/Effects/EffectsViewerDialog.qml</file>
         <file>qml/Audacity/Effects/EffectStyledDialogView.qml</file>

--- a/src/effects/effects_base/effectstypes.h
+++ b/src/effects/effects_base/effectstypes.h
@@ -107,7 +107,7 @@ const std::string EFFECT_OPEN_ACTION = "action://effects/open?effectId=%1";
 const std::string REALTIME_EFFECT_ADD_ACTION = "action://effects/realtime-add?effectId=%1";
 const std::string REALTIME_EFFECT_REPLACE_ACTION = "action://effects/realtime-replace?effectId=%1";
 
-const std::string EFFECT_VIEWER_URI = "audacity://effects/effect_viewer?effectFamily=%1";
+const std::string EFFECT_VIEWER_URI = "audacity://effects/effect_viewer?instanceId=%1&effectFamily=%2";
 
 inline std::string makeEffectAction(const std::string& action, const EffectId& id)
 {

--- a/src/effects/effects_base/effectstypes.h
+++ b/src/effects/effects_base/effectstypes.h
@@ -107,7 +107,7 @@ const std::string EFFECT_OPEN_ACTION = "action://effects/open?effectId=%1";
 const std::string REALTIME_EFFECT_ADD_ACTION = "action://effects/realtime-add?effectId=%1";
 const std::string REALTIME_EFFECT_REPLACE_ACTION = "action://effects/realtime-replace?effectId=%1";
 
-const std::string EFFECT_VIEWER_URI = "audacity://effects/effect_viewer?instanceId=%1&effectFamily=%2";
+const std::string EFFECT_VIEWER_URI = "audacity://effects/effect_viewer?effectFamily=%1";
 
 inline std::string makeEffectAction(const std::string& action, const EffectId& id)
 {

--- a/src/effects/effects_base/ieffectsconfiguration.h
+++ b/src/effects/effects_base/ieffectsconfiguration.h
@@ -22,5 +22,8 @@ public:
     virtual EffectMenuOrganization effectMenuOrganization() const = 0;
     virtual void setEffectMenuOrganization(EffectMenuOrganization) = 0;
     virtual muse::async::Notification effectMenuOrganizationChanged() const = 0;
+
+    virtual double previewMaxDuration() const = 0;
+    virtual void setPreviewMaxDuration(double value) = 0;
 };
 }

--- a/src/effects/effects_base/ieffectsprovider.h
+++ b/src/effects/effects_base/ieffectsprovider.h
@@ -41,6 +41,6 @@ public:
     virtual muse::Ret performEffect(au3::Au3Project& project, Effect* effect, std::shared_ptr<EffectInstance> effectInstance,
                                     EffectSettings& settings) = 0;
 
-    virtual muse::Ret previewEffect(au3::Au3Project& project, Effect* effect, EffectSettings& settings) = 0;
+    virtual muse::Ret previewEffect(const EffectId& effectId, EffectSettings& settings) = 0;
 };
 }

--- a/src/effects/effects_base/internal/abstractviewlauncher.cpp
+++ b/src/effects/effects_base/internal/abstractviewlauncher.cpp
@@ -6,18 +6,15 @@
 namespace au::effects {
 namespace {
 constexpr const char16_t* REALTIME_VIEWER_URI
-    = u"audacity://effects/realtime_viewer?effectState=%1&sync=false&modal=false&floating=true";
-
-static int gInitializationInstanceId = -1;
+    = u"audacity://effects/realtime_viewer?instanceId=%1&effectState=%2&sync=false&modal=false&floating=true";
 }
 
 muse::Ret AbstractViewLauncher::doShowEffect(int instanceId, EffectFamily family) const
 {
     muse::UriQuery uri(EFFECT_VIEWER_URI);
+    uri.addParam("instanceId", muse::Val(instanceId));
     uri.addParam("effectFamily", muse::Val(family));
-    gInitializationInstanceId = instanceId;
     const auto ret = interactive()->openSync(uri);
-    gInitializationInstanceId = -1;
     return ret.ret;
 }
 
@@ -32,7 +29,9 @@ void AbstractViewLauncher::doShowRealtimeEffect(const RealtimeEffectStatePtr& st
         return;
     }
 
-    const muse::UriQuery query{ muse::String(REALTIME_VIEWER_URI).arg(size_t(state.get())) };
+    const auto instanceId = instance->id();
+
+    const muse::UriQuery query{ muse::String(REALTIME_VIEWER_URI).arg(size_t(instanceId)).arg(size_t(state.get())) };
 
     // If the dialog for this specific instance is opened, just raise it.
     if (interactive()->isOpened(query).val) {
@@ -42,9 +41,7 @@ void AbstractViewLauncher::doShowRealtimeEffect(const RealtimeEffectStatePtr& st
         return;
     }
 
-    gInitializationInstanceId = instance->id();
     interactive()->open(query);
-    gInitializationInstanceId = -1;
 }
 
 void AbstractViewLauncher::hideRealtimeEffect(const RealtimeEffectStatePtr& state) const
@@ -52,14 +49,17 @@ void AbstractViewLauncher::hideRealtimeEffect(const RealtimeEffectStatePtr& stat
     IF_ASSERT_FAILED(state) {
         return;
     }
-    const muse::UriQuery query{ muse::String(REALTIME_VIEWER_URI).arg(size_t(state.get())) };
+    const auto instance = std::dynamic_pointer_cast<effects::EffectInstance>(state->GetInstance());
+    if (!instance) {
+        LOGW() << "Could not get instance for " << state->GetID().ToStdString();
+        return;
+    }
+    const auto instanceId = instance->id();
+
+    const muse::UriQuery query{ muse::String(REALTIME_VIEWER_URI).arg(size_t(instanceId)).arg(size_t(state.get())) };
+
     if (interactive()->isOpened(query).val) {
         interactive()->close(query);
     }
-}
-
-int AbstractViewLauncher::initializationInstanceId()
-{
-    return gInitializationInstanceId;
 }
 }

--- a/src/effects/effects_base/internal/abstractviewlauncher.h
+++ b/src/effects/effects_base/internal/abstractviewlauncher.h
@@ -10,10 +10,14 @@
 namespace au::effects {
 class AbstractViewLauncher : public IEffectViewLauncher
 {
+public:
+    static int initializationInstanceId();
+
 protected:
     muse::Inject<muse::IInteractive> interactive;
     muse::Inject<IEffectInstancesRegister> instancesRegister;
 
+    muse::Ret doShowEffect(int instanceId, EffectFamily) const;
     void doShowRealtimeEffect(const RealtimeEffectStatePtr& state) const;
 
 private:

--- a/src/effects/effects_base/internal/abstractviewlauncher.h
+++ b/src/effects/effects_base/internal/abstractviewlauncher.h
@@ -10,9 +10,6 @@
 namespace au::effects {
 class AbstractViewLauncher : public IEffectViewLauncher
 {
-public:
-    static int initializationInstanceId();
-
 protected:
     muse::Inject<muse::IInteractive> interactive;
     muse::Inject<IEffectInstancesRegister> instancesRegister;

--- a/src/effects/effects_base/internal/effectexecutionscenario.cpp
+++ b/src/effects/effects_base/internal/effectexecutionscenario.cpp
@@ -465,8 +465,6 @@ muse::async::Channel<EffectId> EffectExecutionScenario::lastProcessorIdChanged()
 
 muse::Ret EffectExecutionScenario::previewEffect(const EffectInstanceId& effectInstanceId, EffectSettings& settings)
 {
-    au3::Au3Project& project = projectRef();
     EffectId effectId = effectInstancesRegister()->effectIdByInstanceId(effectInstanceId);
-    Effect* effect = effectsProvider()->effect(effectId);
-    return effectsProvider()->previewEffect(project, effect, settings);
+    return effectsProvider()->previewEffect(effectId, settings);
 }

--- a/src/effects/effects_base/internal/effectsconfiguration.cpp
+++ b/src/effects/effects_base/internal/effectsconfiguration.cpp
@@ -10,6 +10,7 @@ using namespace au::effects;
 static const std::string moduleName("effects");
 static const muse::Settings::Key APPLY_EFFECT_TO_ALL_AUDIO(moduleName, "effects/applyEffectToAllAudio");
 static const muse::Settings::Key EFFECT_MENU_ORGANIZATION(moduleName, "effects/effectMenuOrganization");
+static const muse::Settings::Key PREVIEW_MAX_DURATION(moduleName, "effects/previewMaxDuration");
 
 void EffectsConfiguration::init()
 {
@@ -22,6 +23,8 @@ void EffectsConfiguration::init()
     muse::settings()->valueChanged(EFFECT_MENU_ORGANIZATION).onReceive(nullptr, [this](const muse::Val&) {
         m_effectMenuOrganizationChanged.notify();
     });
+
+    muse::settings()->setDefaultValue(PREVIEW_MAX_DURATION, muse::Val(60.0));
 }
 
 bool EffectsConfiguration::applyEffectToAllAudio() const
@@ -56,4 +59,14 @@ void EffectsConfiguration::setEffectMenuOrganization(EffectMenuOrganization orga
 muse::async::Notification EffectsConfiguration::effectMenuOrganizationChanged() const
 {
     return m_effectMenuOrganizationChanged;
+}
+
+double EffectsConfiguration::previewMaxDuration() const
+{
+    return muse::settings()->value(PREVIEW_MAX_DURATION).toDouble();
+}
+
+void EffectsConfiguration::setPreviewMaxDuration(double value)
+{
+    muse::settings()->setSharedValue(PREVIEW_MAX_DURATION, muse::Val(value));
 }

--- a/src/effects/effects_base/internal/effectsconfiguration.h
+++ b/src/effects/effects_base/internal/effectsconfiguration.h
@@ -26,6 +26,9 @@ public:
     void setEffectMenuOrganization(EffectMenuOrganization) override;
     muse::async::Notification effectMenuOrganizationChanged() const override;
 
+    double previewMaxDuration() const override;
+    void setPreviewMaxDuration(double value) override;
+
 private:
     muse::async::Notification m_applyEffectToAllAudioChanged;
     muse::async::Notification m_effectMenuOrganizationChanged;

--- a/src/effects/effects_base/internal/effectsprovider.cpp
+++ b/src/effects/effects_base/internal/effectsprovider.cpp
@@ -568,25 +568,10 @@ muse::Ret EffectsProvider::doEffectPreview(EffectBase& effect, EffectSettings& s
             return ret;
         }
 
-        using namespace BasicUI;
-
-        // The progress dialog must be deleted before stopping the stream
-        // to allow events to flow to the app during StopStream processing.
-        // The progress dialog blocks these events.
-        {
-            auto progress = MakeProgress(effect.GetName(), XO("Previewing"), ProgressShowStop);
-            while (player->isRunning()) {
-                using namespace std::chrono;
-                std::this_thread::sleep_for(100ms);
-                muse::secs_t playPos = player->playbackPosition() - startOffset;
-                auto previewing = progress->Poll(playPos, newCtx.t1);
-
-                if (previewing != BasicUI::ProgressResult::Success || player->reachedEnd().val) {
-                    break;
-                }
-            }
-
-            player->stop();
+        while (player->isRunning()) {
+            using namespace std::chrono;
+            std::this_thread::sleep_for(10ms);
+            QCoreApplication::processEvents();
         }
     }
 

--- a/src/effects/effects_base/internal/effectsprovider.cpp
+++ b/src/effects/effects_base/internal/effectsprovider.cpp
@@ -387,8 +387,14 @@ void restoreEffectStateHack(EffectBase& effect)
 }
 }
 
-muse::Ret EffectsProvider::doEffectPreview(EffectBase& effect, EffectSettings& settings)
+muse::Ret EffectsProvider::previewEffect(const EffectId& effectId, EffectSettings& settings)
 {
+    ::EffectBase* pEffect = this->effect(effectId);
+    if (!pEffect) {
+        return muse::make_ret(muse::Ret::Code::InternalError);
+    }
+    auto& effect = *pEffect;
+
     const bool isNyquist = effect.GetFamily() == NYQUISTEFFECTS_FAMILY;
     const bool isGenerator = effect.GetType() == EffectTypeGenerate;
 
@@ -594,9 +600,4 @@ muse::Ret EffectsProvider::doEffectPreview(EffectBase& effect, EffectSettings& s
     }
 
     return muse::make_ok();
-}
-
-muse::Ret EffectsProvider::previewEffect(au3::Au3Project&, Effect* effect, EffectSettings& settings)
-{
-    return doEffectPreview(*effect, settings);
 }

--- a/src/effects/effects_base/internal/effectsprovider.cpp
+++ b/src/effects/effects_base/internal/effectsprovider.cpp
@@ -446,12 +446,12 @@ muse::Ret EffectsProvider::doEffectPreview(EffectBase& effect, EffectSettings& s
     if (effect.PreviewsFullSelection()) {
         newCtx.t1 = originCtx.t1;
     } else {
-        // Limit preview time to 1mn. We need to pre-render the audio,
-        // which would take a long time and lots of memory for long selections.
+        // Limit preview time:
+        // We need to pre-render the audio, which would take a long time and lots of memory for long selections.
         // On the other hand, preview isn't typically something users would listen to for more than a few seconds.
         // (Au3 used to read `previewLen` from the `/AudioIO/EffectsPreviewLen` setting.
         // There is no plan at the moment to reintroduce it in Au4.)
-        constexpr double maxPreviewLen = 60.0;
+        const double maxPreviewLen = configuration()->previewMaxDuration();
         const double previewLen = std::min(originCtx.t1 - originCtx.t0, maxPreviewLen);
         double previewDuration = 0.0;
         if (isNyquist && isGenerator) {

--- a/src/effects/effects_base/internal/effectsprovider.cpp
+++ b/src/effects/effects_base/internal/effectsprovider.cpp
@@ -442,18 +442,26 @@ muse::Ret EffectsProvider::doEffectPreview(EffectBase& effect, EffectSettings& s
     EffectContext newCtx;
 
     //! Step 3.1 - prepare time
-
-    //const bool previewFullSelection = effect.PreviewsFullSelection(); not used at the moment
-    const double previewLen = originCtx.t1 - originCtx.t0;
-    double previewDuration = 0.0;
-    if (isNyquist && isGenerator) {
-        previewDuration = effect.CalcPreviewInputLength(settings, previewLen);
+    newCtx.t0 = originCtx.t0;
+    if (effect.PreviewsFullSelection()) {
+        newCtx.t1 = originCtx.t1;
     } else {
-        previewDuration = std::min(settings.extra.GetDuration(), effect.CalcPreviewInputLength(settings, previewLen));
+        // Limit preview time to 1mn. We need to pre-render the audio,
+        // which would take a long time and lots of memory for long selections.
+        // On the other hand, preview isn't typically something users would listen to for more than a few seconds.
+        // (Au3 used to read `previewLen` from the `/AudioIO/EffectsPreviewLen` setting.
+        // There is no plan at the moment to reintroduce it in Au4.)
+        constexpr double maxPreviewLen = 60.0;
+        const double previewLen = std::min(originCtx.t1 - originCtx.t0, maxPreviewLen);
+        double previewDuration = 0.0;
+        if (isNyquist && isGenerator) {
+            previewDuration = effect.CalcPreviewInputLength(settings, previewLen);
+        } else {
+            previewDuration = std::min(settings.extra.GetDuration(), effect.CalcPreviewInputLength(settings, previewLen));
+        }
+        newCtx.t1 = originCtx.t0 + previewDuration;
     }
 
-    newCtx.t0 = originCtx.t0;
-    newCtx.t1 = originCtx.t0 + previewDuration;
     if ((newCtx.t1 > originCtx.t1) && !isGenerator) {
         newCtx.t1 = originCtx.t1;
     }
@@ -562,6 +570,16 @@ muse::Ret EffectsProvider::doEffectPreview(EffectBase& effect, EffectSettings& s
         opt.selectedOnly = true;
         opt.startOffset = startOffset;
         opt.isDefaultPolicy = false;
+
+        // Setting looping to `false` ensures that the loop region won't interfere with preview.
+        // Also, looping is of course not effective during preview. Having it visually disabled
+        // makes it clear to the user.
+        const auto loopWasActive = player->isLoopRegionActive();
+        player->setLoopRegionActive(false);
+        const auto restorePlayerState = finally([&] {
+            player->setLoopRegionActive(loopWasActive);
+        });
+        player->setPlaybackRegion({ startOffset + newCtx.t0, startOffset + newCtx.t1 });
 
         muse::Ret ret = player->playTracks(*newCtx.tracks, newCtx.t0, newCtx.t1, opt);
         if (!ret) {

--- a/src/effects/effects_base/internal/effectsprovider.cpp
+++ b/src/effects/effects_base/internal/effectsprovider.cpp
@@ -4,7 +4,6 @@
 #include "effectsprovider.h"
 #include "effecterrors.h"
 
-#include "global/translation.h"
 #include "au3wrap/internal/domconverter.h"
 #include "au3wrap/internal/wxtypes_convert.h"
 #include "au3wrap/internal/progressdialog.h"
@@ -26,7 +25,9 @@
 #include "au3wrap/au3types.h"
 #include "playback/iplayer.h"
 
-#include "log.h"
+#include "framework/global/log.h"
+#include "framework/global/translation.h"
+#include "framework/global/async/async.h"
 
 using namespace muse;
 using namespace au::effects;
@@ -414,22 +415,7 @@ muse::Ret EffectsProvider::previewEffect(const EffectId& effectId, EffectSetting
     //! ============================================================================
     //! NOTE Step 2 - save origin context (state)
     //! ============================================================================
-    struct EffectContext {
-        double t0 = 0.0;
-        double t1 = 0.0;
-        std::shared_ptr<TrackList> tracks;
-        BasicUI::ProgressDialog* progress = nullptr;
-        bool isPreview = false;
-    };
-
     const EffectContext originCtx = { effect.mT0, effect.mT1, effect.mTracks, effect.mProgress, effect.mIsPreview };
-    auto restoreCtx = finally([&] {
-        effect.mT0 = originCtx.t0;
-        effect.mT1 = originCtx.t1;
-        effect.mTracks = originCtx.tracks;
-        effect.mProgress = originCtx.progress;
-        effect.mIsPreview = originCtx.isPreview;
-    });
 
     // restore internal effect state on return (if needed)
     auto cleanup0 = effect.BeginPreview(settings);
@@ -540,7 +526,7 @@ muse::Ret EffectsProvider::previewEffect(const EffectId& effectId, EffectSetting
             ProgressShowStop
             ); // Have only "Stop" button.
 
-        newCtx.progress = progress.get();
+        newCtx.preparingPreviewProgress = progress.get();
         newCtx.isPreview = true;
 
         // apply new context
@@ -548,7 +534,7 @@ muse::Ret EffectsProvider::previewEffect(const EffectId& effectId, EffectSetting
             effect.mT0 = newCtx.t0;
             effect.mT1 = newCtx.t1;
             effect.mTracks = newCtx.tracks;
-            effect.mProgress = newCtx.progress;
+            effect.mProgress = newCtx.preparingPreviewProgress;
             effect.mIsPreview = newCtx.isPreview;
 
             // Update track/group counts
@@ -582,20 +568,49 @@ muse::Ret EffectsProvider::previewEffect(const EffectId& effectId, EffectSetting
         // makes it clear to the user.
         const auto loopWasActive = player->isLoopRegionActive();
         player->setLoopRegionActive(false);
-        const auto restorePlayerState = finally([&] {
-            player->setLoopRegionActive(loopWasActive);
-        });
         player->setPlaybackRegion({ startOffset + newCtx.t0, startOffset + newCtx.t1 });
+
+        m_effectPreviewState.emplace(originCtx, newCtx.tracks);
+        player->playbackStatusChanged().onReceive(this, [this, effectId, loopWasActive](playback::PlaybackStatus status) {
+            if (status == playback::PlaybackStatus::Running) {
+                return;
+            }
+
+            IF_ASSERT_FAILED(status == playback::PlaybackStatus::Stopped) {
+                // Pausing should not be possible during preview.
+                // If we reset the playback context's tracks while playback is still ongoing, though,
+                // we're in for a crash, hence wait and hope that the "stop" signal will come in due time.
+                return;
+            }
+
+            // Wait for other observers of this signal to be finished, in particular the audio engine,
+            // which should stop playback synchronously. Only then we may delete the preview tracks.
+            async::Async::call(this, [this, effectId, loopWasActive] {
+                const auto player = playback()->player();
+                const auto reset = finally([this, player] {
+                    m_effectPreviewState.reset();
+                    player->playbackStatusChanged().disconnect(this);
+                });
+
+                EffectBase* effect = this->effect(effectId);
+                IF_ASSERT_FAILED(effect && m_effectPreviewState) {
+                    return;
+                }
+
+                const EffectContext& originCtx = m_effectPreviewState->originContext;
+                effect->mT0 = originCtx.t0;
+                effect->mT1 = originCtx.t1;
+                effect->mTracks = originCtx.tracks;
+                effect->mProgress = originCtx.preparingPreviewProgress;
+                effect->mIsPreview = originCtx.isPreview;
+
+                player->setLoopRegionActive(loopWasActive);
+            });
+        });
 
         muse::Ret ret = player->playTracks(*newCtx.tracks, newCtx.t0, newCtx.t1, opt);
         if (!ret) {
             return ret;
-        }
-
-        while (player->isRunning()) {
-            using namespace std::chrono;
-            std::this_thread::sleep_for(10ms);
-            QCoreApplication::processEvents();
         }
     }
 

--- a/src/effects/effects_base/internal/effectsprovider.h
+++ b/src/effects/effects_base/internal/effectsprovider.h
@@ -61,7 +61,7 @@ public:
     muse::Ret performEffect(au3::Au3Project& project, Effect* effect, std::shared_ptr<EffectInstance> effectInstance,
                             EffectSettings& settings) override;
 
-    muse::Ret previewEffect(au3::Au3Project& project, Effect* effect, EffectSettings& settings) override;
+    muse::Ret previewEffect(const EffectId& effectId, EffectSettings& settings) override;
 
 private:
 

--- a/src/effects/effects_base/internal/effectsprovider.h
+++ b/src/effects/effects_base/internal/effectsprovider.h
@@ -21,6 +21,11 @@
 
 class EffectBase;
 class EffectSettingsAccess;
+
+namespace BasicUI {
+class ProgressDialog;
+}
+
 namespace au::effects {
 class EffectsProvider : public IEffectsProvider, public muse::async::Asyncable
 {
@@ -64,6 +69,20 @@ public:
     muse::Ret previewEffect(const EffectId& effectId, EffectSettings& settings) override;
 
 private:
+    struct EffectContext {
+        double t0 = 0.0;
+        double t1 = 0.0;
+        std::shared_ptr<TrackList> tracks;
+        BasicUI::ProgressDialog* preparingPreviewProgress = nullptr;
+        bool isPreview = false;
+    };
+
+    struct EffectPreviewState {
+        EffectPreviewState(const EffectContext& originContext, const std::shared_ptr<TrackList>& previewTracks)
+            : originContext(originContext), previewTracks(previewTracks) {}
+        const EffectContext originContext;
+        const std::shared_ptr<TrackList> previewTracks;
+    };
 
     bool isVstSupported() const;
     bool isNyquistSupported() const;
@@ -74,5 +93,6 @@ private:
 
     mutable EffectMetaList m_effects;
     muse::async::Notification m_effectsChanged;
+    std::optional<EffectPreviewState> m_effectPreviewState;
 };
 }

--- a/src/effects/effects_base/qml/Audacity/Effects/EffectControlsDisablingOverlay.qml
+++ b/src/effects/effects_base/qml/Audacity/Effects/EffectControlsDisablingOverlay.qml
@@ -1,0 +1,36 @@
+import QtQuick
+import Audacity.Effects
+
+/**
+ * For third-part effects, the only way we can safely block interaction with the UI is by placing an overlay window.
+ *
+ * With Qt 6.9.1, this doesn't work on Windows for built-in effects, who use QML-drawn controls. The reason is unknown at the time of writing.
+ * We therefore use a simple rectangle component instead.
+ */
+Item {
+    id: root
+
+    required property int effectFamily
+
+    WindowContainer {
+        visible: root.visible && root.effectFamily !== EffectFamily.Builtin
+        anchors.fill: parent
+
+        window: Window {
+            color: "#55555555"
+        }
+    }
+
+    Rectangle {
+        visible: root.visible && root.effectFamily === EffectFamily.Builtin
+        anchors.fill: parent
+
+        color: "#55555555"
+
+        MouseArea {
+            id: interceptingMouseArea
+            anchors.fill: parent
+            hoverEnabled: true
+        }
+    }
+}

--- a/src/effects/effects_base/qml/Audacity/Effects/EffectPresetsBar.qml
+++ b/src/effects/effects_base/qml/Audacity/Effects/EffectPresetsBar.qml
@@ -12,7 +12,7 @@ import Audacity.Effects
 RowLayout {
     id: root
 
-    property var instanceId
+    required property var instanceId
     property int navigationOrder: 0
     property var navigationPanel: null
 
@@ -70,8 +70,7 @@ RowLayout {
 
         onActivated: function (index, value) {
             manageMenuModel.preset = value
-            currentIndex = manageMenuModel.presets.findIndex(
-                        preset => preset.id === value)
+            currentIndex = manageMenuModel.presets.findIndex(preset => preset.id === value)
         }
     }
 

--- a/src/effects/effects_base/qml/Audacity/Effects/EffectStyledDialogView.qml
+++ b/src/effects/effects_base/qml/Audacity/Effects/EffectStyledDialogView.qml
@@ -11,6 +11,8 @@ StyledDialogView {
 
     resizable: false
 
+    required property int instanceId
+
     property NavigationPanel navigationPanel: NavigationPanel {
         name: root.title
         enabled: root.isOpened

--- a/src/effects/effects_base/qml/Audacity/Effects/EffectsViewerDialog.qml
+++ b/src/effects/effects_base/qml/Audacity/Effects/EffectsViewerDialog.qml
@@ -31,9 +31,7 @@ EffectStyledDialogView {
         property int separatorHeight: effectFamily == EffectFamily.Builtin ? separator.height + prv.panelMargins : 0
 
         function closeWindow(accept) {
-            if (prv.viewer.isPreviewing) {
-                prv.viewer.togglePreview()
-            }
+            prv.viewer.stopPreview()
             // Call later because the preview calls `QCoreApplication::processEvents()`,
             // and we must make sure it doesn't do this after we've closed the dialog, or we'll be getting that Qt exception
             // "Object %p destroyed while one of its QML signal handlers is in progress."
@@ -201,7 +199,7 @@ EffectStyledDialogView {
                             buttonId: ButtonBoxModel.CustomButton + 2
                             enabled: prv.isApplyAllowed
 
-                            onClicked: prv.viewer.togglePreview()
+                            onClicked: prv.viewer.isPreviewing ? prv.viewer.stopPreview() : prv.viewer.startPreview()
                         }
 
                         FlatButton {

--- a/src/effects/effects_base/qml/Audacity/Effects/EffectsViewerDialog.qml
+++ b/src/effects/effects_base/qml/Audacity/Effects/EffectsViewerDialog.qml
@@ -16,7 +16,6 @@ import Audacity.AudioUnit
 EffectStyledDialogView {
     id: root
 
-    property alias instanceId: viewerModel.instanceId
     property int effectFamily: EffectFamily.Unknown
 
     QtObject {
@@ -116,7 +115,7 @@ EffectStyledDialogView {
 
                         enabled: !prv.viewer.isPreviewing
                         parentWindow: root.window
-                        instanceId: root.instanceId
+                        instanceId: Boolean(prv.viewer) ? prv.viewer.instanceId : -1
                     }
                 }
 
@@ -250,7 +249,6 @@ EffectStyledDialogView {
     Component {
         id: builtinViewerComp
         BuiltinEffectViewer {
-            instanceId: root.instanceId
             dialogView: root
             usedDestructively: true
         }
@@ -259,7 +257,6 @@ EffectStyledDialogView {
     Component {
         id: lv2ViewerComp
         Lv2Viewer {
-            instanceId: root.instanceId
             title: root.title
         }
     }
@@ -267,7 +264,6 @@ EffectStyledDialogView {
     Component {
         id: audioUnitViewerComp
         AudioUnitViewer {
-            instanceId: root.instanceId
             height: implicitHeight
             topPadding: topPanel.height
             bottomPadding: bbox.implicitHeight + prv.panelMargins * 2
@@ -279,7 +275,6 @@ EffectStyledDialogView {
     Component {
         id: vstViewerComp
         VstViewer {
-            instanceId: root.instanceId
             height: implicitHeight
             topPadding: topPanel.height
             bottomPadding: bbox.implicitHeight + prv.panelMargins * 2

--- a/src/effects/effects_base/qml/Audacity/Effects/EffectsViewerDialog.qml
+++ b/src/effects/effects_base/qml/Audacity/Effects/EffectsViewerDialog.qml
@@ -115,7 +115,7 @@ EffectStyledDialogView {
 
                         enabled: !prv.viewer.isPreviewing
                         parentWindow: root.window
-                        instanceId: Boolean(prv.viewer) ? prv.viewer.instanceId : -1
+                        instanceId: root.instanceId
                     }
                 }
 
@@ -249,6 +249,7 @@ EffectStyledDialogView {
     Component {
         id: builtinViewerComp
         BuiltinEffectViewer {
+            instanceId: root.instanceId
             dialogView: root
             usedDestructively: true
         }
@@ -257,6 +258,7 @@ EffectStyledDialogView {
     Component {
         id: lv2ViewerComp
         Lv2Viewer {
+            instanceId: root.instanceId
             title: root.title
         }
     }
@@ -265,6 +267,8 @@ EffectStyledDialogView {
         id: audioUnitViewerComp
         AudioUnitViewer {
             height: implicitHeight
+
+            instanceId: root.instanceId
             topPadding: topPanel.height
             bottomPadding: bbox.implicitHeight + prv.panelMargins * 2
             sidePadding: prv.viewMargins
@@ -276,6 +280,8 @@ EffectStyledDialogView {
         id: vstViewerComp
         VstViewer {
             height: implicitHeight
+
+            instanceId: root.instanceId
             topPadding: topPanel.height
             bottomPadding: bbox.implicitHeight + prv.panelMargins * 2
             sidePadding: prv.viewMargins

--- a/src/effects/effects_base/qml/Audacity/Effects/EffectsViewerDialog.qml
+++ b/src/effects/effects_base/qml/Audacity/Effects/EffectsViewerDialog.qml
@@ -35,12 +35,8 @@ EffectStyledDialogView {
             // Call later because the preview calls `QCoreApplication::processEvents()`,
             // and we must make sure it doesn't do this after we've closed the dialog, or we'll be getting that Qt exception
             // "Object %p destroyed while one of its QML signal handlers is in progress."
-            Qt.callLater(function () {
-                if (accept) {
-                    root.accept()
-                } else {
-                    root.reject()
-                }
+            Qt.callLater(() => {
+                accept ? root.accept() : root.reject()
             })
         }
     }
@@ -48,11 +44,8 @@ EffectStyledDialogView {
     Connections {
         target: root.window
         function onClosing(event) {
-            prv.closeWindow(false)
-            // Prevent immediate close so preview/cleanup can finish
-            if (event && event.accept !== undefined) {
-                event.accept = false
-            }
+            // Stop preview before closing, for the same reason as in closeWindow()
+            prv.viewer.stopPreview()
         }
     }
 
@@ -194,7 +187,12 @@ EffectStyledDialogView {
                             minWidth: 80
                             isLeftSide: true
 
-                            text: prv.viewer.isPreviewing ? qsTrc("effects", "Stop preview") : qsTrc("effects", "Preview")
+                            text: prv.viewer.isPreviewing ?
+                            //: Shown on a button that stops effect preview
+                            qsTrc("effects", "Stop preview") :
+                            //: Shown on a button that starts effect preview
+                            qsTrc("effects", "Preview")
+
                             buttonRole: ButtonBoxModel.CustomRole
                             buttonId: ButtonBoxModel.CustomButton + 2
                             enabled: prv.isApplyAllowed

--- a/src/effects/effects_base/qml/Audacity/Effects/RealtimeEffectViewerDialog.qml
+++ b/src/effects/effects_base/qml/Audacity/Effects/RealtimeEffectViewerDialog.qml
@@ -63,6 +63,7 @@ EffectStyledDialogView {
     Component {
         id: audioUnitViewerComponent
         AudioUnitViewer {
+            instanceId: root.instanceId
             topPadding: headerBar.y + headerBar.height + prv.padding
             minimumWidth: prv.minimumWidth
         }
@@ -71,6 +72,7 @@ EffectStyledDialogView {
     Component {
         id: lv2ViewerComponent
         Lv2Viewer {
+            instanceId: root.instanceId
             effectState: root.effectState
             title: root.title
         }
@@ -79,6 +81,7 @@ EffectStyledDialogView {
     Component {
         id: vstViewerComponent
         VstViewer {
+            instanceId: root.instanceId
             topPadding: headerBar.y + headerBar.height + prv.padding
             minimumWidth: prv.minimumWidth
         }
@@ -96,6 +99,7 @@ EffectStyledDialogView {
 
             BuiltinEffectViewer {
                 id: viewer
+                instanceId: root.instanceId
                 usedDestructively: false
             }
         }
@@ -141,7 +145,7 @@ EffectStyledDialogView {
                         parentWindow: root.window
                         navigationPanel: root.navigationPanel
                         navigationOrder: 1
-                        instanceId: Boolean(prv.viewItem) ? prv.viewItem.instanceId : -1
+                        instanceId: root.instanceId
                         Layout.fillWidth: true
                     }
                 }

--- a/src/effects/effects_base/qml/Audacity/Effects/RealtimeEffectViewerDialog.qml
+++ b/src/effects/effects_base/qml/Audacity/Effects/RealtimeEffectViewerDialog.qml
@@ -16,7 +16,6 @@ import Audacity.AudioUnit
 EffectStyledDialogView {
     id: root
 
-    property string instanceId
     property alias effectState: viewerModel.effectState
 
     title: viewerModel.title + " - " + viewerModel.trackName
@@ -64,8 +63,6 @@ EffectStyledDialogView {
     Component {
         id: audioUnitViewerComponent
         AudioUnitViewer {
-            id: view
-            instanceId: root.instanceId
             topPadding: headerBar.y + headerBar.height + prv.padding
             minimumWidth: prv.minimumWidth
         }
@@ -74,8 +71,6 @@ EffectStyledDialogView {
     Component {
         id: lv2ViewerComponent
         Lv2Viewer {
-            id: view
-            instanceId: root.instanceId
             effectState: root.effectState
             title: root.title
         }
@@ -84,8 +79,6 @@ EffectStyledDialogView {
     Component {
         id: vstViewerComponent
         VstViewer {
-            id: view
-            instanceId: root.instanceId
             topPadding: headerBar.y + headerBar.height + prv.padding
             minimumWidth: prv.minimumWidth
         }
@@ -99,9 +92,10 @@ EffectStyledDialogView {
             rightPadding: prv.padding
             bottomPadding: prv.padding
 
+            property alias instanceId: viewer.instanceId
+
             BuiltinEffectViewer {
-                id: view
-                instanceId: root.instanceId
+                id: viewer
                 usedDestructively: false
             }
         }
@@ -115,7 +109,6 @@ EffectStyledDialogView {
             Layout.fillWidth: true
 
             window: Window {
-
                 id: win
 
                 color: ui.theme.backgroundPrimaryColor
@@ -148,7 +141,7 @@ EffectStyledDialogView {
                         parentWindow: root.window
                         navigationPanel: root.navigationPanel
                         navigationOrder: 1
-                        instanceId: root.instanceId
+                        instanceId: Boolean(prv.viewItem) ? prv.viewItem.instanceId : -1
                         Layout.fillWidth: true
                     }
                 }

--- a/src/effects/effects_base/qml/Audacity/Effects/qmldir
+++ b/src/effects/effects_base/qml/Audacity/Effects/qmldir
@@ -1,4 +1,5 @@
 module Audacity.Effects
 BypassEffectButton 1.0 BypassEffectButton.qml
+EffectControlsDisablingOverlay 1.0 EffectControlsDisablingOverlay.qml
 EffectPresetsBar 1.0 EffectPresetsBar.qml
 EffectStyledDialogView 1.0 EffectStyledDialogView.qml

--- a/src/effects/effects_base/view/abstracteffectviewmodel.cpp
+++ b/src/effects/effects_base/view/abstracteffectviewmodel.cpp
@@ -3,11 +3,13 @@
 */
 #include "abstracteffectviewmodel.h"
 
+#include "effects/effects_base/internal/abstractviewlauncher.h"
+
 #include "playback/iplayer.h"
 
 namespace au::effects {
 AbstractEffectViewModel::AbstractEffectViewModel(QObject* parent)
-    : QObject(parent)
+    : QObject(parent), m_instanceId{AbstractViewLauncher::initializationInstanceId()}
 {
 }
 
@@ -46,14 +48,5 @@ void AbstractEffectViewModel::stopPreview()
 EffectInstanceId AbstractEffectViewModel::instanceId() const
 {
     return m_instanceId;
-}
-
-void AbstractEffectViewModel::setInstanceId(EffectInstanceId newInstanceId)
-{
-    if (m_instanceId == newInstanceId) {
-        return;
-    }
-    m_instanceId = newInstanceId;
-    emit instanceIdChanged();
 }
 }

--- a/src/effects/effects_base/view/abstracteffectviewmodel.cpp
+++ b/src/effects/effects_base/view/abstracteffectviewmodel.cpp
@@ -33,13 +33,14 @@ bool AbstractEffectViewModel::isPreviewing() const
     return player->playbackStatus() == playback::PlaybackStatus::Running;
 }
 
-void AbstractEffectViewModel::togglePreview()
+void AbstractEffectViewModel::startPreview()
 {
-    if (isPreviewing()) {
-        playback()->player()->stop();
-    } else {
-        doStartPreview();
-    }
+    doStartPreview();
+}
+
+void AbstractEffectViewModel::stopPreview()
+{
+    playback()->player()->stop();
 }
 
 EffectInstanceId AbstractEffectViewModel::instanceId() const

--- a/src/effects/effects_base/view/abstracteffectviewmodel.cpp
+++ b/src/effects/effects_base/view/abstracteffectviewmodel.cpp
@@ -8,8 +8,8 @@
 #include "playback/iplayer.h"
 
 namespace au::effects {
-AbstractEffectViewModel::AbstractEffectViewModel(QObject* parent)
-    : QObject(parent), m_instanceId{AbstractViewLauncher::initializationInstanceId()}
+AbstractEffectViewModel::AbstractEffectViewModel(QObject* parent, int instanceId)
+    : QObject(parent), m_instanceId{instanceId}
 {
     assert(m_instanceId != -1);
 }

--- a/src/effects/effects_base/view/abstracteffectviewmodel.cpp
+++ b/src/effects/effects_base/view/abstracteffectviewmodel.cpp
@@ -11,6 +11,7 @@ namespace au::effects {
 AbstractEffectViewModel::AbstractEffectViewModel(QObject* parent)
     : QObject(parent), m_instanceId{AbstractViewLauncher::initializationInstanceId()}
 {
+    assert(m_instanceId != -1);
 }
 
 void AbstractEffectViewModel::init()

--- a/src/effects/effects_base/view/abstracteffectviewmodel.cpp
+++ b/src/effects/effects_base/view/abstracteffectviewmodel.cpp
@@ -1,0 +1,58 @@
+/*
+* Audacity: A Digital Audio Editor
+*/
+#include "abstracteffectviewmodel.h"
+
+#include "playback/iplayer.h"
+
+namespace au::effects {
+AbstractEffectViewModel::AbstractEffectViewModel(QObject* parent)
+    : QObject(parent)
+{
+}
+
+void AbstractEffectViewModel::init()
+{
+    const auto player = playback()->player();
+    IF_ASSERT_FAILED(player) {
+        return;
+    }
+    player->playbackStatusChanged().onReceive(this, [this](auto) {
+        emit isPreviewingChanged();
+    });
+
+    doInit();
+}
+
+bool AbstractEffectViewModel::isPreviewing() const
+{
+    const auto player = playback()->player();
+    IF_ASSERT_FAILED(player) {
+        return false;
+    }
+    return player->playbackStatus() == playback::PlaybackStatus::Running;
+}
+
+void AbstractEffectViewModel::togglePreview()
+{
+    if (isPreviewing()) {
+        playback()->player()->stop();
+    } else {
+        doStartPreview();
+    }
+}
+
+EffectInstanceId AbstractEffectViewModel::instanceId() const
+{
+    return m_instanceId;
+}
+
+void AbstractEffectViewModel::setInstanceId(EffectInstanceId newInstanceId)
+{
+    if (m_instanceId == newInstanceId) {
+        return;
+    }
+    m_instanceId = newInstanceId;
+    emit instanceIdChanged();
+}
+}

--- a/src/effects/effects_base/view/abstracteffectviewmodel.h
+++ b/src/effects/effects_base/view/abstracteffectviewmodel.h
@@ -25,7 +25,7 @@ protected:
     muse::Inject<au::playback::IPlayback> playback;
 
 public:
-    AbstractEffectViewModel(QObject* parent = nullptr);
+    AbstractEffectViewModel(QObject* parent, int instanceId);
     ~AbstractEffectViewModel() override = default;
 
     Q_INVOKABLE void init();
@@ -44,5 +44,29 @@ protected:
 private:
     virtual void doInit() = 0;
     virtual void doStartPreview() = 0;
+};
+
+class AbstractEffectViewModelFactory : public QObject
+{
+    Q_OBJECT
+public:
+    virtual ~AbstractEffectViewModelFactory() = default;
+
+    Q_INVOKABLE AbstractEffectViewModel* createModel(QObject* parent, int instanceId) const
+    {
+        return doCreateModel(parent, instanceId);
+    }
+
+private:
+    virtual AbstractEffectViewModel* doCreateModel(QObject* parent, int instanceId) const = 0;
+};
+
+template<typename T>
+class EffectViewModelFactory : public AbstractEffectViewModelFactory
+{
+    AbstractEffectViewModel* doCreateModel(QObject* parent, int instanceId) const override
+    {
+        return new T(parent, instanceId);
+    }
 };
 }

--- a/src/effects/effects_base/view/abstracteffectviewmodel.h
+++ b/src/effects/effects_base/view/abstracteffectviewmodel.h
@@ -1,0 +1,49 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+#pragma once
+
+#include "effects/effects_base/ieffectinstancesregister.h"
+#include "effects/effects_base/ieffectexecutionscenario.h"
+#include "playback/iplayback.h"
+
+#include "framework/global/async/asyncable.h"
+#include "framework/global/modularity/ioc.h"
+
+#include <QObject>
+
+namespace au::effects {
+class AbstractEffectViewModel : public QObject, public muse::async::Asyncable
+{
+    Q_OBJECT
+    Q_PROPERTY(EffectInstanceId instanceId READ instanceId WRITE setInstanceId NOTIFY instanceIdChanged FINAL)
+    Q_PROPERTY(bool isPreviewing READ isPreviewing NOTIFY isPreviewingChanged FINAL)
+
+protected:
+    muse::Inject<IEffectInstancesRegister> instancesRegister;
+    muse::Inject<IEffectExecutionScenario> executionScenario;
+    muse::Inject<au::playback::IPlayback> playback;
+
+public:
+    AbstractEffectViewModel(QObject* parent = nullptr);
+    ~AbstractEffectViewModel() override = default;
+
+    Q_INVOKABLE void init();
+    Q_INVOKABLE void togglePreview();
+
+    EffectInstanceId instanceId() const;
+    void setInstanceId(EffectInstanceId newInstanceId);
+
+    bool isPreviewing() const;
+
+signals:
+    void instanceIdChanged();
+    void isPreviewingChanged();
+
+private:
+    virtual void doInit() = 0;
+    virtual void doStartPreview() = 0;
+
+    EffectInstanceId m_instanceId = -1;
+};
+}

--- a/src/effects/effects_base/view/abstracteffectviewmodel.h
+++ b/src/effects/effects_base/view/abstracteffectviewmodel.h
@@ -16,7 +16,7 @@ namespace au::effects {
 class AbstractEffectViewModel : public QObject, public muse::async::Asyncable
 {
     Q_OBJECT
-    Q_PROPERTY(EffectInstanceId instanceId READ instanceId WRITE setInstanceId NOTIFY instanceIdChanged FINAL)
+    Q_PROPERTY(EffectInstanceId instanceId READ instanceId CONSTANT FINAL)
     Q_PROPERTY(bool isPreviewing READ isPreviewing NOTIFY isPreviewingChanged FINAL)
 
 protected:
@@ -33,18 +33,16 @@ public:
     Q_INVOKABLE void stopPreview();
 
     EffectInstanceId instanceId() const;
-    void setInstanceId(EffectInstanceId newInstanceId);
-
     bool isPreviewing() const;
 
 signals:
-    void instanceIdChanged();
     void isPreviewingChanged();
+
+protected:
+    const EffectInstanceId m_instanceId;
 
 private:
     virtual void doInit() = 0;
     virtual void doStartPreview() = 0;
-
-    EffectInstanceId m_instanceId = -1;
 };
 }

--- a/src/effects/effects_base/view/abstracteffectviewmodel.h
+++ b/src/effects/effects_base/view/abstracteffectviewmodel.h
@@ -29,7 +29,8 @@ public:
     ~AbstractEffectViewModel() override = default;
 
     Q_INVOKABLE void init();
-    Q_INVOKABLE void togglePreview();
+    Q_INVOKABLE void startPreview();
+    Q_INVOKABLE void stopPreview();
 
     EffectInstanceId instanceId() const;
     void setInstanceId(EffectInstanceId newInstanceId);

--- a/src/effects/effects_base/view/effectmanagemenu.cpp
+++ b/src/effects/effects_base/view/effectmanagemenu.cpp
@@ -12,19 +12,18 @@ void EffectManageMenu::load()
 {
     AbstractMenuModel::load();
 
-    const EffectInstanceId instanceId = m_instanceId.toULongLong();
-    const EffectId effectId = instancesRegister()->effectIdByInstanceId(instanceId);
+    const EffectId effectId = instancesRegister()->effectIdByInstanceId(m_instanceId);
 
     // subscribe on user presets change
-    presetsController()->userPresetsChanged().onReceive(this, [this, effectId, instanceId](const EffectId& eid) {
+    presetsController()->userPresetsChanged().onReceive(this, [this, effectId](const EffectId& eid) {
         if (effectId != eid) {
             return;
         }
 
-        reload(effectId, instanceId);
+        reload(effectId, m_instanceId);
     });
 
-    reload(effectId, instanceId);
+    reload(effectId, m_instanceId);
 }
 
 void EffectManageMenu::reload(const EffectId& effectId, const EffectInstanceId& instanceId)
@@ -143,12 +142,12 @@ void EffectManageMenu::reload(const EffectId& effectId, const EffectInstanceId& 
     emit presetsChanged();
 }
 
-QString EffectManageMenu::instanceId_prop() const
+int EffectManageMenu::instanceId_prop() const
 {
     return m_instanceId;
 }
 
-void EffectManageMenu::setInstanceId_prop(const QString& newInstanceId)
+void EffectManageMenu::setInstanceId_prop(int newInstanceId)
 {
     if (m_instanceId == newInstanceId) {
         return;
@@ -181,18 +180,16 @@ bool EffectManageMenu::enabled() const
 
 void EffectManageMenu::resetPreset()
 {
-    const EffectInstanceId instanceId = m_instanceId.toULongLong();
     ActionQuery q("action://effects/presets/apply");
-    q.addParam("instanceId", Val(instanceId));
+    q.addParam("instanceId", Val(m_instanceId));
     q.addParam("presetId", Val(m_currentPreset.toStdString()));
     dispatcher()->dispatch(q);
 }
 
 void EffectManageMenu::savePresetAs()
 {
-    const EffectInstanceId instanceId = m_instanceId.toULongLong();
     ActionQuery q("action://effects/presets/save");
-    q.addParam("instanceId", Val(instanceId));
+    q.addParam("instanceId", Val(m_instanceId));
     dispatcher()->dispatch(q);
     emit presetsChanged();
     emit presetChanged();

--- a/src/effects/effects_base/view/effectmanagemenu.h
+++ b/src/effects/effects_base/view/effectmanagemenu.h
@@ -10,7 +10,7 @@ namespace au::effects {
 class EffectManageMenu : public muse::uicomponents::AbstractMenuModel
 {
     Q_OBJECT
-    Q_PROPERTY(QString instanceId READ instanceId_prop WRITE setInstanceId_prop NOTIFY instanceIdChanged FINAL)
+    Q_PROPERTY(int instanceId READ instanceId_prop WRITE setInstanceId_prop NOTIFY instanceIdChanged FINAL)
     Q_PROPERTY(QVariantList presets READ presets NOTIFY presetsChanged FINAL)
     Q_PROPERTY(QString preset READ preset WRITE setPreset NOTIFY presetChanged FINAL)
     Q_PROPERTY(bool enabled READ enabled NOTIFY presetsChanged FINAL)
@@ -21,8 +21,8 @@ class EffectManageMenu : public muse::uicomponents::AbstractMenuModel
 
 public:
 
-    QString instanceId_prop() const;
-    void setInstanceId_prop(const QString& newInstanceId);
+    int instanceId_prop() const;
+    void setInstanceId_prop(int newInstanceId);
     QVariantList presets();
     QString preset() const;
     void setPreset(QString presetId);
@@ -42,7 +42,7 @@ private:
 
     void reload(const EffectId& effectId, const EffectInstanceId& instanceId);
 
-    QString m_instanceId;
+    int m_instanceId = -1;
     QString m_currentPreset;
     QVariantList m_presets;
 };

--- a/src/effects/effects_base/view/effectsviewutils.h
+++ b/src/effects/effects_base/view/effectsviewutils.h
@@ -1,0 +1,10 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+#pragma once
+
+#define REGISTER_AUDACITY_EFFECTS_SINGLETON_TYPE(Factory) \
+    qmlRegisterSingletonType<Factory>("Audacity.Effects", 1, 0, #Factory, \
+                                      [] (QQmlEngine*, QJSEngine*) -> QObject* { \
+        return new Factory(); \
+    });

--- a/src/effects/lv2/internal/lv2viewlauncher.cpp
+++ b/src/effects/lv2/internal/lv2viewlauncher.cpp
@@ -6,17 +6,11 @@
 #include "libraries/lib-components/EffectInterface.h"
 #include "libraries/lib-realtime-effects/RealtimeEffectState.h"
 
-#include "au3wrap/internal/wxtypes_convert.h"
-#include "log.h"
-
 using namespace au::effects;
 
 muse::Ret Lv2ViewLauncher::showEffect(const EffectInstanceId& instanceId) const
 {
-    muse::UriQuery uri(EFFECT_VIEWER_URI);
-    uri.addParam("instanceId", muse::Val(instanceId));
-    uri.addParam("effectFamily", muse::Val(EffectFamily::LV2));
-    return interactive()->openSync(uri).ret;
+    return doShowEffect(instanceId, EffectFamily::LV2);
 }
 
 void Lv2ViewLauncher::showRealtimeEffect(const RealtimeEffectStatePtr& state) const

--- a/src/effects/lv2/lv2effectsmodule.cpp
+++ b/src/effects/lv2/lv2effectsmodule.cpp
@@ -7,6 +7,7 @@
 #include "audioplugins/iaudiopluginmetareaderregister.h"
 
 #include "effects/effects_base/ieffectviewlaunchregister.h"
+#include "effects/effects_base/view/effectsviewutils.h"
 
 #include "internal/lv2effectsrepository.h"
 #include "internal/lv2pluginmetareader.h"
@@ -72,7 +73,7 @@ void Lv2EffectsModule::registerResources()
 
 void Lv2EffectsModule::registerUiTypes()
 {
-    qmlRegisterType<Lv2ViewModel>("Audacity.Lv2", 1, 0, "Lv2ViewModel");
+    REGISTER_AUDACITY_EFFECTS_SINGLETON_TYPE(Lv2ViewModelFactory);
 }
 
 void Lv2EffectsModule::onInit(const muse::IApplication::RunMode& runMode)

--- a/src/effects/lv2/qml/Audacity/Lv2/Lv2Viewer.qml
+++ b/src/effects/lv2/qml/Audacity/Lv2/Lv2Viewer.qml
@@ -17,6 +17,7 @@ Rectangle {
     property alias instanceId: model.instanceId
     property alias effectState: model.effectState
     property alias title: model.title
+    property alias isPreviewing: model.isPreviewing
 
     implicitWidth: textItem.width
     implicitHeight: textItem.height
@@ -31,8 +32,8 @@ Rectangle {
         model.deinit()
     }
 
-    function preview() {
-       model.preview()
+    function togglePreview() {
+        model.togglePreview()
     }
 
     function manage(parent) {

--- a/src/effects/lv2/qml/Audacity/Lv2/Lv2Viewer.qml
+++ b/src/effects/lv2/qml/Audacity/Lv2/Lv2Viewer.qml
@@ -13,30 +13,43 @@ Rectangle {
     id: root
 
     // in
-    property alias instanceId: model.instanceId
-    property alias effectState: model.effectState
-    property alias title: model.title
-    property alias isPreviewing: model.isPreviewing
+    required property int instanceId
+    property string effectState: ""
+
+    // out
+    property string title: prv.viewModel.title
+    property bool isPreviewing: prv.viewModel.isPreviewing
 
     implicitWidth: textItem.width
     implicitHeight: textItem.height
     color: ui.theme.backgroundPrimaryColor
 
+    QtObject {
+        id: prv
+        property var viewModel: {
+            var viewModel = Lv2ViewModelFactory.createModel(root, root.instanceId, root.effectState)
+            viewModel.onExternalUiClosed.connect(function () {
+                window.close()
+            })
+            return viewModel
+        }
+    }
+
     Component.onCompleted: {
-        model.init()
+        prv.viewModel.init()
         Qt.callLater(manageMenuModel.load)
     }
 
     Component.onDestruction: {
-        model.deinit()
+        prv.viewModel.deinit()
     }
 
     function startPreview() {
-        model.startPreview()
+        prv.viewModel.startPreview()
     }
 
     function stopPreview() {
-        model.stopPreview()
+        prv.viewModel.stopPreview()
     }
 
     function manage(parent) {
@@ -49,7 +62,7 @@ Rectangle {
 
     EffectManageMenu {
         id: manageMenuModel
-        instanceId: model.instanceId
+        instanceId: root.instanceId
     }
 
     ContextMenuLoader {
@@ -60,20 +73,13 @@ Rectangle {
         }
     }
 
-    Lv2ViewModel {
-        id: model
-        onExternalUiClosed: {
-            window.close()
-        }
-    }
-
     Text {
         id: textItem
-        visible: model.unsupportedUiReason.length > 0
+        visible: prv.viewModel.unsupportedUiReason.length > 0
         width: visible ? 300 : 0
         height: visible ? 100 : 0
         anchors.centerIn: parent
-        text: "No available UI:\n" + model.unsupportedUiReason + "\n(Plain UI not implemented yet)"
+        text: "No available UI:\n" + prv.viewModel.unsupportedUiReason + "\n(Plain UI not implemented yet)"
         color: ui.theme.fontPrimaryColor
         verticalAlignment: Text.AlignVCenter
         horizontalAlignment: Text.AlignHCenter

--- a/src/effects/lv2/qml/Audacity/Lv2/Lv2Viewer.qml
+++ b/src/effects/lv2/qml/Audacity/Lv2/Lv2Viewer.qml
@@ -10,7 +10,6 @@ import Audacity.Effects
 import Audacity.Lv2
 
 Rectangle {
-
     id: root
 
     // in
@@ -52,7 +51,7 @@ Rectangle {
     ContextMenuLoader {
         id: menuLoader
 
-        onHandleMenuItem: function(itemId) {
+        onHandleMenuItem: function (itemId) {
             manageMenuModel.handleMenuItem(itemId)
         }
     }

--- a/src/effects/lv2/qml/Audacity/Lv2/Lv2Viewer.qml
+++ b/src/effects/lv2/qml/Audacity/Lv2/Lv2Viewer.qml
@@ -31,8 +31,12 @@ Rectangle {
         model.deinit()
     }
 
-    function togglePreview() {
-        model.togglePreview()
+    function startPreview() {
+        model.startPreview()
+    }
+
+    function stopPreview() {
+        model.stopPreview()
     }
 
     function manage(parent) {

--- a/src/effects/lv2/view/lv2viewmodel.cpp
+++ b/src/effects/lv2/view/lv2viewmodel.cpp
@@ -489,9 +489,7 @@ void Lv2ViewModel::onSuilPortWrite(uint32_t port_index, uint32_t buffer_size, ui
                     // Is there a robust way of preventing the user from interacting with the UI
                     // while previewing is active?
                     // In the meantime, we just stop the preview.
-                    if (isPreviewing()) {
-                        togglePreview();
-                    }
+                    stopPreview();
                 }
                 return nullptr;
             });

--- a/src/effects/lv2/view/lv2viewmodel.h
+++ b/src/effects/lv2/view/lv2viewmodel.h
@@ -29,19 +29,15 @@ class Lv2ViewModel : public AbstractEffectViewModel
 {
     Q_OBJECT
     Q_PROPERTY(QString title READ title WRITE setTitle NOTIFY titleChanged FINAL)
-    Q_PROPERTY(QString effectState READ effectState WRITE setEffectState NOTIFY effectStateChanged FINAL)
     Q_PROPERTY(QString unsupportedUiReason READ unsupportedUiReason NOTIFY unsupportedUiReasonChanged FINAL)
 
     muse::Inject<trackedit::IProjectHistory> projectHistory;
 
 public:
-    Lv2ViewModel(QObject* parent = nullptr);
+    Lv2ViewModel(QObject* parent, int instanceId, const QString& effectState);
     ~Lv2ViewModel() override;
 
     Q_INVOKABLE void deinit();
-
-    QString effectState() const;
-    void setEffectState(const QString& state);
 
     QString unsupportedUiReason() const;
 
@@ -51,7 +47,6 @@ public:
 signals:
     void titleChanged();
     void externalUiClosed();
-    void effectStateChanged();
     void unsupportedUiReasonChanged();
 
 private:
@@ -82,14 +77,14 @@ private:
 
     int m_minimumWidth = 0;
     QString m_title;
-    RealtimeEffectStatePtr m_effectState;
+    const RealtimeEffectStatePtr m_effectState;
 
     std::shared_ptr<LV2Instance> m_instance;
     std::unique_ptr<LV2Wrapper> m_wrapper;
     const LilvPlugin* m_lilvPlugin = nullptr;
     const LV2Ports* m_ports = nullptr;
     std::unique_ptr<LV2PortUIStates> m_portUIStates;
-    const LV2EffectOutputs* m_realtimeOutputs = nullptr;
+    const LV2EffectOutputs* const m_realtimeOutputs;
     EffectSettingsAccessPtr m_settingsAccess;
 
     SuilInstancePtr m_suilInstance;
@@ -107,5 +102,17 @@ private:
     bool m_settingsChanged = false;
 
     std::string m_unsupportedUiReason;
+};
+
+class Lv2ViewModelFactory : public QObject
+{
+    Q_OBJECT
+public:
+    virtual ~Lv2ViewModelFactory() = default;
+
+    Q_INVOKABLE Lv2ViewModel* createModel(QObject* parent, int instanceId, const QString& effectState) const
+    {
+        return new Lv2ViewModel(parent, instanceId, effectState);
+    }
 };
 }

--- a/src/effects/lv2/view/lv2viewmodel.h
+++ b/src/effects/lv2/view/lv2viewmodel.h
@@ -5,9 +5,7 @@
 
 #include "lv2uihandler.h"
 
-#include "effects/effects_base/ieffectinstancesregister.h"
-#include "effects/effects_base/ieffectexecutionscenario.h"
-#include "playback/iplayback.h"
+#include "effects/effects_base/view/abstracteffectviewmodel.h"
 #include "trackedit/iprojecthistory.h"
 
 #include "libraries/lib-lv2/LV2UIFeaturesList.h"
@@ -27,29 +25,20 @@ typedef unsigned long XID;
 
 namespace au::effects {
 class ILv2IdleUi;
-class Lv2ViewModel : public QObject
+class Lv2ViewModel : public AbstractEffectViewModel
 {
     Q_OBJECT
-    Q_PROPERTY(int instanceId READ instanceId WRITE setInstanceId NOTIFY instanceIdChanged FINAL)
     Q_PROPERTY(QString title READ title WRITE setTitle NOTIFY titleChanged FINAL)
     Q_PROPERTY(QString effectState READ effectState WRITE setEffectState NOTIFY effectStateChanged FINAL)
     Q_PROPERTY(QString unsupportedUiReason READ unsupportedUiReason NOTIFY unsupportedUiReasonChanged FINAL)
 
-    muse::Inject<IEffectInstancesRegister> instancesRegister;
-    muse::Inject<IEffectExecutionScenario> executionScenario;
-    muse::Inject<au::playback::IPlayback> playback;
     muse::Inject<trackedit::IProjectHistory> projectHistory;
 
 public:
     Lv2ViewModel(QObject* parent = nullptr);
     ~Lv2ViewModel() override;
 
-    Q_INVOKABLE void init();
     Q_INVOKABLE void deinit();
-    Q_INVOKABLE void preview();
-
-    int instanceId() const;
-    void setInstanceId(int newInstanceId);
 
     QString effectState() const;
     void setEffectState(const QString& state);
@@ -60,7 +49,6 @@ public:
     void setTitle(const QString& title);
 
 signals:
-    void instanceIdChanged();
     void titleChanged();
     void externalUiClosed();
     void effectStateChanged();
@@ -68,6 +56,8 @@ signals:
 
 private:
     friend class Lv2UiHandler;
+    void doInit() override;
+    void doStartPreview() override;
     int onResizeUi(int width, int height);
     void onUiClosed();
     void onKeyPressed(Qt::Key);
@@ -90,7 +80,6 @@ private:
 
     Lv2UiHandler m_handler;
 
-    int m_instanceId = -1;
     int m_minimumWidth = 0;
     QString m_title;
     RealtimeEffectStatePtr m_effectState;

--- a/src/effects/vst/internal/vst3viewlauncher.cpp
+++ b/src/effects/vst/internal/vst3viewlauncher.cpp
@@ -47,13 +47,7 @@ muse::Ret Vst3ViewLauncher::showEffect(const EffectInstanceId& instanceId) const
         return muse::make_ret(muse::Ret::Code::InternalError);
     }
 
-    muse::UriQuery uri(EFFECT_VIEWER_URI);
-    uri.addParam("instanceId", muse::Val(instanceId));
-    uri.addParam("effectFamily", muse::Val(EffectFamily::VST3));
-
-    muse::Ret ret = interactive()->openSync(uri).ret;
-
-    return ret;
+    return doShowEffect(instanceId, EffectFamily::VST3);
 }
 
 void Vst3ViewLauncher::showRealtimeEffect(const RealtimeEffectStatePtr& state) const

--- a/src/effects/vst/qml/Audacity/Vst/VstViewer.qml
+++ b/src/effects/vst/qml/Audacity/Vst/VstViewer.qml
@@ -31,6 +31,7 @@ Rectangle {
     id: root
 
     // in
+    required property int instanceId
     property alias sidePadding: view.sidePadding
     property alias topPadding: view.topPadding
     property alias bottomPadding: view.bottomPadding
@@ -38,13 +39,14 @@ Rectangle {
 
     // out
     property alias title: view.title
-    property alias instanceId: viewModel.instanceId
-    property alias isPreviewing: viewModel.isPreviewing
+    property bool isPreviewing: viewModel.isPreviewing
 
     color: ui.theme.backgroundPrimaryColor
 
     implicitWidth: view.implicitWidth
     implicitHeight: view.implicitHeight
+
+    readonly property var viewModel: VstViewModelFactory.createModel(root, instanceId)
 
     Component.onCompleted: {
         viewModel.init()
@@ -70,7 +72,7 @@ Rectangle {
 
     EffectManageMenu {
         id: manageMenuModel
-        instanceId: view.instanceId
+        instanceId: viewModel.instanceId
     }
 
     ContextMenuLoader {
@@ -79,10 +81,6 @@ Rectangle {
         onHandleMenuItem: function (itemId) {
             manageMenuModel.handleMenuItem(itemId)
         }
-    }
-
-    VstViewModel {
-        id: viewModel
     }
 
     VstView {

--- a/src/effects/vst/qml/Audacity/Vst/VstViewer.qml
+++ b/src/effects/vst/qml/Audacity/Vst/VstViewer.qml
@@ -31,7 +31,6 @@ Rectangle {
     id: root
 
     // in
-    property alias instanceId: view.instanceId
     property alias sidePadding: view.sidePadding
     property alias topPadding: view.topPadding
     property alias bottomPadding: view.bottomPadding
@@ -39,6 +38,7 @@ Rectangle {
 
     // out
     property alias title: view.title
+    property alias instanceId: viewModel.instanceId
     property alias isPreviewing: viewModel.isPreviewing
 
     color: ui.theme.backgroundPrimaryColor
@@ -83,10 +83,10 @@ Rectangle {
 
     VstViewModel {
         id: viewModel
-        instanceId: view.instanceId
     }
 
     VstView {
         id: view
+        instanceId: viewModel.instanceId
     }
 }

--- a/src/effects/vst/qml/Audacity/Vst/VstViewer.qml
+++ b/src/effects/vst/qml/Audacity/Vst/VstViewer.qml
@@ -52,8 +52,12 @@ Rectangle {
         Qt.callLater(manageMenuModel.load)
     }
 
-    function togglePreview() {
-        viewModel.togglePreview()
+    function startPreview() {
+        viewModel.startPreview()
+    }
+
+    function stopPreview() {
+        viewModel.stopPreview()
     }
 
     function manage(parent) {

--- a/src/effects/vst/qml/Audacity/Vst/VstViewer.qml
+++ b/src/effects/vst/qml/Audacity/Vst/VstViewer.qml
@@ -39,6 +39,7 @@ Rectangle {
 
     // out
     property alias title: view.title
+    property alias isPreviewing: viewModel.isPreviewing
 
     color: ui.theme.backgroundPrimaryColor
 
@@ -51,8 +52,8 @@ Rectangle {
         Qt.callLater(manageMenuModel.load)
     }
 
-    function preview() {
-        viewModel.preview()
+    function togglePreview() {
+        viewModel.togglePreview()
     }
 
     function manage(parent) {

--- a/src/effects/vst/view/vstviewmodel.cpp
+++ b/src/effects/vst/view/vstviewmodel.cpp
@@ -20,7 +20,7 @@ VstViewModel::~VstViewModel()
     checkSettingChangesFromUi(true);
 }
 
-void VstViewModel::init()
+void VstViewModel::doInit()
 {
     EffectInstanceId id = this->instanceId();
     IF_ASSERT_FAILED(id != 0) {
@@ -117,7 +117,7 @@ void VstViewModel::settingsFromView()
     });
 }
 
-void VstViewModel::preview()
+void VstViewModel::doStartPreview()
 {
     IF_ASSERT_FAILED(m_settingsAccess) {
         return;
@@ -129,18 +129,4 @@ void VstViewModel::preview()
         executionScenario()->previewEffect(instanceId(), settings);
         return nullptr;
     });
-}
-
-int VstViewModel::instanceId() const
-{
-    return m_instanceId;
-}
-
-void VstViewModel::setInstanceId(int newInstanceId)
-{
-    if (m_instanceId == newInstanceId) {
-        return;
-    }
-    m_instanceId = newInstanceId;
-    emit instanceIdChanged();
 }

--- a/src/effects/vst/view/vstviewmodel.cpp
+++ b/src/effects/vst/view/vstviewmodel.cpp
@@ -13,6 +13,10 @@
 
 using namespace au::effects;
 
+VstViewModel::VstViewModel(QObject* parent, int instanceId)
+    : AbstractEffectViewModel(parent, instanceId)
+{}
+
 VstViewModel::~VstViewModel()
 {
     m_settingUpdateTimer.stop();

--- a/src/effects/vst/view/vstviewmodel.h
+++ b/src/effects/vst/view/vstviewmodel.h
@@ -5,27 +5,20 @@
 
 #include <QObject>
 
-#include "global/async/asyncable.h"
-
 #include "modularity/ioc.h"
 #include "trackedit/iprojecthistory.h"
-#include "effects/effects_base/ieffectinstancesregister.h"
-#include "effects/effects_base/ieffectexecutionscenario.h"
 #include "effects/effects_base/irealtimeeffectservice.h"
-
 #include "effects/effects_base/effectstypes.h"
+#include "effects/effects_base/view/abstracteffectviewmodel.h"
 
 class VST3Instance;
 class EffectSettingsAccess;
 namespace au::effects {
-class VstViewModel : public QObject, public muse::async::Asyncable
+class VstViewModel : public AbstractEffectViewModel
 {
     Q_OBJECT
-    Q_PROPERTY(int instanceId READ instanceId WRITE setInstanceId NOTIFY instanceIdChanged FINAL)
 
 public:
-    muse::Inject<IEffectInstancesRegister> instancesRegister;
-    muse::Inject<IEffectExecutionScenario> executionScenario;
     muse::Inject<IRealtimeEffectService> realtimeEffectService;
     muse::Inject<trackedit::IProjectHistory> projectHistory;
 
@@ -33,16 +26,9 @@ public:
     VstViewModel() = default;
     ~VstViewModel() override;
 
-    int instanceId() const;
-    void setInstanceId(int newInstanceId);
-
-    Q_INVOKABLE void init();
-    Q_INVOKABLE void preview();
-
-signals:
-    void instanceIdChanged();
-
 private:
+    void doInit() override;
+    void doStartPreview() override;
 
     std::shared_ptr<EffectSettingsAccess> settingsAccess() const;
     void settingsToView();
@@ -50,7 +36,6 @@ private:
     void checkSettingChangesFromUiWhileIdle();
     void checkSettingChangesFromUi(bool forceCommitting);
 
-    EffectInstanceId m_instanceId = -1;
     std::shared_ptr<VST3Instance> m_auVst3Instance;
     std::shared_ptr<EffectSettingsAccess> m_settingsAccess;
     QTimer m_settingUpdateTimer;

--- a/src/effects/vst/view/vstviewmodel.h
+++ b/src/effects/vst/view/vstviewmodel.h
@@ -23,7 +23,7 @@ public:
     muse::Inject<trackedit::IProjectHistory> projectHistory;
 
 public:
-    VstViewModel() = default;
+    VstViewModel(QObject* parent, int instanceId);
     ~VstViewModel() override;
 
 private:
@@ -39,5 +39,9 @@ private:
     std::shared_ptr<VST3Instance> m_auVst3Instance;
     std::shared_ptr<EffectSettingsAccess> m_settingsAccess;
     QTimer m_settingUpdateTimer;
+};
+
+class VstViewModelFactory : public EffectViewModelFactory<VstViewModel>
+{
 };
 }

--- a/src/effects/vst/vsteffectsmodule.cpp
+++ b/src/effects/vst/vsteffectsmodule.cpp
@@ -10,6 +10,7 @@
 #include "audioplugins/iaudiopluginmetareaderregister.h"
 
 #include "effects/effects_base/ieffectviewlaunchregister.h"
+#include "effects/effects_base/view/effectsviewutils.h"
 
 #include "internal/vsteffectsrepository.h"
 #include "internal/vst3pluginsscanner.h"
@@ -78,7 +79,7 @@ void VstEffectsModule::registerResources()
 void VstEffectsModule::registerUiTypes()
 {
     qmlRegisterType<muse::vst::VstView>("Audacity.Vst", 1, 0, "VstView");
-    qmlRegisterType<VstViewModel>("Audacity.Vst", 1, 0, "VstViewModel");
+    REGISTER_AUDACITY_EFFECTS_SINGLETON_TYPE(VstViewModelFactory);
 }
 
 void VstEffectsModule::onInit(const muse::IApplication::RunMode& runMode)

--- a/src/playback/internal/au3/au3player.cpp
+++ b/src/playback/internal/au3/au3player.cpp
@@ -28,6 +28,8 @@ Au3Player::Au3Player()
 {
     m_playbackStatus.ch.onReceive(this, [this](PlaybackStatus st) {
         if (st == PlaybackStatus::Running) {
+            m_currentTarget.reset();
+            m_consumedSamplesSoFar = 0;
             m_reachedEnd.val = false;
         }
     });
@@ -259,9 +261,6 @@ void Au3Player::stop()
     if (captureMeter) {
         captureMeter->stop();
     }
-
-    m_consumedSamplesSoFar = 0;
-    m_currentTarget.reset();
 }
 
 void Au3Player::pause()
@@ -499,7 +498,7 @@ void Au3Player::updatePlaybackPosition()
 
     const auto timeDiff = duration_cast<milliseconds>(steady_clock::now() - m_currentTarget->time).count() / 1000.0;
     if (timeDiff > 0) {
-        // Hardware buffer was drained an no new data was put in there.
+        // We are past the target time, stop consuming until new data is available.
         return;
     }
 

--- a/src/projectscene/view/trackspanel/realtimeeffectlistitemmenumodel.cpp
+++ b/src/projectscene/view/trackspanel/realtimeeffectlistitemmenumodel.cpp
@@ -26,7 +26,7 @@ void RealtimeEffectListItemMenuModel::doPopulateMenu()
 {
     MenuItemList items;
 
-    items << makeMenuItem("realtimeeffect-remove", muse::TranslatableString("projectscene", "No effect")) << makeSeparator();
+    items << makeMenuItem("realtimeeffect-remove", muse::TranslatableString("projectscene", "Remove effect")) << makeSeparator();
 
     const auto effectMenus = this->effectMenus();
     if (!effectMenus.empty()) {


### PR DESCRIPTION
<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:
Please note that this PR contains the fixes merged on alpha only: https://github.com/audacity/audacity/pull/9710. That PR was already tested by @dozzzzer. We are now porting these changes back to master.
On top of these changes, we here are doing some refactoring: easy changes, but widespread. Hence the following checklist:
- [x] Please smoke-test _all_ built-in effects and generators, in destructive and real-time mode where applicable,
- [x] Smoke-test one third-party effect of each family (VST, AudioUnit and LV2) in destructive and real-time modes,
- [x] Presets work as expected
- [x] In realtime mode, replacing one effect by another works as expected (UI of effect being replaced disappears, that of the new effect appears)
- [x] Autobot test cases have been run
