### PR TITLE
Use calendar date instead of day-of-year in build number

### DIFF
--- a/buildscripts/ci/common/make_build_number_env.cmake
+++ b/buildscripts/ci/common/make_build_number_env.cmake
@@ -7,7 +7,8 @@ set(BUILD_NUMBER "" CACHE STRING "Build number")
 
 if (NOT BUILD_NUMBER)
     # less than 2147483647 to fit in Int32 for WiX packaging tool
-    string(TIMESTAMP BUILD_NUMBER %y%j%H%M)
+    string(TIMESTAMP BUILD_NUMBER %y%m%d%H%M)
+    string(SUBSTRING ${BUILD_NUMBER} 0 9 BUILD_NUMBER)
 endif()
 
 file(MAKE_DIRECTORY ${ARTIFACTS_DIR})


### PR DESCRIPTION
Make artifact names readable by a human

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Autobot test cases have been run
