### PR TITLE
9984 fix(timeline): Set play region on playhead release

### DIFF
--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/PlayCursorHead.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/PlayCursorHead.qml
@@ -2,84 +2,60 @@ import QtQuick
 import Muse.Ui
 import Muse.UiComponents
 
-Item {
-    id: playCursorHead
-
-    property bool timelinePressed: false
-
-    signal setPlaybackPosition(real x)
-    signal playCursorMousePositionChanged(real x)
+StyledIconLabel {
+    id: root
 
     antialiasing: true
 
-    StyledIconLabel {
-        id: playheadIcon
+    y: -1 // offset up to avoid too much cropping
 
-        x: -(playheadIcon.width) / 2
-        y: -1 // offset up to avoid too much cropping
+    iconCode: IconCode.PLAYHEAD_FILLED
+
+    font.pixelSize: 17
+    color: "black"
+
+    StyledIconLabel {
+        id: playheadFill
+
+        // inset the Fill Icon by 1px X,Y
+        x: 1
+        y: 1
 
         iconCode: IconCode.PLAYHEAD_FILLED
 
-        font.pixelSize: 17
+        font.pixelSize: 15
+        color: "white"
+    }
+
+    // we do some pixel trickery to hide the aliased bottom part and "connect" to the PlayCursorLine
+    Rectangle {
+        // this is to remove the aliased part in the bottom of the Icon
+        id: playheadBottomCenterDot
+        width: 1
+        height: 2
+        x: parent.width / 2
+        y: 15
+        color: "white"
+        antialiasing: true
+    }
+    Rectangle {
+        // this is to remove the aliased part in the bottom of the Icon
+        id: playheadBottomCenterDotLeft
+        width: 1
+        height: 1
+        x: (parent.width / 2) - 1
+        y: 16
         color: "black"
-
-        StyledIconLabel {
-            id: playheadFill
-
-            // inset the Fill Icon by 1px X,Y
-            x: 1
-            y: 1
-
-            iconCode: IconCode.PLAYHEAD_FILLED
-
-            font.pixelSize: 15
-            color: "white"
-        }
-
-        // we do some pixel trickery to hide the aliased bottom part and "connect" to the PlayCursorLine
-        Rectangle {
-            // this is to remove the aliased part in the bottom of the Icon
-            id: playheadBottomCenterDot
-            width: 1
-            height: 2
-            x: parent.width / 2
-            y: 15
-            color: "white"
-            antialiasing: true
-        }
-        Rectangle {
-            // this is to remove the aliased part in the bottom of the Icon
-            id: playheadBottomCenterDotLeft
-            width: 1
-            height: 1
-            x: (parent.width / 2) - 1
-            y: 16
-            color: "black"
-            antialiasing: true
-        }
-        Rectangle {
-            // this is to remove the aliased part in the bottom of the Icon
-            id: playheadBottomCenterDotRight
-            width: 1
-            height: 1
-            x: (parent.width / 2) + 1
-            y: 16
-            color: "black"
-            antialiasing: true
-        }
-
-        MouseArea {
-            anchors.fill: parent
-            hoverEnabled: true
-            cursorShape: pressed || timelinePressed ? Qt.ClosedHandCursor : Qt.OpenHandCursor
-
-            onPositionChanged: function (e) {
-                var ix = mapToItem(content, e.x, e.y).x
-                if (pressed) {
-                    setPlaybackPosition(ix)
-                }
-                playCursorMousePositionChanged(ix)
-            }
-        }
+        antialiasing: true
+    }
+    Rectangle {
+        // this is to remove the aliased part in the bottom of the Icon
+        id: playheadBottomCenterDotRight
+        width: 1
+        height: 1
+        x: (parent.width / 2) + 1
+        y: 16
+        color: "black"
+        antialiasing: true
     }
 }

--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TracksItemsView.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TracksItemsView.qml
@@ -320,16 +320,29 @@ Rectangle {
                 anchors.top: parent.top
                 anchors.topMargin: 24
 
-                x: playCursorController.positionX
+                x: playCursorController.positionX - (width / 2)
 
-                timelinePressed: timelineMouseArea.pressed
+                MouseArea {
+                    anchors.fill: parent
+                    hoverEnabled: true
+                    cursorShape: pressed || timelineMouseArea.pressed ? Qt.ClosedHandCursor : Qt.OpenHandCursor
 
-                onSetPlaybackPosition: function (ix) {
-                    playCursorController.seekToX(ix)
-                }
+                    onPositionChanged: function (e) {
+                        var ix = mapToItem(timeline, e.x, e.y).x
+                        if (pressed) {
+                            playCursorController.seekToX(ix)
+                        }
+                        timeline.updateCursorPosition(ix, 0)
+                    }
 
-                onPlayCursorMousePositionChanged: function (ix) {
-                    timeline.updateCursorPosition(ix, 0)
+                    onReleased: function (e) {
+                        var ix = mapToItem(timeline, e.x, e.y).x
+                        playCursorController.seekToX(ix)
+                        if (!timelineMouseArea.playRegionActivated) {
+                            playCursorController.seekToX(ix, playbackState.isPlaying || timeline.context.playbackOnRulerClickEnabled)
+                            playCursorController.setPlaybackRegion(ix, ix)
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
Resolves: #9984 

When drag and drop the playhead the playregion should be updated.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [x] Set different play regions (by selecting content and creating a loop region). Check that everything is working correctly when you click or drag the playhead.