### PR TITLE
10318 Use model setters only after pointer is valid

### DIFF
--- a/src/projectscene/qml/Audacity/ProjectScene/trackruler/WaveformRuler.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/trackruler/WaveformRuler.qml
@@ -16,13 +16,13 @@ Item {
     TrackRulerModel {
         id: rulerModel
 
-        height: initialized ? root.height : 0
+        height: root.height
 
-        trackId: initialized ? model.trackId : -1
-        isStereo: initialized ? model.isStereo : false
+        trackId: model.trackId
+        isStereo: model.isStereo
 
-        isCollapsed: initialized ? root.isCollapsed : false
-        channelHeightRatio: initialized ? root.channelHeightRatio : 1.0
+        isCollapsed: root.isCollapsed
+        channelHeightRatio: root.channelHeightRatio
     }
     MouseArea {
         anchors.fill: parent

--- a/src/projectscene/view/trackruler/trackrulermodel.cpp
+++ b/src/projectscene/view/trackruler/trackrulermodel.cpp
@@ -33,6 +33,7 @@ void TrackRulerModel::init()
     if (!m_model) {
         m_model = buildRulerModel();
     }
+
     m_model->setDbRange(au::playback::PlaybackMeterDbRange::toDouble(configuration()->playbackMeterDbRange()));
     configuration()->playbackMeterDbRangeChanged().onNotify(this, [this]() {
         m_model->setDbRange(au::playback::PlaybackMeterDbRange::toDouble(configuration()->playbackMeterDbRange()));
@@ -62,7 +63,6 @@ void TrackRulerModel::init()
         emit fullStepsChanged();
         emit smallStepsChanged();
     }, muse::async::Asyncable::Mode::SetReplace);
-    setInitialized(true);
 }
 
 std::vector<QVariantMap> TrackRulerModel::fullSteps() const
@@ -137,8 +137,13 @@ bool TrackRulerModel::isCollapsed() const
 
 void TrackRulerModel::setIsCollapsed(bool isCollapsed)
 {
-    if (m_isCollapsed != isCollapsed) {
-        m_isCollapsed = isCollapsed;
+    if (m_isCollapsed == isCollapsed) {
+        return;
+    }
+
+    m_isCollapsed = isCollapsed;
+
+    if (m_model) {
         m_model->setCollapsed(isCollapsed);
         emit fullStepsChanged();
         emit smallStepsChanged();
@@ -152,8 +157,13 @@ int TrackRulerModel::height() const
 
 void TrackRulerModel::setHeight(int height)
 {
-    if (m_height != height) {
-        m_height = height;
+    if (m_height == height) {
+        return;
+    }
+
+    m_height = height;
+
+    if (m_model) {
         m_model->setHeight(height);
         emit fullStepsChanged();
         emit smallStepsChanged();
@@ -176,11 +186,13 @@ double TrackRulerModel::channelHeightRatio() const
 
 void TrackRulerModel::setChannelHeightRatio(double channelHeightRatio)
 {
-    if (!m_model) {
+    if (m_channelHeightRatio == channelHeightRatio) {
         return;
     }
-    if (m_channelHeightRatio != channelHeightRatio) {
-        m_channelHeightRatio = channelHeightRatio;
+
+    m_channelHeightRatio = channelHeightRatio;
+
+    if (m_model) {
         m_model->setChannelHeightRatio(channelHeightRatio);
         emit fullStepsChanged();
         emit smallStepsChanged();
@@ -396,18 +408,4 @@ void TrackRulerModel::setTrackId(const trackedit::TrackId& newTrackId)
 au::trackedit::TrackId TrackRulerModel::trackId() const
 {
     return m_trackId;
-}
-
-bool TrackRulerModel::initialized() const
-{
-    return m_initialized;
-}
-
-void TrackRulerModel::setInitialized(bool newInitialized)
-{
-    if (m_initialized == newInitialized) {
-        return;
-    }
-    m_initialized = newInitialized;
-    emit initializedChanged();
 }

--- a/src/projectscene/view/trackruler/trackrulermodel.h
+++ b/src/projectscene/view/trackruler/trackrulermodel.h
@@ -29,8 +29,6 @@ class TrackRulerModel : public QObject, public muse::async::Asyncable, public mu
     Q_PROPERTY(std::vector<QVariantMap> fullSteps READ fullSteps NOTIFY fullStepsChanged)
     Q_PROPERTY(std::vector<QVariantMap> smallSteps READ smallSteps NOTIFY smallStepsChanged)
 
-    Q_PROPERTY(bool initialized READ initialized WRITE setInitialized NOTIFY initializedChanged FINAL)
-
     Q_PROPERTY(bool isStereo READ isStereo WRITE setIsStereo NOTIFY isStereoChanged FINAL)
     Q_PROPERTY(bool isCollapsed READ isCollapsed WRITE setIsCollapsed NOTIFY isCollapsedChanged FINAL)
     Q_PROPERTY(int height READ height WRITE setHeight NOTIFY heightChanged FINAL)
@@ -92,9 +90,6 @@ public:
 
     bool isHalfWave() const;
 
-    bool initialized() const;
-    void setInitialized(bool newInitialized);
-
 signals:
     void fullStepsChanged();
     void smallStepsChanged();
@@ -114,7 +109,6 @@ signals:
     void trackIdChanged();
 
     void isHalfWaveChanged();
-    void initializedChanged();
 
 private:
     IProjectViewStatePtr viewState() const;
@@ -129,6 +123,5 @@ private:
     bool m_isCollapsed = false;
     int m_height = 0;
     double m_channelHeightRatio = 0.5;
-    bool m_initialized = false;
 };
 }


### PR DESCRIPTION
Resolves: #10318 

Removed the initialized property, since checking the model instance is sufficient.
Setters should not be used if the model is not properly initialized.
The init will later call buildRulerModel that will pass all settings to the model.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Autobot test cases have been run
