### PR TITLE
9922 spectrogram settings navigation

### DIFF
--- a/src/appshell/qml/Preferences/internal/SpectrogramAlgorithmSection.qml
+++ b/src/appshell/qml/Preferences/internal/SpectrogramAlgorithmSection.qml
@@ -24,11 +24,16 @@ SpectrogramBaseSection {
             columnWidth: root.prefsColumnWidth
         }
 
+        clip: false // or the highlight rectangle will be clipped
         spacing: root.mediumSpacing
         width: parent.width
         height: contentHeight
 
         delegate: ComboBoxWithTitle {
+            navigation.panel: root.navigation
+            navigation.order: index
+            navigation.name: "AlgorithmComboBox_" + index
+
             title: controlLabel
             columnWidth: controlWidth
             model: controlPossibleValues

--- a/src/appshell/qml/Preferences/internal/SpectrogramBaseSection.qml
+++ b/src/appshell/qml/Preferences/internal/SpectrogramBaseSection.qml
@@ -28,4 +28,6 @@ BaseSection {
             root.activeFocusRequested(Qt.rect(x, y, width, height))
         }
     }
+
+    navigationOrderEnd: root.navigation.order
 }

--- a/src/appshell/qml/Preferences/internal/SpectrogramColorsSection.qml
+++ b/src/appshell/qml/Preferences/internal/SpectrogramColorsSection.qml
@@ -22,6 +22,8 @@ SpectrogramBaseSection {
         spacing: root.mediumSpacing
 
         Repeater {
+            id: repeater
+
             model: ColorSectionParameterListModel {
                 settingsModel: root.settingsModel
                 columnWidth: root.prefsColumnWidth
@@ -29,6 +31,10 @@ SpectrogramBaseSection {
 
             IncrementalPropertyControlWithTitle {
                 id: control
+
+                navigation.panel: root.navigation
+                navigation.order: index
+                navigation.name: "ColorsIncrementalControl_" + index
 
                 spacing: root.narrowSpacing
                 controlWidth: colorControlWidth
@@ -48,6 +54,10 @@ SpectrogramBaseSection {
 
         ComboBoxWithTitle {
             width: parent.width
+
+            navigation.panel: root.navigation
+            navigation.order: repeater.count
+            navigation.name: "ColorsSchemeComboBox"
 
             title: qsTrc("spectrogram/settings", "Scheme")
             spacing: root.narrowSpacing

--- a/src/appshell/qml/Preferences/internal/SpectrogramScaleSection.qml
+++ b/src/appshell/qml/Preferences/internal/SpectrogramScaleSection.qml
@@ -21,6 +21,7 @@ SpectrogramBaseSection {
 
         navigation.panel: root.navigation
         navigation.name: "ScaleComboBox"
+        navigation.order: 0
 
         title: qsTrc("spectrogram/preferences/settings", "Scale")
         spacing: root.narrowSpacing
@@ -30,6 +31,37 @@ SpectrogramBaseSection {
 
         onValueEdited: function (index) {
             settingsModel.scale = index
+        }
+    }
+
+    Repeater {
+        id: repeater
+
+        model: ScaleSectionParameterListModel {
+            settingsModel: root.settingsModel
+            columnWidth: root.prefsColumnWidth
+        }
+
+        IncrementalPropertyControlWithTitle {
+            id: control
+
+            navigation.panel: root.navigation
+            navigation.order: index + 1
+            navigation.name: "ScaleIncrementalControl_" + index
+
+            spacing: root.narrowSpacing
+            controlWidth: mediumControlWidth
+            title: controlLabel
+            minValue: controlMinValue
+            maxValue: controlMaxValue
+            measureUnitsSymbol: controlUnits
+            decimals: 0
+            step: 1
+
+            currentValue: controlCurrentValue
+            onValueEditingFinished: function (value) {
+                controlCurrentValue = value
+            }
         }
     }
 }

--- a/src/appshell/qml/Preferences/internal/SpectrogramScaleSection.qml
+++ b/src/appshell/qml/Preferences/internal/SpectrogramScaleSection.qml
@@ -19,6 +19,9 @@ SpectrogramBaseSection {
     ComboBoxWithTitle {
         width: parent.width
 
+        navigation.panel: root.navigation
+        navigation.name: "ScaleComboBox"
+
         title: qsTrc("spectrogram/preferences/settings", "Scale")
         spacing: root.narrowSpacing
         columnWidth: root.mediumControlWidth

--- a/src/appshell/qml/Preferences/internal/SpectrogramSelectionSection.qml
+++ b/src/appshell/qml/Preferences/internal/SpectrogramSelectionSection.qml
@@ -25,5 +25,8 @@ SpectrogramBaseSection {
         onClicked: {
             settingsModel.spectralSelectionEnabled = !settingsModel.spectralSelectionEnabled
         }
+
+        navigation.panel: root.navigation
+        navigation.name: "SpectralSelectionEnabledCheckBox"
     }
 }

--- a/src/spectrogram/CMakeLists.txt
+++ b/src/spectrogram/CMakeLists.txt
@@ -57,6 +57,8 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/view/algorithmsectionparameterlistmodel.h
     ${CMAKE_CURRENT_LIST_DIR}/view/colorsectionparameterlistmodel.cpp
     ${CMAKE_CURRENT_LIST_DIR}/view/colorsectionparameterlistmodel.h
+    ${CMAKE_CURRENT_LIST_DIR}/view/scalesectionparameterlistmodel.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/view/scalesectionparameterlistmodel.h
     ${CMAKE_CURRENT_LIST_DIR}/view/globalspectrogramsettingsmodel.cpp
     ${CMAKE_CURRENT_LIST_DIR}/view/globalspectrogramsettingsmodel.h
     ${CMAKE_CURRENT_LIST_DIR}/view/spectrogramview.cpp

--- a/src/spectrogram/iglobalspectrogramconfiguration.h
+++ b/src/spectrogram/iglobalspectrogramconfiguration.h
@@ -16,7 +16,11 @@ class IGlobalSpectrogramConfiguration : MODULE_EXPORT_INTERFACE, public ISpectro
 
 public:
     virtual ~IGlobalSpectrogramConfiguration() = default;
+
+    virtual bool spectralSelectionEnabled() const = 0;
+    virtual void setSpectralSelectionEnabled(bool value) = 0;
     virtual muse::async::Channel<bool> spectralSelectionEnabledChanged() const = 0;
+
     virtual muse::async::Channel<SpectrogramColorScheme> colorSchemeChanged() const = 0;
     virtual muse::async::Channel<int> colorGainDbChanged() const = 0;
     virtual muse::async::Channel<int> colorRangeDbChanged() const = 0;

--- a/src/spectrogram/iglobalspectrogramconfiguration.h
+++ b/src/spectrogram/iglobalspectrogramconfiguration.h
@@ -21,6 +21,8 @@ public:
     virtual void setSpectralSelectionEnabled(bool value) = 0;
     virtual muse::async::Channel<bool> spectralSelectionEnabledChanged() const = 0;
 
+    virtual muse::async::Channel<int> minFreqChanged() const = 0;
+    virtual muse::async::Channel<int> maxFreqChanged() const = 0;
     virtual muse::async::Channel<SpectrogramColorScheme> colorSchemeChanged() const = 0;
     virtual muse::async::Channel<int> colorGainDbChanged() const = 0;
     virtual muse::async::Channel<int> colorRangeDbChanged() const = 0;

--- a/src/spectrogram/internal/au3/au3spectrogramclipchannelpainter.cpp
+++ b/src/spectrogram/internal/au3/au3spectrogramclipchannelpainter.cpp
@@ -65,12 +65,8 @@ float findValue(const float* spectrum, float bin0, float bin1, unsigned nBins, b
 constexpr auto DASH_LENGTH = 10; // pixel
 
 inline SpectrogramColors::ColorGradientChoice
-ChooseColorSet(float bin0, float bin1, float selBinLo,
-               float selBinCenter, float selBinHi, int dashCount, bool isSpectral)
+ChooseColorSet(float bin0, float bin1, float selBinLo, float selBinCenter, float selBinHi, int dashCount)
 {
-    if (!isSpectral) {
-        return SpectrogramColors::ColorGradientTimeSelected;
-    }
     if ((selBinCenter >= 0) && (bin0 <= selBinCenter)
         && (selBinCenter < bin1)) {
         return SpectrogramColors::ColorGradientEdge;
@@ -188,8 +184,6 @@ void Au3SpectrogramClipChannelPainter::fillImage(QImage& image,
                          ? -1
                          : settings.findBin(sqrt(startFrequency * endFrequency), binUnit);
 
-    const bool isSpectral = settings.spectralSelectionEnabled;
-
     SpecCache specCache;
 
     // need explicit resize since specCache.where[] accessed before Populate()
@@ -227,8 +221,7 @@ void Au3SpectrogramClipChannelPainter::fillImage(QImage& image,
 
             // If we are in the time selected range, then we may use a different color set.
             if (maybeSelected) {
-                selected = ChooseColorSet(bin, nextBin, selBinLo, selBinCenter, selBinHi,
-                                          (xx + leftOffset - leftOffset) / DASH_LENGTH, isSpectral);
+                selected = ChooseColorSet(bin, nextBin, selBinLo, selBinCenter, selBinHi, (xx + leftOffset - leftOffset) / DASH_LENGTH);
             }
 
             const float value = specPxCache->values[xx * imageHeight + yy];

--- a/src/spectrogram/internal/au3/au3spectrogramsettings.cpp
+++ b/src/spectrogram/internal/au3/au3spectrogramsettings.cpp
@@ -37,7 +37,6 @@ static const AttachedTrackObjects::RegisteredFactory key1{
         settings->SetZeroPaddingFactor(globalConfig->zeroPaddingFactor());
         settings->colorScheme = globalConfig->colorScheme();
         settings->scaleType = globalConfig->scale();
-        settings->spectralSelectionEnabled = globalConfig->spectralSelectionEnabled();
         settings->algorithm = globalConfig->algorithm();
 
         return settings;
@@ -67,7 +66,6 @@ Au3SpectrogramSettings::Au3SpectrogramSettings(const Au3SpectrogramSettings& oth
     , frequencyGain(other.frequencyGain)
     , colorScheme(other.colorScheme)
     , scaleType(other.scaleType)
-    , spectralSelectionEnabled(other.spectralSelectionEnabled)
     , algorithm(other.algorithm)
     , minFreq(other.minFreq)
     , maxFreq(other.maxFreq)
@@ -97,7 +95,6 @@ Au3SpectrogramSettings& Au3SpectrogramSettings::operator=(const Au3SpectrogramSe
         m_zeroPaddingFactor = other.m_zeroPaddingFactor;
         colorScheme = other.colorScheme;
         scaleType = other.scaleType;
-        spectralSelectionEnabled = other.spectralSelectionEnabled;
         algorithm = other.algorithm;
 
         // Invalidate the caches
@@ -130,7 +127,6 @@ void Au3SpectrogramSettings::WriteXMLAttributes(XMLWriter& writer) const
     writer.WriteAttr("zeroPaddingFactor", m_zeroPaddingFactor);
     writer.WriteAttr("colorScheme", static_cast<int>(colorScheme));
     writer.WriteAttr("scaleType", static_cast<int>(scaleType));
-    writer.WriteAttr("spectralSelectionEnabled", spectralSelectionEnabled);
     writer.WriteAttr("algorithm", static_cast<int>(algorithm));
 }
 
@@ -169,9 +165,6 @@ bool Au3SpectrogramSettings::HandleXMLAttribute(const std::string_view& attr, co
         return true;
     } else if (attr == "scaleType" && valueView.TryGet(nValue)) {
         scaleType = static_cast<SpectrogramScale>(nValue);
-        return true;
-    } else if (attr == "spectralSelectionEnabled" && valueView.TryGet(nValue)) {
-        spectralSelectionEnabled = (nValue != 0);
         return true;
     } else if (attr == "algorithm" && valueView.TryGet(nValue)) {
         algorithm = static_cast<SpectrogramAlgorithm>(nValue);

--- a/src/spectrogram/internal/au3/au3spectrogramsettings.cpp
+++ b/src/spectrogram/internal/au3/au3spectrogramsettings.cpp
@@ -29,6 +29,8 @@ static const AttachedTrackObjects::RegisteredFactory key1{
             return settings;
         }
 
+        settings->minFreq = globalConfig->minFreq();
+        settings->maxFreq = globalConfig->maxFreq();
         settings->range = globalConfig->colorRangeDb();
         settings->gain = globalConfig->colorGainDb();
         settings->frequencyGain = globalConfig->colorHighBoostDbPerDec();

--- a/src/spectrogram/internal/au3/au3spectrogramsettings.h
+++ b/src/spectrogram/internal/au3/au3spectrogramsettings.h
@@ -38,15 +38,14 @@ public:
 
 public:
     bool syncWithGlobalSettings = true;
+    int minFreq = 0;
+    int maxFreq = 0;
     int range = 0;
     int gain = 0;
     int frequencyGain = 0;
     SpectrogramColorScheme colorScheme = static_cast<SpectrogramColorScheme>(0);
     SpectrogramScale scaleType = static_cast<SpectrogramScale>(0);
     SpectrogramAlgorithm algorithm = static_cast<SpectrogramAlgorithm>(0);
-    // For now. When rulers are implemented for spectrogram view, this may need some refactoring.
-    int minFreq = 1;
-    int maxFreq = 20000;
 
     SpectrogramWindowType WindowType() const { return m_windowType; }
     void SetWindowType(SpectrogramWindowType type);

--- a/src/spectrogram/internal/au3/au3spectrogramsettings.h
+++ b/src/spectrogram/internal/au3/au3spectrogramsettings.h
@@ -43,7 +43,6 @@ public:
     int frequencyGain = 0;
     SpectrogramColorScheme colorScheme = static_cast<SpectrogramColorScheme>(0);
     SpectrogramScale scaleType = static_cast<SpectrogramScale>(0);
-    bool spectralSelectionEnabled = false;
     SpectrogramAlgorithm algorithm = static_cast<SpectrogramAlgorithm>(0);
     // For now. When rulers are implemented for spectrogram view, this may need some refactoring.
     int minFreq = 1;

--- a/src/spectrogram/internal/au3/au3trackspectrogramconfiguration.cpp
+++ b/src/spectrogram/internal/au3/au3trackspectrogramconfiguration.cpp
@@ -31,6 +31,26 @@ Au3TrackSpectrogramConfiguration::Au3TrackSpectrogramConfiguration(Au3Spectrogra
     : m_settings(settings)
 {}
 
+int Au3TrackSpectrogramConfiguration::minFreq() const
+{
+    return m_settings.minFreq;
+}
+
+void Au3TrackSpectrogramConfiguration::setMinFreq(int value)
+{
+    m_settings.minFreq = value;
+}
+
+int Au3TrackSpectrogramConfiguration::maxFreq() const
+{
+    return m_settings.maxFreq;
+}
+
+void Au3TrackSpectrogramConfiguration::setMaxFreq(int value)
+{
+    m_settings.maxFreq = value;
+}
+
 int Au3TrackSpectrogramConfiguration::colorGainDb() const
 {
     return m_settings.gain;

--- a/src/spectrogram/internal/au3/au3trackspectrogramconfiguration.cpp
+++ b/src/spectrogram/internal/au3/au3trackspectrogramconfiguration.cpp
@@ -31,19 +31,6 @@ Au3TrackSpectrogramConfiguration::Au3TrackSpectrogramConfiguration(Au3Spectrogra
     : m_settings(settings)
 {}
 
-bool Au3TrackSpectrogramConfiguration::spectralSelectionEnabled() const
-{
-    return m_settings.spectralSelectionEnabled;
-}
-
-void Au3TrackSpectrogramConfiguration::setSpectralSelectionEnabled(bool value)
-{
-    if (m_settings.spectralSelectionEnabled == value) {
-        return;
-    }
-    m_settings.spectralSelectionEnabled = value;
-}
-
 int Au3TrackSpectrogramConfiguration::colorGainDb() const
 {
     return m_settings.gain;

--- a/src/spectrogram/internal/au3/au3trackspectrogramconfiguration.h
+++ b/src/spectrogram/internal/au3/au3trackspectrogramconfiguration.h
@@ -20,6 +20,12 @@ public:
     Au3TrackSpectrogramConfiguration(Au3SpectrogramSettings&);
     ~Au3TrackSpectrogramConfiguration() override = default;
 
+    int minFreq() const override;
+    void setMinFreq(int value) override;
+
+    int maxFreq() const override;
+    void setMaxFreq(int value) override;
+
     int colorGainDb() const override;
     void setColorGainDb(int value) override;
 

--- a/src/spectrogram/internal/au3/au3trackspectrogramconfiguration.h
+++ b/src/spectrogram/internal/au3/au3trackspectrogramconfiguration.h
@@ -20,9 +20,6 @@ public:
     Au3TrackSpectrogramConfiguration(Au3SpectrogramSettings&);
     ~Au3TrackSpectrogramConfiguration() override = default;
 
-    bool spectralSelectionEnabled() const override;
-    void setSpectralSelectionEnabled(bool value) override;
-
     int colorGainDb() const override;
     void setColorGainDb(int value) override;
 

--- a/src/spectrogram/internal/au3/au3trackspectrogramconfiguration.h
+++ b/src/spectrogram/internal/au3/au3trackspectrogramconfiguration.h
@@ -50,8 +50,8 @@ public:
     int zeroPaddingFactor() const override;
     void setZeroPaddingFactor(int value) override;
 
-    bool useGlobalSettings() const;
-    void setUseGlobalSettings(bool value);
+    bool useGlobalSettings() const override;
+    void setUseGlobalSettings(bool value) override;
 
 private:
     Au3SpectrogramSettings& m_settings;

--- a/src/spectrogram/internal/globalspectrogramconfiguration.cpp
+++ b/src/spectrogram/internal/globalspectrogramconfiguration.cpp
@@ -9,6 +9,8 @@ namespace au::spectrogram {
 namespace {
 static const std::string moduleName("spectrogram");
 
+static const muse::Settings::Key MIN_FREQ(moduleName, "spectrogram/minFreq");
+static const muse::Settings::Key MAX_FREQ(moduleName, "spectrogram/maxFreq");
 static const muse::Settings::Key SPECTRAL_SELECTION_ENABLED(moduleName, "spectrogram/spectralSelectionEnabled");
 static const muse::Settings::Key COLOR_SCHEME(moduleName, "spectrogram/colorScheme");
 static const muse::Settings::Key COLOR_GAIN_DB(moduleName, "spectrogram/colorGainDb");
@@ -23,6 +25,18 @@ static const muse::Settings::Key ZERO_PADDING_FACTOR(moduleName, "spectrogram/ze
 
 void GlobalSpectrogramConfiguration::init()
 {
+    muse::settings()->setDefaultValue(MIN_FREQ, muse::Val(0));
+    muse::settings()->valueChanged(MIN_FREQ).onReceive(this, [this](const muse::Val& val) {
+        m_minFreqChanged.send(val.toInt());
+        m_someSettingChanged.notify();
+    });
+
+    muse::settings()->setDefaultValue(MAX_FREQ, muse::Val(20000));
+    muse::settings()->valueChanged(MAX_FREQ).onReceive(this, [this](const muse::Val& val) {
+        m_maxFreqChanged.send(val.toInt());
+        m_someSettingChanged.notify();
+    });
+
     muse::settings()->setDefaultValue(SPECTRAL_SELECTION_ENABLED, muse::Val(true));
     muse::settings()->valueChanged(SPECTRAL_SELECTION_ENABLED).onReceive(this, [this](const muse::Val& val) {
         m_spectralSelectionEnabledChanged.send(val.toBool());
@@ -82,6 +96,42 @@ void GlobalSpectrogramConfiguration::init()
         m_zeroPaddingFactorChanged.send(val.toInt());
         m_someSettingChanged.notify();
     });
+}
+
+int GlobalSpectrogramConfiguration::minFreq() const
+{
+    return muse::settings()->value(MIN_FREQ).toInt();
+}
+
+void GlobalSpectrogramConfiguration::setMinFreq(int value)
+{
+    if (minFreq() == value) {
+        return;
+    }
+    muse::settings()->setSharedValue(MIN_FREQ, muse::Val(value));
+}
+
+muse::async::Channel<int> GlobalSpectrogramConfiguration::minFreqChanged() const
+{
+    return m_minFreqChanged;
+}
+
+int GlobalSpectrogramConfiguration::maxFreq() const
+{
+    return muse::settings()->value(MAX_FREQ).toInt();
+}
+
+void GlobalSpectrogramConfiguration::setMaxFreq(int value)
+{
+    if (maxFreq() == value) {
+        return;
+    }
+    muse::settings()->setSharedValue(MAX_FREQ, muse::Val(value));
+}
+
+muse::async::Channel<int> GlobalSpectrogramConfiguration::maxFreqChanged() const
+{
+    return m_maxFreqChanged;
 }
 
 bool GlobalSpectrogramConfiguration::spectralSelectionEnabled() const

--- a/src/spectrogram/internal/globalspectrogramconfiguration.h
+++ b/src/spectrogram/internal/globalspectrogramconfiguration.h
@@ -17,11 +17,11 @@ public:
 
     int minFreq() const override;
     void setMinFreq(int value) override;
-    muse::async::Channel<int> minFreqChanged() const;
+    muse::async::Channel<int> minFreqChanged() const override;
 
     int maxFreq() const override;
     void setMaxFreq(int value) override;
-    muse::async::Channel<int> maxFreqChanged() const;
+    muse::async::Channel<int> maxFreqChanged() const override;
 
     bool spectralSelectionEnabled() const override;
     void setSpectralSelectionEnabled(bool value) override;

--- a/src/spectrogram/internal/globalspectrogramconfiguration.h
+++ b/src/spectrogram/internal/globalspectrogramconfiguration.h
@@ -15,6 +15,14 @@ public:
 
     void init();
 
+    int minFreq() const override;
+    void setMinFreq(int value) override;
+    muse::async::Channel<int> minFreqChanged() const;
+
+    int maxFreq() const override;
+    void setMaxFreq(int value) override;
+    muse::async::Channel<int> maxFreqChanged() const;
+
     bool spectralSelectionEnabled() const override;
     void setSpectralSelectionEnabled(bool value) override;
     muse::async::Channel<bool> spectralSelectionEnabledChanged() const override;
@@ -58,6 +66,8 @@ public:
     muse::async::Notification someSettingChanged() const override;
 
 private:
+    muse::async::Channel<int> m_minFreqChanged;
+    muse::async::Channel<int> m_maxFreqChanged;
     muse::async::Channel<bool> m_spectralSelectionEnabledChanged;
     muse::async::Channel<SpectrogramColorScheme> m_colorSchemeChanged;
     muse::async::Channel<int> m_colorGainDbChanged;

--- a/src/spectrogram/internal/trackspectrogramconfigurationprovider.cpp
+++ b/src/spectrogram/internal/trackspectrogramconfigurationprovider.cpp
@@ -20,6 +20,8 @@ ITrackSpectrogramConfigurationPtr TrackSpectrogramConfigurationProvider::trackSp
 void TrackSpectrogramConfigurationProvider::copyConfiguration(const ISpectrogramConfiguration& source,
                                                               ISpectrogramConfiguration& destination) const
 {
+    destination.setMinFreq(source.minFreq());
+    destination.setMaxFreq(source.maxFreq());
     destination.setColorGainDb(source.colorGainDb());
     destination.setColorRangeDb(source.colorRangeDb());
     destination.setColorHighBoostDbPerDec(source.colorHighBoostDbPerDec());

--- a/src/spectrogram/internal/trackspectrogramconfigurationprovider.cpp
+++ b/src/spectrogram/internal/trackspectrogramconfigurationprovider.cpp
@@ -20,7 +20,6 @@ ITrackSpectrogramConfigurationPtr TrackSpectrogramConfigurationProvider::trackSp
 void TrackSpectrogramConfigurationProvider::copyConfiguration(const ISpectrogramConfiguration& source,
                                                               ISpectrogramConfiguration& destination) const
 {
-    destination.setSpectralSelectionEnabled(source.spectralSelectionEnabled());
     destination.setColorGainDb(source.colorGainDb());
     destination.setColorRangeDb(source.colorRangeDb());
     destination.setColorHighBoostDbPerDec(source.colorHighBoostDbPerDec());

--- a/src/spectrogram/ispectrogramconfiguration.h
+++ b/src/spectrogram/ispectrogramconfiguration.h
@@ -11,9 +11,6 @@ class ISpectrogramConfiguration
 public:
     virtual ~ISpectrogramConfiguration() = default;
 
-    virtual bool spectralSelectionEnabled() const = 0;
-    virtual void setSpectralSelectionEnabled(bool value) = 0;
-
     virtual SpectrogramColorScheme colorScheme() const = 0;
     virtual void setColorScheme(SpectrogramColorScheme value) = 0;
 

--- a/src/spectrogram/ispectrogramconfiguration.h
+++ b/src/spectrogram/ispectrogramconfiguration.h
@@ -11,6 +11,12 @@ class ISpectrogramConfiguration
 public:
     virtual ~ISpectrogramConfiguration() = default;
 
+    virtual int minFreq() const = 0;
+    virtual void setMinFreq(int value) = 0;
+
+    virtual int maxFreq() const = 0;
+    virtual void setMaxFreq(int value) = 0;
+
     virtual SpectrogramColorScheme colorScheme() const = 0;
     virtual void setColorScheme(SpectrogramColorScheme value) = 0;
 

--- a/src/spectrogram/spectrogrammodule.cpp
+++ b/src/spectrogram/spectrogrammodule.cpp
@@ -7,6 +7,7 @@
 #include "view/abstractspectrogramsettingsmodel.h"
 #include "view/algorithmsectionparameterlistmodel.h"
 #include "view/colorsectionparameterlistmodel.h"
+#include "view/scalesectionparameterlistmodel.h"
 #include "view/globalspectrogramsettingsmodel.h"
 #include "view/spectrogramview.h"
 
@@ -37,6 +38,7 @@ void SpectrogramModule::registerUiTypes()
     qmlRegisterType<GlobalSpectrogramSettingsModel>("Audacity.Spectrogram", 1, 0, "GlobalSpectrogramSettingsModel");
     qmlRegisterType<AlgorithmSectionParameterListModel>("Audacity.Spectrogram", 1, 0, "AlgorithmSectionParameterListModel");
     qmlRegisterType<ColorSectionParameterListModel>("Audacity.Spectrogram", 1, 0, "ColorSectionParameterListModel");
+    qmlRegisterType<ScaleSectionParameterListModel>("Audacity.Spectrogram", 1, 0, "ScaleSectionParameterListModel");
     qmlRegisterType<SpectrogramView>("Audacity.Spectrogram", 1, 0, "SpectrogramView");
 }
 

--- a/src/spectrogram/view/abstractsectionparameterslistmodel.cpp
+++ b/src/spectrogram/view/abstractsectionparameterslistmodel.cpp
@@ -32,7 +32,6 @@ void AbstractSectionParametersListModel::setColumnWidth(int width)
     }
     m_columnWidth = width;
 
-    emit dataChanged(index(0), index(rowCount({}) - 1));
     emit columnWidthChanged();
 }
 

--- a/src/spectrogram/view/abstractspectrogramsettingsmodel.cpp
+++ b/src/spectrogram/view/abstractspectrogramsettingsmodel.cpp
@@ -7,12 +7,28 @@
 #include "framework/global/translation.h"
 #include "framework/global/log.h"
 
-#include <limits>
+#include <algorithm>
 
 namespace au::spectrogram {
 AbstractSpectrogramSettingsModel::AbstractSpectrogramSettingsModel(QObject* parent)
     : QObject(parent)
 {}
+
+void AbstractSpectrogramSettingsModel::setMinFreq(int value)
+{
+    doSetMinFreq(std::clamp(value, frequencyHardMinimum(), frequencyHardMaximum()));
+    if (maxFreq() <= minFreq()) {
+        doSetMaxFreq(minFreq());
+    }
+}
+
+void AbstractSpectrogramSettingsModel::setMaxFreq(int value)
+{
+    doSetMaxFreq(std::clamp(value, frequencyHardMinimum(), frequencyHardMaximum()));
+    if (minFreq() >= maxFreq()) {
+        doSetMinFreq(maxFreq());
+    }
+}
 
 QString AbstractSpectrogramSettingsModel::colorSchemeName(int scheme) const
 {

--- a/src/spectrogram/view/abstractspectrogramsettingsmodel.cpp
+++ b/src/spectrogram/view/abstractspectrogramsettingsmodel.cpp
@@ -30,6 +30,12 @@ void AbstractSpectrogramSettingsModel::setMaxFreq(int value)
     }
 }
 
+int AbstractSpectrogramSettingsModel::frequencyHardMaximum() const
+{
+    const auto sampleRates = audioDevicesProvider()->sampleRates();
+    return static_cast<int>(*std::max_element(sampleRates.begin(), sampleRates.end()) / 2);
+}
+
 QString AbstractSpectrogramSettingsModel::colorSchemeName(int scheme) const
 {
     switch (static_cast<SpectrogramColorScheme>(scheme)) {

--- a/src/spectrogram/view/abstractspectrogramsettingsmodel.h
+++ b/src/spectrogram/view/abstractspectrogramsettingsmodel.h
@@ -11,80 +11,73 @@ class AbstractSpectrogramSettingsModel : public QObject
 {
     Q_OBJECT
 
-    Q_PROPERTY(
-        bool spectralSelectionEnabled READ spectralSelectionEnabled_1 WRITE setSpectralSelectionEnabled_1 NOTIFY spectralSelectionEnabledChanged_1)
+    Q_PROPERTY(int colorGainDb READ colorGainDb WRITE setColorGainDb NOTIFY colorGainDbChanged)
 
-    Q_PROPERTY(int colorGainDb READ colorGainDb_2 WRITE setColorGainDb_2 NOTIFY colorGainDbChanged_2)
-
-    Q_PROPERTY(int colorRangeDb READ colorRangeDb_3 WRITE setColorRangeDb_3 NOTIFY colorRangeDbChanged_3)
+    Q_PROPERTY(int colorRangeDb READ colorRangeDb WRITE setColorRangeDb NOTIFY colorRangeDbChanged)
     Q_PROPERTY(int colorRangeDbMin READ colorRangeDbMin CONSTANT)
 
     Q_PROPERTY(
-        int colorHighBoostDbPerDec READ colorHighBoostDbPerDec_4 WRITE setColorHighBoostDbPerDec_4 NOTIFY colorHighBoostDbPerDecChanged_4)
+        int colorHighBoostDbPerDec READ colorHighBoostDbPerDec WRITE setColorHighBoostDbPerDec NOTIFY colorHighBoostDbPerDecChanged)
     Q_PROPERTY(int colorHighBoostDbPerDecMin READ colorHighBoostDbPerDecMin CONSTANT)
     Q_PROPERTY(int colorHighBoostDbPerDecMax READ colorHighBoostDbPerDecMax CONSTANT)
 
-    Q_PROPERTY(int colorScheme READ colorScheme_5 WRITE setColorScheme_5 NOTIFY colorSchemeChanged_5)
+    Q_PROPERTY(int colorScheme READ colorScheme WRITE setColorScheme NOTIFY colorSchemeChanged)
     Q_PROPERTY(QList<QString> colorSchemeNames READ colorSchemeNames CONSTANT)
 
-    Q_PROPERTY(int scale READ scale_6 WRITE setScale_6 NOTIFY scaleChanged_6)
+    Q_PROPERTY(int scale READ scale WRITE setScale NOTIFY scaleChanged)
     Q_PROPERTY(QList<QString> scaleNames READ scaleNames CONSTANT)
 
-    Q_PROPERTY(int algorithm READ algorithm_7 WRITE setAlgorithm_7 NOTIFY algorithmChanged_7)
-    Q_PROPERTY(int windowType READ windowType_8 WRITE setWindowType_8 NOTIFY windowTypeChanged_8)
-    Q_PROPERTY(int windowSize READ windowSize_9 WRITE setWindowSize_9 NOTIFY windowSizeChanged_9)
-    Q_PROPERTY(int zeroPaddingFactor READ zeroPaddingFactor_10 WRITE setZeroPaddingFactor_10 NOTIFY zeroPaddingFactorChanged_10)
+    Q_PROPERTY(int algorithm READ algorithm WRITE setAlgorithm NOTIFY algorithmChanged)
+    Q_PROPERTY(int windowType READ windowType WRITE setWindowType NOTIFY windowTypeChanged)
+    Q_PROPERTY(int windowSize READ windowSize WRITE setWindowSize NOTIFY windowSizeChanged)
+    Q_PROPERTY(int zeroPaddingFactor READ zeroPaddingFactor WRITE setZeroPaddingFactor NOTIFY zeroPaddingFactorChanged)
 
 public:
     explicit AbstractSpectrogramSettingsModel(QObject* parent = nullptr);
     virtual ~AbstractSpectrogramSettingsModel() = default;
 
-    virtual bool spectralSelectionEnabled_1() const = 0;
-    virtual void setSpectralSelectionEnabled_1(bool value) = 0;
+    virtual int colorGainDb() const = 0;
+    virtual void setColorGainDb(int value) = 0;
 
-    virtual int colorGainDb_2() const = 0;
-    virtual void setColorGainDb_2(int value) = 0;
-
-    virtual int colorRangeDb_3() const = 0;
-    virtual void setColorRangeDb_3(int value) = 0;
+    virtual int colorRangeDb() const = 0;
+    virtual void setColorRangeDb(int value) = 0;
     int colorRangeDbMin() const { return 1; }
 
-    virtual int colorHighBoostDbPerDec_4() const = 0;
-    virtual void setColorHighBoostDbPerDec_4(int value) = 0;
+    virtual int colorHighBoostDbPerDec() const = 0;
+    virtual void setColorHighBoostDbPerDec(int value) = 0;
     int colorHighBoostDbPerDecMin() const { return 0; }
     int colorHighBoostDbPerDecMax() const { return 60; }
 
-    virtual int colorScheme_5() const = 0;
-    virtual void setColorScheme_5(int value) = 0;
+    virtual int colorScheme() const = 0;
+    virtual void setColorScheme(int value) = 0;
     QList<QString> colorSchemeNames() const;
 
-    virtual int scale_6() const = 0;
-    virtual void setScale_6(int value) = 0;
+    virtual int scale() const = 0;
+    virtual void setScale(int value) = 0;
     QList<QString> scaleNames() const;
 
-    virtual int algorithm_7() const = 0;
-    virtual void setAlgorithm_7(int value) = 0;
+    virtual int algorithm() const = 0;
+    virtual void setAlgorithm(int value) = 0;
 
-    virtual int windowType_8() const = 0;
-    virtual void setWindowType_8(int value) = 0;
+    virtual int windowType() const = 0;
+    virtual void setWindowType(int value) = 0;
 
-    virtual int windowSize_9() const = 0;
-    virtual void setWindowSize_9(int value) = 0;
+    virtual int windowSize() const = 0;
+    virtual void setWindowSize(int value) = 0;
 
-    virtual int zeroPaddingFactor_10() const = 0;
-    virtual void setZeroPaddingFactor_10(int value) = 0;
+    virtual int zeroPaddingFactor() const = 0;
+    virtual void setZeroPaddingFactor(int value) = 0;
 
 signals:
-    void spectralSelectionEnabledChanged_1();
-    void colorGainDbChanged_2();
-    void colorRangeDbChanged_3();
-    void colorHighBoostDbPerDecChanged_4();
-    void colorSchemeChanged_5();
-    void scaleChanged_6();
-    void algorithmChanged_7();
-    void windowTypeChanged_8();
-    void windowSizeChanged_9();
-    void zeroPaddingFactorChanged_10();
+    void colorGainDbChanged();
+    void colorRangeDbChanged();
+    void colorHighBoostDbPerDecChanged();
+    void colorSchemeChanged();
+    void scaleChanged();
+    void algorithmChanged();
+    void windowTypeChanged();
+    void windowSizeChanged();
+    void zeroPaddingFactorChanged();
 
 private:
     QString colorSchemeName(int) const;

--- a/src/spectrogram/view/abstractspectrogramsettingsmodel.h
+++ b/src/spectrogram/view/abstractspectrogramsettingsmodel.h
@@ -3,7 +3,10 @@
  */
 #pragma once
 
-#include <QAbstractListModel>
+#include "audio/iaudiodevicesprovider.h"
+
+#include "framework/global/modularity/ioc.h"
+
 #include <QObject>
 
 namespace au::spectrogram {
@@ -35,6 +38,8 @@ class AbstractSpectrogramSettingsModel : public QObject
     Q_PROPERTY(int windowSize READ windowSize WRITE setWindowSize NOTIFY windowSizeChanged)
     Q_PROPERTY(int zeroPaddingFactor READ zeroPaddingFactor WRITE setZeroPaddingFactor NOTIFY zeroPaddingFactorChanged)
 
+    muse::Inject<audio::IAudioDevicesProvider> audioDevicesProvider;
+
 public:
     explicit AbstractSpectrogramSettingsModel(QObject* parent = nullptr);
     virtual ~AbstractSpectrogramSettingsModel() = default;
@@ -45,11 +50,7 @@ public:
 
     virtual int maxFreq() const = 0;
     void setMaxFreq(int value);
-    int frequencyHardMaximum() const
-    {
-        // TODO make dynamic based on sample rate
-        return 22050;
-    }
+    int frequencyHardMaximum() const;
 
     virtual int colorGainDb() const = 0;
     virtual void setColorGainDb(int value) = 0;

--- a/src/spectrogram/view/abstractspectrogramsettingsmodel.h
+++ b/src/spectrogram/view/abstractspectrogramsettingsmodel.h
@@ -11,6 +11,9 @@ class AbstractSpectrogramSettingsModel : public QObject
 {
     Q_OBJECT
 
+    Q_PROPERTY(int minFreq READ minFreq WRITE setMinFreq NOTIFY minFreqChanged)
+    Q_PROPERTY(int maxFreq READ maxFreq WRITE setMaxFreq NOTIFY maxFreqChanged)
+
     Q_PROPERTY(int colorGainDb READ colorGainDb WRITE setColorGainDb NOTIFY colorGainDbChanged)
 
     Q_PROPERTY(int colorRangeDb READ colorRangeDb WRITE setColorRangeDb NOTIFY colorRangeDbChanged)
@@ -35,6 +38,18 @@ class AbstractSpectrogramSettingsModel : public QObject
 public:
     explicit AbstractSpectrogramSettingsModel(QObject* parent = nullptr);
     virtual ~AbstractSpectrogramSettingsModel() = default;
+
+    virtual int minFreq() const = 0;
+    void setMinFreq(int value);
+    int frequencyHardMinimum() const { return 0; }
+
+    virtual int maxFreq() const = 0;
+    void setMaxFreq(int value);
+    int frequencyHardMaximum() const
+    {
+        // TODO make dynamic based on sample rate
+        return 22050;
+    }
 
     virtual int colorGainDb() const = 0;
     virtual void setColorGainDb(int value) = 0;
@@ -69,6 +84,8 @@ public:
     virtual void setZeroPaddingFactor(int value) = 0;
 
 signals:
+    void minFreqChanged();
+    void maxFreqChanged();
     void colorGainDbChanged();
     void colorRangeDbChanged();
     void colorHighBoostDbPerDecChanged();
@@ -80,6 +97,9 @@ signals:
     void zeroPaddingFactorChanged();
 
 private:
+    virtual void doSetMinFreq(int value) = 0;
+    virtual void doSetMaxFreq(int value) = 0;
+
     QString colorSchemeName(int) const;
     QString scaleName(int) const;
 };

--- a/src/spectrogram/view/algorithmsectionparameterlistmodel.cpp
+++ b/src/spectrogram/view/algorithmsectionparameterlistmodel.cpp
@@ -64,10 +64,10 @@ AlgorithmSectionParameterListModel::AlgorithmSectionParameterListModel(QObject* 
 void AlgorithmSectionParameterListModel::onSettingsModelSet(AbstractSpectrogramSettingsModel&)
 {
     const QList<int> roles { ControlCurrentIndexRole, ControlCurrentValueRole };
-    CONNECT_SETTING_CHANGED(algorithmChanged_7, Control::Algorithm, roles);
-    CONNECT_SETTING_CHANGED(windowSizeChanged_9, Control::WindowSize, roles);
-    CONNECT_SETTING_CHANGED(windowTypeChanged_8, Control::WindowType, roles);
-    CONNECT_SETTING_CHANGED(zeroPaddingFactorChanged_10, Control::ZeroPaddingFactor, roles);
+    CONNECT_SETTING_CHANGED(algorithmChanged, Control::Algorithm, roles);
+    CONNECT_SETTING_CHANGED(windowSizeChanged, Control::WindowSize, roles);
+    CONNECT_SETTING_CHANGED(windowTypeChanged, Control::WindowType, roles);
+    CONNECT_SETTING_CHANGED(zeroPaddingFactorChanged, Control::ZeroPaddingFactor, roles);
 }
 
 QVariant AlgorithmSectionParameterListModel::data(const QModelIndex& index, int role) const
@@ -160,16 +160,16 @@ int AlgorithmSectionParameterListModel::controlCurrentValue(Control control) con
 {
     switch (control) {
     case Algorithm: {
-        return m_settingsModel->algorithm_7();
+        return m_settingsModel->algorithm();
     }
     case WindowSize: {
-        return m_settingsModel->windowSize_9();
+        return m_settingsModel->windowSize();
     }
     case WindowType: {
-        return m_settingsModel->windowType_8();
+        return m_settingsModel->windowType();
     }
     case ZeroPaddingFactor: {
-        return m_settingsModel->zeroPaddingFactor_10();
+        return m_settingsModel->zeroPaddingFactor();
     }
     default:
         assert(false);
@@ -181,13 +181,13 @@ int AlgorithmSectionParameterListModel::controlCurrentIndex(Control control) con
 {
     switch (control) {
     case Algorithm:
-        return propertyIndex(algorithmTable, static_cast<SpectrogramAlgorithm>(m_settingsModel->algorithm_7()));
+        return propertyIndex(algorithmTable, static_cast<SpectrogramAlgorithm>(m_settingsModel->algorithm()));
     case WindowSize:
-        return propertyIndex(windowSizeTable, m_settingsModel->windowSize_9());
+        return propertyIndex(windowSizeTable, m_settingsModel->windowSize());
     case WindowType:
-        return propertyIndex(windowTypeTable, static_cast<SpectrogramWindowType>(m_settingsModel->windowType_8()));
+        return propertyIndex(windowTypeTable, static_cast<SpectrogramWindowType>(m_settingsModel->windowType()));
     case ZeroPaddingFactor:
-        return propertyIndex(zeroPaddingFactorTable, m_settingsModel->zeroPaddingFactor_10());
+        return propertyIndex(zeroPaddingFactorTable, m_settingsModel->zeroPaddingFactor());
     default:
         assert(false);
         return 0;
@@ -209,16 +209,16 @@ bool AlgorithmSectionParameterListModel::setData(const QModelIndex& index, const
 
     switch (control) {
     case Algorithm:
-        m_settingsModel->setAlgorithm_7(static_cast<int>(propertyValue(algorithmTable, currentIndex)));
+        m_settingsModel->setAlgorithm(static_cast<int>(propertyValue(algorithmTable, currentIndex)));
         break;
     case WindowSize:
-        m_settingsModel->setWindowSize_9(propertyValue(windowSizeTable, currentIndex));
+        m_settingsModel->setWindowSize(propertyValue(windowSizeTable, currentIndex));
         break;
     case WindowType:
-        m_settingsModel->setWindowType_8(static_cast<int>(propertyValue(windowTypeTable, currentIndex)));
+        m_settingsModel->setWindowType(static_cast<int>(propertyValue(windowTypeTable, currentIndex)));
         break;
     case ZeroPaddingFactor:
-        m_settingsModel->setZeroPaddingFactor_10(static_cast<int>(propertyValue(zeroPaddingFactorTable, currentIndex)));
+        m_settingsModel->setZeroPaddingFactor(static_cast<int>(propertyValue(zeroPaddingFactorTable, currentIndex)));
         break;
     default:
         assert(false);

--- a/src/spectrogram/view/algorithmsectionparameterlistmodel.cpp
+++ b/src/spectrogram/view/algorithmsectionparameterlistmodel.cpp
@@ -225,8 +225,6 @@ bool AlgorithmSectionParameterListModel::setData(const QModelIndex& index, const
         return false;
     }
 
-    emit dataChanged(this->index(control), this->index(control), { ControlCurrentIndexRole, ControlCurrentValueRole });
-
     return true;
 }
 }

--- a/src/spectrogram/view/colorsectionparameterlistmodel.cpp
+++ b/src/spectrogram/view/colorsectionparameterlistmodel.cpp
@@ -16,9 +16,9 @@ ColorSectionParameterListModel::ColorSectionParameterListModel(QObject* parent)
 void ColorSectionParameterListModel::onSettingsModelSet(AbstractSpectrogramSettingsModel&)
 {
     const QList<int> roles { ControlCurrentValueRole };
-    CONNECT_SETTING_CHANGED(colorGainDbChanged_2, Control::ColorGain, roles);
-    CONNECT_SETTING_CHANGED(colorRangeDbChanged_3, Control::ColorRange, roles);
-    CONNECT_SETTING_CHANGED(colorHighBoostDbPerDecChanged_4, Control::ColorHighBoost, roles);
+    CONNECT_SETTING_CHANGED(colorGainDbChanged, Control::ColorGain, roles);
+    CONNECT_SETTING_CHANGED(colorRangeDbChanged, Control::ColorRange, roles);
+    CONNECT_SETTING_CHANGED(colorHighBoostDbPerDecChanged, Control::ColorHighBoost, roles);
 }
 
 QVariant ColorSectionParameterListModel::data(const QModelIndex& index, int role) const
@@ -45,11 +45,11 @@ int ColorSectionParameterListModel::controlCurrentValue(Control control) const
 {
     switch (control) {
     case ColorGain:
-        return m_settingsModel->colorGainDb_2();
+        return m_settingsModel->colorGainDb();
     case ColorRange:
-        return m_settingsModel->colorRangeDb_3();
+        return m_settingsModel->colorRangeDb();
     case ColorHighBoost:
-        return m_settingsModel->colorHighBoostDbPerDec_4();
+        return m_settingsModel->colorHighBoostDbPerDec();
     default:
         assert(false);
         return 0;
@@ -158,13 +158,13 @@ bool ColorSectionParameterListModel::setData(const QModelIndex& index, const QVa
 
     switch (control) {
     case ColorGain:
-        m_settingsModel->setColorGainDb_2(currentValue);
+        m_settingsModel->setColorGainDb(currentValue);
         break;
     case ColorRange:
-        m_settingsModel->setColorRangeDb_3(currentValue);
+        m_settingsModel->setColorRangeDb(currentValue);
         break;
     case ColorHighBoost:
-        m_settingsModel->setColorHighBoostDbPerDec_4(currentValue);
+        m_settingsModel->setColorHighBoostDbPerDec(currentValue);
         break;
     default:
         assert(false);

--- a/src/spectrogram/view/colorsectionparameterlistmodel.cpp
+++ b/src/spectrogram/view/colorsectionparameterlistmodel.cpp
@@ -171,8 +171,6 @@ bool ColorSectionParameterListModel::setData(const QModelIndex& index, const QVa
         return false;
     }
 
-    emit dataChanged(this->index(control), this->index(control), { ControlCurrentValueRole });
-
     return true;
 }
 }

--- a/src/spectrogram/view/globalspectrogramsettingsmodel.cpp
+++ b/src/spectrogram/view/globalspectrogramsettingsmodel.cpp
@@ -10,6 +10,12 @@ GlobalSpectrogramSettingsModel::GlobalSpectrogramSettingsModel(QObject* parent)
 
 void GlobalSpectrogramSettingsModel::componentComplete()
 {
+    configuration()->minFreqChanged().onReceive(this, [this](auto){
+        emit minFreqChanged();
+    });
+    configuration()->maxFreqChanged().onReceive(this, [this](auto){
+        emit maxFreqChanged();
+    });
     configuration()->spectralSelectionEnabledChanged().onReceive(this, [this](auto){
         emit spectralSelectionEnabledChanged();
     });

--- a/src/spectrogram/view/globalspectrogramsettingsmodel.cpp
+++ b/src/spectrogram/view/globalspectrogramsettingsmodel.cpp
@@ -52,6 +52,26 @@ void GlobalSpectrogramSettingsModel::setSpectralSelectionEnabled(bool value)
     configuration()->setSpectralSelectionEnabled(value);
 }
 
+int GlobalSpectrogramSettingsModel::minFreq() const
+{
+    return configuration()->minFreq();
+}
+
+void GlobalSpectrogramSettingsModel::doSetMinFreq(int value)
+{
+    configuration()->setMinFreq(value);
+}
+
+int GlobalSpectrogramSettingsModel::maxFreq() const
+{
+    return configuration()->maxFreq();
+}
+
+void GlobalSpectrogramSettingsModel::doSetMaxFreq(int value)
+{
+    configuration()->setMaxFreq(value);
+}
+
 int GlobalSpectrogramSettingsModel::colorGainDb() const
 {
     return configuration()->colorGainDb();

--- a/src/spectrogram/view/globalspectrogramsettingsmodel.cpp
+++ b/src/spectrogram/view/globalspectrogramsettingsmodel.cpp
@@ -11,133 +11,133 @@ GlobalSpectrogramSettingsModel::GlobalSpectrogramSettingsModel(QObject* parent)
 void GlobalSpectrogramSettingsModel::componentComplete()
 {
     configuration()->spectralSelectionEnabledChanged().onReceive(this, [this](auto){
-        emit spectralSelectionEnabledChanged_1();
+        emit spectralSelectionEnabledChanged();
     });
     configuration()->colorGainDbChanged().onReceive(this, [this](auto){
-        emit colorGainDbChanged_2();
+        emit colorGainDbChanged();
     });
     configuration()->colorRangeDbChanged().onReceive(this, [this](auto){
-        emit colorRangeDbChanged_3();
+        emit colorRangeDbChanged();
     });
     configuration()->colorHighBoostDbPerDecChanged().onReceive(this, [this](auto){
-        emit colorHighBoostDbPerDecChanged_4();
+        emit colorHighBoostDbPerDecChanged();
     });
     configuration()->colorSchemeChanged().onReceive(this, [this](auto){
-        emit colorSchemeChanged_5();
+        emit colorSchemeChanged();
     });
     configuration()->scaleChanged().onReceive(this, [this](auto){
-        emit scaleChanged_6();
+        emit scaleChanged();
     });
     configuration()->algorithmChanged().onReceive(this, [this](auto){
-        emit algorithmChanged_7();
+        emit algorithmChanged();
     });
     configuration()->windowTypeChanged().onReceive(this, [this](auto){
-        emit windowTypeChanged_8();
+        emit windowTypeChanged();
     });
     configuration()->winSizeLog2Changed().onReceive(this, [this](auto){
-        emit windowSizeChanged_9();
+        emit windowSizeChanged();
     });
     configuration()->zeroPaddingFactorChanged().onReceive(this, [this](auto){
-        emit zeroPaddingFactorChanged_10();
+        emit zeroPaddingFactorChanged();
     });
 }
 
-bool GlobalSpectrogramSettingsModel::spectralSelectionEnabled_1() const
+bool GlobalSpectrogramSettingsModel::spectralSelectionEnabled() const
 {
     return configuration()->spectralSelectionEnabled();
 }
 
-void GlobalSpectrogramSettingsModel::setSpectralSelectionEnabled_1(bool value)
+void GlobalSpectrogramSettingsModel::setSpectralSelectionEnabled(bool value)
 {
     configuration()->setSpectralSelectionEnabled(value);
 }
 
-int GlobalSpectrogramSettingsModel::colorGainDb_2() const
+int GlobalSpectrogramSettingsModel::colorGainDb() const
 {
     return configuration()->colorGainDb();
 }
 
-void GlobalSpectrogramSettingsModel::setColorGainDb_2(int value)
+void GlobalSpectrogramSettingsModel::setColorGainDb(int value)
 {
     configuration()->setColorGainDb(value);
 }
 
-int GlobalSpectrogramSettingsModel::colorRangeDb_3() const
+int GlobalSpectrogramSettingsModel::colorRangeDb() const
 {
     return configuration()->colorRangeDb();
 }
 
-void GlobalSpectrogramSettingsModel::setColorRangeDb_3(int value)
+void GlobalSpectrogramSettingsModel::setColorRangeDb(int value)
 {
     configuration()->setColorRangeDb(value);
 }
 
-int GlobalSpectrogramSettingsModel::colorHighBoostDbPerDec_4() const
+int GlobalSpectrogramSettingsModel::colorHighBoostDbPerDec() const
 {
     return configuration()->colorHighBoostDbPerDec();
 }
 
-void GlobalSpectrogramSettingsModel::setColorHighBoostDbPerDec_4(int value)
+void GlobalSpectrogramSettingsModel::setColorHighBoostDbPerDec(int value)
 {
     configuration()->setColorHighBoostDbPerDec(value);
 }
 
-int GlobalSpectrogramSettingsModel::colorScheme_5() const
+int GlobalSpectrogramSettingsModel::colorScheme() const
 {
     return static_cast<int>(configuration()->colorScheme());
 }
 
-void GlobalSpectrogramSettingsModel::setColorScheme_5(int value)
+void GlobalSpectrogramSettingsModel::setColorScheme(int value)
 {
     configuration()->setColorScheme(static_cast<spectrogram::SpectrogramColorScheme>(value));
 }
 
-int GlobalSpectrogramSettingsModel::scale_6() const
+int GlobalSpectrogramSettingsModel::scale() const
 {
     return static_cast<int>(configuration()->scale());
 }
 
-void GlobalSpectrogramSettingsModel::setScale_6(int value)
+void GlobalSpectrogramSettingsModel::setScale(int value)
 {
     configuration()->setScale(static_cast<spectrogram::SpectrogramScale>(value));
 }
 
-int GlobalSpectrogramSettingsModel::algorithm_7() const
+int GlobalSpectrogramSettingsModel::algorithm() const
 {
     return static_cast<int>(configuration()->algorithm());
 }
 
-void GlobalSpectrogramSettingsModel::setAlgorithm_7(int value)
+void GlobalSpectrogramSettingsModel::setAlgorithm(int value)
 {
     configuration()->setAlgorithm(static_cast<spectrogram::SpectrogramAlgorithm>(value));
 }
 
-int GlobalSpectrogramSettingsModel::windowType_8() const
+int GlobalSpectrogramSettingsModel::windowType() const
 {
     return static_cast<int>(configuration()->windowType());
 }
 
-void GlobalSpectrogramSettingsModel::setWindowType_8(int value)
+void GlobalSpectrogramSettingsModel::setWindowType(int value)
 {
     configuration()->setWindowType(static_cast<spectrogram::SpectrogramWindowType>(value));
 }
 
-int GlobalSpectrogramSettingsModel::windowSize_9() const
+int GlobalSpectrogramSettingsModel::windowSize() const
 {
     return 1 << configuration()->winSizeLog2();
 }
 
-void GlobalSpectrogramSettingsModel::setWindowSize_9(int value)
+void GlobalSpectrogramSettingsModel::setWindowSize(int value)
 {
     configuration()->setWinSizeLog2(log2(value));
 }
 
-int GlobalSpectrogramSettingsModel::zeroPaddingFactor_10() const
+int GlobalSpectrogramSettingsModel::zeroPaddingFactor() const
 {
     return configuration()->zeroPaddingFactor();
 }
 
-void GlobalSpectrogramSettingsModel::setZeroPaddingFactor_10(int value)
+void GlobalSpectrogramSettingsModel::setZeroPaddingFactor(int value)
 {
     configuration()->setZeroPaddingFactor(value);
 }

--- a/src/spectrogram/view/globalspectrogramsettingsmodel.h
+++ b/src/spectrogram/view/globalspectrogramsettingsmodel.h
@@ -15,6 +15,8 @@ namespace au::spectrogram {
 class GlobalSpectrogramSettingsModel : public AbstractSpectrogramSettingsModel, public muse::async::Asyncable, public QQmlParserStatus
 {
     Q_OBJECT
+    Q_PROPERTY(
+        bool spectralSelectionEnabled READ spectralSelectionEnabled WRITE setSpectralSelectionEnabled NOTIFY spectralSelectionEnabledChanged)
 
     muse::Inject<IGlobalSpectrogramConfiguration> configuration;
 
@@ -22,35 +24,38 @@ public:
     GlobalSpectrogramSettingsModel(QObject* parent = nullptr);
     ~GlobalSpectrogramSettingsModel() override = default;
 
-    bool spectralSelectionEnabled_1() const override;
-    void setSpectralSelectionEnabled_1(bool value) override;
+    bool spectralSelectionEnabled() const;
+    void setSpectralSelectionEnabled(bool value);
 
-    int colorGainDb_2() const override;
-    void setColorGainDb_2(int value) override;
+    int colorGainDb() const override;
+    void setColorGainDb(int value) override;
 
-    int colorRangeDb_3() const override;
-    void setColorRangeDb_3(int value) override;
+    int colorRangeDb() const override;
+    void setColorRangeDb(int value) override;
 
-    int colorHighBoostDbPerDec_4() const override;
-    void setColorHighBoostDbPerDec_4(int value) override;
+    int colorHighBoostDbPerDec() const override;
+    void setColorHighBoostDbPerDec(int value) override;
 
-    int colorScheme_5() const override;
-    void setColorScheme_5(int value) override;
+    int colorScheme() const override;
+    void setColorScheme(int value) override;
 
-    int scale_6() const override;
-    void setScale_6(int value) override;
+    int scale() const override;
+    void setScale(int value) override;
 
-    int algorithm_7() const override;
-    void setAlgorithm_7(int value) override;
+    int algorithm() const override;
+    void setAlgorithm(int value) override;
 
-    int windowType_8() const override;
-    void setWindowType_8(int value) override;
+    int windowType() const override;
+    void setWindowType(int value) override;
 
-    int windowSize_9() const override;
-    void setWindowSize_9(int value) override;
+    int windowSize() const override;
+    void setWindowSize(int value) override;
 
-    int zeroPaddingFactor_10() const override;
-    void setZeroPaddingFactor_10(int value) override;
+    int zeroPaddingFactor() const override;
+    void setZeroPaddingFactor(int value) override;
+
+signals:
+    void spectralSelectionEnabledChanged();
 
 private:
     void classBegin() override {}

--- a/src/spectrogram/view/globalspectrogramsettingsmodel.h
+++ b/src/spectrogram/view/globalspectrogramsettingsmodel.h
@@ -27,6 +27,12 @@ public:
     bool spectralSelectionEnabled() const;
     void setSpectralSelectionEnabled(bool value);
 
+    int minFreq() const override;
+    void doSetMinFreq(int value) override;
+
+    int maxFreq() const override;
+    void doSetMaxFreq(int value) override;
+
     int colorGainDb() const override;
     void setColorGainDb(int value) override;
 

--- a/src/spectrogram/view/scalesectionparameterlistmodel.cpp
+++ b/src/spectrogram/view/scalesectionparameterlistmodel.cpp
@@ -103,8 +103,6 @@ bool ScaleSectionParameterListModel::setData(const QModelIndex& index, const QVa
         return false;
     }
 
-    emit dataChanged(this->index(control), this->index(control), { ControlCurrentValueRole, ControlMinValueRole, ControlMaxValueRole });
-
     return true;
 }
 }

--- a/src/spectrogram/view/scalesectionparameterlistmodel.cpp
+++ b/src/spectrogram/view/scalesectionparameterlistmodel.cpp
@@ -1,0 +1,110 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+#include "scalesectionparameterlistmodel.h"
+
+#include "abstractspectrogramsettingsmodel.h"
+#include "./spectrogramviewutils.h"
+
+#include "framework/global/translation.h"
+#include "framework/global/log.h"
+
+namespace au::spectrogram {
+ScaleSectionParameterListModel::ScaleSectionParameterListModel(QObject* parent)
+    : AbstractSectionParametersListModel(parent) {}
+
+void ScaleSectionParameterListModel::onSettingsModelSet(AbstractSpectrogramSettingsModel&)
+{
+    const QList<int> roles { ControlCurrentValueRole };
+    CONNECT_SETTING_CHANGED(maxFreqChanged, Control::MaxFreq, roles);
+    CONNECT_SETTING_CHANGED(minFreqChanged, Control::MinFreq, roles);
+}
+
+QVariant ScaleSectionParameterListModel::data(const QModelIndex& index, int role) const
+{
+    if (!m_settingsModel) {
+        return QVariant{};
+    }
+
+    const auto control = static_cast<Control>(index.row());
+    switch (role) {
+    case ControlLabelRole: return controlLabel(control);
+    case ControlUnitsRole: return muse::qtrc("spectrogram/preferences", "Hz");
+    case ControlMinValueRole: return controlMinValue(control);
+    case ControlMaxValueRole: return controlMaxValue(control);
+    case ControlCurrentValueRole: return controlCurrentValue(control);
+    default:
+        assert(false);
+        return QVariant{};
+    }
+}
+
+QHash<int, QByteArray> ScaleSectionParameterListModel::roleNames() const
+{
+    return {
+        { ControlLabelRole, "controlLabel" },
+        { ControlUnitsRole, "controlUnits" },
+        { ControlMinValueRole, "controlMinValue" },
+        { ControlMaxValueRole, "controlMaxValue" },
+        { ControlCurrentValueRole, "controlCurrentValue" },
+    };
+}
+
+QString ScaleSectionParameterListModel::controlLabel(Control control) const
+{
+    switch (control) {
+    case MaxFreq:
+        return muse::qtrc("spectrogram/preferences", "Max frequency");
+    case MinFreq:
+        return muse::qtrc("spectrogram/preferences", "Min frequency");
+    default:
+        assert(false);
+        return QString{};
+    }
+}
+
+int ScaleSectionParameterListModel::controlMinValue(Control) const
+{
+    return m_settingsModel ? m_settingsModel->frequencyHardMinimum() : 0;
+}
+
+int ScaleSectionParameterListModel::controlMaxValue(Control) const
+{
+    return m_settingsModel ? m_settingsModel->frequencyHardMaximum() : 0;
+}
+
+int ScaleSectionParameterListModel::controlCurrentValue(Control control) const
+{
+    switch (control) {
+    case MaxFreq:
+        return m_settingsModel->maxFreq();
+    case MinFreq:
+        return m_settingsModel->minFreq();
+    default:
+        assert(false);
+        return {};
+    }
+}
+
+bool ScaleSectionParameterListModel::setData(const QModelIndex& index, const QVariant& valueVar, int)
+{
+    const auto control = static_cast<Control>(index.row());
+    const auto value = valueVar.toInt();
+
+    switch (control) {
+    case MaxFreq:
+        m_settingsModel->setMaxFreq(value);
+        break;
+    case MinFreq:
+        m_settingsModel->setMinFreq(value);
+        break;
+    default:
+        assert(false);
+        return false;
+    }
+
+    emit dataChanged(this->index(control), this->index(control), { ControlCurrentValueRole, ControlMinValueRole, ControlMaxValueRole });
+
+    return true;
+}
+}

--- a/src/spectrogram/view/scalesectionparameterlistmodel.h
+++ b/src/spectrogram/view/scalesectionparameterlistmodel.h
@@ -1,0 +1,44 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+#pragma once
+
+#include "abstractsectionparameterslistmodel.h"
+
+namespace au::spectrogram {
+class AbstractSpectrogramSettingsModel;
+
+class ScaleSectionParameterListModel : public AbstractSectionParametersListModel
+{
+public:
+    explicit ScaleSectionParameterListModel(QObject* parent = nullptr);
+    ~ScaleSectionParameterListModel() override = default;
+
+private:
+    enum Control {
+        MaxFreq = 0, // Max freq first to be consistent with spectrogram UI
+        MinFreq,
+        _count
+    };
+
+    int rowCount(const QModelIndex&) const override { return static_cast<int>(Control::_count); }
+    QVariant data(const QModelIndex& index, int role) const override;
+    QHash<int, QByteArray> roleNames() const override;
+    bool setData(const QModelIndex& index, const QVariant& value, int role) override;
+
+    void onSettingsModelSet(AbstractSpectrogramSettingsModel& model) override;
+
+    enum Roles {
+        ControlLabelRole = Qt::UserRole + 1,
+        ControlUnitsRole,
+        ControlMinValueRole,
+        ControlMaxValueRole,
+        ControlCurrentValueRole,
+    };
+
+    QString controlLabel(Control) const;
+    int controlMinValue(Control) const;
+    int controlMaxValue(Control) const;
+    int controlCurrentValue(Control) const;
+};
+}

--- a/src/trackedit/internal/snapshotspectrogramconfiguration.h
+++ b/src/trackedit/internal/snapshotspectrogramconfiguration.h
@@ -12,8 +12,7 @@ class SnapshotSpectrogramConfiguration final : public spectrogram::ITrackSpectro
 {
 public:
     SnapshotSpectrogramConfiguration(const ITrackSpectrogramConfiguration& config)
-        : m_spectralSelectionEnabled{config.spectralSelectionEnabled()},
-        m_colorGainDb{config.colorGainDb()},
+        : m_colorGainDb{config.colorGainDb()},
         m_colorRangeDb{config.colorRangeDb()},
         m_colorHighBoostDbPerDec{config.colorHighBoostDbPerDec()},
         m_colorScheme{config.colorScheme()},
@@ -27,9 +26,6 @@ public:
     }
 
     ~SnapshotSpectrogramConfiguration() override = default;
-
-    bool spectralSelectionEnabled() const override { return m_spectralSelectionEnabled; }
-    void setSpectralSelectionEnabled(bool) override { assert(false); }
 
     int colorGainDb() const override { return m_colorGainDb; }
     void setColorGainDb(int) override { assert(false); }
@@ -62,7 +58,6 @@ public:
     void setUseGlobalSettings(bool) override { assert(false); }
 
 private:
-    const bool m_spectralSelectionEnabled;
     const int m_colorGainDb;
     const int m_colorRangeDb;
     const int m_colorHighBoostDbPerDec;

--- a/src/trackedit/internal/snapshotspectrogramconfiguration.h
+++ b/src/trackedit/internal/snapshotspectrogramconfiguration.h
@@ -12,7 +12,9 @@ class SnapshotSpectrogramConfiguration final : public spectrogram::ITrackSpectro
 {
 public:
     SnapshotSpectrogramConfiguration(const ITrackSpectrogramConfiguration& config)
-        : m_colorGainDb{config.colorGainDb()},
+        : m_minFreq{config.minFreq()},
+        m_maxFreq{config.maxFreq()},
+        m_colorGainDb{config.colorGainDb()},
         m_colorRangeDb{config.colorRangeDb()},
         m_colorHighBoostDbPerDec{config.colorHighBoostDbPerDec()},
         m_colorScheme{config.colorScheme()},
@@ -26,6 +28,12 @@ public:
     }
 
     ~SnapshotSpectrogramConfiguration() override = default;
+
+    int minFreq() const override { return m_minFreq; }
+    void setMinFreq(int) override { assert(false); }
+
+    int maxFreq() const override { return m_maxFreq; }
+    void setMaxFreq(int) override { assert(false); }
 
     int colorGainDb() const override { return m_colorGainDb; }
     void setColorGainDb(int) override { assert(false); }
@@ -58,6 +66,8 @@ public:
     void setUseGlobalSettings(bool) override { assert(false); }
 
 private:
+    const int m_minFreq;
+    const int m_maxFreq;
     const int m_colorGainDb;
     const int m_colorRangeDb;
     const int m_colorHighBoostDbPerDec;

--- a/src/trackedit/qml/Audacity/TrackEdit/TrackSpectrogramAlgorithmSection.qml
+++ b/src/trackedit/qml/Audacity/TrackEdit/TrackSpectrogramAlgorithmSection.qml
@@ -26,6 +26,7 @@ TrackSpectrogramBaseSection {
         spacing: root.narrowSpacing
         width: parent.width
         height: contentHeight
+        clip: false // or the highlight rectangle will be clipped
 
         delegate: Row {
             spacing: 0
@@ -43,6 +44,10 @@ TrackSpectrogramBaseSection {
             StyledDropdown {
                 id: comboBox
                 width: controlWidth
+
+                navigation.panel: root.navigation
+                navigation.order: index
+                navigation.name: "AlgorithmComboBox_" + index
 
                 model: controlPossibleValues
                 currentIndex: controlCurrentIndex

--- a/src/trackedit/qml/Audacity/TrackEdit/TrackSpectrogramColorsSection.qml
+++ b/src/trackedit/qml/Audacity/TrackEdit/TrackSpectrogramColorsSection.qml
@@ -21,6 +21,8 @@ TrackSpectrogramBaseSection {
         spacing: root.narrowSpacing
 
         Repeater {
+            id: repeater
+
             model: ColorSectionParameterListModel {
                 settingsModel: root.settingsModel
                 columnWidth: root.prefsColumnWidth
@@ -41,6 +43,10 @@ TrackSpectrogramBaseSection {
 
                 IncrementalPropertyControl {
                     width: root.mediumControlWidth
+
+                    navigation.panel: root.navigation
+                    navigation.order: index
+                    navigation.name: "ColorsIncrementalControl_" + index
 
                     minValue: colorControlMinValue
                     maxValue: colorControlMaxValue
@@ -71,6 +77,10 @@ TrackSpectrogramBaseSection {
 
             StyledDropdown {
                 width: root.largeControlWidth
+
+                navigation.panel: root.navigation
+                navigation.name: "ColorsSchemeComboBox"
+                navigation.order: repeater.count
 
                 model: settingsModel.colorSchemeNames
                 currentIndex: settingsModel.colorScheme

--- a/src/trackedit/qml/Audacity/TrackEdit/TrackSpectrogramScaleSection.qml
+++ b/src/trackedit/qml/Audacity/TrackEdit/TrackSpectrogramScaleSection.qml
@@ -31,6 +31,9 @@ TrackSpectrogramBaseSection {
         StyledDropdown {
             width: root.largeControlWidth
 
+            navigation.panel: root.navigation
+            navigation.name: "ScaleComboBox"
+
             model: settingsModel.scaleNames
             currentIndex: settingsModel.scale
             onActivated: function (index, value) {

--- a/src/trackedit/qml/Audacity/TrackEdit/TrackSpectrogramScaleSection.qml
+++ b/src/trackedit/qml/Audacity/TrackEdit/TrackSpectrogramScaleSection.qml
@@ -41,4 +41,46 @@ TrackSpectrogramBaseSection {
             }
         }
     }
+
+    Repeater {
+        id: repeater
+
+        model: ScaleSectionParameterListModel {
+            settingsModel: root.settingsModel
+            columnWidth: root.prefsColumnWidth
+        }
+
+        Row {
+            spacing: 0
+
+            StyledTextLabel {
+                width: root.mediumControlWidth
+                anchors.verticalCenter: parent.verticalCenter
+
+                text: controlLabel
+                elide: Text.ElideNone
+                wrapMode: Text.NoWrap
+                horizontalAlignment: Text.AlignLeft
+            }
+
+            IncrementalPropertyControl {
+                width: root.mediumControlWidth
+
+                navigation.panel: root.navigation
+                navigation.order: index + 1
+                navigation.name: "ScaleIncrementalControl_" + index
+
+                minValue: controlMinValue
+                maxValue: controlMaxValue
+                measureUnitsSymbol: controlUnits
+                decimals: 0
+                step: 1
+
+                currentValue: controlCurrentValue
+                onValueEditingFinished: function (value) {
+                    controlCurrentValue = value
+                }
+            }
+        }
+    }
 }

--- a/src/trackedit/qml/Audacity/TrackEdit/TrackSpectrogramSelectionSection.qml
+++ b/src/trackedit/qml/Audacity/TrackEdit/TrackSpectrogramSelectionSection.qml
@@ -21,6 +21,10 @@ TrackSpectrogramBaseSection {
             text: qsTrc("appshell/preferences/spectrogram", "Use global settings")
             checked: settingsModel.useGlobalSettings
 
+            navigation.panel: root.navigation
+            navigation.name: "UseGlobalSettingsCheckBox"
+            navigation.order: 0
+
             onClicked: {
                 settingsModel.useGlobalSettings = !settingsModel.useGlobalSettings
             }
@@ -29,6 +33,10 @@ TrackSpectrogramBaseSection {
         CheckBox {
             text: qsTrc("appshell/preferences/spectrogram", "Enable spectral selection")
             checked: settingsModel.spectralSelectionEnabled
+
+            navigation.panel: root.navigation
+            navigation.name: "EnableSpectralSelectionCheckBox"
+            navigation.order: 1
 
             onClicked: {
                 settingsModel.spectralSelectionEnabled = !settingsModel.spectralSelectionEnabled

--- a/src/trackedit/qml/Audacity/TrackEdit/TrackSpectrogramSelectionSection.qml
+++ b/src/trackedit/qml/Audacity/TrackEdit/TrackSpectrogramSelectionSection.qml
@@ -29,18 +29,5 @@ TrackSpectrogramBaseSection {
                 settingsModel.useGlobalSettings = !settingsModel.useGlobalSettings
             }
         }
-
-        CheckBox {
-            text: qsTrc("appshell/preferences/spectrogram", "Enable spectral selection")
-            checked: settingsModel.spectralSelectionEnabled
-
-            navigation.panel: root.navigation
-            navigation.name: "EnableSpectralSelectionCheckBox"
-            navigation.order: 1
-
-            onClicked: {
-                settingsModel.spectralSelectionEnabled = !settingsModel.spectralSelectionEnabled
-            }
-        }
     }
 }

--- a/src/trackedit/qml/Audacity/TrackEdit/TrackSpectrogramSettingsDialog.qml
+++ b/src/trackedit/qml/Audacity/TrackEdit/TrackSpectrogramSettingsDialog.qml
@@ -42,6 +42,9 @@ StyledDialogView {
         padding: 16
 
         TrackSpectrogramSelectionSection {
+            navigation.section: root.navigationSection
+            navigation.order: 0
+
             width: parent.width
             settingsModel: root.settingsModel
             onActiveFocusRequested: function (rect) {
@@ -52,6 +55,9 @@ StyledDialogView {
         SeparatorLine {}
 
         TrackSpectrogramScaleSection {
+            navigation.section: root.navigationSection
+            navigation.order: 1
+
             width: parent.width
             settingsModel: root.settingsModel
             onActiveFocusRequested: function (rect) {
@@ -62,6 +68,9 @@ StyledDialogView {
         SeparatorLine {}
 
         TrackSpectrogramColorsSection {
+            navigation.section: root.navigationSection
+            navigation.order: 2
+
             width: parent.width
             settingsModel: root.settingsModel
             onActiveFocusRequested: function (rect) {
@@ -72,6 +81,9 @@ StyledDialogView {
         SeparatorLine {}
 
         TrackSpectrogramAlgorithmSection {
+            navigation.section: root.navigationSection
+            navigation.order: 3
+
             width: parent.width
             settingsModel: root.settingsModel
             onActiveFocusRequested: function (rect) {
@@ -91,6 +103,9 @@ StyledDialogView {
         anchors.top: separator.bottom
         width: parent.width
 
+        navigationPanel.section: root.navigationSection
+        navigationPanel.order: 4
+
         padding: 12
         spacing: 8
 
@@ -99,6 +114,10 @@ StyledDialogView {
 
             height: prv.buttonHeight
             minWidth: 80
+
+            navigation.panel: bbox.navigationPanel
+            navigation.name: "CancelButton"
+            navigation.order: 1
 
             text: qsTrc("spectrogram/prefs", "Cancel")
             buttonRole: ButtonBoxModel.RejectRole
@@ -114,6 +133,10 @@ StyledDialogView {
 
             height: prv.buttonHeight
             minWidth: 80
+
+            navigation.panel: bbox.navigationPanel
+            navigation.name: "OKButton"
+            navigation.order: 2
 
             text: qsTrc("spectrogram/prefs", "Ok")
             buttonRole: ButtonBoxModel.AcceptRole

--- a/src/trackedit/qml/Audacity/TrackEdit/TrackSpectrogramSettingsDialog.qml
+++ b/src/trackedit/qml/Audacity/TrackEdit/TrackSpectrogramSettingsDialog.qml
@@ -47,9 +47,6 @@ StyledDialogView {
 
             width: parent.width
             settingsModel: root.settingsModel
-            onActiveFocusRequested: function (rect) {
-                root.ensureContentVisibleRequested(rect)
-            }
         }
 
         SeparatorLine {}
@@ -60,9 +57,6 @@ StyledDialogView {
 
             width: parent.width
             settingsModel: root.settingsModel
-            onActiveFocusRequested: function (rect) {
-                root.ensureContentVisibleRequested(rect)
-            }
         }
 
         SeparatorLine {}
@@ -73,9 +67,6 @@ StyledDialogView {
 
             width: parent.width
             settingsModel: root.settingsModel
-            onActiveFocusRequested: function (rect) {
-                root.ensureContentVisibleRequested(rect)
-            }
         }
 
         SeparatorLine {}
@@ -86,9 +77,6 @@ StyledDialogView {
 
             width: parent.width
             settingsModel: root.settingsModel
-            onActiveFocusRequested: function (rect) {
-                root.ensureContentVisibleRequested(rect)
-            }
         }
     }
 

--- a/src/trackedit/view/trackspectrogramsettingsmodel.cpp
+++ b/src/trackedit/view/trackspectrogramsettingsmodel.cpp
@@ -56,6 +56,8 @@ void TrackSpectrogramSettingsModel::componentComplete()
 
     m_initialTrackConfig = std::make_unique<SnapshotSpectrogramConfiguration>(*m_trackConfig);
 
+    emit minFreqChanged();
+    emit maxFreqChanged();
     emit colorGainDbChanged();
     emit colorRangeDbChanged();
     emit colorHighBoostDbPerDecChanged();
@@ -128,6 +130,8 @@ void TrackSpectrogramSettingsModel::setUseGlobalSettings(bool value)
     m_trackConfig->setUseGlobalSettings(value);
     if (value) {
         trackSpectrogramConfigurationProvider()->copyConfiguration(*globalSpectrogramConfiguration(), *m_trackConfig);
+        emit minFreqChanged();
+        emit maxFreqChanged();
         emit colorGainDbChanged();
         emit colorRangeDbChanged();
         emit colorHighBoostDbPerDecChanged();
@@ -140,6 +144,36 @@ void TrackSpectrogramSettingsModel::setUseGlobalSettings(bool value)
         sendRepaintRequest();
     }
     emit useGlobalSettingsChanged();
+}
+
+int TrackSpectrogramSettingsModel::minFreq() const
+{
+    return m_trackConfig ? m_trackConfig->minFreq() : 0;
+}
+
+void TrackSpectrogramSettingsModel::doSetMinFreq(int value)
+{
+    if (m_trackConfig->minFreq() == value) {
+        return;
+    }
+    m_trackConfig->setMinFreq(value);
+    emit minFreqChanged();
+    onSettingChanged();
+}
+
+int TrackSpectrogramSettingsModel::maxFreq() const
+{
+    return m_trackConfig ? m_trackConfig->maxFreq() : 0;
+}
+
+void TrackSpectrogramSettingsModel::doSetMaxFreq(int value)
+{
+    if (m_trackConfig->maxFreq() == value) {
+        return;
+    }
+    m_trackConfig->setMaxFreq(value);
+    emit maxFreqChanged();
+    onSettingChanged();
 }
 
 int TrackSpectrogramSettingsModel::colorGainDb() const

--- a/src/trackedit/view/trackspectrogramsettingsmodel.cpp
+++ b/src/trackedit/view/trackspectrogramsettingsmodel.cpp
@@ -56,16 +56,15 @@ void TrackSpectrogramSettingsModel::componentComplete()
 
     m_initialTrackConfig = std::make_unique<SnapshotSpectrogramConfiguration>(*m_trackConfig);
 
-    emit spectralSelectionEnabledChanged_1();
-    emit colorGainDbChanged_2();
-    emit colorRangeDbChanged_3();
-    emit colorHighBoostDbPerDecChanged_4();
-    emit colorSchemeChanged_5();
-    emit scaleChanged_6();
-    emit algorithmChanged_7();
-    emit windowTypeChanged_8();
-    emit windowSizeChanged_9();
-    emit zeroPaddingFactorChanged_10();
+    emit colorGainDbChanged();
+    emit colorRangeDbChanged();
+    emit colorHighBoostDbPerDecChanged();
+    emit colorSchemeChanged();
+    emit scaleChanged();
+    emit algorithmChanged();
+    emit windowTypeChanged();
+    emit windowSizeChanged();
+    emit zeroPaddingFactorChanged();
     emit useGlobalSettingsChanged();
 
     sendRepaintRequest();
@@ -129,173 +128,158 @@ void TrackSpectrogramSettingsModel::setUseGlobalSettings(bool value)
     m_trackConfig->setUseGlobalSettings(value);
     if (value) {
         trackSpectrogramConfigurationProvider()->copyConfiguration(*globalSpectrogramConfiguration(), *m_trackConfig);
-        emit spectralSelectionEnabledChanged_1();
-        emit colorGainDbChanged_2();
-        emit colorRangeDbChanged_3();
-        emit colorHighBoostDbPerDecChanged_4();
-        emit colorSchemeChanged_5();
-        emit scaleChanged_6();
-        emit algorithmChanged_7();
-        emit windowTypeChanged_8();
-        emit windowSizeChanged_9();
-        emit zeroPaddingFactorChanged_10();
+        emit colorGainDbChanged();
+        emit colorRangeDbChanged();
+        emit colorHighBoostDbPerDecChanged();
+        emit colorSchemeChanged();
+        emit scaleChanged();
+        emit algorithmChanged();
+        emit windowTypeChanged();
+        emit windowSizeChanged();
+        emit zeroPaddingFactorChanged();
         sendRepaintRequest();
     }
     emit useGlobalSettingsChanged();
 }
 
-bool TrackSpectrogramSettingsModel::spectralSelectionEnabled_1() const
-{
-    return m_trackConfig ? m_trackConfig->spectralSelectionEnabled() : false;
-}
-
-void TrackSpectrogramSettingsModel::setSpectralSelectionEnabled_1(bool value)
-{
-    if (m_trackConfig->spectralSelectionEnabled() == value) {
-        return;
-    }
-    m_trackConfig->setSpectralSelectionEnabled(value);
-    emit spectralSelectionEnabledChanged_1();
-    onSettingChanged();
-}
-
-int TrackSpectrogramSettingsModel::colorGainDb_2() const
+int TrackSpectrogramSettingsModel::colorGainDb() const
 {
     return m_trackConfig ? m_trackConfig->colorGainDb() : 0;
 }
 
-void TrackSpectrogramSettingsModel::setColorGainDb_2(int value)
+void TrackSpectrogramSettingsModel::setColorGainDb(int value)
 {
     if (m_trackConfig->colorGainDb() == value) {
         return;
     }
+
     m_trackConfig->setColorGainDb(value);
-    emit colorGainDbChanged_2();
+    emit colorGainDbChanged();
     onSettingChanged();
 }
 
-int TrackSpectrogramSettingsModel::colorRangeDb_3() const
+int TrackSpectrogramSettingsModel::colorRangeDb() const
 {
     return m_trackConfig ? m_trackConfig->colorRangeDb() : 0;
 }
 
-void TrackSpectrogramSettingsModel::setColorRangeDb_3(int value)
+void TrackSpectrogramSettingsModel::setColorRangeDb(int value)
 {
     if (m_trackConfig->colorRangeDb() == value) {
         return;
     }
     m_trackConfig->setColorRangeDb(value);
-    emit colorRangeDbChanged_3();
+    emit colorRangeDbChanged();
     onSettingChanged();
 }
 
-int TrackSpectrogramSettingsModel::colorHighBoostDbPerDec_4() const
+int TrackSpectrogramSettingsModel::colorHighBoostDbPerDec() const
 {
     return m_trackConfig ? m_trackConfig->colorHighBoostDbPerDec() : 0;
 }
 
-void TrackSpectrogramSettingsModel::setColorHighBoostDbPerDec_4(int value)
+void TrackSpectrogramSettingsModel::setColorHighBoostDbPerDec(int value)
 {
     if (m_trackConfig->colorHighBoostDbPerDec() == value) {
         return;
     }
     m_trackConfig->setColorHighBoostDbPerDec(value);
-    emit colorHighBoostDbPerDecChanged_4();
+    emit colorHighBoostDbPerDecChanged();
     onSettingChanged();
 }
 
-int TrackSpectrogramSettingsModel::colorScheme_5() const
+int TrackSpectrogramSettingsModel::colorScheme() const
 {
     return m_trackConfig ? static_cast<int>(m_trackConfig->colorScheme()) : 0;
 }
 
-void TrackSpectrogramSettingsModel::setColorScheme_5(int value)
+void TrackSpectrogramSettingsModel::setColorScheme(int value)
 {
     const auto scheme = static_cast<spectrogram::SpectrogramColorScheme>(value);
     if (m_trackConfig->colorScheme() == scheme) {
         return;
     }
     m_trackConfig->setColorScheme(scheme);
-    emit colorSchemeChanged_5();
+    emit colorSchemeChanged();
     onSettingChanged();
 }
 
-int TrackSpectrogramSettingsModel::scale_6() const
+int TrackSpectrogramSettingsModel::scale() const
 {
     return m_trackConfig ? static_cast<int>(m_trackConfig->scale()) : 0;
 }
 
-void TrackSpectrogramSettingsModel::setScale_6(int value)
+void TrackSpectrogramSettingsModel::setScale(int value)
 {
     const auto scale = static_cast<spectrogram::SpectrogramScale>(value);
     if (m_trackConfig->scale() == scale) {
         return;
     }
     m_trackConfig->setScale(scale);
-    emit scaleChanged_6();
+    emit scaleChanged();
     onSettingChanged();
 }
 
-int TrackSpectrogramSettingsModel::algorithm_7() const
+int TrackSpectrogramSettingsModel::algorithm() const
 {
     return m_trackConfig ? static_cast<int>(m_trackConfig->algorithm()) : 0;
 }
 
-void TrackSpectrogramSettingsModel::setAlgorithm_7(int value)
+void TrackSpectrogramSettingsModel::setAlgorithm(int value)
 {
     const auto algorithm = static_cast<spectrogram::SpectrogramAlgorithm>(value);
     if (m_trackConfig->algorithm() == algorithm) {
         return;
     }
     m_trackConfig->setAlgorithm(algorithm);
-    emit algorithmChanged_7();
+    emit algorithmChanged();
     onSettingChanged();
 }
 
-int TrackSpectrogramSettingsModel::windowType_8() const
+int TrackSpectrogramSettingsModel::windowType() const
 {
     return m_trackConfig ? static_cast<int>(m_trackConfig->windowType()) : 0;
 }
 
-void TrackSpectrogramSettingsModel::setWindowType_8(int value)
+void TrackSpectrogramSettingsModel::setWindowType(int value)
 {
     const auto windowType = static_cast<spectrogram::SpectrogramWindowType>(value);
     if (m_trackConfig->windowType() == windowType) {
         return;
     }
     m_trackConfig->setWindowType(windowType);
-    emit windowTypeChanged_8();
+    emit windowTypeChanged();
     onSettingChanged();
 }
 
-int TrackSpectrogramSettingsModel::windowSize_9() const
+int TrackSpectrogramSettingsModel::windowSize() const
 {
     return m_trackConfig ? 1 << m_trackConfig->winSizeLog2() : 0;
 }
 
-void TrackSpectrogramSettingsModel::setWindowSize_9(int value)
+void TrackSpectrogramSettingsModel::setWindowSize(int value)
 {
     assert(isPowerOfTwo(value));
     if (m_trackConfig->winSizeLog2() == logTwo(value)) {
         return;
     }
     m_trackConfig->setWinSizeLog2(logTwo(value));
-    emit windowSizeChanged_9();
+    emit windowSizeChanged();
     onSettingChanged();
 }
 
-int TrackSpectrogramSettingsModel::zeroPaddingFactor_10() const
+int TrackSpectrogramSettingsModel::zeroPaddingFactor() const
 {
     return m_trackConfig ? m_trackConfig->zeroPaddingFactor() : 0;
 }
 
-void TrackSpectrogramSettingsModel::setZeroPaddingFactor_10(int value)
+void TrackSpectrogramSettingsModel::setZeroPaddingFactor(int value)
 {
     if (m_trackConfig->zeroPaddingFactor() == value) {
         return;
     }
     m_trackConfig->setZeroPaddingFactor(value);
-    emit zeroPaddingFactorChanged_10();
+    emit zeroPaddingFactorChanged();
     onSettingChanged();
 }
 } // namespace au::spectrogram

--- a/src/trackedit/view/trackspectrogramsettingsmodel.h
+++ b/src/trackedit/view/trackspectrogramsettingsmodel.h
@@ -38,35 +38,32 @@ public:
     bool useGlobalSettings() const;
     void setUseGlobalSettings(bool value);
 
-    bool spectralSelectionEnabled_1() const override;
-    void setSpectralSelectionEnabled_1(bool value) override;
+    int colorGainDb() const override;
+    void setColorGainDb(int value) override;
 
-    int colorGainDb_2() const override;
-    void setColorGainDb_2(int value) override;
+    int colorRangeDb() const override;
+    void setColorRangeDb(int value) override;
 
-    int colorRangeDb_3() const override;
-    void setColorRangeDb_3(int value) override;
+    int colorHighBoostDbPerDec() const override;
+    void setColorHighBoostDbPerDec(int value) override;
 
-    int colorHighBoostDbPerDec_4() const override;
-    void setColorHighBoostDbPerDec_4(int value) override;
+    int colorScheme() const override;
+    void setColorScheme(int value) override;
 
-    int colorScheme_5() const override;
-    void setColorScheme_5(int value) override;
+    int scale() const override;
+    void setScale(int value) override;
 
-    int scale_6() const override;
-    void setScale_6(int value) override;
+    int algorithm() const override;
+    void setAlgorithm(int value) override;
 
-    int algorithm_7() const override;
-    void setAlgorithm_7(int value) override;
+    int windowType() const override;
+    void setWindowType(int value) override;
 
-    int windowType_8() const override;
-    void setWindowType_8(int value) override;
+    int windowSize() const override;
+    void setWindowSize(int value) override;
 
-    int windowSize_9() const override;
-    void setWindowSize_9(int value) override;
-
-    int zeroPaddingFactor_10() const override;
-    void setZeroPaddingFactor_10(int value) override;
+    int zeroPaddingFactor() const override;
+    void setZeroPaddingFactor(int value) override;
 
 signals:
     void trackIdChanged();

--- a/src/trackedit/view/trackspectrogramsettingsmodel.h
+++ b/src/trackedit/view/trackspectrogramsettingsmodel.h
@@ -38,6 +38,12 @@ public:
     bool useGlobalSettings() const;
     void setUseGlobalSettings(bool value);
 
+    int minFreq() const override;
+    void doSetMinFreq(int value) override;
+
+    int maxFreq() const override;
+    void doSetMaxFreq(int value) override;
+
     int colorGainDb() const override;
     void setColorGainDb(int value) override;
 


### PR DESCRIPTION
Resolves: #9922

Beside adding navigation, this PR does two other things:
* "Enable spectral selection" is a global setting only,
* adds min- and max frequency settings

- [ ] I signed [CLA](https://www.audacityteam.org/cla/)
- [ ] The title of the pull request describes an issue it addresses
- [ ] If changes are extensive, then there is a sequence of easily reviewable commits
- [ ] Each commit's message describes its purpose and effects
- [ ] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [ ] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:
- [x] "Enable spectral selection" is a global setting only,
- [x] "Min frequency" and "Max frequency" settings (both global and per-track) are now available and work
- [x] Both global and per-track spectrogram settings are navigable with keyboard
- [ ] Autobot test cases have been run
