### PR TITLE
Delete wave track item right away on track removal

### DIFF
--- a/src/projectscene/view/trackspanel/paneltrackslistmodel.cpp
+++ b/src/projectscene/view/trackspanel/paneltrackslistmodel.cpp
@@ -657,7 +657,7 @@ void PanelTracksListModel::onTrackRemoved(const trackedit::Track& track)
             const auto it = m_trackList.begin() + i;
             const auto item = *it;
             m_trackList.erase(it);
-            item->deleteLater();
+            delete item;
             endRemoveRows();
             break;
         }


### PR DESCRIPTION
Resolves: #9810

Delete object right away avoiding historyChanged to be called for a already removed track.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Autobot test cases have been run
