### PR TITLE
Avoid crash while clicking on the timeline

### DIFF
--- a/src/projectscene/view/timeline/playregioncontroller.cpp
+++ b/src/projectscene/view/timeline/playregioncontroller.cpp
@@ -2,11 +2,11 @@
 * Audacity: A Digital Audio Editor
 */
 
-#include "playregioncontroller.h"
-
 #include <cmath>
 
-#include "log.h"
+#include "framework/global/log.h"
+
+#include "playregioncontroller.h"
 
 namespace au::projectscene {
 PlayRegionController::PlayRegionController(QObject* parent)
@@ -18,6 +18,16 @@ void PlayRegionController::init()
 {
     globalContext()->currentProjectChanged().onNotify(this, [this]() {
         updateIsActive();
+    });
+
+    uicontextResolver()->currentUiContextChanged().onNotify(this, [this]() {
+        finishInteraction(m_dragStartPos);
+    });
+
+    connect(qApp, &QApplication::applicationStateChanged, this, [this](Qt::ApplicationState state){
+        if (state != Qt::ApplicationActive) {
+            finishInteraction(m_dragStartPos);
+        }
     });
 
     updateIsActive();
@@ -56,16 +66,6 @@ void PlayRegionController::startInteraction(double pos, bool ctrlPressed)
     if (m_action != UserInputAction::None) {
         playbackController()->loopEditingBegin();
     }
-
-    connect(qApp, &QApplication::applicationStateChanged, this, [this](Qt::ApplicationState state){
-        if (state != Qt::ApplicationActive) {
-            finishInteraction(m_dragStartPos);
-        }
-    });
-
-    uicontextResolver()->currentUiContextChanged().onNotify(this, [this]() {
-        finishInteraction(m_dragStartPos);
-    });
 }
 
 void PlayRegionController::updatePosition(double pos)


### PR DESCRIPTION
Resolves: #9890 

Clicking on the timeline multiple times crashes the app.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Autobot test cases have been run
