### PR TITLE
Add AGENTS.md with build instructions and known issues

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,21 @@
+# Audacity (AU4) — Build Instructions
+
+This project uses CMake presets. User-local config lives in `CMakeUserPresets.json` and `.vscode/settings.json` (both gitignored). See `BUILDING.md` for full setup details.
+
+## Build
+
+```sh
+cmake --preset default
+cmake --build --preset build
+cmake --build --preset install   # installs to build/<preset>/install/
+```
+
+On Windows with the Ninja generator, run from a **VS Developer Command Prompt** (or source `vcvars64.bat` first). The VS Code CMake Tools extension handles this automatically via `cmake.useVsDeveloperEnvironment`.
+
+The executable is `build/<preset>/install/bin/Audacity4` (`.exe` on Windows).
+
+## Known Issues
+
+1. **Never use the `Debug` build type.** The `libcurl` debug artifact is missing from `muse_deps`. Use `RelWithDebInfo` or `Release`.
+2. **Always set `CMAKE_INSTALL_PREFIX` to a subdirectory** (e.g. `build/install`). The repo root contains a file named `INSTALL` which collides with CMake's install directory on case-insensitive filesystems.
+3. **Ninja on Windows requires the VS Developer environment.** Without it, `rc.exe` and `mt.exe` are missing and configure fails.


### PR DESCRIPTION
Provides always-on workspace instructions for AI agents:
- Build commands using CMake presets
- Three known issues: no Debug builds (libcurl), INSTALL file conflict, and Ninja requiring VS Developer environment

Resolves build issues encountered when setting up the Audacity workspace in VSCode on Windows.


<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Autobot test cases have been run
