### PR TITLE
Fix #10143 - Build: VST3_SDK_DIR env var required but error message asks for VST3SDK_DIR

### DIFF
--- a/cmake-proxies/cmake-modules/Findvst3sdk.cmake
+++ b/cmake-proxies/cmake-modules/Findvst3sdk.cmake
@@ -14,7 +14,7 @@ if( NOT vst3sdk_FOUND )
    endif()
 
    if( NOT EXISTS ${vst3sdk_DIR} )
-      message( STATUS "VST3SDK not found. Please set VST3SDK_DIR to the path to the vst3sdk directory." )
+      message( STATUS "VST3SDK not found. Please set VST3_SDK_DIR to the path to the vst3sdk directory." )
       return()
    endif()
 


### PR DESCRIPTION
Resolves: #10143 

Build: VST3_SDK_DIR env var required but cmake error message asks for VST3SDK_DIR

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Autobot test cases have been run
