### PR TITLE
fix: solo/mute handling is performed via change detecor

### DIFF
--- a/src/au3wrap/internal/domconverter.cpp
+++ b/src/au3wrap/internal/domconverter.cpp
@@ -71,6 +71,26 @@ au::trackedit::TrackViewType trackViewType(const Au3Track* track)
         return type;
     }
 }
+
+bool trackSolo(const Au3Track* track)
+{
+    const auto* playableTrack = dynamic_cast<const PlayableTrack*>(track);
+    if (playableTrack == nullptr) {
+        return false;
+    }
+
+    return playableTrack->GetSolo();
+}
+
+bool trackMute(const Au3Track* track)
+{
+    const auto* playableTrack = dynamic_cast<const PlayableTrack*>(track);
+    if (playableTrack == nullptr) {
+        return false;
+    }
+
+    return playableTrack->GetMute();
+}
 }
 
 au::trackedit::Clip DomConverter::clip(const Au3WaveTrack* waveTrack, const Au3WaveClip* au3clip)
@@ -114,6 +134,8 @@ au::trackedit::Track DomConverter::track(const Au3Track* track)
     au4t.format = trackFormat(track);
     au4t.viewType = trackViewType(track);
     au4t.rate = trackRate(track);
+    au4t.solo = trackSolo(track);
+    au4t.mute = trackMute(track);
     return au4t;
 }
 

--- a/src/projectscene/view/tracksitemsview/viewtrackslistmodel.h
+++ b/src/projectscene/view/tracksitemsview/viewtrackslistmodel.h
@@ -13,7 +13,6 @@
 #include "context/iglobalcontext.h"
 #include "projectscene/iprojectsceneconfiguration.h"
 #include "trackedit/iselectioncontroller.h"
-#include "trackedit/iprojecthistory.h"
 #include "trackedit/itrackeditinteraction.h"
 #include "playback/itrackplaybackcontrol.h"
 #include "playback/iplaybackconfiguration.h"
@@ -32,7 +31,6 @@ class ViewTracksListModel : public QAbstractListModel, public muse::async::Async
     muse::Inject<au::context::IGlobalContext> globalContext;
     muse::Inject<projectscene::IProjectSceneConfiguration> projectSceneConfiguration;
     muse::Inject<trackedit::ISelectionController> selectionController;
-    muse::Inject<trackedit::IProjectHistory> projectHistory;
     muse::Inject<trackedit::ITrackeditInteraction> trackeditInteraction;
     muse::Inject<playback::ITrackPlaybackControl> trackPlaybackControl;
     muse::Inject<playback::IPlaybackConfiguration> playbackConfiguration;
@@ -74,6 +72,8 @@ private:
         DbRangeRole,
         ColorRole,
     };
+
+    QModelIndex indexOf(trackedit::TrackId trackId);
 
     std::vector<trackedit::Track> m_trackList;
 };

--- a/src/projectscene/view/trackspanel/wavetrackitem.cpp
+++ b/src/projectscene/view/trackspanel/wavetrackitem.cpp
@@ -77,12 +77,6 @@ void WaveTrackItem::init(const trackedit::Track& track)
         muteOrSoloChanged();
     }, muse::async::Asyncable::Mode::SetReplace);
 
-    projectHistory()->historyChanged().onNotify(this, [this]() {
-        if (isAudible()) {
-            muteOrSoloChanged();
-        }
-    }, muse::async::Asyncable::Mode::SetReplace);
-
     const int inputChannelsCount = audioDevicesProvider()->inputChannelsSelected();
     m_recordStreamChannelsMatch = (trackType() == trackedit::TrackType::Mono && inputChannelsCount == 1)
                                   || (trackType() == trackedit::TrackType::Stereo && inputChannelsCount == 2);

--- a/src/projectscene/view/trackspanel/wavetrackitem.h
+++ b/src/projectscene/view/trackspanel/wavetrackitem.h
@@ -7,7 +7,6 @@
 #include "playback/iplayback.h"
 #include "playback/itrackplaybackcontrol.h"
 #include "record/irecord.h"
-#include "trackedit/iprojecthistory.h"
 
 #include "trackitem.h"
 
@@ -33,7 +32,6 @@ class WaveTrackItem : public TrackItem
     muse::Inject<playback::IPlayback> playback;
     muse::Inject<record::IRecord> record;
     muse::Inject<audio::IAudioDevicesProvider> audioDevicesProvider;
-    muse::Inject<trackedit::IProjectHistory> projectHistory;
 
 public:
     explicit WaveTrackItem(QObject* parent = nullptr);

--- a/src/trackedit/dom/track.h
+++ b/src/trackedit/dom/track.h
@@ -62,7 +62,9 @@ struct Track {
     muse::draw::Color color;
     TrackFormat format = TrackFormat::Undefined;
     TrackViewType viewType = TrackViewType::Unspecified;
-    uint64_t rate;
+    uint64_t rate = 0;
+    bool solo = false;
+    bool mute = false;
 };
 
 using TrackList = std::vector<Track>;

--- a/src/trackedit/internal/changedetection.cpp
+++ b/src/trackedit/internal/changedetection.cpp
@@ -252,7 +252,9 @@ void notifyOfUndoRedo(const TracksAndItems& before,
     {
         auto trackFieldComparison = [](const Track& first, const Track& second) {
             return first.type == second.type
-                   && first.title == second.title;
+                   && first.title == second.title
+                   && first.solo == second.solo
+                   && first.mute == second.mute;
 
             //! For now these do not result in "autosave",
             //  and so should not be criteria under undo/redo.


### PR DESCRIPTION
The original approach was causing an assert on undo

STR:
- Create a clip
- Copy the clip to a new track
- Undo

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [x] Undo redo correctly restores mute/solo state
- [x] Adding/removing/moving tracks behaves as expected
