### PR TITLE
Fix accessibility of UpdateNotificationDialog

### DIFF
--- a/src/update/UpdateNotificationDialog.cpp
+++ b/src/update/UpdateNotificationDialog.cpp
@@ -47,7 +47,7 @@ UpdateNotificationDialog::UpdateNotificationDialog(wxWindow* parent, const Notif
         htmlContent += notification.message;
         htmlContent += wxT("</body></html>");
 
-        auto htmlWindow = safenew wxHtmlWindow(S.GetParent(), wxID_ANY,
+        auto htmlWindow = safenew HtmlWindow(S.GetParent(), wxID_ANY,
             wxDefaultPosition, wxSize(400, -1), wxHW_SCROLLBAR_AUTO);
         htmlWindow->SetBorders(10);
         htmlWindow->SetPage(htmlContent);


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/9942

Problem:
wxHtmlWindow is not accessible for users of screen readers - the text is not read.

Fix:
Use HtmlWindow instead.


<!-- Use "x" to fill the checkboxes below like [x] -->

- [x ] I signed [CLA](https://www.audacityteam.org/cla/)
- [ x] The title of the pull request describes an issue it addresses
- [x ] If changes are extensive, then there is a sequence of easily reviewable commits
- [ x] Each commit's message describes its purpose and effects
- [x ] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x ] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Autobot test cases have been run
