### PR TITLE
9977 spectrogram optimizations

### DIFF
--- a/src/spectrogram/CMakeLists.txt
+++ b/src/spectrogram/CMakeLists.txt
@@ -13,6 +13,7 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/spectrogrammodule.h
     ${CMAKE_CURRENT_LIST_DIR}/spectrogramtypes.h
 
+    ${CMAKE_CURRENT_LIST_DIR}/internal/iclipchannelreader.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/clipparameters.cpp
     ${CMAKE_CURRENT_LIST_DIR}/internal/clipparameters.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/macromagic.h
@@ -30,8 +31,12 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/internal/trackspectrogramconfigurationprovider.cpp
     ${CMAKE_CURRENT_LIST_DIR}/internal/trackspectrogramconfigurationprovider.h
 
-    ${CMAKE_CURRENT_LIST_DIR}/internal/au3/SpectrumCache.cpp
-    ${CMAKE_CURRENT_LIST_DIR}/internal/au3/SpectrumCache.h
+    ${CMAKE_CURRENT_LIST_DIR}/internal/au3/au3clipchannelreader.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/internal/au3/au3clipchannelreader.h
+    ${CMAKE_CURRENT_LIST_DIR}/internal/au3/au3concurrentclipchannelreader.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/internal/au3/au3concurrentclipchannelreader.h
+    ${CMAKE_CURRENT_LIST_DIR}/internal/au3/au3spectrogrampainter.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/internal/au3/au3spectrogrampainter.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/au3/au3spectrogrampainter.cpp
     ${CMAKE_CURRENT_LIST_DIR}/internal/au3/au3spectrogrampainter.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/au3/au3spectrogramclipchannelpainter.cpp
@@ -41,7 +46,9 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/internal/au3/au3spectrogramutils.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/au3/au3trackspectrogramconfiguration.cpp
     ${CMAKE_CURRENT_LIST_DIR}/internal/au3/au3trackspectrogramconfiguration.h
-
+    ${CMAKE_CURRENT_LIST_DIR}/internal/au3/SpectrumCache.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/internal/au3/SpectrumCache.h
+    
     ${CMAKE_CURRENT_LIST_DIR}/view/abstractsectionparameterslistmodel.cpp
     ${CMAKE_CURRENT_LIST_DIR}/view/abstractsectionparameterslistmodel.h
     ${CMAKE_CURRENT_LIST_DIR}/view/abstractspectrogramsettingsmodel.cpp
