### PR TITLE
Automatic latency compensation checkbox

### DIFF
--- a/au3/libraries/au3-audio-devices/AudioIOBase.cpp
+++ b/au3/libraries/au3-audio-devices/AudioIOBase.cpp
@@ -179,8 +179,7 @@ void AudioIOBase::HandleDeviceChange()
         playbackParameters.suggestedLatency
             =Pa_GetDeviceInfo(playDeviceNum)->defaultLowOutputLatency;
     } else {
-        playbackParameters.suggestedLatency
-            =AudioIOLatencyCorrection.GetDefault() / 1000.0;
+        playbackParameters.suggestedLatency = AudioIOLatencyCompensation.GetDefault() / 1000.0;
     }
 
     PaStreamParameters captureParameters;
@@ -193,8 +192,7 @@ void AudioIOBase::HandleDeviceChange()
         captureParameters.suggestedLatency
             =Pa_GetDeviceInfo(recDeviceNum)->defaultLowInputLatency;
     } else {
-        captureParameters.suggestedLatency
-            =AudioIOLatencyCorrection.GetDefault() / 1000.0;
+        captureParameters.suggestedLatency = AudioIOLatencyCompensation.GetDefault() / 1000.0;
     }
 
     // try opening for record and playback
@@ -940,8 +938,7 @@ wxString AudioIOBase::GetDeviceInfo() const
             playbackParameters.suggestedLatency
                 =Pa_GetDeviceInfo(playDeviceNum)->defaultLowOutputLatency;
         } else {
-            playbackParameters.suggestedLatency
-                =AudioIOLatencyCorrection.GetDefault() / 1000.0;
+            playbackParameters.suggestedLatency = AudioIOLatencyCompensation.GetDefault() / 1000.0;
         }
 
         PaStreamParameters captureParameters;
@@ -954,8 +951,7 @@ wxString AudioIOBase::GetDeviceInfo() const
             captureParameters.suggestedLatency
                 =Pa_GetDeviceInfo(recDeviceNum)->defaultLowInputLatency;
         } else {
-            captureParameters.suggestedLatency
-                =AudioIOLatencyCorrection.GetDefault() / 1000.0;
+            captureParameters.suggestedLatency = AudioIOLatencyCompensation.GetDefault() / 1000.0;
         }
 
         // Not really doing I/O so pass nullptr for the callback function
@@ -1055,10 +1051,10 @@ auto AudioIOBase::GetAllDeviceInfo() -> std::vector<AudioIODiagnostics>
 
 StringSetting AudioIOHost{
     L"/AudioIO/Host", L"" };
