### PR TITLE
9696 - Add mic metering and input monitoring on track context menu

### DIFF
--- a/src/projectscene/view/trackspanel/trackcontextmenumodel.cpp
+++ b/src/projectscene/view/trackspanel/trackcontextmenumodel.cpp
@@ -63,6 +63,7 @@ MenuItemList TrackContextMenuModel::makeStereoTrackItems()
         makeMenu(muse::TranslatableString(TRANSLATABLE_STRING_CONTEXT, "Track view"), makeTrackViewItems()),
         makeMenu(muse::TranslatableString(TRANSLATABLE_STRING_CONTEXT, "Track color"), makeTrackColorItems(), TRACK_COLOR_MENU_ID),
         makeItemWithArg("toggle-vertical-rulers"),
+        makeMenu(muse::TranslatableString(TRANSLATABLE_STRING_CONTEXT, "Meters && monitoring"), makeMeterMonitoringItems()),
         makeSeparator(),
         makeItemWithArg("track-swap-channels"),
         makeItemWithArg("track-split-stereo-to-lr"),
@@ -87,6 +88,7 @@ MenuItemList TrackContextMenuModel::makeMonoTrackItems()
         makeMenu(muse::TranslatableString(TRANSLATABLE_STRING_CONTEXT, "Track view"), makeTrackViewItems()),
         makeMenu(muse::TranslatableString(TRANSLATABLE_STRING_CONTEXT, "Track color"), makeTrackColorItems(), TRACK_COLOR_MENU_ID),
         makeItemWithArg("toggle-vertical-rulers"),
+        makeMenu(muse::TranslatableString(TRANSLATABLE_STRING_CONTEXT, "Meters && monitoring"), makeMeterMonitoringItems()),
         makeSeparator(),
         makeItemWithArg("track-make-stereo"),
         makeSeparator(),
@@ -431,4 +433,13 @@ muse::uicomponents::MenuItemList TrackContextMenuModel::makeTrackViewItems()
         }
     }
     return items;
+}
+
+muse::uicomponents::MenuItemList TrackContextMenuModel::makeMeterMonitoringItems()
+{
+    return {
+        makeItemWithArg("action://record/toggle-mic-metering"),
+        makeSeparator(),
+        makeItemWithArg("action://record/toggle-input-monitoring"),
+    };
 }

--- a/src/projectscene/view/trackspanel/trackcontextmenumodel.h
+++ b/src/projectscene/view/trackspanel/trackcontextmenumodel.h
@@ -48,6 +48,7 @@ private:
     muse::uicomponents::MenuItemList makeTrackRateItems();
     muse::uicomponents::MenuItemList makeTrackMoveItems();
     muse::uicomponents::MenuItemList makeTrackViewItems();
+    muse::uicomponents::MenuItemList makeMeterMonitoringItems();
 
     muse::uicomponents::MenuItem* makeItemWithArg(const muse::actions::ActionCode& actionCode);
 

--- a/src/record/internal/recordcontroller.cpp
+++ b/src/record/internal/recordcontroller.cpp
@@ -3,7 +3,7 @@
 */
 #include "recordcontroller.h"
 
-#include "translation.h"
+#include "framework/global/translation.h"
 
 using namespace muse;
 using namespace au::record;
@@ -14,12 +14,16 @@ static const ActionQuery RECORD_START_QUERY("action://record/start");
 static const ActionQuery RECORD_PAUSE_QUERY("action://record/pause");
 static const ActionQuery RECORD_STOP_QUERY("action://record/stop");
 static const ActionQuery RECORD_LEVEL_QUERY("action://record/level"); // doesn't have callback here