@@ -59,7 +66,6 @@ set(MODULE_SRC
 
 set(MODULE_QML_IMPORT ${CMAKE_CURRENT_LIST_DIR}/qml)
 set(MODULE_USE_UNITY OFF)
-set(MODULE_LINK au3wrap)
+set(MODULE_LINK au3wrap Qt6::Concurrent)
 
 setup_module()
-

--- a/src/spectrogram/internal/au3/SpectrumCache.h
+++ b/src/spectrogram/internal/au3/SpectrumCache.h
@@ -3,6 +3,7 @@
  */
 #pragma once
 
+#include "internal/iclipchannelreader.h"
 #include "spectrogramtypes.h"
 
 #include "au3-utility/MemoryX.h"
@@ -14,9 +15,10 @@
 class sampleCount;
 class WaveClipChannel;
 using WaveChannelInterval = WaveClipChannel;
-class WideSampleSequence;
 
 namespace au::spectrogram {
+class IClipChannelReader;
+
 using Floats = ArrayOf<float>;
 class Au3SpectrogramSettings;
 
@@ -65,12 +67,25 @@ public:
     int dirty;
 
 private:
-    // Calculate one column of the spectrum
-    bool CalculateOneSpectrum(
-        const Au3SpectrogramSettings& settings, const WaveChannelInterval& clip, const int xx, double pixelsPerSecond, int lowerBoundX,
-        int upperBoundX, const std::vector<float>& gainFactors, float* __restrict scratch, float* __restrict out) const;
+    struct SpectrumParams {
+        const int xx;
+        const double pixelsPerSecond;
+        const int lowerBoundX;
+        const int upperBoundX;
+        const std::vector<float>& gainFactors;
+        float* const __restrict scratch;
+        float* const __restrict out;
+    };
 
-    mutable std::optional<AudioSegmentSampleView> mSampleCacheHolder;
+    struct ClipParams {
+        const long long numSamples;
+        const int sampleRate;
+        const double stretchRatio;
+    };
+
+    // Calculate one column of the spectrum
+    bool CalculateOneSpectrum(const Au3SpectrogramSettings& settings, IClipChannelReader& reader, const SpectrumParams& spectrumParams,
+                              const ClipParams& clipParams) const;
 };
 
 class SpecPxCache

--- a/src/spectrogram/internal/au3/au3clipchannelreader.cpp
+++ b/src/spectrogram/internal/au3/au3clipchannelreader.cpp
@@ -1,0 +1,20 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+#include "au3clipchannelreader.h"
+
+#include "au3-wave-track/WaveClip.h"
+#include "au3-wave-track/WaveTrack.h"
+
+namespace au::spectrogram {
+Au3ClipChannelReader::Au3ClipChannelReader(const WaveChannelInterval& waveChannelInterval)
+    : m_waveChannelInterval(waveChannelInterval)
+{
+}
+
+void Au3ClipChannelReader::readSamples(long long from, int myLen, float* destination, bool mayThrow)
+{
+    m_sampleCacheHolder.emplace(m_waveChannelInterval.GetSampleView(from, myLen, mayThrow));
+    m_sampleCacheHolder->Copy(destination, myLen);
+}
+} // namespace au::spectrogram

--- a/src/spectrogram/internal/au3/au3clipchannelreader.h
+++ b/src/spectrogram/internal/au3/au3clipchannelreader.h
@@ -1,0 +1,24 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+#pragma once
+
+#include "internal/iclipchannelreader.h"
+
+#include "au3-stretching-sequence/AudioSegmentSampleView.h"
+#include "au3-wave-track/WaveTrack.h"
+
+namespace au::spectrogram {
+class Au3ClipChannelReader final : public IClipChannelReader
+{
+public:
+    Au3ClipChannelReader(const WaveChannelInterval& waveChannelInterval);
+    ~Au3ClipChannelReader() override = default;
+
+    void readSamples(long long from, int myLen, float* destination, bool mayThrow) override;
+
+private:
+    const WaveChannelInterval& m_waveChannelInterval;
+    std::optional<AudioSegmentSampleView> m_sampleCacheHolder;
+};
+}

--- a/src/spectrogram/internal/au3/au3concurrentclipchannelreader.cpp
+++ b/src/spectrogram/internal/au3/au3concurrentclipchannelreader.cpp
@@ -1,0 +1,24 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+#include "au3concurrentclipchannelreader.h"
+
+#include "au3-wave-track/WaveClip.h"
+#include "au3-math/SampleCount.h"
+
+namespace au::spectrogram {
+Au3ConcurrentClipChannelReader::Au3ConcurrentClipChannelReader(const WaveChannelInterval& waveChannelInterval)
+    : m_waveChannelInterval(waveChannelInterval)
+{
+}
+
+void Au3ConcurrentClipChannelReader::readSamples(long long from, int myLen, float* destination, bool mayThrow)
+{
+    //! Careful: GetSampleView may be declared `const`, the SqliteSampleBlock::GetFloatSampleView it calls is not.
+    //! Hence it's probably safest to lock right from the start.
+    std::lock_guard<std::mutex> lock(m_sampleCacheMutex);
+    auto sampleView = m_waveChannelInterval.GetSampleView(sampleCount { from }, myLen, mayThrow);
+    sampleView.Copy(destination, myLen);
+    m_sampleCacheHolders.emplace_back(std::move(sampleView));
+}
+}

--- a/src/spectrogram/internal/au3/au3concurrentclipchannelreader.h
+++ b/src/spectrogram/internal/au3/au3concurrentclipchannelreader.h
@@ -1,0 +1,30 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+#pragma once
+
+#include "internal/iclipchannelreader.h"
+
+#include "au3-stretching-sequence/AudioSegmentSampleView.h"
+#include "au3-wave-track/WaveTrack.h"
+
+#include <mutex>
+#include <vector>
+
+class WaveClipChannel;
+
+namespace au::spectrogram {
+class Au3ConcurrentClipChannelReader final : public IClipChannelReader
+{
+public:
+    Au3ConcurrentClipChannelReader(const WaveChannelInterval&);
+    ~Au3ConcurrentClipChannelReader() override = default;
+
+    void readSamples(long long from, int myLen, float* destination, bool mayThrow) override;
+
+private:
+    const WaveChannelInterval& m_waveChannelInterval;
+    std::vector<AudioSegmentSampleView> m_sampleCacheHolders;
+    std::mutex m_sampleCacheMutex;
+};
+}

--- a/src/spectrogram/internal/au3/au3spectrogramclipchannelpainter.cpp
+++ b/src/spectrogram/internal/au3/au3spectrogramclipchannelpainter.cpp
@@ -203,6 +203,7 @@ void Au3SpectrogramClipChannelPainter::fillImage(QImage& image,
     // Bug 2389 - always draw at least one pixel of selection.
     int selectedX = timeToPosition(viewInfo, selectionInfo.startTime) - leftOffset;
 
+    // There used to be a pragma omp parallel for here. Can/Should we use QtConcurrent?
     for (int xx = 0; xx < imageWidth; ++xx) {
         const auto w0 = sampleCount(
             0.5 + sampleRate / stretchRatio
@@ -214,6 +215,7 @@ void Au3SpectrogramClipChannelPainter::fillImage(QImage& image,
         bool maybeSelected = ssel0 <= w0 && w1 < ssel1;
         maybeSelected = maybeSelected || (xx == selectedX);
 
+        // There used to be a pragma omp parallel for here. Can/Should we use QtConcurrent?
         for (int yy = 0; yy < imageHeight; ++yy) {
             const float bin     = bins[yy];
             const float nextBin = bins[yy + 1];

--- a/src/spectrogram/internal/au3/au3spectrogramsettings.cpp
+++ b/src/spectrogram/internal/au3/au3spectrogramsettings.cpp
@@ -4,6 +4,8 @@
 #include "au3spectrogramsettings.h"
 
 #include "iglobalspectrogramconfiguration.h"
+#include "au3spectrogramutils.h"
+#include "spectrogramtypes.h"
 
 #include "au3-basic-ui/BasicUI.h"
 #include "au3-fft/FFT.h"
@@ -11,8 +13,6 @@
 #include "au3-wave-track/WaveTrack.h"
 
 #include "framework/global/log.h"
-#include "au3spectrogramutils.h"
-#include "spectrogramtypes.h"
 
 #include <algorithm>
 #include <cmath>
@@ -29,17 +29,16 @@ static const AttachedTrackObjects::RegisteredFactory key1{
             return settings;
         }
 
-        const SpectrogramSettings globalSettings = globalConfig->allSettings();
-        settings->range = globalSettings.colorRangeDb;
-        settings->gain = globalSettings.colorGainDb;
-        settings->frequencyGain = globalSettings.colorHighBoostDbPerDec;
-        settings->SetWindowType(globalSettings.windowType);
-        settings->SetWindowSize(1 << globalSettings.winSizeLog2);
-        settings->SetZeroPaddingFactor(globalSettings.zeroPaddingFactor);
-        settings->colorScheme = globalSettings.colorScheme;
-        settings->scaleType = globalSettings.scale;
-        settings->spectralSelectionEnabled = globalSettings.spectralSelectionEnabled;
-        settings->algorithm = globalSettings.algorithm;
+        settings->range = globalConfig->colorRangeDb();
+        settings->gain = globalConfig->colorGainDb();
+        settings->frequencyGain = globalConfig->colorHighBoostDbPerDec();
+        settings->SetWindowType(globalConfig->windowType());
+        settings->SetWindowSize(1 << globalConfig->winSizeLog2());
+        settings->SetZeroPaddingFactor(globalConfig->zeroPaddingFactor());
+        settings->colorScheme = globalConfig->colorScheme();
+        settings->scaleType = globalConfig->scale();
+        settings->spectralSelectionEnabled = globalConfig->spectralSelectionEnabled();
+        settings->algorithm = globalConfig->algorithm();
 
         return settings;
     }
@@ -62,24 +61,26 @@ Au3SpectrogramSettings& Au3SpectrogramSettings::Get(WaveTrack& track)
 }
 
 Au3SpectrogramSettings::Au3SpectrogramSettings(const Au3SpectrogramSettings& other)
-    : minFreq(other.minFreq)
-    , maxFreq(other.maxFreq)
+    : syncWithGlobalSettings(other.syncWithGlobalSettings)
     , range(other.range)
     , gain(other.gain)
     , frequencyGain(other.frequencyGain)
-    , m_windowType(other.m_windowType)
-    , m_windowSize(other.m_windowSize)
-    , m_zeroPaddingFactor(other.m_zeroPaddingFactor)
     , colorScheme(other.colorScheme)
     , scaleType(other.scaleType)
     , spectralSelectionEnabled(other.spectralSelectionEnabled)
     , algorithm(other.algorithm)
+    , minFreq(other.minFreq)
+    , maxFreq(other.maxFreq)
 
     // Do not copy these!
     , hFFT{}
     , window{}
     , tWindow{}
     , dWindow{}
+
+    , m_windowType(other.m_windowType)
+    , m_windowSize(other.m_windowSize)
+    , m_zeroPaddingFactor(other.m_zeroPaddingFactor)
 {
 }
 

--- a/src/spectrogram/internal/au3/au3trackspectrogramconfiguration.cpp
+++ b/src/spectrogram/internal/au3/au3trackspectrogramconfiguration.cpp
@@ -171,34 +171,4 @@ void Au3TrackSpectrogramConfiguration::setUseGlobalSettings(bool value)
 {
     m_settings.syncWithGlobalSettings = value;
 }
-
-SpectrogramSettings Au3TrackSpectrogramConfiguration::allSettings() const
-{
-    SpectrogramSettings allSettings;
-    allSettings.spectralSelectionEnabled = spectralSelectionEnabled();
-    allSettings.colorGainDb = colorGainDb();
-    allSettings.colorRangeDb = colorRangeDb();
-    allSettings.colorHighBoostDbPerDec = colorHighBoostDbPerDec();
-    allSettings.colorScheme = colorScheme();
-    allSettings.scale = scale();
-    allSettings.algorithm = algorithm();
-    allSettings.windowType = windowType();
-    allSettings.winSizeLog2 = winSizeLog2();
-    allSettings.zeroPaddingFactor = zeroPaddingFactor();
-    return allSettings;
-}
-
-void Au3TrackSpectrogramConfiguration::setAllSettings(const SpectrogramSettings& allSettings)
-{
-    setSpectralSelectionEnabled(allSettings.spectralSelectionEnabled);
-    setColorGainDb(allSettings.colorGainDb);
-    setColorRangeDb(allSettings.colorRangeDb);
-    setColorHighBoostDbPerDec(allSettings.colorHighBoostDbPerDec);
-    setColorScheme(allSettings.colorScheme);
-    setScale(allSettings.scale);
-    setAlgorithm(allSettings.algorithm);
-    setWindowType(allSettings.windowType);
-    setWinSizeLog2(allSettings.winSizeLog2);
-    setZeroPaddingFactor(allSettings.zeroPaddingFactor);
-}
 }

--- a/src/spectrogram/internal/au3/au3trackspectrogramconfiguration.h
+++ b/src/spectrogram/internal/au3/au3trackspectrogramconfiguration.h
@@ -53,9 +53,6 @@ public:
     bool useGlobalSettings() const;
     void setUseGlobalSettings(bool value);
 
-    SpectrogramSettings allSettings() const override;
-    void setAllSettings(const SpectrogramSettings&) override;
-
 private:
     Au3SpectrogramSettings& m_settings;
 };

--- a/src/spectrogram/internal/globalspectrogramconfiguration.cpp
+++ b/src/spectrogram/internal/globalspectrogramconfiguration.cpp
@@ -264,36 +264,6 @@ muse::async::Channel<int> GlobalSpectrogramConfiguration::zeroPaddingFactorChang
     return m_zeroPaddingFactorChanged;
 }
 
-SpectrogramSettings GlobalSpectrogramConfiguration::allSettings() const
-{
-    SpectrogramSettings settings;
-    settings.spectralSelectionEnabled = spectralSelectionEnabled();
-    settings.colorScheme = colorScheme();
-    settings.colorGainDb = colorGainDb();
-    settings.colorRangeDb = colorRangeDb();
-    settings.colorHighBoostDbPerDec = colorHighBoostDbPerDec();
-    settings.scale = scale();
-    settings.algorithm = algorithm();
-    settings.windowType = windowType();
-    settings.winSizeLog2 = winSizeLog2();
-    settings.zeroPaddingFactor = zeroPaddingFactor();
-    return settings;
-}
-
-void GlobalSpectrogramConfiguration::setAllSettings(const SpectrogramSettings& settings)
-{
-    setSpectralSelectionEnabled(settings.spectralSelectionEnabled);
-    setColorScheme(settings.colorScheme);
-    setColorGainDb(settings.colorGainDb);
-    setColorRangeDb(settings.colorRangeDb);
-    setColorHighBoostDbPerDec(settings.colorHighBoostDbPerDec);
-    setScale(settings.scale);
-    setAlgorithm(settings.algorithm);
-    setWindowType(settings.windowType);
-    setWinSizeLog2(settings.winSizeLog2);
-    setZeroPaddingFactor(settings.zeroPaddingFactor);
-}
-
 muse::async::Notification GlobalSpectrogramConfiguration::someSettingChanged() const
 {
     return m_someSettingChanged;

--- a/src/spectrogram/internal/globalspectrogramconfiguration.h
+++ b/src/spectrogram/internal/globalspectrogramconfiguration.h
@@ -55,8 +55,6 @@ public:
     void setZeroPaddingFactor(int value) override;
     muse::async::Channel<int> zeroPaddingFactorChanged() const override;
 
-    SpectrogramSettings allSettings() const override;
-    void setAllSettings(const SpectrogramSettings&) override;
     muse::async::Notification someSettingChanged() const override;
 
 private:

--- a/src/spectrogram/internal/iclipchannelreader.h
+++ b/src/spectrogram/internal/iclipchannelreader.h
@@ -1,0 +1,13 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+#pragma once
+
+namespace au::spectrogram {
+class IClipChannelReader
+{
+public:
+    virtual ~IClipChannelReader() = default;
+    virtual void readSamples(long long from, int myLen, float* destination, bool mayThrow) = 0;
+};
+}

--- a/src/spectrogram/internal/trackspectrogramconfigurationprovider.cpp
+++ b/src/spectrogram/internal/trackspectrogramconfigurationprovider.cpp
@@ -16,4 +16,19 @@ ITrackSpectrogramConfigurationPtr TrackSpectrogramConfigurationProvider::trackSp
 {
     return Au3TrackSpectrogramConfiguration::create(trackId, *globalContext());
 }
+
+void TrackSpectrogramConfigurationProvider::copyConfiguration(const ISpectrogramConfiguration& source,
+                                                              ISpectrogramConfiguration& destination) const
+{
+    destination.setSpectralSelectionEnabled(source.spectralSelectionEnabled());
+    destination.setColorGainDb(source.colorGainDb());
+    destination.setColorRangeDb(source.colorRangeDb());
+    destination.setColorHighBoostDbPerDec(source.colorHighBoostDbPerDec());
+    destination.setColorScheme(source.colorScheme());
+    destination.setScale(source.scale());
+    destination.setAlgorithm(source.algorithm());
+    destination.setWindowType(source.windowType());
+    destination.setWinSizeLog2(source.winSizeLog2());
+    destination.setZeroPaddingFactor(source.zeroPaddingFactor());
+}
 }

--- a/src/spectrogram/internal/trackspectrogramconfigurationprovider.h
+++ b/src/spectrogram/internal/trackspectrogramconfigurationprovider.h
@@ -22,5 +22,6 @@ public:
     void init();
 
     ITrackSpectrogramConfigurationPtr trackSpectrogramConfiguration(int trackId) const override;
+    void copyConfiguration(const ISpectrogramConfiguration& source, ISpectrogramConfiguration& destination) const override;
 };
 }

