### PR TITLE
implement compressed .aup3 storage using WavPack 

### DIFF
--- a/au3/libraries/au3-project-file-io/CMakeLists.txt
+++ b/au3/libraries/au3-project-file-io/CMakeLists.txt
@@ -19,6 +19,8 @@ set( SOURCES
    ProjectSerializer.cpp
    ProjectSerializer.h
    SqliteSampleBlock.cpp
+   WavPackCompressor.cpp
+   WavPackCompressor.h
 )
 
 set( LIBRARIES
@@ -34,10 +36,11 @@ list( APPEND LIBRARIES
    au3-sentry-reporting-interface
 )
 
-# Only this library needs sqlite, so make the dependency private
+# Only this library needs sqlite and wavpack, so make the dependency private
 list( APPEND LIBRARIES
    PRIVATE
       au3-sqlite-helpers-interface
+      wavpack::wavpack
 )
 
 audacity_library( ${TARGET} "${SOURCES}" "${LIBRARIES}"

--- a/au3/libraries/au3-project-file-io/ProjectFileIO.cpp
+++ b/au3/libraries/au3-project-file-io/ProjectFileIO.cpp
@@ -165,7 +165,9 @@ static const char* ProjectFileSchema
       "  sumrms               REAL,"
       "  summary256           BLOB,"
       "  summary64k           BLOB,"
-      "  samples              BLOB"
+      "  samples              BLOB,"
+      "  compr_type           INTEGER DEFAULT 0,"
+      "  sample_count         INTEGER"
       ");";
 
 class SQLiteBlobStream final
@@ -742,6 +744,28 @@ bool ProjectFileIO::CheckVersion()
     if (wxStrtoul<char**>(result, nullptr, 10) != ProjectFileID) {
         SetError(XO("This is not an Audacity project file"));
         return false;
+    }
+
+    // Check if compr_type column exists in sampleblocks (Migration for older 4.0 alpha/dev projects)
+    if (GetValue("SELECT count(*) FROM pragma_table_info('sampleblocks') WHERE name='compr_type';", result)) {
+        if (wxStrtol<char**>(result, nullptr, 10) == 0) {
+            if (!Exec("ALTER TABLE sampleblocks ADD COLUMN compr_type INTEGER DEFAULT 0;", nullptr)) {
+                return false;
+            }
+        }
+    }
+
+    // Check if sample_count column exists (Migration for older 4.0 alpha/dev projects)
+    if (GetValue("SELECT count(*) FROM pragma_table_info('sampleblocks') WHERE name='sample_count';", result)) {
+        if (wxStrtol<char**>(result, nullptr, 10) == 0) {
+            if (!Exec("ALTER TABLE sampleblocks ADD COLUMN sample_count INTEGER;", nullptr)) {
+                return false;
+            }
+            // Populate sample_count for existing blocks: (sampleformat >> 16) & 255 is the sample size
+            if (!Exec("UPDATE sampleblocks SET sample_count = length(samples) / ((sampleformat >> 16) & 255) WHERE sample_count IS NULL;", nullptr)) {
+                return false;
+            }
+        }
     }
 
     // Get the project file version

--- a/au3/libraries/au3-project-file-io/SqliteSampleBlock.cpp
+++ b/au3/libraries/au3-project-file-io/SqliteSampleBlock.cpp
@@ -23,6 +23,8 @@ Paul Licameli -- split from SampleBlock.cpp and SampleBlock.h
 #include "au3-track/UndoTracks.h"
 #include "au3-wave-track/WaveTrack.h"
 #include "au3-wave-track/WaveTrackUtilities.h"
+#include "au3-project-rate/QualitySettings.h"
+#include "WavPackCompressor.h"
 
 #include "au3-sentry-reporting/SentryHelper.h"
 #include <wx/log.h>
@@ -112,6 +114,7 @@ private:
     size_t mSampleBytes;
     size_t mSampleCount;
     sampleFormat mSampleFormat;
+    int mComprType{ 0 };
 
     ArrayOf<char> mSummary256;
     ArrayOf<char> mSummary64k;
@@ -329,6 +332,7 @@ SqliteSampleBlock::SqliteSampleBlock(
     mSumMin = 0.0;
     mSumMax = 0.0;
     mSumRms = 0.0;
+    mComprType = 0;
 }
 
 SqliteSampleBlock::~SqliteSampleBlock()
@@ -412,7 +416,7 @@ size_t SqliteSampleBlock::DoGetSamples(samplePtr dest,
 
     // Prepare and cache statement...automatically finalized at DB close
     sqlite3_stmt* stmt = Conn()->Prepare(DBConnection::GetSamples,
-                                         "SELECT samples FROM sampleblocks WHERE blockid = ?1;");
+                                         "SELECT samples, compr_type FROM sampleblocks WHERE blockid = ?1;");
 
     return GetBlob(dest,
                    destformat,
@@ -615,6 +619,21 @@ size_t SqliteSampleBlock::GetBlob(void* dest,
     // Retrieve returned data
     samplePtr src = (samplePtr)sqlite3_column_blob(stmt, 0);
     size_t blobbytes = (size_t)sqlite3_column_bytes(stmt, 0);
+    int comprType = sqlite3_column_int(stmt, 1);
+
+    std::vector<uint8_t> decompressedData;
+    if (comprType == 1) { // WavPack
+        auto decompressed = audacity::project::WavPackDecompress(src, blobbytes);
+        if (decompressed) {
+            decompressedData = std::move(decompressed->data);
+            src = (samplePtr)decompressedData.data();
+            blobbytes = decompressedData.size();
+        } else {
+            // Handle error? For now, we'll just continue and it will likely result in silent/garbage data or a crash later
+            // Throwing might be better
+            Conn()->ThrowException(false);
+        }
+    }
 
     srcoffset = std::min(srcoffset, blobbytes);
     minbytes = std::min(srcbytes, blobbytes - srcoffset);
@@ -695,7 +714,7 @@ void SqliteSampleBlock::Load(SampleBlockID sbid)
     // Prepare and cache statement...automatically finalized at DB close
     sqlite3_stmt* stmt = Conn()->Prepare(DBConnection::LoadSampleBlock,
                                          "SELECT sampleformat, summin, summax, sumrms,"
-                                         "       length(samples)"
+                                         "       length(samples), compr_type, sample_count"
                                          "  FROM sampleblocks WHERE blockid = ?1;");
 
     // Bind statement parameters
@@ -732,7 +751,12 @@ void SqliteSampleBlock::Load(SampleBlockID sbid)
     mSumMax = sqlite3_column_double(stmt, 2);
     mSumRms = sqlite3_column_double(stmt, 3);
     mSampleBytes = sqlite3_column_int(stmt, 4);
-    mSampleCount = mSampleBytes / SAMPLE_SIZE(mSampleFormat);
+    mComprType = sqlite3_column_int(stmt, 5);
+    if (sqlite3_column_type(stmt, 6) != SQLITE_NULL) {
+        mSampleCount = (size_t)sqlite3_column_int64(stmt, 6);
+    } else {
+        mSampleCount = mSampleBytes / SAMPLE_SIZE(mSampleFormat);
+    }
 
     // Clear statement bindings and rewind statement
     sqlite3_clear_bindings(stmt);
@@ -749,11 +773,23 @@ void SqliteSampleBlock::Commit(Sizes sizes)
     auto db = DB();
     int rc;
 
+    mComprType = 0;
+    std::vector<uint8_t> compressed;
+    if (QualitySettings::ProjectCompressionSetting.ReadEnum() == QualitySettings::CompressionMethod::WavPack) {
+        compressed = audacity::project::WavPackCompress(mSamples.get(), mSampleCount, mSampleFormat);
+        if (!compressed.empty()) {
+            mComprType = 1;
+        }
+    }
+
+    const void* sampleData = mComprType == 1 ? compressed.data() : mSamples.get();
+    size_t sampleDataSize = mComprType == 1 ? compressed.size() : mSampleBytes;
+
     // Prepare and cache statement...automatically finalized at DB close
     sqlite3_stmt* stmt = Conn()->Prepare(DBConnection::InsertSampleBlock,
                                          "INSERT INTO sampleblocks (sampleformat, summin, summax, sumrms,"
-                                         "                          summary256, summary64k, samples)"
-                                         "                         VALUES(?1,?2,?3,?4,?5,?6,?7);");
+                                         "                          summary256, summary64k, samples, compr_type, sample_count)"
+                                         "                         VALUES(?1,?2,?3,?4,?5,?6,?7,?8,?9);");
 
     // Bind statement parameters
     // Might return SQLITE_MISUSE which means it's our mistake that we violated
@@ -764,7 +800,9 @@ void SqliteSampleBlock::Commit(Sizes sizes)
         || sqlite3_bind_double(stmt, 4, mSumRms)
         || sqlite3_bind_blob(stmt, 5, mSummary256.get(), mSummary256Bytes, SQLITE_STATIC)
         || sqlite3_bind_blob(stmt, 6, mSummary64k.get(), mSummary64kBytes, SQLITE_STATIC)
-        || sqlite3_bind_blob(stmt, 7, mSamples.get(), mSampleBytes, SQLITE_STATIC)) {
+        || sqlite3_bind_blob(stmt, 7, sampleData, sampleDataSize, SQLITE_STATIC)
+        || sqlite3_bind_int(stmt, 8, mComprType)
+        || sqlite3_bind_int64(stmt, 9, (sqlite3_int64)mSampleCount)) {
         ADD_EXCEPTION_CONTEXT(
             "sqlite3.rc", std::to_string(sqlite3_errcode(Conn()->DB())));
         ADD_EXCEPTION_CONTEXT("sqlite3.context", "SqliteSampleBlock::Commit::bind");

--- a/au3/libraries/au3-project-file-io/WavPackCompressor.cpp
+++ b/au3/libraries/au3-project-file-io/WavPackCompressor.cpp
@@ -1,0 +1,280 @@
+/*  SPDX-License-Identifier: GPL-2.0-or-later */
+/*!********************************************************************
+
+  Audacity: A Digital Audio Editor
+
+  WavPackCompressor.cpp
+
+  Dmitry Vedenko
+  Generalized for project storage
+
+**********************************************************************/
+
+#include "WavPackCompressor.h"
+
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <algorithm>
+
+#include <wavpack/wavpack.h>
+
+#include "au3-math/SampleFormat.h"
+
+namespace audacity::project {
+
+namespace {
+struct Exporter final
+{
+    WavpackContext* Context { nullptr };
+    std::vector<uint8_t> CompressedData;
+    sampleFormat Format;
+    long long BlockId;
+
+    Exporter(size_t numSamples, sampleFormat format, long long blockId)
+        : Format{format}
+        , BlockId{blockId}
+    {
+        WavpackConfig config = {};
+
+        config.num_channels = 1;
+        config.channel_mask = 0x4;
+        config.sample_rate = 44100; // Irrelevant for raw block storage, but WavPack needs a value
+
+        config.bytes_per_sample = SAMPLE_SIZE(Format);
+        config.bits_per_sample = config.bytes_per_sample * 8;
+        config.float_norm_exp = Format == floatSample ? 127 : 0;
+
+        config.flags = CONFIG_FAST_FLAG;
+
+        Context = WavpackOpenFileOutput(WriteBlock, this, nullptr);
+
+        if (Context) {
+            if (!WavpackSetConfiguration(Context, &config, numSamples) || !WavpackPackInit(Context)) {
+                WavpackCloseFile(Context);
+                Context = nullptr;
+            }
+        }
+    }
+
+    ~Exporter()
+    {
+        if (Context != nullptr) {
+            WavpackCloseFile(Context);
+        }
+    }
+
+    std::vector<uint8_t> Compress(const void* src, size_t numSamples)
+    {
+        if (Context == nullptr) {
+            return {};
+        }
+
+        // Reserve 1.2 times the size of the original data as a safe bet
+        CompressedData.reserve(numSamples * SAMPLE_SIZE(Format) * 12 / 10);
+
+        if (Format == int16Sample) {
+            constexpr size_t conversionSamplesCount = 4096;
+            const int16_t* int16Data = static_cast<const int16_t*>(src);
+            std::vector<int32_t> buffer(conversionSamplesCount);
+
+            for (size_t firstSample = 0; firstSample < numSamples; firstSample += conversionSamplesCount) {
+                const auto samplesThisRun = std::min(conversionSamplesCount, numSamples - firstSample);
+                for (size_t i = 0; i < samplesThisRun; ++i) {
+                    buffer[i] = (static_cast<int32_t>(int16Data[firstSample + i]) * 65536) >> 16;
+                }
+                WavpackPackSamples(Context, buffer.data(), samplesThisRun);
+            }
+        } else {
+            WavpackPackSamples(Context, static_cast<int32_t*>(const_cast<void*>(src)), numSamples);
+        }
+
+        Flush();
+
+        return std::move(CompressedData);
+    }
+
+    void Flush()
+    {
+        if (Context == nullptr) {
+            return;
+        }
+
+        WavpackFlushSamples(Context);
+
+        const std::string formatString = std::to_string(unsigned(Format));
+        WavpackAppendTagItem(Context, "FORMAT", formatString.data(), (int)formatString.size());
+
+        if (BlockId != 0) {
+            const std::string blockIdString = std::to_string(BlockId);
+            WavpackAppendTagItem(Context, "BLOCK_ID", blockIdString.data(), (int)blockIdString.size());
+        }
+
+        WavpackWriteTag(Context);
+        WavpackCloseFile(Context);
+        Context = nullptr;
+    }
+
+    static int WriteBlock(void* id, void* data, int32_t length)
+    {
+        if (id == nullptr || data == nullptr || length == 0) {
+            return true;
+        }
+
+        Exporter* exporter = static_cast<Exporter*>(id);
+        auto start = reinterpret_cast<uint8_t*>(data);
+        exporter->CompressedData.insert(exporter->CompressedData.end(), start, start + length);
+
+        return true;
+    }
+};
+
+struct Importer final
+{
+    WavpackContext* Context { nullptr };
+    const void* Data { nullptr };
+    const int64_t Size { 0 };
+    int64_t Offset { 0 };
+    uint32_t SamplesCount { 0 };
+    uint8_t UngetcChar { 0 };
+    bool UngetcFlag { false };
+
+    sampleFormat Format { (sampleFormat)0 }; // undefinedSample
+    long long BlockId { 0 };
+
+    Importer(const void* data, const int64_t size)
+        : Data{data}
+        , Size{size}
+    {
+        if (Data == nullptr || Size == 0) {
+            return;
+        }
+
+        char error[81];
+        Context = WavpackOpenFileInputEx64(&raw_reader, this, nullptr, error, OPEN_TAGS, 0);
+
+        if (Context == nullptr) {
+            return;
+        }
+
+        SamplesCount = (uint32_t)WavpackGetNumSamples(Context);
+
+        char tagBuffer[32];
+        if (WavpackGetTagItem(Context, "FORMAT", tagBuffer, sizeof(tagBuffer)) > 0) {
+            Format = static_cast<sampleFormat>(std::stoul(tagBuffer));
+        }
+
+        if (WavpackGetTagItem(Context, "BLOCK_ID", tagBuffer, sizeof(tagBuffer)) > 0) {
+            BlockId = std::stoll(tagBuffer);
+        }
+    }
+
+    ~Importer()
+    {
+        if (Context != nullptr) {
+            WavpackCloseFile(Context);
+        }
+    }
+
+    bool Unpack(void* dest)
+    {
+        if (Context == nullptr || SamplesCount == 0 || Format == (sampleFormat)0) {
+            return false;
+        }
+
+        if (Format == int16Sample) {
+            std::vector<int32_t> buffer(SamplesCount);
+            if (WavpackUnpackSamples(Context, buffer.data(), SamplesCount) != SamplesCount) {
+                return false;
+            }
+            int16_t* out = static_cast<int16_t*>(dest);
+            for (size_t i = 0; i < SamplesCount; ++i) {
+                out[i] = static_cast<int16_t>(buffer[i]);
+            }
+        } else {
+            if (WavpackUnpackSamples(Context, static_cast<int32_t*>(dest), SamplesCount) != SamplesCount) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    static int32_t raw_read_bytes(void* id, void* data, int32_t bcount)
+    {
+        Importer* importer = static_cast<Importer*>(id);
+        uint8_t* outptr = static_cast<uint8_t*>(data);
+
+        if (importer->UngetcFlag) {
+            *outptr++ = importer->UngetcChar;
+            importer->UngetcFlag = false;
+            bcount--;
+        }
+
+        const auto bytesToCopy = std::min<int32_t>(bcount, (int32_t)(importer->Size - importer->Offset));
+        if (bytesToCopy > 0) {
+            std::memcpy(outptr, static_cast<const uint8_t*>(importer->Data) + importer->Offset, bytesToCopy);
+            importer->Offset += bytesToCopy;
+            outptr += bytesToCopy;
+        }
+
+        return static_cast<int32_t>(outptr - static_cast<uint8_t*>(data));
+    }
+
+    static int32_t raw_write_bytes(void*, void*, int32_t) { return 0; }
+    static int64_t raw_get_pos(void* id) { return static_cast<Importer*>(id)->Offset; }
+    static int raw_set_pos_abs(void* id, int64_t pos)
+    {
+        Importer* importer = static_cast<Importer*>(id);
+        if (pos < 0 || pos > importer->Size) return 1;
+        importer->Offset = pos;
+        return 0;
+    }
+    static int raw_set_pos_rel(void* id, int64_t delta, int mode)
+    {
+        Importer* importer = static_cast<Importer*>(id);
+        int64_t newPos = 0;
+        if (mode == SEEK_SET) newPos = delta;
+        else if (mode == SEEK_CUR) newPos = importer->Offset + delta;
+        else if (mode == SEEK_END) newPos = importer->Size + delta;
+        return raw_set_pos_abs(id, newPos);
+    }
+    static int raw_push_back_byte(void* id, int c) { Importer* imp = static_cast<Importer*>(id); imp->UngetcChar = (uint8_t)c; imp->UngetcFlag = true; return c; }
+    static int64_t raw_get_length(void* id) { return static_cast<Importer*>(id)->Size; }
+    static int raw_can_seek(void*) { return 1; }
+    static int raw_close_stream(void*) { return 0; }
+
+    WavpackStreamReader64 raw_reader { raw_read_bytes,  raw_write_bytes,
+                                       raw_get_pos,     raw_set_pos_abs,
+                                       raw_set_pos_rel, raw_push_back_byte,
+                                       raw_get_length,  raw_can_seek,
+                                       nullptr,         raw_close_stream };
+};
+} // namespace
+
+std::vector<uint8_t> WavPackCompress(const void* src, size_t numSamples, sampleFormat format, long long blockId)
+{
+    Exporter exporter(numSamples, format, blockId);
+    return exporter.Compress(src, numSamples);
+}
+
+std::optional<DecompressedBlock> WavPackDecompress(const void* src, size_t srcSize)
+{
+    Importer importer(src, srcSize);
+    if (importer.Context == nullptr || importer.SamplesCount == 0) {
+        return std::nullopt;
+    }
+
+    DecompressedBlock result;
+    result.format = importer.Format;
+    result.sampleCount = importer.SamplesCount;
+    result.data.resize(result.sampleCount * SAMPLE_SIZE(result.format));
+
+    if (!importer.Unpack(result.data.data())) {
+        return std::nullopt;
+    }
+
+    return result;
+}
+
+} // namespace audacity::project

--- a/au3/libraries/au3-project-file-io/WavPackCompressor.h
+++ b/au3/libraries/au3-project-file-io/WavPackCompressor.h
@@ -1,0 +1,36 @@
+/*  SPDX-License-Identifier: GPL-2.0-or-later */
+/*!********************************************************************
+
+  Audacity: A Digital Audio Editor
+
+  WavPackCompressor.h
+
+  Dmitry Vedenko
+  Generalized for project storage
+
+**********************************************************************/
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <vector>
+
+#include "au3-math/SampleFormat.h"
+
+namespace audacity::project {
+
+struct DecompressedBlock final
+{
+    sampleFormat format;
+    size_t sampleCount;
+    std::vector<uint8_t> data;
+};
+
+std::vector<uint8_t> WavPackCompress(
+    const void* src, size_t numSamples, sampleFormat format,
+    long long blockId = 0);
+
+std::optional<DecompressedBlock> WavPackDecompress(
+    const void* src, size_t srcSize);
+
+} // namespace audacity::project

--- a/au3/libraries/au3-project-rate/QualitySettings.cpp
+++ b/au3/libraries/au3-project-rate/QualitySettings.cpp
@@ -39,3 +39,12 @@ sampleFormat QualitySettings::SampleFormatChoice()
 {
     return SampleFormatSetting.ReadEnum();
 }
+
+EnumSetting< QualitySettings::CompressionMethod > QualitySettings::ProjectCompressionSetting{
+    L"/Quality/ProjectCompression",
+    {
+        { L"None", XO("None (lossless)") },
+        { L"WavPack", XO("WavPack (lossless)") }
+    },
+    0, // None
+};

--- a/au3/libraries/au3-project-rate/QualitySettings.h
+++ b/au3/libraries/au3-project-rate/QualitySettings.h
@@ -20,6 +20,12 @@ namespace QualitySettings {
 extern PROJECT_RATE_API IntSetting DefaultSampleRate;
 extern PROJECT_RATE_API EnumSetting< sampleFormat > SampleFormatSetting;
 extern PROJECT_RATE_API sampleFormat SampleFormatChoice();
+
+enum class CompressionMethod : int {
+    None = 0,
+    WavPack = 1
+};
+extern PROJECT_RATE_API EnumSetting< CompressionMethod > ProjectCompressionSetting;
 }
 
 #endif

--- a/au3/src/prefs/QualityPrefs.cpp
+++ b/au3/src/prefs/QualityPrefs.cpp
@@ -103,6 +103,17 @@ void QualityPrefs::PopulateOrExchange(ShuttleGui& S)
         S.EndMultiColumn();
     }
     S.EndStatic();
+    
+    S.StartStatic(XO("Project Storage"));
+    {
+        S.StartMultiColumn(2);
+        {
+            S.TieChoice(XXO("Project &Compression:"),
+                        QualitySettings::ProjectCompressionSetting);
+        }
+        S.EndMultiColumn();
+    }
+    S.EndStatic();
     S.EndScroller();
 }
 


### PR DESCRIPTION
#4877 

This PR implements lossless audio compression for Audacity project files (.aup3) using the WavPack library. This significantly reduces the disk space required for projects while maintaining bit-perfect audio quality and transparent access during editing.

Key Changes
Generalized WavPack Utility: Extracted and decoupled WavPack compression logic from the cloud sync module, providing a reusable implementation for project storage.
Enhanced Database Schema:
Added compr_type to track the compression method used for each block.
Added sample_count to explicitly store the number of samples in a compressed block (as blob size no longer maps directly to sample count).
Project Migration: Implemented automatic schema migration in 
ProjectFileIO
 to upgrade older projects without data loss.
Transparent I/O: Modified 
SqliteSampleBlock
 to handle compression during project saves and automatic decompression during playback and loading.
User Interface: Added a "Project Compression" setting under Preferences > Quality to allow users to toggle between uncompressed and WavPack compressed storage.
Technical Details
Library: WavPack (Lossless mode).
Storage Strategy: Only new or modified audio blocks are compressed based on the user's current preference. Existing blocks remain as-is until rewritten.
Backward Compatibility: Projects stored with compression can be opened in this version regardless of the "None" setting being active, as decompression is determined per-block.
Verification Results
Integrity: Verified bit-perfect reconstruction of original audio after compression cycles.
Stability: Tested migration path for existing projects; older files are upgraded seamlessly on first open.
Performance: Significant file size reduction observed for projects with compression enabled (varies based on audio content).