### PR TITLE
fix: send opt out request only when it is toggled off

### DIFF
--- a/src/update/UpdateManager.cpp
+++ b/src/update/UpdateManager.cpp
@@ -62,6 +62,11 @@ BEGIN_EVENT_TABLE(UpdateManager, wxEvtHandler)
     EVT_TIMER(ID_TIMER, UpdateManager::OnTimer)
 END_EVENT_TABLE()
 
+UpdateManager::UpdateManager()
+{
+   mSendAnonymousUsageInfo = SendAnonymousUsageInfo->ReadWithDefault(false);
+}
+
 UpdateManager& UpdateManager::GetInstance()
 {
     static UpdateManager updateManager;
@@ -405,16 +410,23 @@ void UpdateManager::SendOptOutRequest() const {
 
 void UpdateManager::UpdatePrefs()
 {
+   const bool updatedSendAnonymousUsageInfo = SendAnonymousUsageInfo->Read();
+   bool prefsUpdated = false;
+
    //! Create the instance id if the user allowed it and it was not created before
-   if (SendAnonymousUsageInfo->Read()) {
+   if (updatedSendAnonymousUsageInfo && !mSendAnonymousUsageInfo) {
       if(InstanceId->Read().IsEmpty()) {
          InstanceId->Write(audacity::Uuid::Generate().ToHexString());
-         gPrefs->Flush();
+         prefsUpdated = true;
       }
    }
-   else {
+   else if (mSendAnonymousUsageInfo && !updatedSendAnonymousUsageInfo) {
       SendOptOutRequest();
    }
+
+   mSendAnonymousUsageInfo = updatedSendAnonymousUsageInfo;
+   if (prefsUpdated)
+      gPrefs->Flush();
 }
 
 std::vector<Notification> UpdateManager::GetActiveNotifications() const

--- a/src/update/UpdateManager.h
+++ b/src/update/UpdateManager.h
@@ -33,7 +33,7 @@
 class UpdateManager final : public wxEvtHandler, public PrefsListener
 {
 public:
-    UpdateManager() = default;
+    UpdateManager();
 
     static UpdateManager& GetInstance();
     static void Start(bool suppressModal);
@@ -76,6 +76,7 @@ private:
 
     std::mutex mUpdateMutex;
     bool mOnProgress{ false };
+    bool mSendAnonymousUsageInfo{ false };
 
 public:
     DECLARE_EVENT_TABLE()


### PR DESCRIPTION
The opt-out request was sent whenever the preferences were saved.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [ ] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Autobot test cases have been run
