### PR TITLE
Feature/audacity3 podcast chapters json export

### DIFF
--- a/libraries/lib-label-track/LabelTrack.cpp
+++ b/libraries/lib-label-track/LabelTrack.cpp
@@ -47,7 +47,7 @@ for drawing different aspects of the label and its text box.
 
 const FileNames::FileType LabelTrack::SubripFiles{ XO("SubRip text file"), { wxT("srt") }, true };
 const FileNames::FileType LabelTrack::WebVTTFiles{ XO("WebVTT file"), { wxT("vtt") }, true };
-const FileNames::FileType LabelTrack::PodcastChaptersFiles{ XO("JSON file"), { wxT("json") }, true };
+const FileNames::FileType LabelTrack::PodcastChaptersFiles{ XO("Podcast Chapters"), { wxT("json") }, true };
 const FileNames::FileType LabelTrack::AllSupportedFiles{ XO("Supported label file"), { wxT("srt"), wxT("txt") }, true };
 
 EnumSetting<bool> LabelStyleSetting {

--- a/libraries/lib-label-track/LabelTrack.cpp
+++ b/libraries/lib-label-track/LabelTrack.cpp
@@ -47,7 +47,7 @@ for drawing different aspects of the label and its text box.
 
 const FileNames::FileType LabelTrack::SubripFiles{ XO("SubRip text file"), { wxT("srt") }, true };
 const FileNames::FileType LabelTrack::WebVTTFiles{ XO("WebVTT file"), { wxT("vtt") }, true };
-const FileNames::FileType LabelTrack::PodcastChaptersFiles{ XO("Podcast Chapters JSON"), { wxT("json") }, true };
+const FileNames::FileType LabelTrack::PodcastChaptersFiles{ XO("JSON file"), { wxT("json") }, true };
 const FileNames::FileType LabelTrack::AllSupportedFiles{ XO("Supported label file"), { wxT("srt"), wxT("txt") }, true };
 
 EnumSetting<bool> LabelStyleSetting {

--- a/libraries/lib-label-track/LabelTrack.cpp
+++ b/libraries/lib-label-track/LabelTrack.cpp
@@ -560,7 +560,6 @@ static wxString SubRipTimestampFromDouble(double timestamp, bool webvtt)
 
 // Helper function to escape JSON special characters
 // Podcast 2.0 Chapters spec requires proper JSON escaping
-// Order matters: backslash must be escaped first to avoid double-escaping
 static wxString EscapeJSON(const wxString& input)
 {
    wxString result;
@@ -568,7 +567,7 @@ static wxString EscapeJSON(const wxString& input)
    for (auto ch : input) {
       wchar_t c = static_cast<wchar_t>(ch);
       switch (c) {
-         case '\\': result += wxT("\\\\"); break;  // Must be first
+         case '\\': result += wxT("\\\\"); break;
          case '"':  result += wxT("\\\""); break;
          case '\n': result += wxT("\\n");  break;
          case '\r': result += wxT("\\r");  break;

--- a/libraries/lib-label-track/LabelTrack.h
+++ b/libraries/lib-label-track/LabelTrack.h
@@ -31,6 +31,7 @@ enum class LabelFormat
    TEXT,
    SUBRIP,
    WEBVTT,
+   PODCAST_CHAPTERS_JSON,
 };
 
 LABEL_TRACK_API
@@ -130,6 +131,7 @@ class LABEL_TRACK_API LabelTrack final
 
    static const FileNames::FileType SubripFiles;
    static const FileNames::FileType WebVTTFiles;
+   static const FileNames::FileType PodcastChaptersFiles;
    static const FileNames::FileType AllSupportedFiles;
 
 private:

--- a/libraries/lib-label-track/LabelTrack.h
+++ b/libraries/lib-label-track/LabelTrack.h
@@ -57,7 +57,7 @@ public:
    struct BadFormatException {};
    static LabelStruct Import(wxTextFile &file, int &index, LabelFormat format);
 
-   void Export(wxTextFile &file, LabelFormat format, int index) const;
+   void Export(wxTextFile &file, LabelFormat format, int index, bool isLast = false) const;
 
    /// Relationships between selection region and labels
    enum TimeRelations
@@ -158,6 +158,11 @@ public:
    void Import(wxTextFile & f, LabelFormat format);
    void Export(wxTextFile & f, LabelFormat format) const;
 
+private:
+   void ExportHeader(wxTextFile &f, LabelFormat format) const;
+   void ExportFooter(wxTextFile &f, LabelFormat format) const;
+
+public:
    int GetNumLabels() const;
    const LabelStruct *GetLabel(int index) const;
    const LabelArray &GetLabels() const { return mLabels; }

--- a/src/menus/FileMenus.cpp
+++ b/src/menus/FileMenus.cpp
@@ -327,7 +327,7 @@ void OnExportLabels(const CommandContext &context)
       wxEmptyString,
       fName,
       wxT("txt"),
-      { FileNames::TextFiles, LabelTrack::SubripFiles, LabelTrack::WebVTTFiles },
+      { FileNames::TextFiles, LabelTrack::SubripFiles, LabelTrack::WebVTTFiles, LabelTrack::PodcastChaptersFiles },
       wxFD_SAVE | wxFD_OVERWRITE_PROMPT | wxRESIZE_BORDER,
       &window);
 

--- a/src/menus/FileMenus.cpp
+++ b/src/menus/FileMenus.cpp
@@ -336,14 +336,6 @@ void OnExportLabels(const CommandContext &context)
 
    LabelFormat format = LabelTrack::FormatForFileName(fName);
 
-   // Ensure filename has correct extension for selected format
-   if (format == LabelFormat::PODCAST_CHAPTERS_JSON && fName.Right(5).CmpNoCase(wxT(".json")) != 0) {
-      // Add .json extension if not present
-      wxFileName fileName(fName);
-      fileName.SetExt(wxT("json"));
-      fName = fileName.GetFullPath();
-   }
-
    // Move existing files out of the way.  Otherwise wxTextFile will
    // append to (rather than replace) the current file.
 

--- a/src/menus/FileMenus.cpp
+++ b/src/menus/FileMenus.cpp
@@ -336,6 +336,14 @@ void OnExportLabels(const CommandContext &context)
 
    LabelFormat format = LabelTrack::FormatForFileName(fName);
 
+   // Ensure filename has correct extension for selected format
+   if (format == LabelFormat::PODCAST_CHAPTERS_JSON && fName.Right(5).CmpNoCase(wxT(".json")) != 0) {
+      // Add .json extension if not present
+      wxFileName fileName(fName);
+      fileName.SetExt(wxT("json"));
+      fName = fileName.GetFullPath();
+   }
+
    // Move existing files out of the way.  Otherwise wxTextFile will
    // append to (rather than replace) the current file.
 


### PR DESCRIPTION
## Title
feat: Add Podcast 2.0 Chapters JSON export for label tracks

## Description
Resolves: https://github.com/audacity/audacity/issues/7078

Add support for exporting label tracks in Podcast 2.0 Chapters JSON format, enabling podcasters to create chapter markers compatible with modern podcast apps.

## Changes

- Add `PODCAST_CHAPTERS_JSON` to `LabelFormat` enum in `LabelTrack.h`
- Add `PodcastChaptersFiles` file type constant in `LabelTrack.cpp`
- Update `FormatForFileName()` to detect `.json` extension
- Implement JSON export in `LabelStruct::Export()` with proper string escaping
- Implement JSON export in `LabelTrack::Export()` with JSON header/footer
- Add "Podcast Chapters" option to Export Labels dialog in `FileMenus.cpp`

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Autobot test cases have been run
