### PR TITLE
Shortcuts: Assigned a default shortcut to "zoom to fit project"

### DIFF
--- a/src/app/configs/data/shortcuts.xml
+++ b/src/app/configs/data/shortcuts.xml
@@ -960,10 +960,6 @@
         <seq>Ctrl+F</seq>
     </SC>
     <SC>
-        <key>fit-in-window</key>
-        <seq>Ctrl+F</seq>
-    </SC>
-    <SC>
         <key>fit-v</key>
         <seq>Ctrl+Shift+F</seq>
     </SC>


### PR DESCRIPTION
Resolves: [Assign the shortcut to "zoom to fit project" ](https://github.com/audacity/audacity/issues/9490)

The fix was pretty straightforward. I believe no further explanation is required.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [ ] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Autobot test cases have been run

Update: 

I have to edit Audacity's CLA that I signed
