### PR TITLE
Fix crash on chirp generation

### DIFF
--- a/src/trackedit/internal/au3/au3selectioncontroller.cpp
+++ b/src/trackedit/internal/au3/au3selectioncontroller.cpp
@@ -57,10 +57,9 @@ void Au3SelectionController::init()
             }
 
             setSelectedLabels(savedSelectedLabels, true);
+            setSelectedClips(savedSelectedClips, true);
 
-            if (!savedSelectedClips.empty()) {
-                setSelectedClips(savedSelectedClips, true);
-            } else {
+            if (savedSelectedClips.empty()) {
                 setSelectedTracks(savedSelectedTracks, true);
             }
 


### PR DESCRIPTION
Resolves: #10330 

Selection Controller uses stale values if the consecutive projects have no selected clips

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Autobot test cases have been run