--- a/src/spectrogram/ispectrogramconfiguration.h
+++ b/src/spectrogram/ispectrogramconfiguration.h
@@ -43,8 +43,5 @@ public:
 
     virtual int zeroPaddingFactor() const = 0;
     virtual void setZeroPaddingFactor(int value) = 0;
-
-    virtual SpectrogramSettings allSettings() const = 0;
-    virtual void setAllSettings(const SpectrogramSettings&) = 0;
 };
 } // namespace au::spectrogram

--- a/src/spectrogram/itrackspectrogramconfigurationprovider.h
+++ b/src/spectrogram/itrackspectrogramconfigurationprovider.h
@@ -16,5 +16,6 @@ public:
     virtual ~ITrackSpectrogramConfigurationProvider() = default;
 
     virtual ITrackSpectrogramConfigurationPtr trackSpectrogramConfiguration(int trackId) const = 0;
+    virtual void copyConfiguration(const ISpectrogramConfiguration& source, ISpectrogramConfiguration& destination) const = 0;
 };
 }

--- a/src/spectrogram/spectrogramtypes.h
+++ b/src/spectrogram/spectrogramtypes.h
@@ -44,19 +44,6 @@ enum class SpectrogramWindowType {
     _count
 };
 
-struct SpectrogramSettings {
-    bool spectralSelectionEnabled = false;
-    SpectrogramColorScheme colorScheme = static_cast<SpectrogramColorScheme>(0);
-    int colorGainDb = 0;
-    int colorRangeDb = 0;
-    int colorHighBoostDbPerDec = 0;
-    SpectrogramScale scale = static_cast<SpectrogramScale>(0);
-    SpectrogramAlgorithm algorithm = static_cast<SpectrogramAlgorithm>(0);
-    SpectrogramWindowType windowType = static_cast<SpectrogramWindowType>(0);
-    int winSizeLog2 = 0;
-    int zeroPaddingFactor = 0;
-};
-
 struct SelectionInfo {
     static constexpr int UndefinedFrequency = -1;
 

--- a/src/trackedit/internal/snapshotspectrogramconfiguration.h
+++ b/src/trackedit/internal/snapshotspectrogramconfiguration.h
@@ -3,15 +3,15 @@
  */
 #pragma once
 
-#include "spectrogram/ispectrogramconfiguration.h"
+#include "spectrogram/itrackspectrogramconfiguration.h"
 
 #include <cassert>
 
 namespace au::trackedit {
-class SnapshotSpectrogramConfiguration final : public spectrogram::ISpectrogramConfiguration
+class SnapshotSpectrogramConfiguration final : public spectrogram::ITrackSpectrogramConfiguration
 {
 public:
-    SnapshotSpectrogramConfiguration(const ISpectrogramConfiguration& config)
+    SnapshotSpectrogramConfiguration(const ITrackSpectrogramConfiguration& config)
         : m_spectralSelectionEnabled{config.spectralSelectionEnabled()},
         m_colorGainDb{config.colorGainDb()},
         m_colorRangeDb{config.colorRangeDb()},
@@ -21,7 +21,8 @@ public:
         m_algorithm{config.algorithm()},
         m_windowType{config.windowType()},
         m_winSizeLog2{config.winSizeLog2()},
-        m_zeroPaddingFactor{config.zeroPaddingFactor()}
+        m_zeroPaddingFactor{config.zeroPaddingFactor()},
+        m_useGlobalSettings{config.useGlobalSettings()}
     {
     }
 
@@ -57,13 +58,8 @@ public:
     int zeroPaddingFactor() const override { return m_zeroPaddingFactor; }
     void setZeroPaddingFactor(int) override { assert(false); }
 
-    spectrogram::SpectrogramSettings allSettings() const override
-    {
-        assert(false);
-        return {};
-    }
-
-    void setAllSettings(const spectrogram::SpectrogramSettings&) override { assert(false); }
+    bool useGlobalSettings() const override { return m_useGlobalSettings; }
+    void setUseGlobalSettings(bool) override { assert(false); }
 
 private:
     const bool m_spectralSelectionEnabled;
@@ -76,5 +72,6 @@ private:
     const spectrogram::SpectrogramWindowType m_windowType;
     const int m_winSizeLog2;
     const int m_zeroPaddingFactor;
+    const bool m_useGlobalSettings;
 };
 }

--- a/src/trackedit/internal/trackspectrogramsettingsupdater.cpp
+++ b/src/trackedit/internal/trackspectrogramsettingsupdater.cpp
@@ -13,14 +13,6 @@ void TrackSpectrogramSettingsUpdater::init()
         maybeApplyGlobalSettingsToTrack();
     });
 
