### PR TITLE
Address some HiDPI issues on wxGTK3/Linux

### DIFF
--- a/src/TrackInfo.cpp
+++ b/src/TrackInfo.cpp
@@ -15,6 +15,7 @@ Paul Licameli split from TrackPanel.cpp
 #include <wx/app.h>
 #include <wx/dc.h>
 #include <wx/font.h>
+#include <wx/settings.h>
 #include <wx/window.h>
 
 #include "AColor.h"
@@ -37,8 +38,11 @@ struct Settings : PrefsListener {
 
    void UpdatePrefs() override
    {
-#if defined __WXMAC__
+#if defined(__WXMAC__)
       int fontSize = 12;
+#elif defined(__WXGTK__)
+      auto defaultFont = wxSystemSettings::GetFont(wxSYS_DEFAULT_GUI_FONT);
+      int fontSize = defaultFont.GetPointSize();
 #else
       int fontSize = 10;
 #endif

--- a/src/widgets/MeterPanel.cpp
+++ b/src/widgets/MeterPanel.cpp
@@ -51,6 +51,7 @@
 #include <wx/textdlg.h>
 #include <wx/numdlg.h>
 #include <wx/radiobut.h>
+#include <wx/settings.h>
 #include <wx/tooltip.h>
 
 #include <math.h>
@@ -1101,8 +1102,11 @@ float MeterPanel::GetPeakHold() const
 wxFont MeterPanel::GetFont() const
 {
    int fontSize = 10;
-#if defined __WXMSW__
+#if defined(__WXMSW__)
    fontSize = 8;
+#elif defined(__WXGTK__)
+   auto defaultFont = wxSystemSettings::GetFont(wxSYS_DEFAULT_GUI_FONT);
+   fontSize = defaultFont.GetPointSize() - 2;
 #endif
 
    return wxFont(fontSize, wxFONTFAMILY_SWISS, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL);

--- a/src/widgets/auStaticText.cpp
+++ b/src/widgets/auStaticText.cpp
@@ -23,6 +23,7 @@ can't be.
 #include <cassert>
 
 #include <wx/dcclient.h>
+#include <wx/settings.h>
 
 BEGIN_EVENT_TABLE(auStaticText, wxWindow)
     EVT_PAINT(auStaticText::OnPaint)
@@ -36,8 +37,11 @@ auStaticText::auStaticText(wxWindow* parent, wxString textIn) :
    int textWidth, textHeight;
 
    int fontSize = 11;
-   #ifdef __WXMSW__
+   #if defined(__WXMSW__)
       fontSize = 9;
+   #elif defined(__WXGTK__)
+      auto defaultFont = wxSystemSettings::GetFont(wxSYS_DEFAULT_GUI_FONT);
+      fontSize = defaultFont.GetPointSize();
    #endif
    wxFont font(fontSize, wxFONTFAMILY_DEFAULT, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL);
    GetTextExtent(textIn, &textWidth, &textHeight, NULL, NULL, &font);


### PR DESCRIPTION
While we all expect all possible HiDPI issues will be solved with Audacity 4, I guess Audacity 3 is with us for some more time, so why won't we make it a bit nicer.

This small series addresses two of the most irritating issues I have with Audacity 3 on my 160 DPI laptop screen:
- huge labels on  Time Signature, Snapping and Selection Toolbars;
- huge dB labels on Playback and Recording meters.

The idea is to use the default wxWidgets font size instead of hardcoding a particular value. The solution is restricted to wxGTK3, as wxGTK3/Linux X11 is the only platform I can test things on.

Related to #503 and a few issues closed as its duplicates, but not resolves them completely of course.

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Autobot test cases have been run
