### PR TITLE
use explicit stopPreview function

### DIFF
--- a/src/effects/audio_unit/view/audiounitviewmodel.cpp
+++ b/src/effects/audio_unit/view/audiounitviewmodel.cpp
@@ -90,6 +90,11 @@ void au::effects::AudioUnitViewModel::doStartPreview()
     });
 }
 
+void au::effects::AudioUnitViewModel::doStopPreview()
+{
+    effectsProvider()->stopPreview();
+}
+
 void AudioUnitViewModel::deinit()
 {
     if (m_eventListenerRef) {

--- a/src/effects/audio_unit/view/audiounitviewmodel.h
+++ b/src/effects/audio_unit/view/audiounitviewmodel.h
@@ -7,6 +7,7 @@
 
 #include <QObject>
 
+#include "effects/effects_base/ieffectsprovider.h"
 #include "modularity/ioc.h"
 #include "context/iglobalcontext.h"
 #include "playback/iplayback.h"
@@ -27,6 +28,7 @@ class AudioUnitViewModel : public AbstractEffectViewModel
     muse::Inject<IRealtimeEffectService> realtimeEffectService{ this };
     muse::Inject<au::playback::IPlayback> playback{ this };
     muse::Inject<trackedit::IProjectHistory> projectHistory{ this };
+    muse::Inject<IEffectsProvider> effectsProvider{ this };
 
 public:
     AudioUnitViewModel(QObject* parent, int instanceId);
@@ -43,6 +45,7 @@ signals:
 private:
     void doInit() override;
     void doStartPreview() override;
+    void doStopPreview() override;
 
     using EventListenerPtr = AudioUnitCleanup<AUEventListenerRef, AUListenerDispose>;
     static void EventListenerCallback(void* inCallbackRefCon, void* inObject, const AudioUnitEvent* inEvent, UInt64 inEventHostTime,

--- a/src/effects/builtin/common/builtineffectmodel.cpp
+++ b/src/effects/builtin/common/builtineffectmodel.cpp
@@ -59,6 +59,11 @@ void BuiltinEffectModel::doStartPreview()
     }
 }
 
+void BuiltinEffectModel::doStopPreview()
+{
+    effectsProvider()->stopPreview();
+}
+
 void BuiltinEffectModel::modifySettings(const std::function<void(EffectSettings& settings)>& modifier)
 {
     const EffectSettingsAccessPtr access = this->settingsAccess();

--- a/src/effects/builtin/common/builtineffectmodel.h
+++ b/src/effects/builtin/common/builtineffectmodel.h
@@ -74,6 +74,7 @@ protected:
 private:
     void doInit() override;
     void doStartPreview() override;
+    void doStopPreview() override;
 
     EffectSettingsAccessPtr settingsAccess() const;
 };

--- a/src/effects/effects_base/ieffectsprovider.h
+++ b/src/effects/effects_base/ieffectsprovider.h
@@ -42,5 +42,6 @@ public:
                                     EffectSettings& settings) = 0;
 
     virtual muse::Ret previewEffect(const EffectId& effectId, EffectSettings& settings) = 0;
+    virtual void stopPreview() = 0;
 };
 }

--- a/src/effects/effects_base/internal/effectsprovider.h
+++ b/src/effects/effects_base/internal/effectsprovider.h
@@ -71,6 +71,7 @@ public:
                             EffectSettings& settings) override;
 
     muse::Ret previewEffect(const EffectId& effectId, EffectSettings& settings) override;
+    void stopPreview() override;
 
 private:
     struct EffectContext {
@@ -82,10 +83,13 @@ private:
     };
 
     struct EffectPreviewState {
-        EffectPreviewState(const EffectContext& originContext, const std::shared_ptr<TrackList>& previewTracks)
-            : originContext(originContext), previewTracks(previewTracks) {}
+        EffectPreviewState(const EffectId& effectId, const EffectContext& originContext,
+                           const std::shared_ptr<TrackList>& previewTracks, bool loopWasActive)
+            : effectId(effectId), originContext(originContext), previewTracks(previewTracks), loopWasActive(loopWasActive) {}
+        const EffectId effectId;
         const EffectContext originContext;
         const std::shared_ptr<TrackList> previewTracks;
+        const bool loopWasActive;
     };
 
     bool isVstSupported() const;

