### PR TITLE
Horizontal scrolling - fix crash of debug version on Windows

### DIFF
--- a/libraries/lib-viewport/Viewport.cpp
+++ b/libraries/lib-viewport/Viewport.cpp
@@ -223,9 +223,10 @@ void Viewport::ScrollHorizontalByPixels(int deltaPixels)
     if (!mpCallbacks)
         return;
     int current = mpCallbacks->GetHorizontalThumbPosition();
-    int max = mpCallbacks->GetHorizontalRange() -
-              mpCallbacks->GetHorizontalThumbSize();
-    int newPos = std::clamp(current - deltaPixels, 0, max);
+    int max = std::max(
+       0, mpCallbacks->GetHorizontalRange() -
+       mpCallbacks->GetHorizontalThumbSize());
+    int newPos = std::clamp(current + deltaPixels, 0, max);
     sbarH += deltaPixels;
     sbarH = std::clamp<wxInt64>(
         sbarH,


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/10032

Problem:
When no horizontal scrolling is possible, trying to scroll by dragging using the middle mouse button causes a debug exception.

When this is the case, in the call to void Viewport::ScrollHorizontalByPixels(int deltaPixels), in the call to std::clamp(current - deltaPixels, 0, max), max can be negative, leading to clamp() being undefined.

Additional issue, scrollbar thumb moves in the wrong direction.

Fix:
Ensure max is not negative (as is done in other funtions in the file, eg Viewport::SetHorizontalThumb()).

Scrollbar thumb now moves in the correct direction.


<!-- Use "x" to fill the checkboxes below like [x] -->

- [x ] I signed [CLA](https://www.audacityteam.org/cla/)
- [x ] The title of the pull request describes an issue it addresses
- [x ] If changes are extensive, then there is a sequence of easily reviewable commits
- [x ] Each commit's message describes its purpose and effects
- [x ] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x ] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Autobot test cases have been run
