### PR TITLE
Fix MixerBoard Mute and Solo buttons display

### DIFF
--- a/src/MixerBoard.cpp
+++ b/src/MixerBoard.cpp
@@ -1180,7 +1180,7 @@ void MixerBoard::UpdateWidth()
 //
 
 
-void MixerBoard::MakeButtonBitmap( wxMemoryDC & dc, wxBitmap & WXUNUSED(bitmap), wxRect & bev, const TranslatableString & str, bool up )
+void MixerBoard::MakeButtonBitmap( wxMemoryDC & dc, wxBitmap & bitmap, wxRect & bev, const TranslatableString & str, bool up )
 {
 
    const auto translation = str.Translation();
@@ -1190,6 +1190,8 @@ void MixerBoard::MakeButtonBitmap( wxMemoryDC & dc, wxBitmap & WXUNUSED(bitmap),
    #ifdef __WXMSW__
       fontSize = 8;
    #endif
+
+   dc.SelectObject(bitmap);
    wxFont font(fontSize, wxFONTFAMILY_SWISS, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL);
    GetTextExtent(translation, &textWidth, &textHeight, NULL, NULL, &font);
 
@@ -1205,6 +1207,7 @@ void MixerBoard::MakeButtonBitmap( wxMemoryDC & dc, wxBitmap & WXUNUSED(bitmap),
    dc.SetBackgroundMode(wxTRANSPARENT);
    dc.DrawText(translation, x, y);
 //   dc.DrawText(translation, 0, 0);
+   dc.SelectObject(wxNullBitmap);
 }
 
 void MixerBoard::CreateMuteSoloImages()
@@ -1218,7 +1221,6 @@ void MixerBoard::CreateMuteSoloImages()
    mMuteSoloWidth = kRightSideStackWidth - kInset;
 
    wxBitmap bitmap(mMuteSoloWidth, MUTE_SOLO_HEIGHT,24);
-   dc.SelectObject(bitmap);
    wxRect bev(0, 0, mMuteSoloWidth, MUTE_SOLO_HEIGHT);
 
    const bool up=true;


### PR DESCRIPTION
wxWidgets 3.2 documentation insists that the bitmap shoud be unselected from DC before using its data, either by selecting wxNullBitmap or by destroying the device context[1]. Failing to do it may lead to various glitches. For example, all the images created in MixerBoard::CreateMuteSoloImages were same on my system -- and same as the first one, mImageMuteUp.

Selecting the bitmap every time before drawing, and unselecting it very time after drawing solves the issue for me.

[1] https://docs.wxwidgets.org/3.2/classwx_memory_d_c.html#a93d218796ba9359eb4aec2ae46a813e6

Resolves: #9368

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Autobot test cases have been run
