### PR TITLE
fixed #10076: In the case of a multi-line label, it must always be on top of the other labels when you enter Edit mode

### DIFF
--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TrackLabelsContainer.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TrackLabelsContainer.qml
@@ -149,7 +149,7 @@ TrackItemsContainer {
                             width: itemData.width
                             x: itemData.x
                             y: (itemData.visualHeight + 2) * itemData.level
-                            z: itemData.level
+                            z: Boolean(itemData) && itemData.isEditing ? 1000 : itemData.level
 
                             asynchronous: true
 


### PR DESCRIPTION
Resolves: #10076