+static const ActionQuery RECORD_TOGGLE_MIC_METERING("action://record/toggle-mic-metering");
+static const ActionQuery RECORD_TOGGLE_INPUT_MONITORING("action://record/toggle-input-monitoring");
 
 void RecordController::init()
 {
     dispatcher()->reg(this, RECORD_START_QUERY, this, &RecordController::toggleRecord);
     dispatcher()->reg(this, RECORD_PAUSE_QUERY, this, &RecordController::pause);
     dispatcher()->reg(this, RECORD_STOP_QUERY, this, &RecordController::stop);
+    dispatcher()->reg(this, RECORD_TOGGLE_MIC_METERING, this, &RecordController::toggleMicMetering);
+    dispatcher()->reg(this, RECORD_TOGGLE_INPUT_MONITORING, this, &RecordController::toggleInputMonitoring);
 
     playbackController()->isPlayingChanged().onNotify(this, [this]() {
         m_isRecordAllowedChanged.notify();
@@ -116,6 +120,36 @@ void RecordController::stop()
     }
 
     setCurrentRecordStatus(RecordStatus::Stopped);
+}
+
+void RecordController::toggleMicMetering()
+{
+    configuration()->setIsMicMeteringOn(!configuration()->isMicMeteringOn());
+}
+
+muse::async::Notification RecordController::isMicMeteringOnChanged() const
+{
+    return configuration()->isMicMeteringOnChanged();
+}
+
+bool RecordController::isMicMeteringOn() const
+{
+    return configuration()->isMicMeteringOn();
+}
+
+void RecordController::toggleInputMonitoring()
+{
+    configuration()->setIsInputMonitoringOn(!configuration()->isInputMonitoringOn());
+}
+
+muse::async::Notification RecordController::isInputMonitoringOnChanged() const
+{
+    return configuration()->isInputMonitoringOnChanged();
+}
+
+bool RecordController::isInputMonitoringOn() const
+{
+    return configuration()->isInputMonitoringOn();
 }
 
 void RecordController::setCurrentRecordStatus(RecordStatus status)

--- a/src/record/internal/recordcontroller.h
+++ b/src/record/internal/recordcontroller.h
@@ -4,17 +4,18 @@
 #ifndef AU_RECORD_RECORDCONTROLLER_H
 #define AU_RECORD_RECORDCONTROLLER_H
 
-#include "async/asyncable.h"
-#include "actions/actionable.h"
+#include "framework/global/async/asyncable.h"
+#include "framework/actions/actionable.h"
 
 #include "modularity/ioc.h"
-#include "actions/iactionsdispatcher.h"
 #include "context/iglobalcontext.h"
-#include "iinteractive.h"
+#include "framework/actions/iactionsdispatcher.h"
+#include "framework/global/iinteractive.h"
 #include "playback/iplaybackcontroller.h"
+#include "record/irecordconfiguration.h"
 
-#include "../irecord.h"
-#include "../irecordcontroller.h"
+#include "record/irecord.h"
+#include "record/irecordcontroller.h"
 
 namespace au::record {
 class RecordController : public IRecordController, public muse::actions::Actionable, public muse::async::Asyncable, public muse::Injectable
@@ -24,6 +25,7 @@ class RecordController : public IRecordController, public muse::actions::Actiona
     muse::Inject<muse::IInteractive> interactive;
     muse::Inject<IRecord> record;
     muse::Inject<playback::IPlaybackController> playbackController;
+    muse::Inject<record::IRecordConfiguration> configuration;
 
 public:
     void init();
@@ -40,6 +42,12 @@ public:
 
     bool canReceiveAction(const muse::actions::ActionCode& code) const override;
 
+    bool isMicMeteringOn() const override;
+    muse::async::Notification isMicMeteringOnChanged() const override;
+
+    bool isInputMonitoringOn() const override;
+    muse::async::Notification isInputMonitoringOnChanged() const override;
+
 private:
     enum class RecordStatus {
         Stopped = 0,
@@ -53,6 +61,8 @@ private:
     void start();
     void pause();
     void stop();
+    void toggleMicMetering();
+    void toggleInputMonitoring();
 
     void setCurrentRecordStatus(RecordStatus status);
 
@@ -60,6 +70,8 @@ private:
     muse::async::Notification m_isRecordAllowedChanged;
 
     RecordStatus m_currentRecordStatus = RecordStatus::Stopped;
+
+    muse::async::Channel<muse::actions::ActionCode> m_actionCheckedChanged;
 };
 }
 

--- a/src/record/internal/recorduiactions.h
+++ b/src/record/internal/recorduiactions.h
@@ -4,12 +4,11 @@
 #ifndef AU_RECORD_RECORDUIACTIONS_H
 #define AU_RECORD_RECORDUIACTIONS_H
 
-#include "async/asyncable.h"
+#include "framework/global/async/asyncable.h"
 
 #include "modularity/ioc.h"
 #include "context/iuicontextresolver.h"
-
-#include "ui/iuiactionsmodule.h"
+#include "framework/ui/iuiactionsmodule.h"
 
 #include "recordcontroller.h"
 
@@ -36,6 +35,7 @@ private:
 
     std::shared_ptr<RecordController> m_controller;
     muse::async::Channel<muse::actions::ActionCodeList> m_actionEnabledChanged;
+    muse::async::Channel<muse::actions::ActionCodeList> m_actionCheckedChanged;
 };
 }
 

--- a/src/record/irecordcontroller.h
+++ b/src/record/irecordcontroller.h
@@ -25,6 +25,12 @@ public:
 
     virtual muse::secs_t recordPosition() const = 0;
     virtual muse::async::Channel<muse::secs_t> recordPositionChanged() const = 0;
+
+    virtual bool isMicMeteringOn() const = 0;
+    virtual muse::async::Notification isMicMeteringOnChanged() const = 0;
+
+    virtual bool isInputMonitoringOn() const = 0;
+    virtual muse::async::Notification isInputMonitoringOnChanged() const = 0;
 };
 }
 

--- a/src/record/tests/mocks/recordcontrollermock.h
+++ b/src/record/tests/mocks/recordcontrollermock.h
@@ -19,5 +19,11 @@ public:
 
     MOCK_METHOD(muse::secs_t, recordPosition, (), (const, override));
     MOCK_METHOD(muse::async::Channel<muse::secs_t>, recordPositionChanged, (), (const, override));
+
+    MOCK_METHOD(bool, isMicMeteringOn, (), (const, override));
+    MOCK_METHOD(muse::async::Notification, isMicMeteringOnChanged, (), (const, override));
+
+    MOCK_METHOD(bool, isInputMonitoringOn, (), (const, override));
+    MOCK_METHOD(muse::async::Notification, isInputMonitoringOnChanged, (), (const, override));
 };
 }


### PR DESCRIPTION
Resolves: #9696 

Add mic metering and input monitoring options to the track context menu.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Autobot test cases have been run
