### PR TITLE
Add Open Audio dialog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 CMakeUserPresets.json
 
+au4
 # Autotools generated files
 locale/Makefile.in
 Makefile

--- a/libraries/lib-cloud-audiocom/CloudSyncService.cpp
+++ b/libraries/lib-cloud-audiocom/CloudSyncService.cpp
@@ -13,11 +13,13 @@
 #include <algorithm>
 #include <cassert>
 #include <chrono>
+#include <fstream>
 #include <mutex>
 #include <string>
 
 #include "CloudLibrarySettings.h"
 
+#include "UserService.h"
 #include "sync/CloudProjectsDatabase.h"
 #include "sync/CloudSyncDTO.h"
 #include "sync/RemoteProjectSnapshot.h"
@@ -677,5 +679,332 @@ void CloudSyncService::ReportUploadStats(
    // Keep response alive
    response->setRequestFinishedCallback([response](auto) {});
 }
+
+void GetAudioInfo(
+   OAuthService& oAuthService, const ServiceConfig& serviceConfig,
+   std::string audioId,
+   std::function<void(sync::CloudAudioFullInfo, ResponseResult)> callback)
+{
+   assert(callback);
+
+   PerformProjectGetRequest(
+      oAuthService, serviceConfig.GetAudioInfoUrl(audioId),
+      [callback = std::move(callback)](ResponseResult result)
+      {
+         if (result.Code != SyncResultCode::Success)
+         {
+            callback(sync::CloudAudioFullInfo {}, std::move(result));
+            return;
+         }
+
+         auto audioInfo = sync::DeserializeCloudAudioFullInfo(result.Content);
+
+         if (!audioInfo)
+         {
+            callback({}, { SyncResultCode::UnexpectedResponse,
+                     std::move(result.Content) });
+            return;
+         }
+
+         callback(std::move(*audioInfo), std::move(result));
+      });
+}
+
+void GetAudioDownloadInfo(
+   OAuthService& oAuthService, const ServiceConfig& serviceConfig,
+   std::string audioId,
+   std::function<void(sync::CloudAudioDownloadInfo, ResponseResult)> callback)
+{
+   assert(callback);
+
+   PerformProjectGetRequest(oAuthService, serviceConfig.GetAudioDownloadListUrl(audioId),
+      [callback = std::move(callback)](ResponseResult result)
+      {
+         if (result.Code != SyncResultCode::Success)
+         {
+            callback(sync::CloudAudioDownloadInfo {}, std::move(result));
+            return;
+         }
+
+         auto downloadInfo = sync::DeserializeCloudAudioDownloadInfo(result.Content);
+
+         if (!downloadInfo)
+         {
+            callback({}, {
+               SyncResultCode::UnexpectedResponse,
+               std::move(result.Content) });
+            return;
+         }
+
+         callback(std::move(*downloadInfo), std::move(result));
+      });
+}
+
+CloudSyncService::GetAudioInfoFuture GetAudioInfo(
+   concurrency::CancellationContextPtr context, std::string_view audioId) {
+         using namespace audacity::network_manager;
+
+   auto promise = std::make_shared<CloudSyncService::GetAudioInfoPromise>();
+
+   auto& serviceConfig = GetServiceConfig();
+   auto& oAuthService = GetOAuthService();
+
+   auto request =
+      Request(serviceConfig.GetAudioInfoUrl(audioId));
+
+   request.setHeader(
+      common_headers::ContentType, common_content_types::ApplicationJson);
+   request.setHeader(
+      common_headers::Accept, common_content_types::ApplicationJson);
+
+   SetCommonHeaders(request);
+   SetOptionalHeaders(request);
+
+   auto response = NetworkManager::GetInstance().doGet(request);
+
+   context->OnCancelled(response);
+
+   response->setRequestFinishedCallback(
+      [promise, response](auto)
+      {
+         auto responseResult = GetResponseResult(*response, true);
+
+         if (responseResult.Code != SyncResultCode::Success)
+         {
+            promise->set_value(responseResult);
+            return;
+         }
+
+         auto audioInfo =
+            sync::DeserializeCloudAudioInfo(responseResult.Content);
+
+         if (!audioInfo)
+         {
+            promise->set_value(
+               ResponseResult { SyncResultCode::UnexpectedResponse,
+                                std::move(responseResult.Content) });
+            return;
+         }
+
+         promise->set_value(std::move(*audioInfo));
+      });
+
+   return promise->get_future();
+
+}
+
+CloudSyncService::GetAudioListFuture CloudSyncService::GetAudioList(
+   concurrency::CancellationContextPtr context, int page, int pageSize,
+   std::string_view searchString)
+{
+   using namespace audacity::network_manager;
+
+   auto promise = std::make_shared<GetAudioListPromise>();
+
+   auto& serviceConfig = GetServiceConfig();
+   auto& oAuthService  = GetOAuthService();
+
+   auto request = Request(serviceConfig.GetAudioListUrl(page, pageSize, searchString));
+
+   request.setHeader(
+      common_headers::ContentType, common_content_types::ApplicationJson);
+   request.setHeader(
+      common_headers::Accept, common_content_types::ApplicationJson);
+
+   SetCommonHeaders(request);
+   SetOptionalHeaders(request);
+
+   auto response = NetworkManager::GetInstance().doGet(request);
+
+   context->OnCancelled(response);
+
+   response->setRequestFinishedCallback(
+      [promise, response](auto)
+      {
+         auto responseResult = GetResponseResult(*response, true);
+
+         if (responseResult.Code != SyncResultCode::Success)
+         {
+            promise->set_value(responseResult);
+            return;
+         }
+
+         auto audios = sync::DeserializePaginatedAudioResponse(responseResult.Content);
+
+         if (!audios)
+         {
+            promise->set_value(
+               ResponseResult { SyncResultCode::UnexpectedResponse,
+                                std::move(responseResult.Content) });
+            return;
+         }
+
+         promise->set_value(std::move(*audios));
+      });
+
+   return promise->get_future();
+}
+
+void CloudSyncService::DownloadAudio(const std::string& name, const std::string& format, const std::string& url) {
+   using namespace audacity::network_manager;
+   using namespace sync;
+
+   const Request request(url);
+   auto response = NetworkManager::GetInstance().doGet(request);
+
+   const auto filename = sync::MakeSafeFilePath(wxFileName::GetTempDir(), name, format);
+   auto audioFile = std::make_shared<std::ofstream>(filename.ToStdString(), std::ios::binary);
+
+   response->setRequestFinishedCallback([response, this, filename, name, format, audioFile]
+      (IResponse*) {
+         if (audioFile && audioFile->is_open())
+            audioFile->close();
+
+         if (response->getError() != NetworkError::NoError)
+         {
+            BasicUI::CallAfter([] {
+               ShowErrorDialog( {},
+               XC("Error importing cloud audio", "cloud sync"),
+               XC("Can't download cloud audio", "update dialog"),
+               wxString(),
+               BasicUI::ErrorDialogOptions{ BasicUI::ErrorDialogType::ModalErrorReport });
+            });
+
+            mDownloadInProcess.store(false);
+            mDownloadAudioPromise.set_value({DownloadAudioResult::StatusCode::Failed, {}, {}});
+
+            return;
+         }
+
+         mDownloadAudioPromise.set_value({
+            DownloadAudioResult::StatusCode::Succeeded,
+            {},
+            filename.ToStdString(),
+            name,
+            format
+         });
+         mDownloadInProcess.store(false);
+      }
+   );
+
+   // Called each time, since downloading for update progress status.
+   response->setDownloadProgressCallback([this]
+      (int64_t current, int64_t expected) {
+         mDownloadProgress.store(static_cast<double>(current) / expected);
+         mProgressCallback(mDownloadProgress.load());
+      }
+   );
+
+   // Called each time, since downloading for get data.
+   response->setOnDataReceivedCallback([audioFile]
+      (IResponse* response) {
+         if (response->getError() == NetworkError::NoError)
+         {
+               std::vector<char> buffer(response->getBytesAvailable());
+
+               uint64_t bytes = response->readData(buffer.data(), buffer.size());
+
+               if (audioFile && audioFile->is_open())
+                  audioFile->write(buffer.data(), bytes);
+         }
+      }
+   );
+}
+
+CloudSyncService::DownloadAudioFuture CloudSyncService::DownloadCloudAudio(
+   std::string_view audioId,
+   sync::ProgressCallback callback)
+{
+   ASSERT_MAIN_THREAD();
+
+   mDownloadAudioPromise = {};
+
+   if (mDownloadInProcess.exchange(true))
+   {
+      mDownloadAudioPromise.set_value(
+         { sync::DownloadAudioResult::StatusCode::Blocked, {}, {}});
+      return mDownloadAudioPromise.get_future();
+   }
+
+   if (audioId.empty())
+   {
+      mDownloadAudioPromise.set_value(
+         { sync::DownloadAudioResult::StatusCode::Failed,
+           { SyncResultCode::InternalClientError, "Empty audioId" },
+           {} });
+      return mDownloadAudioPromise.get_future();
+   }
+
+   if (!callback)
+      mProgressCallback = [](auto...) { return true; };
+   else
+      mProgressCallback = std::move(callback);
+
+   GetAudioInfo(GetOAuthService(), GetServiceConfig(), std::string(audioId),
+      [this](sync::CloudAudioFullInfo audioInfo, ResponseResult result)
+      {
+         if (result.Code != SyncResultCode::Success)
+         {
+            mDownloadInProcess.store(false);
+            mDownloadAudioPromise.set_value(
+               { sync::DownloadAudioResult::StatusCode::Failed,
+                 std::move(result),
+                 {} });
+            return;
+         }
+
+         if (!audioInfo.IsDownloadable && audioInfo.AuthorId != GetUserService().GetUserId()) {
+            mDownloadInProcess.store(false);
+            mDownloadAudioPromise.set_value(
+               { sync::DownloadAudioResult::StatusCode::Failed,
+                 { SyncResultCode::Forbidden, "You don't have permission to download this audio" },
+                 {} });
+            return;
+         }
+
+         GetAudioDownloadInfo(GetOAuthService(), GetServiceConfig(), audioInfo.Id,
+            [this, audioInfo](sync::CloudAudioDownloadInfo downloadInfo, ResponseResult result)
+            {
+               if (result.Code != SyncResultCode::Success)
+               {
+                  mDownloadInProcess.store(false);
+                  mDownloadAudioPromise.set_value(
+                     { sync::DownloadAudioResult::StatusCode::Failed,
+                     std::move(result),
+                     {} });
+               }
+               else
+               {
+                  if (downloadInfo.Items.empty())
+                  {
+                     mDownloadInProcess.store(false);
+                     mDownloadAudioPromise.set_value(
+                        { sync::DownloadAudioResult::StatusCode::Failed,
+                        { SyncResultCode::UnexpectedResponse,
+                           "Empty download items" },
+                        {} });
+                     return;
+                  }
+                  // find source file (the one that was uploaded, before any transcodes) url and download file
+                  auto item = std::find_if(downloadInfo.Items.begin(), downloadInfo.Items.end(),
+                     [](const auto& item)
+                     {
+                        return item.IsSource;
+                     });
+                  // If source file not found, download first available format
+                  if (item == downloadInfo.Items.end())
+                     item = downloadInfo.Items.begin();
+                  DownloadAudio(audioInfo.Title, item->Format, item->Url);
+               }
+            }
+         );
+      }
+   );
+
+
+
+   return mDownloadAudioPromise.get_future();
+}
+
 
 } // namespace audacity::cloud::audiocom

