### PR TITLE
Hyperlinks should use a darker, more legible color, and not inherit the accent color. #9260

### DIFF
--- a/src/app/configs/dark.cfg
+++ b/src/app/configs/dark.cfg
@@ -12,7 +12,7 @@
     "button_color": "#626A73",
     "font_primary_color": "#F0F5FA",
     "font_secondary_color": "#F4F7F9",
-    "link_color": "#677CE4",
+    "link_color": "#8095FF",
     "focus_color": "#75507b",
     "white_color": "#FFFFFF",
     "black_color": "#000000",

--- a/src/app/configs/light.cfg
+++ b/src/app/configs/light.cfg
@@ -12,7 +12,7 @@
     "button_color": "#C2C4CF",
     "font_primary_color": "#14151A",
     "font_secondary_color": "#F4F5F9",
-    "link_color": "#677CE4",
+    "link_color": "#4060FF",
     "focus_color": "#75507b",
     "white_color": "#FFFFFF",
     "black_color": "#000000",


### PR DESCRIPTION
Resolves: Hyperlinks should use a darker, more legible color, and not inherit the accent color. https://github.com/audacity/audacity/issues/9260

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Autobot test cases have been run
