### PR TITLE
fix: incorrect time span passed to the painter was causing slow drawing

### DIFF
--- a/src/projectscene/view/tracksitemsview/waveview.cpp
+++ b/src/projectscene/view/tracksitemsview/waveview.cpp
@@ -85,7 +85,7 @@ IWavePainter::Params WaveView::getWavePainterParams() const
 
     params.zoom = m_context->zoom();
     params.fromTime = (m_clipTime.itemStartTime - m_clipTime.startTime);
-    params.toTime = params.fromTime + (m_clipTime.itemEndTime - m_clipTime.startTime);
+    params.toTime = params.fromTime + (m_clipTime.itemEndTime - m_clipTime.itemStartTime);
     params.selectionStartTime = m_clipTime.selectionStartTime;
     params.selectionEndTime = m_clipTime.selectionEndTime;
     params.channelHeightRatio = m_channelHeightRatio;


### PR DESCRIPTION
Resolves: #9974, #9883
incorrect time span passed to the painter was causing slow drawing
<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Autobot test cases have been run