-BoolSetting AudioIOAutomaticLatencyCorrection{
-    L"/AudioIO/AutomaticLatencyCorrection", true };
-DoubleSetting AudioIOLatencyCorrection{
-    L"/AudioIO/LatencyCorrection", -130.0 };
+BoolSetting AudioIOAutomaticLatencyCompensation{
+    L"/AudioIO/AutomaticLatencyCompensation", true };
+DoubleSetting AudioIOLatencyCompensation{
+    L"/AudioIO/LatencyCompensation", -130.0 };
 DoubleSetting AudioIOLatencyDuration{
     L"/AudioIO/LatencyDuration", 100.0 };
 StringSetting AudioIOPlaybackDevice{

--- a/au3/libraries/au3-audio-devices/AudioIOBase.cpp
+++ b/au3/libraries/au3-audio-devices/AudioIOBase.cpp
@@ -730,7 +730,8 @@ int AudioIOBase::getPlayDevIndex(const wxString& devNameArg)
 
     if (!devName.empty()) {
         wxString hostName = AudioIOHost.Read();
-        int deviceIndex = DeviceManager::Instance()->GetOutputDevicePaIndex(hostName.ToStdString(wxConvUTF8), devName.ToStdString(wxConvUTF8));
+        int deviceIndex = DeviceManager::Instance()->GetOutputDevicePaIndex(hostName.ToStdString(wxConvUTF8), devName.ToStdString(
+                                                                                wxConvUTF8));
         if (deviceIndex >= 0) {
             return deviceIndex;
         }
@@ -1054,6 +1055,8 @@ auto AudioIOBase::GetAllDeviceInfo() -> std::vector<AudioIODiagnostics>
 
 StringSetting AudioIOHost{
     L"/AudioIO/Host", L"" };
+BoolSetting AudioIOAutomaticLatencyCorrection{
+    L"/AudioIO/AutomaticLatencyCorrection", true };
 DoubleSetting AudioIOLatencyCorrection{
     L"/AudioIO/LatencyCorrection", -130.0 };
 DoubleSetting AudioIOLatencyDuration{

--- a/au3/libraries/au3-audio-devices/AudioIOBase.h
+++ b/au3/libraries/au3-audio-devices/AudioIOBase.h
@@ -404,8 +404,8 @@ protected:
 #include "au3-preferences/Prefs.h"
 
 extern AUDIO_DEVICES_API StringSetting AudioIOHost;
-extern AUDIO_DEVICES_API DoubleSetting AudioIOLatencyCorrection;
-extern AUDIO_DEVICES_API BoolSetting AudioIOAutomaticLatencyCorrection;
+extern AUDIO_DEVICES_API DoubleSetting AudioIOLatencyCompensation;
+extern AUDIO_DEVICES_API BoolSetting AudioIOAutomaticLatencyCompensation;
 extern AUDIO_DEVICES_API DoubleSetting AudioIOLatencyDuration;
 extern AUDIO_DEVICES_API StringSetting AudioIOPlaybackDevice;
 extern AUDIO_DEVICES_API StringSetting AudioIOPlaybackSource;

--- a/au3/libraries/au3-audio-devices/AudioIOBase.h
+++ b/au3/libraries/au3-audio-devices/AudioIOBase.h
@@ -405,6 +405,7 @@ protected:
 
 extern AUDIO_DEVICES_API StringSetting AudioIOHost;
 extern AUDIO_DEVICES_API DoubleSetting AudioIOLatencyCorrection;
+extern AUDIO_DEVICES_API BoolSetting AudioIOAutomaticLatencyCorrection;
 extern AUDIO_DEVICES_API DoubleSetting AudioIOLatencyDuration;
 extern AUDIO_DEVICES_API StringSetting AudioIOPlaybackDevice;
 extern AUDIO_DEVICES_API StringSetting AudioIOPlaybackSource;

--- a/au3/libraries/au3-audio-io/AudioIO.cpp
+++ b/au3/libraries/au3-audio-io/AudioIO.cpp
@@ -699,8 +699,8 @@ bool AudioIO::StartPortAudioStream(const AudioIOStartStreamOptions& options,
                   : // Otherwise, use the (likely incorrect) latency reported by PA
                   stream->outputLatency;
 
-            if (AudioIOAutomaticLatencyCorrection.Read()) {
-                mRecordingSchedule.mLatencyCorrection = -stream->inputLatency - outputLatency;
+            if (AudioIOAutomaticLatencyCompensation.Read()) {
+                mRecordingSchedule.mLatencyCompensation = -stream->inputLatency - outputLatency;
             }
 
             mHardwarePlaybackLatencyMs = outputLatency * 1000.0;
@@ -981,8 +981,7 @@ int AudioIO::StartStream(const TransportSequences& sequences,
     const auto preRoll = std::max(0.0, std::min(t0, options.preRoll));
     mRecordingSchedule = {};
     mRecordingSchedule.mPreRoll = preRoll;
-    mRecordingSchedule.mLatencyCorrection
-        =AudioIOLatencyCorrection.Read() / 1000.0;
+    mRecordingSchedule.mLatencyCompensation = AudioIOLatencyCompensation.Read() / 1000.0;
     mRecordingSchedule.mDuration = t1 - t0;
     if (options.pCrossfadeData) {
         mRecordingSchedule.mCrossfadeData.swap(*options.pCrossfadeData);
@@ -2982,7 +2981,7 @@ void AudioIoCallback::DrainInputBuffers(
         // Assume that any good partial buffer should be written leftmost
         // and zeroes will be padded after; label the zeroes.
         auto start = mPlaybackSchedule.GetSequenceTime()
-                     + len / mRate + mRecordingSchedule.mLatencyCorrection;
+                     + len / mRate + mRecordingSchedule.mLatencyCompensation;
         auto duration = (framesPerBuffer - len) / mRate;
         auto pLast = mLostCaptureIntervals.empty()
                      ? nullptr : &mLostCaptureIntervals.back();

--- a/au3/libraries/au3-audio-io/AudioIO.cpp
+++ b/au3/libraries/au3-audio-io/AudioIO.cpp
@@ -699,7 +699,12 @@ bool AudioIO::StartPortAudioStream(const AudioIOStartStreamOptions& options,
                   : // Otherwise, use the (likely incorrect) latency reported by PA
                   stream->outputLatency;
 
+            if (AudioIOAutomaticLatencyCorrection.Read()) {
+                mRecordingSchedule.mLatencyCorrection = -stream->inputLatency - outputLatency;
+            }
+
             mHardwarePlaybackLatencyMs = outputLatency * 1000.0;
+            mHardwareCaptureLatencyMs = stream->inputLatency * 1000.0;
             mHardwarePlaybackLatencyFrames = lrint(outputLatency * stream->sampleRate);
 #ifdef __WXGTK__
             // DV: When using ALSA PortAudio does not report the buffer size.
@@ -1922,7 +1927,7 @@ void AudioIO::AudioThread(std::atomic<bool>& finish)
             lastState = ProcessingState::eSkipProcessing;
 
             if (gAudioIO->IsMonitoring()) {
-               lastState = ProcessingState::eMonitoringProcessing;
+                lastState = ProcessingState::eMonitoringProcessing;
             }
         }
 

--- a/au3/libraries/au3-audio-io/AudioIO.h
+++ b/au3/libraries/au3-audio-io/AudioIO.h
@@ -212,7 +212,7 @@ public:
     void SendVuInputMeterData(const float* inputSamples, unsigned long framesPerBuffer, const TimePoint& dacTime);
     void SendVuOutputMeterData(const float* outputMeterFloats, unsigned long framesPerBuffer, const TimePoint& dacTime);
     void PushMasterOutputMeterValues(const IMeterSenderPtr& sender, const float* values, uint8_t channels, unsigned long frames,
-                             const TimePoint& dacTime);
+                                     const TimePoint& dacTime);
     void PushTrackMeterValues(const IMeterSenderPtr& sender, unsigned long frames, const TimePoint& dacTime);
     void PushInputMeterValues(const IMeterSenderPtr& sender, const float* values, unsigned long frames, const TimePoint& dacTime);
 
@@ -241,7 +241,7 @@ public:
         size_t channelIndex{};
     };
     std::vector<TrackChannelInfo> mCaptureChannelLayout;
-    std::vector<std::vector<size_t>> mTrackChannelSourceMap;
+    std::vector<std::vector<size_t> > mTrackChannelSourceMap;
     bool mCaptureNeedsMixdown{ false };
     //!Buffers that hold outcome of transformations applied to each individual sample source.
     //!Number of buffers equals to the sum of number all source channels.
@@ -278,6 +278,7 @@ public:
     /// Hardware output latency in frames
     size_t mHardwarePlaybackLatencyFrames { 0u };
     double mHardwarePlaybackLatencyMs{ 0 };
+    double mHardwareCaptureLatencyMs{ 0 };
     /// Occupancy of the queue we try to maintain, with bigger batches if needed
     size_t mPlaybackQueueMinimum;
 
@@ -521,6 +522,8 @@ public:
     sampleFormat GetCaptureFormat() const { return mCaptureFormat; }
     size_t GetNumPlaybackChannels() const { return mNumPlaybackChannels; }
     size_t GetNumCaptureChannels() const { return mNumCaptureChannels; }
+    int GetHardwarePlaybackLatencyMs() const { return mHardwarePlaybackLatencyMs; }
+    int GetHardwareCaptureLatencyMs() const { return mHardwareCaptureLatencyMs; }
 
     // Meaning really capturing, not just pre-rolling
     bool IsCapturing() const;

--- a/au3/libraries/au3-audio-io/PlaybackSchedule.cpp
+++ b/au3/libraries/au3-audio-io/PlaybackSchedule.cpp
@@ -193,7 +193,7 @@ void PlaybackSchedule::Init(
     if (pRecordingSchedule) {
         // adjust mT1 so that we don't give paComplete too soon to fill up the
         // desired length of recording
-        mT1 -= pRecordingSchedule->mLatencyCorrection;
+        mT1 -= pRecordingSchedule->mLatencyCompensation;
     }
 
     // Main thread's initialization of mTime

--- a/au3/libraries/au3-audio-io/PlaybackSchedule.h
+++ b/au3/libraries/au3-audio-io/PlaybackSchedule.h
@@ -30,7 +30,7 @@ constexpr size_t TimeQueueGrainSize = 480;
 
 struct RecordingSchedule {
     double mPreRoll{};
-    double mLatencyCorrection{}; // negative value usually
+    double mLatencyCompensation{}; // negative value usually
     double mDuration{};
     PRCrossfadeData mCrossfadeData;
 
@@ -39,7 +39,7 @@ struct RecordingSchedule {
     double mPosition{};
     bool mLatencyCorrected{};
 
-    double TotalCorrection() const { return mLatencyCorrection - mPreRoll; }
+    double TotalCorrection() const { return mLatencyCompensation - mPreRoll; }
     double ToConsume() const;
     double Consumed() const;
     double ToDiscard() const;

--- a/au3/src/prefs/DevicePrefs.cpp
+++ b/au3/src/prefs/DevicePrefs.cpp
@@ -304,7 +304,7 @@ void DevicePrefs::PopulateOrExchange(ShuttleGui& S)
             w = S
                 .NameSuffix(XO("milliseconds"))
                 .TieNumericTextBox(XXO("&Latency compensation:"),
-                                   AudioIOLatencyCorrection, 25);
+                                   AudioIOLatencyCompensation, 25);
             S.AddUnits(XO("milliseconds"));
         }
         S.EndThreeColumn();
@@ -539,7 +539,7 @@ bool DevicePrefs::Commit()
     }
 
     AudioIOLatencyDuration.Invalidate();
-    AudioIOLatencyCorrection.Invalidate();
+    AudioIOLatencyCompensation.Invalidate();
 
     QualitySettings::DefaultSampleRate.Invalidate();
 

--- a/docs/portaudio-reported-playback-capture-latency.md
+++ b/docs/portaudio-reported-playback-capture-latency.md
@@ -16,17 +16,17 @@ PortAudio reports these latencies, but experiments showed that they weren't reli
 
 ## Results
 
-| OS  | Host        | requested buffer size (\*) | PA-reported output buffer size (\*\*) | PA-reported input buffer size | Measured round-trip | error (reported - actual) |
-| --- | ----------- | -------------------------- | ------------------------------------- | ----------------------------- | ------------------- | ------------------------- |
-| Win | WASAPI      | 0.25                       | 0.27                                  | 0.26                          | 0.075               | 0.455                     |
-| Win | WASAPI      | 0.1                        | 0.12                                  | 0.11                          | 0.075               | 0.155                     |
-| Win | WASAPI      | 0.02                       | 0.04                                  | 0.03                          | 0.075               | -0.005                    |
-| Win | DirectSound | 0.25                       | 0.25                                  | 0.0625                        | 0.42                | -0.1075                   |
-| Win | DirectSound | 0.1                        | 0.1                                   | 0.025                         | 0.115               | 0.01                      |
-| Win | DirectSound | 0.02                       | didn't work                           | didn't work                   | didn't work         | didn't work               |
-| Win | ASIO        | 0.5                        | 0.050498866213151930                  | 0.047936507936507937          | 0.1                 | -0.0015646258503401456    |
-| Win | ASIO        | 0.1                        | 0.050498866213151930                  | 0.047936507936507937          | 0.1                 | -0.0015646258503401456    |
-| Win | ASIO        | 0.02                       | 0.026507936507936508                  | 0.024716553287981859          | 0.054               | -0.0027755102040816285    |
+| OS  | Host        | requested buffer size (ms) (\*) | PA-reported output buffer size (ms) (\*\*) | PA-reported input buffer size (ms) | Measured round-trip (ms) | error (reported - actual) (ms) |
+| --- | ----------- | ------------------------------- | ------------------------------------------ | ---------------------------------- | ------------------------ | ------------------------------ |
+| Win | WASAPI      | 250                             | 270                                        | 260                                | 75                       | 455                            |
+| Win | WASAPI      | 100                             | 120                                        | 110                                | 75                       | 155                            |
+| Win | WASAPI      | 20                              | 40                                         | 30                                 | 75                       | -5                             |
+| Win | DirectSound | 250                             | 250                                        | 62.5                               | 420                      | -107.5                         |
+| Win | DirectSound | 100                             | 100                                        | 25                                 | 115                      | 10                             |
+| Win | DirectSound | 20                              | didn't work                                | didn't work                        | didn't work              | didn't work                    |
+| Win | ASIO        | 500                             | 50.5                                       | 47.9                               | 100                      | -1.6                           |
+| Win | ASIO        | 100                             | 50.5                                       | 47.9                               | 100                      | -1.6                           |
+| Win | ASIO        | 20                              | 26.5                                       | 24.7                               | 54                       | -2.8                           |
 
-(\*) applies to both input and output, e.g. 0.25 means 0.25 for the input + 0.25 for the output, in total 0.5.
+(\*) applies to both input and output, e.g. 250 means 250 for the input + 250 for the output, in total 500.
 (\*\*) for one same requested size, may differ wildly depending on whether only playback is active or playback and recording. Here we write the values obtained when both are active.

--- a/docs/portaudio-reported-playback-capture-latency.md
+++ b/docs/portaudio-reported-playback-capture-latency.md
@@ -1,0 +1,32 @@
+Imagine there were an audio cable plugged from your output back to your input. You press play, and at some stage, the project audio will reach back the input and become recorded. Latency compensation simply consists of discarding all incoming audio until the project audio arrives. Then users could play their project, record themselves on the fly and the incoming audio would be in sync without further manual adjustment required.
+
+Audacity already has a latency-compensation setting for the user to adjust manually. Automatically adjusting this setting optimally would be trivial as soon as we knew the round-trip latency of the audio device.
+
+PortAudio reports these latencies, but experiments showed that they weren't reliable. Here I make an experiment that I believe to provide exact estimates of round-trip latency.
+
+## Description of experiment
+
+- Connect the selected output device to the selected input device with an audio cable.
+- Before recording starts, create a wav file.
+- In the audio IO callback (on the audio driver thread)
+    - overwrite the output buffer with one second of silence, then with a sine wave
+    - write the samples of the input buffer to the wav file.
+- When recording stops, close the wav file.
+- Open the file in Audacity and observe the latency.
+
+## Results
+
+| OS  | Host        | requested buffer size (\*) | PA-reported output buffer size (\*\*) | PA-reported input buffer size | Measured round-trip | error (reported - actual) |
+| --- | ----------- | -------------------------- | ------------------------------------- | ----------------------------- | ------------------- | ------------------------- |
+| Win | WASAPI      | 0.25                       | 0.27                                  | 0.26                          | 0.075               | 0.455                     |
+| Win | WASAPI      | 0.1                        | 0.12                                  | 0.11                          | 0.075               | 0.155                     |
+| Win | WASAPI      | 0.02                       | 0.04                                  | 0.03                          | 0.075               | -0.005                    |
+| Win | DirectSound | 0.25                       | 0.25                                  | 0.0625                        | 0.42                | -0.1075                   |
+| Win | DirectSound | 0.1                        | 0.1                                   | 0.025                         | 0.115               | 0.01                      |
+| Win | DirectSound | 0.02                       | didn't work                           | didn't work                   | didn't work         | didn't work               |
+| Win | ASIO        | 0.5                        | 0.050498866213151930                  | 0.047936507936507937          | 0.1                 | -0.0015646258503401456    |
+| Win | ASIO        | 0.1                        | 0.050498866213151930                  | 0.047936507936507937          | 0.1                 | -0.0015646258503401456    |
+| Win | ASIO        | 0.02                       | 0.026507936507936508                  | 0.024716553287981859          | 0.054               | -0.0027755102040816285    |
+
+(\*) applies to both input and output, e.g. 0.25 means 0.25 for the input + 0.25 for the output, in total 0.5.
+(\*\*) for one same requested size, may differ wildly depending on whether only playback is active or playback and recording. Here we write the values obtained when both are active.

--- a/src/au3audio/internal/au3audiodevicesprovider.cpp
+++ b/src/au3audio/internal/au3audiodevicesprovider.cpp
@@ -27,9 +27,9 @@ static const muse::Settings::Key PLAYBACK_DEVICE("au3audio", "AudioIO/PlaybackDe
 static const muse::Settings::Key RECORDING_DEVICE("au3audio", "AudioIO/RecordingDevice");
 static const muse::Settings::Key INPUT_CHANNELS("au3audio", "AudioIO/RecordChannels");
 
-static const muse::Settings::Key AUTOMATIC_LATENCY_CORRECTION("au3audio", "AudioIO/AutomaticLatencyCorrection");
+static const muse::Settings::Key AUTOMATIC_LATENCY_COMPENSATION("au3audio", "AudioIO/AutomaticLatencyCompensation");
 static const muse::Settings::Key LATENCY_DURATION("au3audio", "AudioIO/LatencyDuration");
-static const muse::Settings::Key LATENCY_CORRECTION("au3audio", "AudioIO/LatencyCorrection");
+static const muse::Settings::Key LATENCY_COMPENSATION("au3audio", "AudioIO/LatencyCompensation");
 
 static const muse::Settings::Key DEFAULT_PROJECT_SAMPLE_RATE("au3audio", "SamplingRate/DefaultProjectSampleRate");
 static const muse::Settings::Key DEFAULT_PROJECT_SAMPLE_FORMAT("au3audio", "SamplingRate/DefaultProjectSampleFormatChoice");
@@ -81,8 +81,8 @@ void Au3AudioDevicesProvider::init()
 
     muse::settings()->setDefaultValue(INPUT_CHANNELS, muse::Val(1));
     muse::settings()->setDefaultValue(LATENCY_DURATION, muse::Val(100.0));
-    muse::settings()->setDefaultValue(AUTOMATIC_LATENCY_CORRECTION, muse::Val(false));
-    muse::settings()->setDefaultValue(LATENCY_CORRECTION, muse::Val(-130.0));
+    muse::settings()->setDefaultValue(AUTOMATIC_LATENCY_COMPENSATION, muse::Val(false));
+    muse::settings()->setDefaultValue(LATENCY_COMPENSATION, muse::Val(-130.0));
     muse::settings()->setDefaultValue(DEFAULT_PROJECT_SAMPLE_RATE, muse::Val(AudioIOBase::GetOptimalSupportedSampleRate()));
     muse::settings()->setDefaultValue(DEFAULT_PROJECT_SAMPLE_FORMAT,
                                       muse::Val(QualitySettings::SampleFormatSetting.Default().Internal().ToStdString()));
@@ -109,7 +109,7 @@ void Au3AudioDevicesProvider::init()
         m_inputChannelsChanged.notify();
     });
 
-    muse::settings()->valueChanged(AUTOMATIC_LATENCY_CORRECTION).onReceive(nullptr, [this](const muse::Val& val) {
+    muse::settings()->valueChanged(AUTOMATIC_LATENCY_COMPENSATION).onReceive(nullptr, [this](const muse::Val& val) {
         m_automaticCompensationEnabledChanged.notify();
     });
 
@@ -117,7 +117,7 @@ void Au3AudioDevicesProvider::init()
         m_bufferLengthChanged.notify();
     });
 
-    muse::settings()->valueChanged(LATENCY_CORRECTION).onReceive(nullptr, [this](const muse::Val& val) {
+    muse::settings()->valueChanged(LATENCY_COMPENSATION).onReceive(nullptr, [this](const muse::Val& val) {
         m_latencyCompensationChanged.notify();
     });
 
@@ -245,22 +245,22 @@ void Au3AudioDevicesProvider::setBufferLength(double newBufferLength)
 
 bool Au3AudioDevicesProvider::automaticCompensationEnabled() const
 {
-    return muse::settings()->value(AUTOMATIC_LATENCY_CORRECTION).toBool();
+    return muse::settings()->value(AUTOMATIC_LATENCY_COMPENSATION).toBool();
 }
 
 void Au3AudioDevicesProvider::setAutomaticCompensationEnabled(bool enabled)
 {
-    muse::settings()->setLocalValue(AUTOMATIC_LATENCY_CORRECTION, muse::Val(enabled));
+    muse::settings()->setLocalValue(AUTOMATIC_LATENCY_COMPENSATION, muse::Val(enabled));
 }
 
 double Au3AudioDevicesProvider::latencyCompensation() const
 {
-    return muse::settings()->value(LATENCY_CORRECTION).toDouble();
+    return muse::settings()->value(LATENCY_COMPENSATION).toDouble();
 }
 
 void Au3AudioDevicesProvider::setLatencyCompensation(double newLatencyCompensation)
 {
-    muse::settings()->setLocalValue(LATENCY_CORRECTION, muse::Val(newLatencyCompensation));
+    muse::settings()->setLocalValue(LATENCY_COMPENSATION, muse::Val(newLatencyCompensation));
 }
 
 std::vector<uint64_t> Au3AudioDevicesProvider::sampleRates() const

--- a/src/au3audio/internal/au3audiodevicesprovider.h
+++ b/src/au3audio/internal/au3audiodevicesprovider.h
@@ -50,6 +50,10 @@ public:
     void setBufferLength(double newBufferLength) override;
     muse::async::Notification bufferLengthChanged() const override;
 
+    bool automaticCompensationEnabled() const override;
+    void setAutomaticCompensationEnabled(bool enabled) override;
+    muse::async::Notification automaticCompensationEnabledChanged() const override;
+
     double latencyCompensation() const override;
     void setLatencyCompensation(double newLatencyCompensation) override;
     muse::async::Notification latencyCompensationChanged() const override;
@@ -87,6 +91,7 @@ private:
     muse::async::Notification m_inputChannelsChanged;
     muse::async::Notification m_inputChannelsListChanged;
     muse::async::Notification m_bufferLengthChanged;
+    muse::async::Notification m_automaticCompensationEnabledChanged;
     muse::async::Notification m_latencyCompensationChanged;
     muse::async::Notification m_defaultSampleRateChanged;
     muse::async::Notification m_defaultSampleFormatChanged;

--- a/src/au3audio/internal/au3audioengine.cpp
+++ b/src/au3audio/internal/au3audioengine.cpp
@@ -67,7 +67,13 @@ int Au3AudioEngine::startStream(const TransportSequences& sequences, const doubl
     AudioIOStartStreamOptions options = ProjectAudioIO::GetDefaultOptions(project, isDefaultPlayTrackPolicy);
     options.inputMonitoring = recordConfiguration()->isInputMonitoringOn();
     options.rate = audioStreamSampleRate;
-    return AudioIO::Get()->StartStream(sequences, startTime, endTime, mixerEndTime, options);
+    auto& audioIO = *AudioIO::Get();
+    const int token = audioIO.StartStream(sequences, startTime, endTime, mixerEndTime, options);
+    if (token > 0) {
+        LOGI() << "PortAudio latency report (ms): outputLatency=" << audioIO.GetHardwarePlaybackLatencyMs() <<
+            ", inputLatency=" << audioIO.GetHardwareCaptureLatencyMs();
+    }
+    return token;
 }
 
 void Au3AudioEngine::stopStream()

--- a/src/audio/iaudiodevicesprovider.h
+++ b/src/audio/iaudiodevicesprovider.h
@@ -40,6 +40,10 @@ public:
     virtual void setBufferLength(double newBufferLength) = 0;
     virtual muse::async::Notification bufferLengthChanged() const = 0;
 
+    virtual bool automaticCompensationEnabled() const = 0;
+    virtual void setAutomaticCompensationEnabled(bool enabled) = 0;
+    virtual muse::async::Notification automaticCompensationEnabledChanged() const = 0;
+
     virtual double latencyCompensation() const = 0;
     virtual void setLatencyCompensation(double newLatencyCompensation) = 0;
     virtual muse::async::Notification latencyCompensationChanged() const = 0;

--- a/src/preferences/qml/Audacity/Preferences/commonaudioapiconfigurationmodel.cpp
+++ b/src/preferences/qml/Audacity/Preferences/commonaudioapiconfigurationmodel.cpp
@@ -69,6 +69,7 @@ void CommonAudioApiConfigurationModel::load()
     audioDevicesProvider()->inputDeviceChanged().onNotify(this, [this]() { emit currentInputDeviceIdChanged(); });
     audioDevicesProvider()->inputChannelsAvailableChanged().onNotify(this, [this](){ emit inputChannelsListChanged(); });
     audioDevicesProvider()->inputChannelsChanged().onNotify(this, [this](){ emit currentInputChannelsSelectedChanged(); });
+    audioDevicesProvider()->automaticCompensationEnabledChanged().onNotify(this, [this](){ emit automaticCompensationEnabledChanged(); });
     audioDevicesProvider()->bufferLengthChanged().onNotify(this, [this](){ emit bufferLengthChanged(); });
     audioDevicesProvider()->latencyCompensationChanged().onNotify(this, [this](){ emit latencyCompensationChanged(); });
     audioDevicesProvider()->defaultSampleRateChanged().onNotify(this, [this](){
@@ -169,6 +170,20 @@ void CommonAudioApiConfigurationModel::bufferLengthSelected(const QString& buffe
     }
 
     audioDevicesProvider()->setBufferLength(bufferLengthStr.toDouble());
+}
+
+bool CommonAudioApiConfigurationModel::automaticCompensationEnabled() const
+{
+    return audioDevicesProvider()->automaticCompensationEnabled();
+}
+
+void CommonAudioApiConfigurationModel::setAutomaticCompensationEnabled(bool enabled)
+{
+    if (enabled == automaticCompensationEnabled()) {
+        return;
+    }
+
+    audioDevicesProvider()->setAutomaticCompensationEnabled(enabled);
 }
 
 double CommonAudioApiConfigurationModel::latencyCompensation() const

--- a/src/preferences/qml/Audacity/Preferences/commonaudioapiconfigurationmodel.h
+++ b/src/preferences/qml/Audacity/Preferences/commonaudioapiconfigurationmodel.h
@@ -45,6 +45,7 @@ class CommonAudioApiConfigurationModel : public QObject, public muse::async::Asy
     Q_PROPERTY(QVariantList inputDeviceList READ inputDeviceList NOTIFY inputDeviceListChanged)
 
     Q_PROPERTY(double bufferLength READ bufferLength NOTIFY bufferLengthChanged)
+    Q_PROPERTY(bool automaticCompensationEnabled READ automaticCompensationEnabled NOTIFY automaticCompensationEnabledChanged)
     Q_PROPERTY(double latencyCompensation READ latencyCompensation NOTIFY latencyCompensationChanged)
 
     Q_PROPERTY(QString currentInputChannelsSelected READ currentInputChannelsSelected NOTIFY currentInputChannelsSelectedChanged)
@@ -84,6 +85,9 @@ public:
     double bufferLength() const;
     Q_INVOKABLE void bufferLengthSelected(const QString& bufferLengthStr);
 
+    bool automaticCompensationEnabled() const;
+    Q_INVOKABLE void setAutomaticCompensationEnabled(bool enabled);
+
     double latencyCompensation() const;
     Q_INVOKABLE void latencyCompensationSelected(const QString& latencyCompensationStr);
 
@@ -121,6 +125,7 @@ signals:
 
     void bufferLengthChanged();
     void latencyCompensationChanged();
+    void automaticCompensationEnabledChanged();
 
     void currentInputChannelsSelectedChanged();
     void inputChannelsListChanged();

--- a/src/preferences/qml/Audacity/Preferences/internal/BufferAndLatencySection.qml
+++ b/src/preferences/qml/Audacity/Preferences/internal/BufferAndLatencySection.qml
@@ -60,29 +60,47 @@ BaseSection {
         navigation.panel: root.navigation
         navigation.row: 1
 
-        onValueEdited: function(newValue) {
+        onValueEdited: function (newValue) {
             apiModel.bufferLengthSelected(newValue)
         }
     }
 
-    IncrementalPropertyControlWithTitle {
-        title: qsTrc("preferences", "Latency compensation")
+    StyledTextLabel {
+        text: qsTrc("preferences", "Latency compensation")
+
+        width: root.columnWidth
+        horizontalAlignment: Qt.AlignLeft
+        wrapMode: Text.WordWrap
+        maximumLineCount: 2
+    }
+
+    CheckBox {
+        id: automaticCompensationCheckbox
+
+        text: qsTrc("preferences", "Automatic")
+        checked: apiModel.automaticCompensationEnabled
+        onClicked: apiModel.setAutomaticCompensationEnabled(!checked)
+
+        navigation.name: "AutomaticLatencyCompensationCheckBox"
+        navigation.panel: root.navigation
+        navigation.row: 2
+    }
+
+    IncrementalPropertyControl {
 
         currentValue: apiModel.latencyCompensation
 
-        enabled: !playbackState.isPlaying
-
-        columnWidth: root.columnWidth
-        spacing: root.columnSpacing
+        enabled: !playbackState.isPlaying && !apiModel.automaticCompensationEnabled
+        implicitWidth: 100
 
         //: Abbreviation of "milliseconds"
         measureUnitsSymbol: qsTrc("global", "ms")
 
         navigation.name: "LatencyCompensationControl"
         navigation.panel: root.navigation
-        navigation.row: 2
+        navigation.row: 3
 
-        onValueEdited: function(newValue) {
+        onValueEdited: function (newValue) {
             apiModel.latencyCompensationSelected(newValue)
         }
     }


### PR DESCRIPTION
Resolves: #10185

Checkbox disabled by default.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [x] New automatic-latency-compensation checkbox is accessible via keyboard (like the other elements in the audio settings prefs)
- [x] By default it is OFF
- [x] When enabling it, the "Latency compensation" spin box is greyed out
- [x] Latency compensation and the automatic checkbox are both persistent
- [ ] Autobot test cases have been run

Additionally, please check if the compensation is accurate on Linux using ALSA (it is for me). Suggested way of doing this:
* create a rhythm track in AU3, import it in AU4,
* select open speakers and microphone so that the mic picks up the speakers
* add another track, press record

Both should be in sync +/- a few ms - +4 in the image below:
<img width="1920" height="1102" alt="image" src="https://github.com/user-attachments/assets/b274e7a0-442c-4f95-b150-fe957f2d4639" />
