### PR TITLE
Fix Linux desktop entry description and keywords to match other platforms

### DIFF
--- a/buildscripts/packaging/Linux+BSD/org.audacityteam.Audacity.desktop.in
+++ b/buildscripts/packaging/Linux+BSD/org.audacityteam.Audacity.desktop.in
@@ -1,22 +1,70 @@
 [Desktop Entry]
 # Write keys in the order specified in https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#recognized-keys
 # After editing, run this command to check for errors: $ desktop-file-validate [filename]
+Name=@DESKTOP_LAUNCHER_NAME@
 Type=Application
 # Version of Desktop Entry Spec, not Audacity version. Don't upgrade prematurely.
 Version=1.0
-Name=@DESKTOP_LAUNCHER_NAME@
-GenericName=Audio editor
-GenericName[de]=Audioeditor
-GenericName[fr]=Éditeur audio
-Comment=The world's most popular audio editing and recording app
-Comment[ru]=Самое популярное приложение для редактирования и записи звука в мире
-Comment[fr]=Une application de montage et d'enregistrement audio
 Icon=audacity@MUSE_APP_INSTALL_SUFFIX@
 Exec=audacity@MUSE_APP_INSTALL_SUFFIX@ %U
 Terminal=false
 MimeType=application/x-audacity;
-Categories=AudioVideo;Audio;Graphics;2DGraphics;VectorGraphics;RasterGraphics;Publishing;Midi;Mixer;Sequencer;Music;Qt;
-Keywords=audio;music;sound;mixing;mastering;production;producing;editing audio;mp3;wav;flac;MIDI;playing;playback;effects;synth;
-Keywords[de]=Musik;Audio;Mischend;Musizieren;Mastering;Musikprogramm;mp3;wav;flac;MIDI;Audioeffekte;Synth;
 StartupNotify=true
 StartupWMClass=@WINDOW_MANAGER_CLASS@
+
+Categories=AudioVideo;Audio;AudioVideoEditing;
+
+Keywords=sound;music editing;voice channel;frequency;modulation;audio trim;clipping;noise reduction;multi track audio editor;edit;mixing;WAV;AIFF;FLAC;MP2;MP3;
+
+GenericName=Sound Editor
+GenericName[ar]=محرر أصوات
+GenericName[ca]=Editor d'àudio
+GenericName[co]=Editore audio
+GenericName[da]=Lydredigeringsprogram
+GenericName[de]=Audio-Editor
+GenericName[el]=Επεξεργαστής ήχου
+GenericName[es]=Editor de audio
+GenericName[fr]=Éditeur audio
+GenericName[hi]=ध्वनि संपादक
+GenericName[gu]=ધ્વનિ સંપાદક
+GenericName[kn]=ಧ್ವನಿ ಸಂಪಾದಕ
+GenericName[it]=editore di suoni
+GenericName[ta]=ஒலி ஆசிரியர்
+GenericName[la]=sonus editor
+GenericName[ja]=音声編集ソフト
+GenericName[ko]=오디오 편집기
+GenericName[lt]=Garsų rengyklė
+GenericName[nl]=Geluidseditor
+GenericName[pl]=Edytor dźwięku
+GenericName[pt_BR]=Editor de áudio
+GenericName[pt_PT]=Editor de áudio
+GenericName[ru]=Редактор звуковых файлов
+GenericName[sk]=Zvukový Editor
+GenericName[tr]=Ses Düzenleyici
+GenericName[uk]=Редактор звукових файлів
+GenericName[zh_CN]=音频编辑器
+GenericName[zh_TW]=音訊編輯器
+
+Comment=Record and edit audio files
+Comment[ar]=سجل و حرر ملفات صوت
+Comment[ca]=Enregistreu i editeu els fitxers d'àudio
+Comment[co]=Arregistrà è mudificà schedarii audio
+Comment[da]=Optag og rediger lydfiler
+Comment[de]=Audio-Dateien aufnehmen und bearbeiten
+Comment[el]=Ηχογράφηση και επεξεργασία αρχείων ήχου
+Comment[es]=Grabar y editar archivos de audio
+Comment[fr]=Enregistrer et éditer des fichiers audio
+Comment[hi]=ऑडियो फ़ाइल अंकित व संपादित करता है
+Comment[ja]=音声ファイルの録音と編集
+Comment[ko]=오디오 파일 녹음과 편집
+Comment[lt]=Įrašyti ir montuoti garso failus
+Comment[nl]=Audiobestanden opnemen en bewerken
+Comment[pl]=Nagrywaj i edytuj pliki dźwiękowe
+Comment[pt_BR]=Gravar e editar arquivos de áudio
+Comment[pt_PT]=Gravar e editar ficheiros de áudio
+Comment[ru]=Запись и редактирование звуковых файлов
+Comment[sk]=Nahráva a upravuje audio súbory.
+Comment[tr]=Ses dosyalarını kaydetme ve düzenleme
+Comment[uk]=Запис і редагування звукових файлів
+Comment[zh_CN]=录音和编辑音频文件
+Comment[zh_TW]=錄音和編輯音訊檔案


### PR DESCRIPTION
Resolves: #10411 

The Linux desktop entry currently seems to be copied almost verbatim from Musescore, with minimal changes to correct the application name and English description. This PR finishes the effort by adding translated descriptions (checked by multilingual friends, but I don't speak those languages, so take them with a grain of salt), and corrects the keywords to more accurately match the application's use case and description.
I ran all the translations through LanguageTool and used a dictionary for the German keywords, but it would probably be ideal if someone who fluently speaks other languages could verify them.

Please let me know if any further changes need to be made!

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Autobot test cases have been run
