### PR TITLE
Constant-Q in au4 spectrogram

### DIFF
--- a/src/au3wrap/CMakeLists.txt
+++ b/src/au3wrap/CMakeLists.txt
@@ -65,6 +65,7 @@ add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/thirdparty/soxr au3-soxr)
 add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/thirdparty/pffft au3-pffft)
 add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/thirdparty/portmixer au3-portmixer)
 add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/thirdparty/twolame au3-twolame)
+add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/thirdparty/tft)
 list(APPEND AU3_LINK twolame)
 
 # Conditional time-stretching and pitch-shifting libraries

--- a/src/au3wrap/thirdparty/tft/CMakeLists.txt
+++ b/src/au3wrap/thirdparty/tft/CMakeLists.txt
@@ -1,0 +1,10 @@
+include(FetchContent)
+set( TFT_VERSION 0.5 )
+FetchContent_Declare(
+   tft
+   GIT_REPOSITORY https://github.com/kgramhans/tft.git
+   GIT_TAG 1d96301673ebc05fa09a7bd505eacd82ee0fea33
+)
+FetchContent_MakeAvailable(tft)
+
+

--- a/src/spectrogram/CMakeLists.txt
+++ b/src/spectrogram/CMakeLists.txt
@@ -68,6 +68,6 @@ set(MODULE_SRC
 
 set(MODULE_QML_IMPORT ${CMAKE_CURRENT_LIST_DIR}/qml)
 set(MODULE_USE_UNITY OFF)
-set(MODULE_LINK au3wrap Qt6::Concurrent)
+set(MODULE_LINK au3wrap Qt6::Concurrent tft)
 
 setup_module()

--- a/src/spectrogram/internal/au3/SpectrumCache.h
+++ b/src/spectrogram/internal/au3/SpectrumCache.h
@@ -50,6 +50,10 @@ public:
     void Populate(
         const Au3SpectrogramSettings& settings, const WaveChannelInterval& clip, int copyBegin, int copyEnd, size_t numPixels,
         double pixelsPerSecond);
+    // Calculate the dirty columns at the begin and end of the cache (Constant-Q variant)
+    void PopulateConstantQ(
+        const Au3SpectrogramSettings& settings, const WaveChannelInterval& clip, int copyBegin, int copyEnd, size_t numPixels,
+        double pixelsPerSecond);
 
     size_t len { 0 };      // counts pixels, not samples
     std::optional<SpectrogramAlgorithm> algorithm;

--- a/src/spectrogram/internal/au3/au3spectrogramsettings.cpp
+++ b/src/spectrogram/internal/au3/au3spectrogramsettings.cpp
@@ -14,8 +14,11 @@
 
 #include "framework/global/log.h"
 
+#include "tft/WaveletCalculator.h"
+
 #include <algorithm>
 #include <cmath>
+#include <memory>
 
 namespace au::spectrogram {
 namespace {
@@ -181,6 +184,7 @@ void Au3SpectrogramSettings::DestroyWindows()
     window.reset();
     dWindow.reset();
     tWindow.reset();
+    pTFCalculator.reset(nullptr);
 }
 
 namespace {
@@ -248,7 +252,13 @@ void RecreateWindow(
 
 void Au3SpectrogramSettings::CacheWindows()
 {
-    if (hFFT == NULL || window == NULL || (algorithm == SpectrogramAlgorithm::Reassignment && (tWindow == NULL || dWindow == NULL))) {
+    if (isConstantQ()) {
+        if (pTFCalculator == nullptr) {
+            // JUST USING CONSTANT PARAMETERS FOR NOW. @todo : Should be inferred from settings
+            pTFCalculator = std::make_unique<TFT::WaveletCalculator>(10 /*octaves*/, 0.4 /*fmax*/, 18 /*Q*/, 50 /*overlap*/);
+        }
+    } else if (hFFT == nullptr || window == nullptr
+               || (algorithm == SpectrogramAlgorithm::Reassignment && (tWindow == nullptr || dWindow == nullptr))) {
         double scale;
         auto factor = ZeroPaddingFactor();
         const auto fftLen = WindowSize() * factor;

--- a/src/spectrogram/internal/au3/au3spectrogramsettings.h
+++ b/src/spectrogram/internal/au3/au3spectrogramsettings.h
@@ -3,8 +3,11 @@
  */
 #pragma once
 
+#include <memory>
+
 #include "iglobalspectrogramconfiguration.h"
 #include "spectrogramtypes.h"
+#include "tft/TimeFrequencyCalculator.h"
 
 #include "au3-math/SampleFormat.h"
 #include "au3-fft/RealFFTf.h"
@@ -47,6 +50,8 @@ public:
     SpectrogramScale scaleType = static_cast<SpectrogramScale>(0);
     SpectrogramAlgorithm algorithm = static_cast<SpectrogramAlgorithm>(0);
 
+    bool isConstantQ() const { return false; }  // If you want to play around with ConstantQ analysis, you can Change to for instance WindowType() == SpectrogramWindowType::Gaussian45
+
     SpectrogramWindowType WindowType() const { return m_windowType; }
     void SetWindowType(SpectrogramWindowType type);
 
@@ -66,6 +71,9 @@ public:
     // Two other windows for computing reassigned spectrogram
     Floats tWindow;        // Window times time parameter
     Floats dWindow;        // Derivative of window
+
+    // calculator needed for constant-Q spectrogram
+    std::unique_ptr<TFT::ITimeFrequencyCalculator> pTFCalculator;
 
 private:
     enum {


### PR DESCRIPTION
Resolves: *#9509*

*Constant-Q Spectrogram into Audacity 4*

The current Pull request deals with optimised calculation of Constant-Q spectrogram which was already added to Audacity 3 code base

- The bulk part of the code is hidden away in a third-party lib, thus interference with audacity code should be minimal
- Changes to GUI (Spectrogram settings) have _not_ been settled
- For demonstration purposes, choosing Window type "Gaussian (a=4.5)" will silently implement a Constant-Q spectrogram (Q=18). This is of course a temporary solution that can be easily reverted

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Autobot test cases have been run