--- a/src/effects/effects_base/view/abstracteffectviewmodel.cpp
+++ b/src/effects/effects_base/view/abstracteffectviewmodel.cpp
@@ -43,7 +43,7 @@ void AbstractEffectViewModel::startPreview()
 
 void AbstractEffectViewModel::stopPreview()
 {
-    playback()->player()->stop();
+    doStopPreview();
 }
 
 EffectInstanceId AbstractEffectViewModel::instanceId() const

--- a/src/effects/effects_base/view/abstracteffectviewmodel.h
+++ b/src/effects/effects_base/view/abstracteffectviewmodel.h
@@ -44,6 +44,7 @@ protected:
 private:
     virtual void doInit() = 0;
     virtual void doStartPreview() = 0;
+    virtual void doStopPreview() = 0;
 };
 
 class AbstractEffectViewModelFactory : public QObject

--- a/src/effects/lv2/view/lv2viewmodel.cpp
+++ b/src/effects/lv2/view/lv2viewmodel.cpp
@@ -176,6 +176,11 @@ void Lv2ViewModel::doStartPreview()
     });
 }
 
+void Lv2ViewModel::doStopPreview()
+{
+    effectsProvider()->stopPreview();
+}
+
 std::optional<XID> Lv2ViewModel::x11Window() const
 {
     if (!m_isX11Window) {

--- a/src/effects/lv2/view/lv2viewmodel.h
+++ b/src/effects/lv2/view/lv2viewmodel.h
@@ -6,6 +6,7 @@
 #include "lv2uihandler.h"
 
 #include "effects/effects_base/view/abstracteffectviewmodel.h"
+#include "effects/effects_base/ieffectsprovider.h"
 #include "trackedit/iprojecthistory.h"
 
 #include "au3-lv2/LV2UIFeaturesList.h"
@@ -32,6 +33,7 @@ class Lv2ViewModel : public AbstractEffectViewModel
     Q_PROPERTY(QString unsupportedUiReason READ unsupportedUiReason NOTIFY unsupportedUiReasonChanged FINAL)
 
     muse::Inject<trackedit::IProjectHistory> projectHistory { this };
+    muse::Inject<IEffectsProvider> effectsProvider{ this };
 
 public:
     Lv2ViewModel(QObject* parent, int instanceId, const QString& effectState);
@@ -53,6 +55,8 @@ private:
     friend class Lv2UiHandler;
     void doInit() override;
     void doStartPreview() override;
+    void doStopPreview() override;
+
     int onResizeUi(int width, int height);
     void onUiClosed();
     void onKeyPressed(Qt::Key);

--- a/src/effects/vst/view/vstviewmodel.cpp
+++ b/src/effects/vst/view/vstviewmodel.cpp
@@ -134,3 +134,8 @@ void VstViewModel::doStartPreview()
         return nullptr;
     });
 }
+
+void VstViewModel::doStopPreview()
+{
+    effectsProvider()->stopPreview();
+}

--- a/src/effects/vst/view/vstviewmodel.h
+++ b/src/effects/vst/view/vstviewmodel.h
@@ -10,6 +10,7 @@
 #include "effects/effects_base/irealtimeeffectservice.h"
 #include "effects/effects_base/effectstypes.h"
 #include "effects/effects_base/view/abstracteffectviewmodel.h"
+#include "effects/effects_base/ieffectsprovider.h"
 
 class VST3Instance;
 class EffectSettingsAccess;
@@ -21,6 +22,7 @@ class VstViewModel : public AbstractEffectViewModel
 public:
     muse::Inject<IRealtimeEffectService> realtimeEffectService{ this };
     muse::Inject<trackedit::IProjectHistory> projectHistory{ this };
+    muse::Inject<IEffectsProvider> effectsProvider{ this };
 
 public:
     VstViewModel(QObject* parent, int instanceId);
@@ -29,6 +31,7 @@ public:
 private:
     void doInit() override;
     void doStartPreview() override;
+    void doStopPreview() override;
 
     std::shared_ptr<EffectSettingsAccess> settingsAccess() const;
     void settingsToView();


### PR DESCRIPTION
Resolves: #10056

Prevent race between effect preview and effect application by explicitly stopping the preview rather than relying on the playback stop signal.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Autobot test cases have been run