--- a/libraries/lib-cloud-audiocom/CloudSyncService.h
+++ b/libraries/lib-cloud-audiocom/CloudSyncService.h
@@ -31,6 +31,8 @@ namespace sync
 {
 class LocalProjectSnapshot;
 class PaginatedProjectsResponse;
+class PaginatedAudioResponse;
+class CloudAudioInfo;
 class ProjectInfo;
 class SnapshotInfo;
 class RemoteProjectSnapshot;
@@ -44,11 +46,27 @@ struct ProjectSyncResult final
       Failed,
    };
 
-   StatusCode Status {};
+   StatusCode Status { StatusCode::Failed };
    ResponseResult Result;
    std::string ProjectPath;
    TransferStats Stats;
 }; // struct ProjectSyncResult
+
+struct DownloadAudioResult final
+{
+   enum class StatusCode
+   {
+      Succeeded,
+      Failed,
+      Blocked,
+   };
+
+   StatusCode Status { StatusCode::Failed };
+   ResponseResult Result;
+   std::string AudioPath;
+   std::string Title;
+   std::string Format;
+}; // struct DownloadAudioResult
 
 using ProgressCallback = std::function<bool(double)>;
 
@@ -56,6 +74,10 @@ using GetProjectsResult =
    std::variant<sync::PaginatedProjectsResponse, ResponseResult>;
 
 using GetHeadSnapshotIDResult = std::variant<std::string, ResponseResult>;
+
+using GetAudioListResult = std::variant<sync::PaginatedAudioResponse, ResponseResult>;
+using GetAudioInfoResult = std::variant<sync::CloudAudioInfo, ResponseResult>;
+
 } // namespace sync
 
 //! CloudSyncService is responsible for saving and loading projects from the
@@ -82,6 +104,15 @@ public:
    using GetHeadSnapshotIDPromise = std::promise<sync::GetHeadSnapshotIDResult>;
    using GetHeadSnapshotIDFuture  = std::future<sync::GetHeadSnapshotIDResult>;
 
+   using GetAudioListPromise = std::promise<sync::GetAudioListResult>;
+   using GetAudioListFuture  = std::future<sync::GetAudioListResult>;
+
+   using GetAudioInfoPromise = std::promise<sync::GetAudioInfoResult>;
+   using GetAudioInfoFuture  = std::future<sync::GetAudioInfoResult>;
+
+   using DownloadAudioPromise = std::promise<sync::DownloadAudioResult>;
+   using DownloadAudioFuture  = std::future<sync::DownloadAudioResult>;
+
    enum class SyncMode
    {
       Normal,
@@ -93,6 +124,15 @@ public:
    GetProjectsFuture GetProjects(
       concurrency::CancellationContextPtr context, int page, int pageSize,
       std::string_view searchString);
+
+   //! Retrieve the list of audio from the cloud
+   GetAudioListFuture GetAudioList(
+      concurrency::CancellationContextPtr context, int page, int pageSize,
+      std::string_view searchString);
+
+   [[nodiscard]] DownloadAudioFuture DownloadCloudAudio(
+      std::string_view audioId,
+      sync::ProgressCallback callback);
 
    //! Open the project from the cloud. This operation is asynchronous.
    [[nodiscard]] SyncFuture OpenFromCloud(
@@ -126,6 +166,8 @@ private:
       const sync::ProjectInfo& projectInfo,
       const sync::SnapshotInfo& snapshotInfo, SyncMode mode);
 
+   void DownloadAudio(const std::string& name, const std::string& format, const std::string& url);
+
    void UpdateDowloadProgress(double downloadProgress);
 
    void
@@ -137,9 +179,12 @@ private:
    SyncPromise mSyncPromise;
    sync::ProgressCallback mProgressCallback;
 
+   DownloadAudioPromise mDownloadAudioPromise;
+
    std::atomic<double> mDownloadProgress { 0.0 };
    std::atomic<bool> mProgressUpdateQueued { false };
 
    std::atomic<bool> mSyncInProcess { false };
+   std::atomic<bool> mDownloadInProcess { false };
 };
 } // namespace audacity::cloud::audiocom

--- a/libraries/lib-cloud-audiocom/ServiceConfig.cpp
+++ b/libraries/lib-cloud-audiocom/ServiceConfig.cpp
@@ -354,6 +354,56 @@ std::string ServiceConfig::GetDeleteSnapshotUrl(
       });
 }
 