-    appShellConfiguration()->settingsApplied().onNotify(this, [this]{
-        forEachTrack([](ITrackeditProject& trackeditProject, const Track& track, spectrogram::ITrackSpectrogramConfiguration& config){
-            if (config.useGlobalSettings()) {
-                trackeditProject.notifyAboutTrackChanged(track);
-            }
-        });
-    });
-
     globalContext()->currentTrackeditProjectChanged().onNotify(this, [this]{
         maybeApplyGlobalSettingsToTrack();
     });
@@ -30,9 +22,10 @@ void TrackSpectrogramSettingsUpdater::init()
 
 void TrackSpectrogramSettingsUpdater::maybeApplyGlobalSettingsToTrack()
 {
-    forEachTrack([this](ITrackeditProject&, const Track&, spectrogram::ITrackSpectrogramConfiguration& config){
+    forEachTrack([this](ITrackeditProject& trackeditProject, const Track& track, spectrogram::ITrackSpectrogramConfiguration& config){
         if (config.useGlobalSettings()) {
-            config.setAllSettings(globalSpectrogramConfiguration()->allSettings());
+            trackSpectrogramConfigurationProvider()->copyConfiguration(*globalSpectrogramConfiguration(), config);
+            trackeditProject.notifyAboutTrackChanged(track);
         }
     });
 }

--- a/src/trackedit/internal/trackspectrogramsettingsupdater.cpp
+++ b/src/trackedit/internal/trackspectrogramsettingsupdater.cpp
@@ -38,6 +38,9 @@ void TrackSpectrogramSettingsUpdater::forEachTrack(std::function<void(ITrackedit
         return;
     }
     for (const Track& track : trackeditProject->trackList()) {
+        if (track.type != TrackType::Mono && track.type != TrackType::Stereo) {
+            continue;
+        }
         const auto trackConfig = trackSpectrogramConfigurationProvider()->trackSpectrogramConfiguration(track.id);
         IF_ASSERT_FAILED(trackConfig) {
             continue;

--- a/src/trackedit/internal/trackspectrogramsettingsupdater.h
+++ b/src/trackedit/internal/trackspectrogramsettingsupdater.h
@@ -6,7 +6,6 @@
 #include "context/iglobalcontext.h"
 #include "spectrogram/iglobalspectrogramconfiguration.h"
 #include "spectrogram/itrackspectrogramconfigurationprovider.h"
-#include "appshell/iappshellconfiguration.h"
 
 #include "framework/global/async/asyncable.h"
 #include "framework/global/modularity/ioc.h"
@@ -19,7 +18,6 @@ class TrackSpectrogramSettingsUpdater : public muse::async::Asyncable
 {
     muse::Inject<au::context::IGlobalContext> globalContext;
     muse::Inject<spectrogram::IGlobalSpectrogramConfiguration> globalSpectrogramConfiguration;
-    muse::Inject<au::appshell::IAppShellConfiguration> appShellConfiguration;
     muse::Inject<spectrogram::ITrackSpectrogramConfigurationProvider> trackSpectrogramConfigurationProvider;
 
 public:

--- a/src/trackedit/qml/Audacity/TrackEdit/TrackSpectrogramSettingsDialog.qml
+++ b/src/trackedit/qml/Audacity/TrackEdit/TrackSpectrogramSettingsDialog.qml
@@ -95,20 +95,6 @@ StyledDialogView {
         spacing: 8
 
         FlatButton {
-            id: previewBtn
-
-            height: prv.buttonHeight
-            minWidth: 80
-            isLeftSide: true
-
-            text: qsTrc("spectrogram/prefs", "Preview")
-            buttonRole: ButtonBoxModel.CustomRole
-            buttonId: ButtonBoxModel.CustomButton + 1
-
-            onClicked: settingsModel.preview()
-        }
-
-        FlatButton {
             id: cancelBtn
 
             height: prv.buttonHeight
@@ -129,13 +115,13 @@ StyledDialogView {
             height: prv.buttonHeight
             minWidth: 80
 
-            text: qsTrc("spectrogram/prefs", "Apply")
+            text: qsTrc("spectrogram/prefs", "Ok")
             buttonRole: ButtonBoxModel.AcceptRole
-            buttonId: ButtonBoxModel.Apply
+            buttonId: ButtonBoxModel.Ok
             accentButton: true
 
             onClicked: {
-                settingsModel.apply()
+                settingsModel.accept()
                 root.accept()
             }
         }

--- a/src/trackedit/view/trackspectrogramsettingsmodel.h
+++ b/src/trackedit/view/trackspectrogramsettingsmodel.h
@@ -28,8 +28,7 @@ public:
     TrackSpectrogramSettingsModel(QObject* parent = nullptr);
     ~TrackSpectrogramSettingsModel() override;
 
-    Q_INVOKABLE void preview();
-    Q_INVOKABLE void apply();
+    Q_INVOKABLE void accept();
 
     int trackId() const { return m_trackId; }
     void setTrackId(int value);
@@ -74,38 +73,15 @@ signals:
     void useGlobalSettingsChanged();
 
 private:
-    void doSetUseGlobalSettings(bool value);
-    void doSetSpectralSelectionEnabled_1(bool value, bool resetUseGlobalSettings);
-    void doSetColorGainDb_2(int value, bool resetUseGlobalSettings);
-    void doSetColorRangeDb_3(int value, bool resetUseGlobalSettings);
-    void doSetColorHighBoostDbPerDec_4(int value, bool resetUseGlobalSettings);
-    void doSetColorScheme_5(int value, bool resetUseGlobalSettings);
-    void doSetScale_6(int value, bool resetUseGlobalSettings);
-    void doSetAlgorithm_7(int value, bool resetUseGlobalSettings);
-    void doSetWindowType_8(int value, bool resetUseGlobalSettings);
-    void doSetWindowSize_9(int value, bool resetUseGlobalSettings);
-    void doSetZeroPaddingFactor_10(int value, bool resetUseGlobalSettings);
-
     void classBegin() override {}
     void componentComplete() override;
 
-    void readFromConfig(const spectrogram::ISpectrogramConfiguration&);
-    void writeToConfig(spectrogram::ISpectrogramConfiguration&);
+    void onSettingChanged();
     void sendRepaintRequest();
 
     int m_trackId = -1;
-    bool m_useGlobalSettings = false;
-    bool m_spectralSelectionEnabled_1 = false;
-    int m_colorGainDb_2 = 0;
-    int m_colorRangeDb_3 = 0;
-    int m_colorHighBoostDbPerDec_4 = 0;
-    spectrogram::SpectrogramColorScheme m_colorScheme_5 = static_cast<spectrogram::SpectrogramColorScheme>(0);
-    spectrogram::SpectrogramScale m_scale_6 = static_cast<spectrogram::SpectrogramScale>(0);
-    spectrogram::SpectrogramAlgorithm m_algorithm_7 = static_cast<spectrogram::SpectrogramAlgorithm>(0);
-    spectrogram::SpectrogramWindowType m_windowType_8 = static_cast<spectrogram::SpectrogramWindowType>(0);
-    int m_windowSize_9 = 0;
-    int m_zeroPaddingFactor_10 = 0;
 
-    std::unique_ptr<spectrogram::ISpectrogramConfiguration> m_configToRevertTo;
+    std::shared_ptr<spectrogram::ITrackSpectrogramConfiguration> m_trackConfig;
+    std::unique_ptr<spectrogram::ITrackSpectrogramConfiguration> m_initialTrackConfig;
 };
 }


### PR DESCRIPTION
Resolves: #9977

* Parallelizes computation of spectrogram individual spectra, average speed up across OSs was measured to be 500%.
* Consequently, "Apply" and "Preview" buttons, that were here because of this previous slowness, can now be removed, improving UX and simplifying code.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [ ] I signed [CLA](https://www.audacityteam.org/cla/)
- [ ] The title of the pull request describes an issue it addresses
- [ ] If changes are extensive, then there is a sequence of easily reviewable commits
- [ ] Each commit's message describes its purpose and effects
- [ ] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [ ] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:
- [x] Changing a spectrogram setting in the track preferences is reflected immediately,
- [x] "Preview" button is gone in track spectrogram settings,
- [x] Changing a spectrogram setting in the global preferences is reflected immediately in the tracks with spectrogram view and whose "Use global settings" setting is ON.
- [ ] "Cancel" button of both global preferences and track spectrogram settings restores the original settings
- [ ] Autobot test cases have been run
