### PR TITLE
9882 Fix mouse click to reset clip indicator

### DIFF
--- a/src/projectscene/qml/Audacity/ProjectScene/trackspanel/WaveTrackItem.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/trackspanel/WaveTrackItem.qml
@@ -104,7 +104,7 @@ TrackItem {
                     rightVolumePressureMeter.resetClipped()
                 }
 
-                TapHandler { onTapped: clearMeters() }
+                TapHandler { onTapped: volumePressureContainer.clearMeters() }
 
                 VolumePressureMeter {
                     id: leftOrMonoVolumePressureMeter


### PR DESCRIPTION
Resolves: #9882

Use container id to call clearMeters function from onTapped handler.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Autobot test cases have been run