+std::string ServiceConfig::GetAudioListUrl(
+   int page, int pageSize, std::string_view searchTerm) const
+{
+   if (searchTerm.empty())
+      return Substitute(
+         "{api_url}/my/audio?page={page}&per-page={page_size}",
+         { { "api_url", mApiEndpoint },
+           { "page", std::to_string(page) },
+           { "page_size", std::to_string(pageSize) }, });
+
+   return Substitute(
+      "{api_url}/my/audio?page={page}&per-page={page_size}&q={search_term}",
+      { { "api_url", mApiEndpoint },
+        { "page", std::to_string(page) },
+        { "page_size", std::to_string(pageSize) },
+        { "search_term", searchTerm }, });
+}
+std::string ServiceConfig::GetAudioInfoUrl(std::string_view audioId) const
+{
+   static constexpr auto kAudioFields =
+      "id,"
+      "slug,"
+      "title,"
+      "tags,"
+      "author_name,"
+      "username,"
+      "date_created,"
+      "date_updated,"
+      "is_public,"
+      "is_downloadable,"
+      "author.id";
+
+   return Substitute(
+      "{api_url}/audio/{audio_id}?fields={fields}&expand=author",
+      {
+         { "api_url", mApiEndpoint },
+         { "audio_id", audioId },
+         { "fields", kAudioFields },
+      });
+}
+
+std::string ServiceConfig::GetAudioDownloadListUrl(std::string_view audioId) const {
+   return Substitute(
+      "{api_url}/download/{audio_id}",
+      {
+         { "api_url", mApiEndpoint },
+         { "audio_id", audioId },
+      });
+}
+
 std::string ServiceConfig::GetNetworkStatsUrl(std::string_view projectId) const
 {
    return Substitute(

--- a/libraries/lib-cloud-audiocom/ServiceConfig.h
+++ b/libraries/lib-cloud-audiocom/ServiceConfig.h
@@ -74,6 +74,10 @@ public:
    std::string GetDeleteSnapshotUrl(
       std::string_view projectId, std::string_view snapshotId) const;
 
+   std::string GetAudioListUrl(int page, int pageSize, std::string_view searchTerm) const;
+   std::string GetAudioInfoUrl(std::string_view audioId) const;
+   std::string GetAudioDownloadListUrl(std::string_view audioId) const;
+
    std::string GetNetworkStatsUrl(std::string_view projectId) const;
    std::string GetProjectPagePath(std::string_view userSlug, std::string_view projectSlug,
       AudiocomTrace) const;

--- a/libraries/lib-cloud-audiocom/sync/CloudSyncDTO.h
+++ b/libraries/lib-cloud-audiocom/sync/CloudSyncDTO.h
@@ -135,6 +135,54 @@ struct PaginatedProjectsResponse final
    PaginationInfo Pagination;
 }; // struct PaginatedProjectsResponse
 
+struct CloudAudioInfo final
+{
+   std::string Id;
+
+   std::string Username;
+   std::string AuthorName;
+   std::string Slug;
+   std::string Title;
+   std::vector<std::string> Tags;
+
+   int64_t Created {};
+}; // struct CloudAudioInfo
+
+struct CloudAudioFullInfo final
+{
+   std::string Id;
+
+   std::string Username;
+   std::string AuthorName;
+   std::string AuthorId;
+   std::string Slug;
+   std::string Title;
+   std::vector<std::string> Tags;
+
+   bool IsDownloadable {};
+   int64_t Created {};
+}; // struct CloudAudioFullInfo
+
+
+struct CloudAudioDownloadInfoItem final
+{
+   std::string Format;
+   std::string Url;
+   int64_t Size {};
+   bool IsSource {};
+}; // struct CloudAudioDownloadInfoItem
+
+struct CloudAudioDownloadInfo final
+{
+   std::vector<CloudAudioDownloadInfoItem> Items;
+}; // struct CloudAudioDownloadInfo
+
+struct PaginatedAudioResponse final
+{
+   std::vector<CloudAudioInfo> Items;
+   PaginationInfo Pagination;
+}; // struct PaginatedAudioResponse
+
 struct NetworkStats final
 {
    int64_t Files {};
@@ -154,6 +202,16 @@ DeserializeCreateSnapshotResponse(const std::string& data);
 std::optional<PaginatedProjectsResponse>
 DeserializePaginatedProjectsResponse(const std::string& data);
 
+// Audio
+std::optional<PaginatedAudioResponse>
+DeserializePaginatedAudioResponse(const std::string& data);
+
+std::optional<CloudAudioDownloadInfo>
+DeserializeCloudAudioDownloadInfo(const std::string& data);
+
+std::optional<CloudAudioInfo> DeserializeCloudAudioInfo(const std::string& data);
+std::optional<CloudAudioFullInfo> DeserializeCloudAudioFullInfo(const std::string& data);
+
 std::optional<ProjectInfo> DeserializeProjectInfo(const std::string& data);
 std::optional<SnapshotInfo> DeserializeSnapshotInfo(const std::string& data);
 
@@ -161,5 +219,8 @@ std::string Serialize(NetworkStats stats);
 
 CLOUD_AUDIOCOM_API wxString
 MakeSafeProjectPath(const wxString& rootDir, const wxString& projectName);
+
+CLOUD_AUDIOCOM_API wxString
+MakeSafeFilePath(const wxString& rootDir, const wxString& fileName, const wxString& fileExtension);
 
 } // namespace audacity::cloud::audiocom::sync

--- a/modules/sharing/mod-cloud-audiocom/CMakeLists.txt
+++ b/modules/sharing/mod-cloud-audiocom/CMakeLists.txt
@@ -12,6 +12,8 @@ set( SOURCES
 
    ui/dialogs/AudioComDialogBase.cpp
    ui/dialogs/AudioComDialogBase.h
+   ui/dialogs/AudioListDialog.cpp
+   ui/dialogs/AudioListDialog.h
    ui/dialogs/CloudLocationDialog.cpp
    ui/dialogs/CloudLocationDialog.h
    ui/dialogs/CloudProjectPropertiesDialog.cpp
@@ -74,6 +76,8 @@ set( SOURCES
    CloudProjectMixdownUtils.h
    CloudProjectOpenUtils.cpp
    CloudProjectOpenUtils.h
+   CloudAudioOpenUtils.cpp
+   CloudAudioOpenUtils.h
    CloudLoginHandler.cpp
 )
 

--- a/modules/sharing/mod-cloud-audiocom/CloudAudioOpenUtils.cpp
+++ b/modules/sharing/mod-cloud-audiocom/CloudAudioOpenUtils.cpp
@@ -1,0 +1,160 @@
+/*  SPDX-License-Identifier: GPL-2.0-or-later */
+/*!********************************************************************
+
+  Audacity: A Digital Audio Editor
+
+  CloudAudioOpenUtils.cpp
+
+  Dmitry Vedenko / Dmitry Makarenko
+
+**********************************************************************/
+#include "CloudAudioOpenUtils.h"
+
+#include <memory>
+#include <wx/filefn.h>
+#include <wx/log.h>
+
+#include "BasicUI.h"
+#include "ExportUtils.h"
+#include "CloudSyncService.h"
+
+#include "AuthorizationHandler.h"
+
+#include "ActiveProject.h"
+#include "Project.h"
+#include "ProjectFileIO.h"
+#include "ProjectManager.h"
+#include "ProjectFileManager.h"
+#include "Track.h"
+#include "WaveTrack.h"
+#include "WaveClip.h"
+#include "ui/dialogs/LinkFailedDialog.h"
+
+namespace audacity::cloud::audiocom::sync
+{
+
+namespace {
+
+auto MakeProgress()
+{
+   return BasicUI::MakeProgress(
+      XO("Open from audio.com"), XO("Downloading audio"),
+      BasicUI::ProgressShowCancel);
+}
+
+auto MakePoller(BasicUI::ProgressDialog& dialog)
+{
+   return [&dialog](double progress)
+   {
+      return dialog.Poll(static_cast<unsigned>(progress * 10000), 10000ULL) ==
+             BasicUI::ProgressResult::Success;
+   };
+}
+
+template<typename T>
+T GetResult(std::future<T>& future)
+{
+   while (future.wait_for(std::chrono::milliseconds(50)) !=
+          std::future_status::ready) {
+            BasicUI::Yield();
+            wxSafeYield();
+          }
+
+   return future.get();
+}
+
+
+AudacityProject* GetTargetProject()
+{
+   auto project = GetActiveProject().lock();
+   if (!project || !ProjectManager::SafeToOpenProjectInto(*project)) {
+      return ProjectManager::New();
+   }
+   return project.get();
+}
+
+void FixupProject(AudacityProject& project, const std::string& title)
+{
+   auto tracks = TrackList::Get(project).Any<WaveTrack>();
+
+   if (!tracks.empty()) {
+      auto firstTrack = *tracks.first;
+
+      if (firstTrack->GetNumClips()) {
+         firstTrack->GetClip(0)->SetName(title);
+      }
+   }
+
+   project.SetProjectName(title);
+   ProjectFileIO::Get(project).MarkTemporary();
+   ProjectFileIO::Get(project).SetProjectTitle(-1);
+}
+
+}
+
+AudacityProject* OpenAudioFromCloud(std::string_view audioId) {
+   ASSERT_MAIN_THREAD();
+
+   auto authResult =
+      PerformBlockingAuth(nullptr, AudiocomTrace::OpenFromCloudMenu);
+
+   if (authResult.Result != AuthResult::Status::Authorised)
+   {
+      LinkFailedDialog dialog { nullptr,
+                                AudiocomTrace::OpenFromCloudMenu };
+      dialog.ShowModal();
+      return nullptr;
+   }
+
+   auto progressDialog = MakeProgress();
+
+   auto future = CloudSyncService::Get().DownloadCloudAudio(
+      audioId,
+      MakePoller(*progressDialog));
+
+   auto result = GetResult(future);
+
+   progressDialog.reset();
+
+   if (result.Status != DownloadAudioResult::StatusCode::Succeeded) {
+      wxLogError(
+         "Failed to download audio from cloud: %s",
+         result.Result.Content);
+      BasicUI::ShowErrorDialog( {},
+         XO("Open from audio.com"),
+         XO("Failed to download audio from cloud.\n%s")
+            .Format(result.Result.Content),
+         {}
+         );
+      return nullptr;
+   }
+
+   FilePath audioPath = result.AudioPath;
+
+   if (!wxFileExists(audioPath)) {
+      wxLogError(
+         "Downloaded audio file does not exist: %s",
+         audioPath);
+      BasicUI::ShowErrorDialog( {},
+         XO("Open from audio.com"),
+         XO("Downloaded audio file does not exist."),
+         {}
+         );
+      return nullptr;
+   }
+
+   auto project = GetTargetProject();
+
+   ProjectFileManager::Get(*project).Import(audioPath, false);
+   FixupProject(*project, result.Title);
+
+   wxRemoveFile(audioPath);
+
+   return project;
+}
+
+bool HandleAudioLink(std::string_view link) {
+   return false;
+}
+
+} // namespace audacity::cloud::audiocom::sync

--- a/modules/sharing/mod-cloud-audiocom/CloudAudioOpenUtils.h
+++ b/modules/sharing/mod-cloud-audiocom/CloudAudioOpenUtils.h
@@ -1,0 +1,24 @@
+/*  SPDX-License-Identifier: GPL-2.0-or-later */
+/*!********************************************************************
+
+  Audacity: A Digital Audio Editor
+
+  CloudAudioOpenUtils.h
+
+  Dmitry Vedenko / Dmitry Makarenko
+
+**********************************************************************/
+#pragma once
+
+#include <string_view>
+
+class AudacityProject;
+
+namespace audacity::cloud::audiocom::sync
+{
+
+AudacityProject* OpenAudioFromCloud(std::string_view audioId);
+
+bool HandleAudioLink(std::string_view link);
+
+} // namespace audacity::cloud::audiocom::sync

--- a/modules/sharing/mod-cloud-audiocom/menus/AudioComMenus.cpp
+++ b/modules/sharing/mod-cloud-audiocom/menus/AudioComMenus.cpp
@@ -13,6 +13,7 @@
 #include "CloudProjectFileIOExtensions.h"
 #include "CloudProjectMixdownUtils.h"
 #include "CommandContext.h"
+#include "CommandFlag.h"
 #include "ExportUtils.h"
 #include "MenuRegistry.h"
 
@@ -22,6 +23,7 @@
 #include "ProjectWindow.h"
 
 #include "ui/dialogs/ProjectsListDialog.h"
+#include "ui/dialogs/AudioListDialog.h"
 #include "ui/dialogs/ShareAudioDialog.h"
 
 #include "CommonCommandFlags.h"
@@ -36,13 +38,22 @@ void OnSaveToCloud(const CommandContext& context)
    SaveToCloud(context.project, UploadMode::Normal);
 }
 
-void OnOpenFromCloud(const CommandContext& context)
+void OnOpenProjectFromCloud(const CommandContext& context)
 {
    ProjectsListDialog dialog { ProjectWindow::Find(&context.project),
                                &context.project };
 
    dialog.ShowModal();
 }
+
+void OnOpenAudioFromCloud(const CommandContext& context)
+{
+   AudioListDialog dialog { ProjectWindow::Find(&context.project),
+                               &context.project };
+
+   dialog.ShowModal();
+}
+
 
 void OnUpdateMixdown(const CommandContext& context)
 {
@@ -87,6 +98,25 @@ const ReservedCommandFlag& IsCloudProjectFlag()
 
 using namespace MenuRegistry;
 
+
+auto OpenFromCloud()
+{
+   static auto menu = std::shared_ptr{
+   Menu( wxT("OpenFromCloud"), XXO("Open &From Cloud"),
+      Command( wxT("OpenProjectFromCloud"), XXO("Open Cloud &Project..."),
+         OnOpenProjectFromCloud,
+         AlwaysEnabledFlag ),
+      Command( wxT("OpenAudioFromCloud"), XXO("Open Cloud &Audio File..."),
+         OnOpenAudioFromCloud,
+         AlwaysEnabledFlag )
+   ) };
+   return menu;
+}
+
+AttachedItem sOpenCloudMenuAttachment{ Indirect(OpenFromCloud()),
+   Placement{ wxT("File/Basic"), { OrderingHint::End } }
+};
+
 AttachedItem sSaveAttachment { Command(
                                   wxT("SaveToCloud"), XXO("Save &To Cloud..."),
                                   OnSaveToCloud, AlwaysEnabledFlag),
@@ -97,12 +127,6 @@ AttachedItem sMixdownAttachment { Command(
                                      XXO("&Update Cloud Audio Preview"),
                                      OnUpdateMixdown, IsCloudProjectFlag()),
                                   wxT("File/Save") };
-
-AttachedItem sOpenAttachment { Command(
-                                  wxT("OpenFromCloud"),
-                                  XXO("Open Fro&m Cloud..."), OnOpenFromCloud,
-                                  AlwaysEnabledFlag),
-                               wxT("File/Basic") };
 
 AttachedItem sShareAttachment { Command(
                                    wxT("ShareAudio"), XXO("S&hare Audio..."),

--- a/modules/sharing/mod-cloud-audiocom/ui/dialogs/AudioListDialog.cpp
+++ b/modules/sharing/mod-cloud-audiocom/ui/dialogs/AudioListDialog.cpp
@@ -1,0 +1,884 @@
+/*  SPDX-License-Identifier: GPL-2.0-or-later */
+/*!********************************************************************
+
+  Audacity: A Digital Audio Editor
+
+  AudioListDialog.cpp
+
+  Dmitry Vedenko / Dmitry Makarenko
+
+**********************************************************************/
+
+#include "AudioListDialog.h"
+
+#include <chrono>
+
+#include <wx/button.h>
+#include <wx/grid.h>
+#include <wx/sizer.h>
+#include <wx/stattext.h>
+#include <wx/textctrl.h>
+#include <wx/timer.h>
+
+#include "BasicUI.h"
+#include "CodeConversions.h"
+#include "Internat.h"
+#include "wxWidgetsWindowPlacement.h"
+
+#include "AuthorizationHandler.h"
+#include "CloudSyncService.h"
+#include "ServiceConfig.h"
+#include "OAuthService.h"
+#include "UserService.h"
+#include "ExportUtils.h"
+
+#include "sync/CloudSyncDTO.h"
+
+#include "CloudAudioOpenUtils.h"
+
+#if wxUSE_ACCESSIBILITY
+#include "WindowAccessible.h"
+#endif
+
+namespace audacity::cloud::audiocom::sync
+{
+
+namespace
+{
+const auto OpenFromCloudTitle = XO("Open cloud audio file");
+} // namespace
+
+class AudioListDialog::AudioTableData final : public wxGridTableBase
+{
+public:
+   AudioTableData(AudioListDialog& owner, int pageSize)
+       : mOwner { owner }
+       , mPageSize { pageSize }
+   {
+   }
+
+   enum Column
+   {
+      Title,
+      Created,
+      Tags,
+      Count,
+      // Unused now, keep for possible future use
+      Author,
+   };
+
+   int GetNumberRows() override
+   {
+      return static_cast<int>(mResponse.Items.size());
+   }
+
+   int GetNumberCols() override
+   {
+      return static_cast<int>(Column::Count);
+   }
+
+   static wxString FormatTime(int64_t time)
+   {
+     using namespace std::chrono;
+
+      const auto time_passed =
+         system_clock::now() - system_clock::from_time_t(time);
+
+      if (time_passed < minutes(1))
+         return XO("less than 1 minute").Translation();
+      if (time_passed < hours(1))
+         return XP("one minute ago", "%d minutes ago",
+                   0)(static_cast<int>(
+                         duration_cast<minutes>(time_passed).count()))
+            .Translation();
+      if (time_passed < hours(48))
+         return XP("one hour ago", "%d hours ago", 0)(
+                   static_cast<int>(duration_cast<hours>(time_passed).count()))
+            .Translation();
+
+      return wxDateTime(static_cast<time_t>(time)).Format();
+   }
+
+   wxString GetValue(int row, int col) override
+   {
+      if (row < 0 || row >= static_cast<int>(mResponse.Items.size()))
+         return {};
+
+      const auto& item = mResponse.Items[row];
+
+      switch (col)
+      {
+      case Column::Title:
+         return ToWXString(item.Title);
+      case Column::Author:
+         return ToWXString(item.AuthorName.empty() ? item.Username : item.AuthorName);
+      case Column::Tags:
+      {
+         if (item.Tags.empty())
+            return {};
+         wxString tags = {};
+         for (size_t i = 0; i < item.Tags.size(); ++i)
+         {
+            if (i) tags += ", ";
+            tags += ToWXString(item.Tags[i]);
+         }
+         return tags;
+      }
+      case Column::Created:
+         return FormatTime(item.Created);
+      default:
+         return {};
+      }
+   }
+
+   void SetValue(int row, int col, const wxString& value) override {}
+
+   wxString GetRowLabelValue(int row) override { return wxString::Format("%d", row + 1); }
+
+   wxString GetColLabelValue(int col) override
+   {
+      switch (col)
+      {
+     case Column::Title:
+        return XO("Title").Translation();
+     case Column::Author:
+        return XO("Author").Translation();
+     case Column::Tags:
+        return XO("Tags").Translation();
+     case Column::Created:
+        return XO("Created").Translation();
+      default:
+         return {};
+      }
+   }
+
+   wxString GetCornerLabelValue() const override { return {}; }
+
+   int GetColWidth(int col) const
+   {
+      static const int colWidths[] = { 300, 250, 200, 100 };
+      const int count = static_cast<int>(Column::Count);
+      return (col >= 0 && col < count) ? colWidths[col] : 0;
+   }
+
+   void Refresh(int page, const wxString& searchTerm)
+   {
+      using namespace std::chrono_literals;
+
+      auto authResult = PerformBlockingAuth(
+         mOwner.mProject, AudiocomTrace::OpenFromCloudMenu);
+
+      switch (authResult.Result)
+      {
+      case AuthResult::Status::Authorised:
+         break;
+      case AuthResult::Status::Failure:
+         BasicUI::ShowErrorDialog(
+            wxWidgetsWindowPlacement { &mOwner }, OpenFromCloudTitle,
+            XO("Failed to authorize account"), {},
+            BasicUI::ErrorDialogOptions {}.Log(
+               audacity::ToWString(authResult.ErrorMessage)));
+         [[fallthrough]];
+      default:
+         mOwner.EndModal(0);
+         return;
+      }
+
+      mOwner.OnBeforeRefresh();
+
+      auto progressDialog = BasicUI::MakeGenericProgress(
+         wxWidgetsWindowPlacement { &mOwner }, OpenFromCloudTitle,
+         XO("Loading audio list..."));
+
+      auto cancellationContext = concurrency::CancellationContext::Create();
+
+      auto future = CloudSyncService::Get().GetAudioList(
+         cancellationContext, page, mPageSize, ToUTF8(searchTerm));
+
+      while (std::future_status::ready != future.wait_for(100ms))
+      {
+         BasicUI::Yield();
+         if (progressDialog->Pulse() != BasicUI::ProgressResult::Success)
+            cancellationContext->Cancel();
+      }
+
+      auto result = future.get();
+
+      if (!mResponse.Items.empty())
+      {
+         wxGridTableMessage msg(
+            this, wxGRIDTABLE_NOTIFY_ROWS_DELETED, 0, mResponse.Items.size());
+
+         GetView()->ProcessTableMessage(msg);
+      }
+
+      if (std::holds_alternative<PaginatedAudioResponse>(result))
+      {
+         auto response = std::get_if<PaginatedAudioResponse>(&result);
+         mResponse     = std::move(*response);
+
+         if (!mResponse.Items.empty())
+         {
+            wxGridTableMessage msg(
+               this, wxGRIDTABLE_NOTIFY_ROWS_APPENDED, mResponse.Items.size(),
+               0);
+
+            GetView()->ProcessTableMessage(msg);
+         }
+
+         mOwner.OnRefreshCompleted(true);
+      }
+      else
+      {
+         auto responseResult = std::get_if<ResponseResult>(&result);
+
+         BasicUI::ShowErrorDialog(
+            wxWidgetsWindowPlacement { &mOwner }, OpenFromCloudTitle,
+            XO("Failed to get audio list"), {},
+            BasicUI::ErrorDialogOptions {}.Log(
+               audacity::ToWString(responseResult->Content)));
+
+         if (mResponse.Items.empty())
+            mOwner.EndModal(0);
+
+         mOwner.OnRefreshCompleted(false);
+      }
+   }
+
+   bool HasPrevPage() const
+   {
+      return mResponse.Pagination.CurrentPage > 1;
+   }
+
+   bool HasNextPage() const
+   {
+      return mResponse.Pagination.CurrentPage < mResponse.Pagination.PagesCount;
+   }
+
+   void PrevPage()
+   {
+      if (HasPrevPage())
+         Refresh(mResponse.Pagination.CurrentPage - 1, mOwner.mLastSearchValue);
+   }
+
+   void NextPage()
+   {
+      if (HasNextPage())
+         Refresh(mResponse.Pagination.CurrentPage + 1, mOwner.mLastSearchValue);
+   }
+
+   int GetCurrentPage() const
+   {
+      return mResponse.Pagination.CurrentPage;
+   }
+
+   int GetPagesCount() const
+   {
+      return mResponse.Pagination.PagesCount;
+   }
+
+   const CloudAudioInfo* GetSelectedAudioInfo() const
+   {
+      const auto sel = GetView()->GetSelectedRows();
+      if (sel.empty())
+         return nullptr;
+
+      const auto row = sel[0];
+      if (row < 0 || row >= static_cast<int>(mResponse.Items.size()))
+         return nullptr;
+
+      return &mResponse.Items[row];
+   }
+
+   std::string GetSelectedAudioUrl() const
+   {
+      const auto selectedRow = mOwner.mAudioTable->GetSelectedRows();
+
+      if (selectedRow.empty())
+         return {};
+
+      auto& userService = GetUserService();
+      auto& oauthService = GetOAuthService();
+      auto& serviceConfig = GetServiceConfig();
+
+      auto userId = audacity::ToUTF8(userService.GetUserId());
+      auto& item = mResponse.Items[selectedRow[0]];
+
+      auto audioPage = serviceConfig.GetAudioPagePath(item.Username, item.Slug, AudiocomTrace::OpenFromCloudMenu);
+      auto url = oauthService.MakeAudioComAuthorizeURL(userId, audioPage);
+
+      return url;
+   }
+
+private:
+   AudioListDialog& mOwner;
+   const int mPageSize;
+
+   PaginatedAudioResponse mResponse;
+};
+
+#if wxUSE_ACCESSIBILITY
+
+class AudioListDialog::AudioListAccessible : public WindowAccessible
+{
+public:
+   AudioListAccessible(wxGrid& owner, AudioTableData& data)
+       : WindowAccessible { owner.GetGridWindow() }
+       , mOwner { owner }
+       , mAudioData { data }
+   {
+   }
+
+   void SetSelectedRow(int rowId)
+   {
+      if (mLastId != InvalidRow)
+      {
+         NotifyEvent(
+            wxACC_EVENT_OBJECT_SELECTIONREMOVE, mOwner.GetGridWindow(),
+            wxOBJID_CLIENT, mLastId);
+      }
+
+      if (&mOwner == wxWindow::FindFocus())
+      {
+         NotifyEvent(
+            wxACC_EVENT_OBJECT_FOCUS, mOwner.GetGridWindow(), wxOBJID_CLIENT,
+            rowId + 1);
+      }
+
+      NotifyEvent(
+         wxACC_EVENT_OBJECT_SELECTION, mOwner.GetGridWindow(), wxOBJID_CLIENT,
+         rowId + 1);
+
+      mLastId = rowId + 1;
+   }
+
+   void TableDataUpdated()
+   {
+      NotifyEvent(
+         wxACC_EVENT_OBJECT_REORDER, mOwner.GetGridWindow(), wxOBJID_CLIENT, 0);
+   }
+
+private:
+   wxAccStatus GetChild(int childId, wxAccessible** child) override
+   {
+      if (childId == wxACC_SELF)
+         *child = this;
+      else
+         *child = nullptr;
+
+      return wxACC_OK;
+   }
+
+   wxAccStatus GetChildCount(int* childCount) override
+   {
+      *childCount = mAudioData.GetRowsCount();
+      return wxACC_OK;
+   }
+
+   wxAccStatus
+   GetDefaultAction(int WXUNUSED(childId), wxString* actionName) override
+   {
+      actionName->clear();
+      return wxACC_OK;
+   }
+
+   // Returns the description for this object or a child.
+   wxAccStatus
+   GetDescription(int WXUNUSED(childId), wxString* description) override
+   {
+      description->clear();
+      return wxACC_OK;
+   }
+
+   // Returns help text for this object or a child, similar to tooltip text.
+   wxAccStatus GetHelpText(int WXUNUSED(childId), wxString* helpText) override
+   {
+      helpText->clear();
+      return wxACC_OK;
+   }
+
+   // Returns the keyboard shortcut for this object or child.
+   // Return e.g. ALT+K
+   wxAccStatus
+   GetKeyboardShortcut(int WXUNUSED(childId), wxString* shortcut) override
+   {
+      shortcut->clear();
+      return wxACC_OK;
+   }
+
+   wxAccStatus GetLocation(wxRect& rect, int elementId) override
+   {
+      if (elementId == wxACC_SELF)
+      {
+         rect = mOwner.GetRect();
+         rect.SetPosition(
+            mOwner.GetParent()->ClientToScreen(rect.GetPosition()));
+      }
+      else
+      {
+         const auto row = elementId - 1;
+
+         if (row > mAudioData.GetRowsCount())
+            return wxACC_OK; // ?
+
+         wxRect rowRect;
+
+         for (int col = 0; col < mAudioData.GetColsCount(); ++col)
+            rowRect.Union(mOwner.CellToRect(elementId - 1, col));
+
+         rowRect.SetPosition(
+            mOwner.CalcScrolledPosition(rowRect.GetPosition()));
+         rowRect.SetPosition(
+            mOwner.GetGridWindow()->ClientToScreen(rowRect.GetPosition()));
+
+         rect = rowRect;
+      }
+
+      return wxACC_OK;
+   }
+
+   wxAccStatus GetName(int childId, wxString* name) override
+   {
+      if (childId == wxACC_SELF)
+         return wxACC_OK;
+
+      const auto row = childId - 1;
+
+      if (row > mAudioData.GetRowsCount())
+         return wxACC_OK; // ?
+
+      for (int col = 0; col < mAudioData.GetColsCount(); ++col)
+      {
+         if (col != 0)
+            *name += ", ";
+
+         *name += mAudioData.GetColLabelValue(col) + " " +
+                  mAudioData.GetValue(row, col);
+      }
+
+      return wxACC_OK;
+   }
+
+   wxAccStatus GetParent(wxAccessible**) override
+   {
+      return wxACC_NOT_IMPLEMENTED;
+   }
+
+   wxAccStatus GetRole(int childId, wxAccRole* role) override
+   {
+      if (childId == wxACC_SELF)
+      {
+#   if defined(__WXMSW__)
+         *role = wxROLE_SYSTEM_TABLE;
+#   endif
+
+#   if defined(__WXMAC__)
+         *role = wxROLE_SYSTEM_GROUPING;
+#   endif
+      }
+      else
+      {
+         *role = wxROLE_SYSTEM_TEXT;
+      }
+
+      return wxACC_OK;
+   }
+
+   wxAccStatus GetSelections(wxVariant*) override
+   {
+      return wxACC_NOT_IMPLEMENTED;
+   }
+
+   wxAccStatus GetState(int childId, long* state) override
+   {
+      int flag = wxACC_STATE_SYSTEM_FOCUSABLE | wxACC_STATE_SYSTEM_SELECTABLE;
+
+      if (childId == wxACC_SELF)
+      {
+         *state = 0;
+         return wxACC_FAIL;
+      }
+
+#   if defined(__WXMSW__)
+      flag |= wxACC_STATE_SYSTEM_FOCUSED | wxACC_STATE_SYSTEM_SELECTED |
+              wxACC_STATE_SYSTEM_UNAVAILABLE | wxACC_STATE_SYSTEM_FOCUSED;
+#   endif
+
+#   if defined(__WXMAC__)
+      flag |= wxACC_STATE_SYSTEM_UNAVAILABLE;
+
+      if (childId == mLastId)
+         flag |= wxACC_STATE_SYSTEM_SELECTED | wxACC_STATE_SYSTEM_FOCUSED;
+#   endif
+
+      *state = flag;
+
+      return wxACC_OK;
+   }
+
+   wxAccStatus GetValue(int childId, wxString* strValue) override
+   {
+      strValue->clear();
+
+#   if defined(__WXMSW__)
+      return wxACC_OK;
+#   elif defined(__WXMAC__)
+      return GetName(childId, strValue);
+#   else
+      return wxACC_NOT_IMPLEMENTED;
+#   endif
+   }
+
+#   if defined(__WXMAC__)
+   wxAccStatus Select(int childId, wxAccSelectionFlags selectFlags) override
+   {
+      if (childId == wxACC_SELF)
+         return wxACC_OK;
+
+      if (selectFlags & wxACC_SEL_TAKESELECTION)
+         mOwner.SetGridCursor(childId - 1, 0);
+
+      mOwner.SelectBlock(
+         childId - 1, 0, childId - 1, 0, selectFlags & wxACC_SEL_ADDSELECTION);
+
+      return wxACC_OK;
+   }
+#   endif
+
+   wxAccStatus GetFocus(int* childId, wxAccessible** child) override
+   {
+      if (&mOwner == wxWindow::FindFocus())
+      {
+         if (mAudioData.GetRowsCount() == 0)
+            *child = this;
+         else
+            *childId = mLastId;
+      }
+
+      return wxACC_OK;
+   }
+
+   wxGrid& mOwner;
+   AudioTableData& mAudioData;
+
+   static constexpr int InvalidRow = -1;
+   int mLastId { InvalidRow };
+}; // class AudioListAccessible
+
+#endif
+
+AudioListDialog::AudioListDialog(
+   wxWindow* parent, AudacityProject* project)
+    : wxDialogWrapper { parent, wxID_ANY, OpenFromCloudTitle }
+    , mProject { project }
+{
+   auto header =
+      safenew wxStaticText { this, wxID_ANY,
+                             XO("Open cloud audio file").Translation() };
+   auto searchHeader =
+      safenew wxStaticText { this, wxID_ANY, XO("Search:").Translation() };
+
+   mSearchCtrl = safenew wxTextCtrl { this,          wxID_ANY,
+                                      wxEmptyString, wxDefaultPosition,
+                                      wxDefaultSize, wxTE_PROCESS_ENTER };
+
+   mAudioTable = safenew wxGrid { this, wxID_ANY };
+
+   mAudioTableData = safenew AudioTableData { *this, 15 };
+
+   mAudioTable->SetDefaultRowSize(32);
+
+   mAudioTable->SetGridLineColour(
+      mAudioTable->GetDefaultCellBackgroundColour());
+   mAudioTable->SetCellHighlightPenWidth(0);
+
+   mAudioTable->SetDefaultCellAlignment(wxALIGN_LEFT, wxALIGN_CENTER);
+   mAudioTable->SetTable(mAudioTableData, true);
+   mAudioTable->SetRowLabelSize(0);
+
+   mAudioTable->EnableEditing(false);
+   mAudioTable->SetSelectionMode(wxGrid::wxGridSelectRows);
+   mAudioTable->SetTabBehaviour(wxGrid::Tab_Leave);
+
+   mAudioTable->SetMinSize({ -1, 32 * 16 + 9 });
+
+   for (auto i = 0; i < mAudioTableData->GetNumberCols(); ++i)
+      mAudioTable->SetColSize(i, mAudioTableData->GetColWidth(i));
+
+#if wxUSE_ACCESSIBILITY
+   mAccessible =
+      safenew AudioListAccessible { *mAudioTable, *mAudioTableData };
+   mAudioTable->GetGridWindow()->SetAccessible(mAccessible);
+#endif
+
+   mPageLabel = safenew wxStaticText { this, wxID_ANY, {} };
+   mPrevPageButton =
+      safenew wxButton { this, wxID_ANY, XO("Prev").Translation() };
+   mNextPageButton =
+      safenew wxButton { this, wxID_ANY, XO("Next").Translation() };
+   mOpenButton = safenew wxButton { this, wxID_ANY, XO("Open").Translation() };
+   mOpenAudioCom = safenew wxButton { this, wxID_ANY,
+                                      XO("View in audio.com").Translation() };
+
+   auto topSizer = safenew wxBoxSizer { wxVERTICAL };
+
+   auto headerSizer = safenew wxBoxSizer { wxHORIZONTAL };
+   headerSizer->Add(header, wxSizerFlags().CenterVertical().Left());
+   headerSizer->AddStretchSpacer();
+   headerSizer->Add(
+      searchHeader, wxSizerFlags().CenterVertical().Border(wxRIGHT, 4));
+   headerSizer->Add(mSearchCtrl, wxSizerFlags().CenterVertical());
+
+   topSizer->Add(headerSizer, wxSizerFlags().Expand().Border(wxALL, 16));
+   topSizer->Add(
+      mAudioTable, wxSizerFlags().Expand().Border(wxLEFT | wxRIGHT, 16));
+
+   auto pageSizer = safenew wxBoxSizer { wxHORIZONTAL };
+   pageSizer->Add(mPageLabel, wxSizerFlags().CenterVertical());
+   pageSizer->AddStretchSpacer();
+   pageSizer->Add(mPrevPageButton, wxSizerFlags().CenterVertical());
+   pageSizer->Add(mNextPageButton, wxSizerFlags().CenterVertical());
+   topSizer->AddSpacer(8);
+   topSizer->Add(
+      pageSizer, wxSizerFlags().Expand().Border(wxLEFT | wxRIGHT, 16));
+
+   auto buttonsSizer = safenew wxBoxSizer { wxHORIZONTAL };
+   buttonsSizer->Add(mOpenAudioCom, wxSizerFlags().CenterVertical());
+   buttonsSizer->AddStretchSpacer();
+   buttonsSizer->Add(mOpenButton, wxSizerFlags().CenterVertical());
+
+   topSizer->Add(buttonsSizer, wxSizerFlags().Expand().Border(wxALL, 16));
+
+   mOpenButton->Disable();
+   mOpenAudioCom->Disable();
+
+   mSearchTimer = std::make_unique<wxTimer>(this);
+
+   SetSizer(topSizer);
+   Fit();
+   Center();
+
+   SetupHandlers();
+   BasicUI::CallAfter([this]
+                      { mAudioTableData->Refresh(1, mLastSearchValue); });
+}
+
+AudioListDialog::~AudioListDialog() = default;
+
+void AudioListDialog::SetupHandlers()
+{
+   mPrevPageButton->Bind(
+      wxEVT_BUTTON, [this](auto&) { mAudioTableData->PrevPage(); });
+
+   mNextPageButton->Bind(
+      wxEVT_BUTTON, [this](auto&) { mAudioTableData->NextPage(); });
+
+   mOpenButton->Bind(wxEVT_BUTTON, [this](auto&) { OnOpen(); });
+
+   mOpenAudioCom->Bind(wxEVT_BUTTON, [this](auto&) { OnOpenAudioCom(); });
+
+   mAudioTable->Bind(
+      wxEVT_GRID_CELL_LEFT_DCLICK, [this](auto&) { OnOpen(); });
+
+   Bind(
+      wxEVT_CHAR_HOOK,
+      [this](auto& evt)
+      {
+         if (!IsEscapeKey(evt))
+         {
+            evt.Skip();
+            return;
+         }
+
+         EndModal(wxID_CANCEL);
+      });
+
+   mAudioTable->Bind(
+      wxEVT_GRID_RANGE_SELECT, [this](auto& evt) { OnGridSelect(evt); });
+
+   mAudioTable->Bind(
+      wxEVT_GRID_SELECT_CELL, [this](auto& evt) { OnSelectCell(evt); });
+
+   mAudioTable->Bind(
+      wxEVT_KEY_UP,
+      [this](auto& evt)
+      {
+         const auto keyCode = evt.GetKeyCode();
+         if (keyCode != WXK_RETURN && keyCode != WXK_NUMPAD_ENTER)
+         {
+            evt.Skip();
+            return;
+         }
+
+         OnOpen();
+      });
+
+   mAudioTable->Bind(
+      wxEVT_KEY_DOWN,
+      [this](auto& evt)
+      {
+         const auto keyCode = evt.GetKeyCode();
+         // prevent being able to up arrow past the first row (issue #6251)
+         if (keyCode == WXK_UP && mAudioTable->GetGridCursorRow() == 0) {
+               return;
+         }
+         // prevent being able to down arrow past the last row (issue #6251)
+         if (keyCode == WXK_DOWN &&
+            mAudioTable->GetGridCursorRow() ==
+            mAudioTable->GetNumberRows() - 1) {
+               return;
+         }
+         if (keyCode != WXK_RETURN && keyCode != WXK_NUMPAD_ENTER)
+         {
+            evt.Skip();
+            return;
+         }
+      });
+
+   mAudioTable->Bind(
+      wxEVT_GRID_TABBING,
+      [this](auto& evt)
+      {
+         // needed for correct tabbing - see issue #6190
+         NavigateIn(evt.ShiftDown() ? wxNavigationKeyEvent::IsBackward :
+            wxNavigationKeyEvent::IsForward);
+      });
+
+   mAudioTable->Bind(
+      wxEVT_SET_FOCUS,
+      [this](auto& evt)
+      {
+         // needed so that for screen readers a row rather than the whole
+         // table is the initial focus - see issue #6190
+#if wxUSE_ACCESSIBILITY
+         int row = mAudioTable->GetGridCursorRow();
+         if (row != -1)
+            mAccessible->SetSelectedRow(row);
+#endif
+         evt.Skip();
+      });
+
+   mSearchCtrl->Bind(wxEVT_TEXT, [this](auto&) { OnSearchTextChanged(); });
+
+   mSearchCtrl->Bind(
+      wxEVT_TEXT_ENTER, [this](auto&) { OnSearchTextSubmitted(); });
+
+   Bind(wxEVT_TIMER, [this](auto&) { OnSearchTextSubmitted(); });
+}
+
+void AudioListDialog::OnBeforeRefresh()
+{
+   mAudioTable->Enable(false);
+   mPrevPageButton->Enable(false);
+   mNextPageButton->Enable(false);
+}
+
+void AudioListDialog::OnRefreshCompleted(bool success)
+{
+   mAudioTable->Enable(success);
+
+   mPrevPageButton->Enable(success && mAudioTableData->HasPrevPage());
+   mNextPageButton->Enable(success && mAudioTableData->HasNextPage());
+
+   FormatPageLabel();
+
+   if (success && mAudioTableData->GetNumberRows() > 0)
+   {
+      mAudioTable->AutoSizeColumn(AudioTableData::Column::Tags, false);
+   }
+
+   mAudioTable->ForceRefresh();
+
+#if wxUSE_ACCESSIBILITY
+   if (mAccessible)
+      mAccessible->TableDataUpdated();
+#endif
+}
+
+void AudioListDialog::FormatPageLabel()
+{
+   if (mAudioTableData->GetPagesCount() == 0)
+   {
+      mPageLabel->SetLabel({});
+      return;
+   }
+
+   mPageLabel->SetLabel(XO("Page %d of %d")
+                           .Format(
+                              mAudioTableData->GetCurrentPage(),
+                              mAudioTableData->GetPagesCount())
+                           .Translation());
+}
+
+void AudioListDialog::OnOpen()
+{
+   if (mAudioTable->GetSelectedRows().empty())
+      return;
+
+   const auto audioInfo = mAudioTableData->GetSelectedAudioInfo();
+
+   if (audioInfo == nullptr)
+      return;
+
+   EndModal(wxID_OK);
+
+   BasicUI::CallAfter(
+      [project = mProject, selectedAudioId = audioInfo->Id]
+      { OpenAudioFromCloud(selectedAudioId); });
+}
+
+void AudioListDialog::OnOpenAudioCom()
+{
+   if (mAudioTable->GetSelectedRows().empty())
+      return;
+
+   const auto selectedAudioUrl = mAudioTableData->GetSelectedAudioUrl();
+
+   if (selectedAudioUrl.empty())
+      return;
+
+   BasicUI::OpenInDefaultBrowser(ToWXString(selectedAudioUrl));
+}
+
+void AudioListDialog::OnGridSelect(wxGridRangeSelectEvent& event)
+{
+   mInRangeSelection = event.Selecting();
+
+   const auto sel = mAudioTable->GetSelectedRows();
+   mOpenButton->Enable(!sel.empty());
+   mOpenAudioCom->Enable(!sel.empty());
+}
+
+void AudioListDialog::OnSelectCell(wxGridEvent& event)
+{
+   const auto sel = mAudioTable->GetSelectedRows();
+   mOpenButton->Enable(!sel.empty());
+   mOpenAudioCom->Enable(!sel.empty());
+
+#if wxUSE_ACCESSIBILITY
+   if (mAccessible)
+      mAccessible->SetSelectedRow(event.GetRow());
+#endif
+}
+
+void AudioListDialog::OnSearchTextChanged()
+{
+   mSearchTimer->StartOnce(250);
+}
+
+void AudioListDialog::OnSearchTextSubmitted()
+{
+   if (mSearchTimer->IsRunning())
+      mSearchTimer->Stop();
+
+   const auto value = mSearchCtrl->GetValue();
+
+   if (value == mLastSearchValue)
+      return;
+
+   mLastSearchValue = value;
+
+   mAudioTableData->Refresh(1, mLastSearchValue);
+}
+
+} // namespace audacity::cloud::audiocom::sync

--- a/modules/sharing/mod-cloud-audiocom/ui/dialogs/AudioListDialog.h
+++ b/modules/sharing/mod-cloud-audiocom/ui/dialogs/AudioListDialog.h
@@ -1,0 +1,85 @@
+/*  SPDX-License-Identifier: GPL-2.0-or-later */
+/*!********************************************************************
+
+  Audacity: A Digital Audio Editor
+
+  AudioListDialog.h
+
+  Dmitry Vedenko / Dmitry Makarenko
+
+**********************************************************************/
+
+#pragma once
+
+#include <memory>
+
+#include "wxPanelWrapper.h"
+
+class AudacityProject;
+
+class wxButton;
+class wxGrid;
+class wxGridTableBase;
+class wxStaticText;
+class wxTextCtrl;
+class wxGridRangeSelectEvent;
+class wxGridEvent;
+class wxCommandEvent;
+class wxTimer;
+
+namespace audacity::cloud::audiocom::sync
+{
+
+class AudioListDialog final : public wxDialogWrapper
+{
+public:
+   AudioListDialog(wxWindow* parent, AudacityProject* project);
+   ~AudioListDialog() override;
+
+private:
+   class AudioTableData;
+#if wxUSE_ACCESSIBILITY
+   class AudioListAccessible;
+#endif
+
+   void SetupHandlers();
+
+   void OnBeforeRefresh();
+   void OnRefreshCompleted(bool success);
+   void FormatPageLabel();
+
+   void OnOpen();
+   void OnOpenAudioCom();
+
+   void OnGridSelect(wxGridRangeSelectEvent& event);
+   void OnSelectCell(wxGridEvent& event);
+
+   void OnSearchTextChanged();
+   void OnSearchTextSubmitted();
+
+   AudacityProject* mProject { nullptr };
+
+   wxTextCtrl* mSearchCtrl { nullptr };
+
+   wxGrid* mAudioTable { nullptr };
+   AudioTableData* mAudioTableData { nullptr };
+
+   wxStaticText* mPageLabel { nullptr };
+   wxButton* mPrevPageButton { nullptr };
+   wxButton* mNextPageButton { nullptr };
+
+   wxButton* mOpenButton { nullptr };
+   wxButton* mOpenAudioCom { nullptr };
+
+   wxString mLastSearchValue;
+
+   std::unique_ptr<wxTimer> mSearchTimer;
+
+#if wxUSE_ACCESSIBILITY
+   AudioListAccessible* mAccessible { nullptr };
+#endif
+
+   bool mInRangeSelection { false };
+};
+
+} // namespace audacity::cloud::audiocom::sync


### PR DESCRIPTION
Resolves: #9774

Adds a new dialog allowing the user to download cloud audio from audio.com.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [x] Works on all three OS
- [x] Works with non-default audio names: emojis, RTL characters, random unicode characters etc
- [x] Cancelling and connection drops is resolved gracefully
- [x] The search function is not working, will be implemented on the backend side, to be tested before the release