### PR TITLE
Spectral view vertical zoom

### DIFF
--- a/src/projectscene/internal/projectsceneactionscontroller.cpp
+++ b/src/projectscene/internal/projectsceneactionscontroller.cpp
@@ -151,7 +151,7 @@ void ProjectSceneActionsController::togglePlaybackOnRulerClickEnabled()
 
 void ProjectSceneActionsController::toggleTrackHalfWave(const muse::actions::ActionQuery& q)
 {
-    IF_ASSERT_FAILED(q.params().size() == 1) {
+    IF_ASSERT_FAILED(q.params().size() >= 1) {
         return;
     }
     const int trackId = q.param("trackId").toInt();

--- a/src/projectscene/projectscene.qrc
+++ b/src/projectscene/projectscene.qrc
@@ -74,7 +74,7 @@
         <file>qml/Audacity/ProjectScene/tracksitemsview/LoopRegionGuideline.qml</file>
         <file>qml/Audacity/ProjectScene/trackruler/TrackRulerCustomizePopup.qml</file>
         <file>qml/Audacity/ProjectScene/trackruler/WaveformRuler.qml</file>
-        <file>qml/Audacity/ProjectScene/trackruler/SpectrogramRuler.qml</file>
+        <file>qml/Audacity/ProjectScene/trackruler/SpectrogramTrackRulers.qml</file>
         <file>qml/Audacity/ProjectScene/tracksitemsview/labeleditor/LabelEditorDialog.qml</file>
         <file>qml/Audacity/ProjectScene/tracksitemsview/labeleditor/LabelEditorTopPanel.qml</file>
         <file>qml/Audacity/ProjectScene/tracksitemsview/labeleditor/LabelEditorLabelsTableView.qml</file>

--- a/src/projectscene/qml/Audacity/ProjectScene/qmldir
+++ b/src/projectscene/qml/Audacity/ProjectScene/qmldir
@@ -20,4 +20,4 @@ VolumePressureRuler 1.0 trackspanel/audio/VolumePressureRuler.qml
 VolumeTooltip 1.0 trackspanel/audio/VolumeTooltip.qml
 TrackRulerCustomizePopup 1.0 trackruler/TrackRulerCustomizePopup.qml
 WaveformRuler 1.0 trackruler/WaveformRuler.qml
-SpectrogramRuler 1.0 trackruler/SpectrogramRuler.qml
+SpectrogramTrackRulers 1.0 trackruler/SpectrogramTrackRulers.qml

--- a/src/projectscene/qml/Audacity/ProjectScene/trackruler/SpectrogramRuler.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/trackruler/SpectrogramRuler.qml
@@ -1,5 +1,0 @@
-import QtQuick
-
-Rectangle {
-    color: "gray"
-}

--- a/src/projectscene/qml/Audacity/ProjectScene/trackruler/SpectrogramTrackRulers.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/trackruler/SpectrogramTrackRulers.qml
@@ -1,0 +1,49 @@
+import QtQuick
+import QtQuick.Layouts
+
+import Muse.Ui
+import Muse.UiComponents
+
+import Audacity.ProjectScene
+import Audacity.Spectrogram
+
+Rectangle {
+    id: root
+
+    color: "grey"
+    border.width: 0
+
+    required property int trackId
+    required property bool isStereo
+    required property real channelHeightRatio
+
+    signal channelZoomChanged(int channel)
+
+    Column {
+        anchors.fill: parent
+
+        SpectrogramChannelRuler {
+            width: root.width
+            height: root.isStereo ? root.height * root.channelHeightRatio : root.height
+
+            trackId: root.trackId
+            onZoomChanged: root.channelZoomChanged(0)
+        }
+
+        SeparatorLine {
+            id: separatorLine
+            width: root.width
+            visible: root.isStereo
+        }
+
+        SpectrogramChannelRuler {
+            width: root.width
+            height: root.height * (1 - root.channelHeightRatio) - separatorLine.height
+
+            visible: root.isStereo
+            trackId: root.trackId
+
+            onZoomChanged: root.channelZoomChanged(1)
+        }
+    }
+}

--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/VerticalRulersPanel.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/VerticalRulersPanel.qml
@@ -193,11 +193,19 @@ Rectangle {
                             channelHeightRatio: trackViewState.channelHeightRatio
                         }
 
-                        SpectrogramRuler {
+                        SpectrogramTrackRulers {
                             Layout.fillWidth: true
                             Layout.fillHeight: true
 
                             visible: model.isSpectrogramViewVisible
+
+                            trackId: model.trackId
+                            isStereo: model.isStereo
+                            channelHeightRatio: trackViewState.channelHeightRatio
+
+                            onChannelZoomChanged: function (channel) {
+                                trackViewState.spectrogramVerticalZoomChanged(trackId, channel)
+                            }
                         }
                     }
                 }

--- a/src/projectscene/view/common/trackviewstatemodel.cpp
+++ b/src/projectscene/view/common/trackviewstatemodel.cpp
@@ -175,3 +175,19 @@ au::playback::PlaybackMeterModel* TrackViewStateModel::meterModel() const
 {
     return m_meterModel;
 }
+
+void TrackViewStateModel::spectrogramVerticalZoomChanged(trackedit::TrackId trackId, int channel)
+{
+    Q_UNUSED(channel);
+    const auto prj = globalContext()->currentTrackeditProject();
+    IF_ASSERT_FAILED(prj) {
+        return;
+    }
+    const auto track = prj->track(trackId);
+    IF_ASSERT_FAILED(track) {
+        return;
+    }
+    prj->notifyAboutTrackChanged(*track);
+    projectHistory()->modifyState();
+    projectHistory()->markUnsaved();
+}

--- a/src/projectscene/view/common/trackviewstatemodel.cpp
+++ b/src/projectscene/view/common/trackviewstatemodel.cpp
@@ -178,16 +178,7 @@ au::playback::PlaybackMeterModel* TrackViewStateModel::meterModel() const
 
 void TrackViewStateModel::spectrogramVerticalZoomChanged(trackedit::TrackId trackId, int channel)
 {
+    Q_UNUSED(trackId);
     Q_UNUSED(channel);
-    const auto prj = globalContext()->currentTrackeditProject();
-    IF_ASSERT_FAILED(prj) {
-        return;
-    }
-    const auto track = prj->track(trackId);
-    IF_ASSERT_FAILED(track) {
-        return;
-    }
-    prj->notifyAboutTrackChanged(*track);
-    projectHistory()->modifyState();
     projectHistory()->markUnsaved();
 }

--- a/src/projectscene/view/common/trackviewstatemodel.h
+++ b/src/projectscene/view/common/trackviewstatemodel.h
@@ -12,6 +12,7 @@
 #include "playback/iplaybackcontroller.h"
 #include "playback/iplaybackconfiguration.h"
 #include "record/irecordcontroller.h"
+#include "trackedit/iprojecthistory.h"
 
 #include "playback/view/common/playbackmetermodel.h"
 #include "types/val.h"
@@ -38,6 +39,7 @@ class TrackViewStateModel : public QObject, public muse::Injectable, public muse
     muse::Inject<context::IGlobalContext> globalContext{ this };
     muse::Inject<playback::IPlaybackController> playbackController{ this };
     muse::Inject<record::IRecordController> recordController{ this };
+    muse::Inject<trackedit::IProjectHistory> projectHistory{ this };
 
 public:
     TrackViewStateModel(QObject* parent = nullptr);
@@ -53,6 +55,8 @@ public:
     bool isTrackCollapsed() const;
     double channelHeightRatio() const;
     Q_INVOKABLE void changeChannelHeightRatio(double ratio);
+
+    Q_INVOKABLE void spectrogramVerticalZoomChanged(trackedit::TrackId trackId, int channel);
 
     QVariant displayBounds() const;
 

--- a/src/projectscene/view/trackspanel/trackcontextmenumodel.cpp
+++ b/src/projectscene/view/trackspanel/trackcontextmenumodel.cpp
@@ -457,6 +457,11 @@ muse::uicomponents::MenuItemList TrackContextMenuModel::makeTrackViewItems()
     m_trackViewTypeChangeActionCodeList.clear();
     muse::uicomponents::MenuItemList items;
     items.reserve(5);
+
+    const auto prj = globalContext()->currentTrackeditProject();
+    const std::optional<trackedit::Track> track = prj ? prj->track(m_trackId) : std::nullopt;
+    const auto trackTitle = track.has_value() ? track->title.toStdString() : "";
+
     for (const std::string action : { TRACK_VIEW_WAVEFORM_ACTION,
                                       TRACK_VIEW_SPECTROGRAM_ACTION,
                                       TRACK_VIEW_MULTI_ACTION,
@@ -468,6 +473,7 @@ muse::uicomponents::MenuItemList TrackContextMenuModel::makeTrackViewItems()
         } else {
             muse::actions::ActionQuery query(action);
             query.addParam("trackId", muse::Val { m_trackId });
+            query.addParam("trackTitle", muse::Val { trackTitle });
             items.push_back(makeMenuItem(query.toString()));
             m_trackViewTypeChangeActionCodeList.push_back(action);
         }

--- a/src/spectrogram/CMakeLists.txt
+++ b/src/spectrogram/CMakeLists.txt
@@ -76,11 +76,12 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/view/scalesectionparameterlistmodel.h
     ${CMAKE_CURRENT_LIST_DIR}/view/globalspectrogramsettingsmodel.cpp
     ${CMAKE_CURRENT_LIST_DIR}/view/globalspectrogramsettingsmodel.h
-    
     ${CMAKE_CURRENT_LIST_DIR}/view/channelspectralselectionmodel.cpp
     ${CMAKE_CURRENT_LIST_DIR}/view/channelspectralselectionmodel.h
     ${CMAKE_CURRENT_LIST_DIR}/view/clipchannelspectrogramview.cpp
     ${CMAKE_CURRENT_LIST_DIR}/view/clipchannelspectrogramview.h
+    ${CMAKE_CURRENT_LIST_DIR}/view/spectrogramchannelrulermodel.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/view/spectrogramchannelrulermodel.h
     ${CMAKE_CURRENT_LIST_DIR}/view/spectrogramhit.cpp
     ${CMAKE_CURRENT_LIST_DIR}/view/spectrogramhit.h
     ${CMAKE_CURRENT_LIST_DIR}/view/spectrogramviewutils.h

--- a/src/spectrogram/CMakeLists.txt
+++ b/src/spectrogram/CMakeLists.txt
@@ -35,6 +35,7 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/internal/spectrogramcolors.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/globalspectrogramconfiguration.cpp
     ${CMAKE_CURRENT_LIST_DIR}/internal/globalspectrogramconfiguration.h
+    ${CMAKE_CURRENT_LIST_DIR}/internal/snapshotspectrogramconfiguration.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/spectrogramutils.cpp
     ${CMAKE_CURRENT_LIST_DIR}/internal/spectrogramutils.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/spectrogramservice.cpp
@@ -83,6 +84,8 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/view/spectrogramhit.cpp
     ${CMAKE_CURRENT_LIST_DIR}/view/spectrogramhit.h
     ${CMAKE_CURRENT_LIST_DIR}/view/spectrogramviewutils.h
+    ${CMAKE_CURRENT_LIST_DIR}/view/trackspectrogramsettingsmodel.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/view/trackspectrogramsettingsmodel.h
 )
 
 set(MODULE_QML_IMPORT ${CMAKE_CURRENT_LIST_DIR}/qml)

--- a/src/spectrogram/internal/snapshotspectrogramconfiguration.h
+++ b/src/spectrogram/internal/snapshotspectrogramconfiguration.h
@@ -7,8 +7,8 @@
 
 #include <cassert>
 
-namespace au::trackedit {
-class SnapshotSpectrogramConfiguration final : public spectrogram::ITrackSpectrogramConfiguration
+namespace au::spectrogram {
+class SnapshotSpectrogramConfiguration final : public ITrackSpectrogramConfiguration
 {
 public:
     SnapshotSpectrogramConfiguration(const ITrackSpectrogramConfiguration& config)
@@ -44,17 +44,17 @@ public:
     int colorHighBoostDbPerDec() const override { return m_colorHighBoostDbPerDec; }
     void setColorHighBoostDbPerDec(int) override { assert(false); }
 
-    spectrogram::SpectrogramColorScheme colorScheme() const override { return m_colorScheme; }
-    void setColorScheme(spectrogram::SpectrogramColorScheme) override { assert(false); }
+    SpectrogramColorScheme colorScheme() const override { return m_colorScheme; }
+    void setColorScheme(SpectrogramColorScheme) override { assert(false); }
 
-    spectrogram::SpectrogramScale scale() const override { return m_scale; }
-    void setScale(spectrogram::SpectrogramScale) override { assert(false); }
+    SpectrogramScale scale() const override { return m_scale; }
+    void setScale(SpectrogramScale) override { assert(false); }
 
-    spectrogram::SpectrogramAlgorithm algorithm() const override { return m_algorithm; }
-    void setAlgorithm(spectrogram::SpectrogramAlgorithm) override { assert(false); }
+    SpectrogramAlgorithm algorithm() const override { return m_algorithm; }
+    void setAlgorithm(SpectrogramAlgorithm) override { assert(false); }
 
-    spectrogram::SpectrogramWindowType windowType() const override { return m_windowType; }
-    void setWindowType(spectrogram::SpectrogramWindowType) override { assert(false); }
+    SpectrogramWindowType windowType() const override { return m_windowType; }
+    void setWindowType(SpectrogramWindowType) override { assert(false); }
 
     int winSizeLog2() const override { return m_winSizeLog2; }
     void setWinSizeLog2(int) override { assert(false); }
@@ -71,10 +71,10 @@ private:
     const int m_colorGainDb;
     const int m_colorRangeDb;
     const int m_colorHighBoostDbPerDec;
-    const spectrogram::SpectrogramColorScheme m_colorScheme;
-    const spectrogram::SpectrogramScale m_scale;
-    const spectrogram::SpectrogramAlgorithm m_algorithm;
-    const spectrogram::SpectrogramWindowType m_windowType;
+    const SpectrogramColorScheme m_colorScheme;
+    const SpectrogramScale m_scale;
+    const SpectrogramAlgorithm m_algorithm;
+    const SpectrogramWindowType m_windowType;
     const int m_winSizeLog2;
     const int m_zeroPaddingFactor;
     const bool m_useGlobalSettings;

--- a/src/spectrogram/internal/spectrogramservice.cpp
+++ b/src/spectrogram/internal/spectrogramservice.cpp
@@ -71,9 +71,7 @@ double SpectrogramService::yToFrequency(int trackId, double spectrogramY, double
 
     const auto [minFreq, maxFreq] = spectrogramBounds(*config, trackSampleRate(trackId));
     const NumberScale numberScale{ config->scale(), minFreq, maxFreq };
-    return std::clamp(numberScale.positionToValue((spectrogramHeight - spectrogramY) / spectrogramHeight),
-                      minFreq,
-                      maxFreq);
+    return numberScale.positionToValue((spectrogramHeight - spectrogramY) / spectrogramHeight);
 }
 
 double SpectrogramService::frequencyToY(int trackId, double frequency, double spectrogramHeight) const

--- a/src/spectrogram/internal/spectrogramservice.cpp
+++ b/src/spectrogram/internal/spectrogramservice.cpp
@@ -57,6 +57,10 @@ double SpectrogramService::trackSampleRate(int trackId) const
     return waveTrack->GetRate();
 }
 
+double SpectrogramService::frequencyHardMaximum(int trackId) const
+{
+    return trackSampleRate(trackId) / 2;
+}
 
 double SpectrogramService::yToFrequency(int trackId, double spectrogramY, double spectrogramHeight) const
 {

--- a/src/spectrogram/internal/spectrogramservice.cpp
+++ b/src/spectrogram/internal/spectrogramservice.cpp
@@ -24,6 +24,16 @@ ITrackSpectrogramConfigurationPtr SpectrogramService::trackSpectrogramConfigurat
     return Au3TrackSpectrogramConfiguration::create(trackId, *globalContext());
 }
 
+muse::async::Channel<int> SpectrogramService::trackSpectrogramConfigurationChanged() const
+{
+    return m_trackSpectrogramConfigurationChanged;
+}
+
+void SpectrogramService::notifyAboutTrackSpectrogramConfigurationChanged(int trackId)
+{
+    m_trackSpectrogramConfigurationChanged.send(trackId);
+}
+
 void SpectrogramService::copyConfiguration(const ISpectrogramConfiguration& source,
                                            ISpectrogramConfiguration& destination) const
 {

--- a/src/spectrogram/internal/spectrogramservice.h
+++ b/src/spectrogram/internal/spectrogramservice.h
@@ -27,6 +27,7 @@ public:
     ITrackSpectrogramConfigurationPtr trackSpectrogramConfiguration(int trackId) const override;
 
     void copyConfiguration(const ISpectrogramConfiguration& source, ISpectrogramConfiguration& destination) const override;
+    double frequencyHardMaximum(int trackId) const override;
     double yToFrequency(int trackId, double spectrogramY, double spectrogramHeight) const override;
     double frequencyToY(int trackId, double frequency, double spectrogramHeight) const override;
 

--- a/src/spectrogram/internal/spectrogramservice.h
+++ b/src/spectrogram/internal/spectrogramservice.h
@@ -25,6 +25,8 @@ public:
     void init();
 
     ITrackSpectrogramConfigurationPtr trackSpectrogramConfiguration(int trackId) const override;
+    muse::async::Channel<int> trackSpectrogramConfigurationChanged() const override;
+    void notifyAboutTrackSpectrogramConfigurationChanged(int trackId) override;
 
     void copyConfiguration(const ISpectrogramConfiguration& source, ISpectrogramConfiguration& destination) const override;
     double frequencyHardMaximum(int trackId) const override;
@@ -33,5 +35,7 @@ public:
 
 private:
     double trackSampleRate(int trackId) const;
+
+    muse::async::Channel<int> m_trackSpectrogramConfigurationChanged;
 };
 }

--- a/src/spectrogram/internal/spectrogramservice.h
+++ b/src/spectrogram/internal/spectrogramservice.h
@@ -25,7 +25,12 @@ public:
     void init();
 
     ITrackSpectrogramConfigurationPtr trackSpectrogramConfiguration(int trackId) const override;
+
     void copyConfiguration(const ISpectrogramConfiguration& source, ISpectrogramConfiguration& destination) const override;
     double yToFrequency(int trackId, double spectrogramY, double spectrogramHeight) const override;
+    double frequencyToY(int trackId, double frequency, double spectrogramHeight) const override;
+
+private:
+    double trackSampleRate(int trackId) const;
 };
 }

--- a/src/spectrogram/ispectrogramservice.h
+++ b/src/spectrogram/ispectrogramservice.h
@@ -18,5 +18,6 @@ public:
     virtual ITrackSpectrogramConfigurationPtr trackSpectrogramConfiguration(int trackId) const = 0;
     virtual void copyConfiguration(const ISpectrogramConfiguration& source, ISpectrogramConfiguration& destination) const = 0;
     virtual double yToFrequency(int trackId, double spectrogramY, double spectrogramHeight) const = 0;
+    virtual double frequencyToY(int trackId, double frequency, double spectrogramHeight) const = 0;
 };
 }

--- a/src/spectrogram/ispectrogramservice.h
+++ b/src/spectrogram/ispectrogramservice.h
@@ -6,6 +6,7 @@
 #include "itrackspectrogramconfiguration.h"
 
 #include "framework/global/modularity/imoduleinterface.h"
+#include "framework/global/async/channel.h"
 
 namespace au::spectrogram {
 class ISpectrogramService : MODULE_EXPORT_INTERFACE
@@ -16,6 +17,9 @@ public:
     virtual ~ISpectrogramService() = default;
 
     virtual ITrackSpectrogramConfigurationPtr trackSpectrogramConfiguration(int trackId) const = 0;
+    virtual muse::async::Channel<int /*track id*/> trackSpectrogramConfigurationChanged() const = 0;
+    virtual void notifyAboutTrackSpectrogramConfigurationChanged(int trackId) = 0;
+
     virtual void copyConfiguration(const ISpectrogramConfiguration& source, ISpectrogramConfiguration& destination) const = 0;
     virtual double frequencyHardMaximum(int trackId) const = 0;
     virtual double yToFrequency(int trackId, double spectrogramY, double spectrogramHeight) const = 0;

--- a/src/spectrogram/ispectrogramservice.h
+++ b/src/spectrogram/ispectrogramservice.h
@@ -17,6 +17,7 @@ public:
 
     virtual ITrackSpectrogramConfigurationPtr trackSpectrogramConfiguration(int trackId) const = 0;
     virtual void copyConfiguration(const ISpectrogramConfiguration& source, ISpectrogramConfiguration& destination) const = 0;
+    virtual double frequencyHardMaximum(int trackId) const = 0;
     virtual double yToFrequency(int trackId, double spectrogramY, double spectrogramHeight) const = 0;
     virtual double frequencyToY(int trackId, double frequency, double spectrogramHeight) const = 0;
 };

--- a/src/spectrogram/qml/Audacity/Spectrogram/SpectrogramChannelRuler.qml
+++ b/src/spectrogram/qml/Audacity/Spectrogram/SpectrogramChannelRuler.qml
@@ -1,0 +1,35 @@
+import QtQuick
+
+import Audacity.Spectrogram
+
+Rectangle {
+    id: root
+
+    color: "gray"
+
+    required property int trackId
+    signal zoomChanged
+
+    SpectrogramChannelRulerModel {
+        id: rulerModel
+        trackId: root.trackId
+        channelHeight: root.height
+        onZoomChanged: root.zoomChanged()
+    }
+
+    MouseArea {
+        anchors.fill: parent
+        acceptedButtons: Qt.NoButton
+
+        onWheel: function (wheelEvent) {
+            if (wheelEvent.modifiers & Qt.ControlModifier) {
+                wheelEvent.accepted = true
+                if (wheelEvent.angleDelta.y > 0) {
+                    rulerModel.zoomIn(wheelEvent.y)
+                } else if (wheelEvent.angleDelta.y < 0) {
+                    rulerModel.zoomOut(wheelEvent.y)
+                }
+            }
+        }
+    }
+}

--- a/src/spectrogram/qml/Audacity/Spectrogram/qmldir
+++ b/src/spectrogram/qml/Audacity/Spectrogram/qmldir
@@ -1,4 +1,5 @@
 module Audacity.Spectrogram
 ClipSpectrogramView 1.0 ClipSpectrogramView.qml
 ChannelSpectralSelectionContainer 1.0 ChannelSpectralSelectionContainer.qml
+SpectrogramChannelRuler 1.0 SpectrogramChannelRuler.qml
 TrackSpectralSelectionContainer 1.0 TrackSpectralSelectionContainer.qml

--- a/src/spectrogram/spectrogram.qrc
+++ b/src/spectrogram/spectrogram.qrc
@@ -3,6 +3,7 @@
         <file>qml/Audacity/Spectrogram/qmldir</file>
         <file>qml/Audacity/Spectrogram/ClipSpectrogramView.qml</file>
         <file>qml/Audacity/Spectrogram/ChannelSpectralSelectionContainer.qml</file>
+        <file>qml/Audacity/Spectrogram/SpectrogramChannelRuler.qml</file>
         <file>qml/Audacity/Spectrogram/TrackSpectralSelectionContainer.qml</file>
     </qresource>
 </RCC>

--- a/src/spectrogram/spectrogrammodule.cpp
+++ b/src/spectrogram/spectrogrammodule.cpp
@@ -11,6 +11,7 @@
 #include "view/colorsectionparameterlistmodel.h"
 #include "view/scalesectionparameterlistmodel.h"
 #include "view/globalspectrogramsettingsmodel.h"
+#include "view/trackspectrogramsettingsmodel.h"
 
 #include "view/spectrogramhit.h"
 #include "view/clipchannelspectrogramview.h"
@@ -52,6 +53,7 @@ void SpectrogramModule::registerUiTypes()
     qmlRegisterType<ClipChannelSpectrogramView>("Audacity.Spectrogram", 1, 0, "ClipChannelSpectrogramView");
     qmlRegisterType<ChannelSpectralSelectionModel>("Audacity.Spectrogram", 1, 0, "ChannelSpectralSelectionModel");
     qmlRegisterType<SpectrogramHit>("Audacity.Spectrogram", 1, 0, "SpectrogramHit");
+    qmlRegisterType<TrackSpectrogramSettingsModel>("Audacity.Spectrogram", 1, 0, "TrackSpectrogramSettingsModel");
     qmlRegisterSingletonType<SpectrogramHitFactory>("Audacity.Spectrogram", 1, 0, "SpectrogramHitFactory",
                                                     [](QQmlEngine*, QJSEngine*) -> QObject* {
         return new SpectrogramHitFactory();

--- a/src/spectrogram/spectrogrammodule.cpp
+++ b/src/spectrogram/spectrogrammodule.cpp
@@ -9,6 +9,7 @@
 #include "view/abstractspectrogramsettingsmodel.h"
 #include "view/algorithmsectionparameterlistmodel.h"
 #include "view/colorsectionparameterlistmodel.h"
+#include "view/spectrogramchannelrulermodel.h"
 #include "view/scalesectionparameterlistmodel.h"
 #include "view/globalspectrogramsettingsmodel.h"
 #include "view/trackspectrogramsettingsmodel.h"
@@ -53,6 +54,7 @@ void SpectrogramModule::registerUiTypes()
     qmlRegisterType<ClipChannelSpectrogramView>("Audacity.Spectrogram", 1, 0, "ClipChannelSpectrogramView");
     qmlRegisterType<ChannelSpectralSelectionModel>("Audacity.Spectrogram", 1, 0, "ChannelSpectralSelectionModel");
     qmlRegisterType<SpectrogramHit>("Audacity.Spectrogram", 1, 0, "SpectrogramHit");
+    qmlRegisterType<SpectrogramChannelRulerModel>("Audacity.Spectrogram", 1, 0, "SpectrogramChannelRulerModel");
     qmlRegisterType<TrackSpectrogramSettingsModel>("Audacity.Spectrogram", 1, 0, "TrackSpectrogramSettingsModel");
     qmlRegisterSingletonType<SpectrogramHitFactory>("Audacity.Spectrogram", 1, 0, "SpectrogramHitFactory",
                                                     [](QQmlEngine*, QJSEngine*) -> QObject* {

--- a/src/spectrogram/view/abstractspectrogramsettingsmodel.cpp
+++ b/src/spectrogram/view/abstractspectrogramsettingsmodel.cpp
@@ -11,12 +11,11 @@
 
 namespace au::spectrogram {
 AbstractSpectrogramSettingsModel::AbstractSpectrogramSettingsModel(QObject* parent)
-    : QObject(parent), muse::Injectable(muse::iocCtxForQmlObject(this))
-{}
+    : QObject(parent) {}
 
 void AbstractSpectrogramSettingsModel::setMinFreq(int value)
 {
-    doSetMinFreq(std::clamp(value, frequencyHardMinimum(), frequencyHardMaximum()));
+    doSetMinFreq(value);
     if (maxFreq() <= minFreq()) {
         doSetMaxFreq(minFreq());
     }
@@ -24,16 +23,10 @@ void AbstractSpectrogramSettingsModel::setMinFreq(int value)
 
 void AbstractSpectrogramSettingsModel::setMaxFreq(int value)
 {
-    doSetMaxFreq(std::clamp(value, frequencyHardMinimum(), frequencyHardMaximum()));
+    doSetMaxFreq(value);
     if (minFreq() >= maxFreq()) {
         doSetMinFreq(maxFreq());
     }
-}
-
-int AbstractSpectrogramSettingsModel::frequencyHardMaximum() const
-{
-    const auto sampleRates = audioDevicesProvider()->sampleRates();
-    return static_cast<int>(*std::max_element(sampleRates.begin(), sampleRates.end()) / 2);
 }
 
 QString AbstractSpectrogramSettingsModel::colorSchemeName(int scheme) const

--- a/src/spectrogram/view/abstractspectrogramsettingsmodel.h
+++ b/src/spectrogram/view/abstractspectrogramsettingsmodel.h
@@ -5,12 +5,10 @@
 
 #include "audio/iaudiodevicesprovider.h"
 
-#include "framework/global/modularity/ioc.h"
-
 #include <QObject>
 
 namespace au::spectrogram {
-class AbstractSpectrogramSettingsModel : public QObject, public muse::Injectable
+class AbstractSpectrogramSettingsModel : public QObject
 {
     Q_OBJECT
 
@@ -38,19 +36,15 @@ class AbstractSpectrogramSettingsModel : public QObject, public muse::Injectable
     Q_PROPERTY(int windowSize READ windowSize WRITE setWindowSize NOTIFY windowSizeChanged)
     Q_PROPERTY(int zeroPaddingFactor READ zeroPaddingFactor WRITE setZeroPaddingFactor NOTIFY zeroPaddingFactorChanged)
 
-    muse::Inject<audio::IAudioDevicesProvider> audioDevicesProvider{ this };
-
 public:
     explicit AbstractSpectrogramSettingsModel(QObject* parent = nullptr);
     virtual ~AbstractSpectrogramSettingsModel() = default;
 
     virtual int minFreq() const = 0;
     void setMinFreq(int value);
-    int frequencyHardMinimum() const { return 0; }
 
     virtual int maxFreq() const = 0;
     void setMaxFreq(int value);
-    int frequencyHardMaximum() const;
 
     virtual int colorGainDb() const = 0;
     virtual void setColorGainDb(int value) = 0;

--- a/src/spectrogram/view/channelspectralselectionmodel.cpp
+++ b/src/spectrogram/view/channelspectralselectionmodel.cpp
@@ -16,30 +16,12 @@ ChannelSpectralSelectionModel::ChannelSpectralSelectionModel(QObject* parent)
 
 double ChannelSpectralSelectionModel::positionToFrequency(double y) const
 {
-    const auto config = spectrogramService()->trackSpectrogramConfiguration(m_trackId);
-    if (!config) {
-        return SelectionInfo::UndefinedFrequency;
-    }
-
-    const auto [minFreq, maxFreq] = spectrogramBounds(*config, m_trackSampleRate);
-
-    const NumberScale numberScale(config->scale(), minFreq, maxFreq);
-    const double position = 1.0 - y / m_channelHeight;
-    return numberScale.positionToValue(position);
+    return spectrogramService()->yToFrequency(m_trackId, y, m_channelHeight);
 }
 
 double ChannelSpectralSelectionModel::frequencyToPosition(double frequency) const
 {
-    const auto config = spectrogramService()->trackSpectrogramConfiguration(m_trackId);
-    if (!config) {
-        return 0.0;
-    }
-
-    const auto [minFreq, maxFreq] = spectrogramBounds(*config, m_trackSampleRate);
-
-    const NumberScale numberScale(config->scale(), minFreq, maxFreq);
-    const double valuePosition = numberScale.valueToPosition(frequency);
-    return (1.0 - valuePosition) * m_channelHeight;
+    return spectrogramService()->frequencyToY(m_trackId, frequency, m_channelHeight);
 }
 
 void ChannelSpectralSelectionModel::setTrackSampleRate(double rate)

--- a/src/spectrogram/view/channelspectralselectionmodel.h
+++ b/src/spectrogram/view/channelspectralselectionmodel.h
@@ -80,7 +80,6 @@ public:
 
 signals:
     void trackSampleRateChanged();
-    void zoomChanged();
     void channelHeightChanged();
     void trackIdChanged();
     void channelChanged();

--- a/src/spectrogram/view/clipchannelspectrogramview.cpp
+++ b/src/spectrogram/view/clipchannelspectrogramview.cpp
@@ -22,6 +22,11 @@ void ClipChannelSpectrogramView::componentComplete()
             update();
         }
     });
+    spectrogramService()->trackSpectrogramConfigurationChanged().onReceive(this, [this](int trackId) {
+        if (trackId == m_trackId) {
+            update();
+        }
+    });
 }
 
 void ClipChannelSpectrogramView::setClipId(int id)

--- a/src/spectrogram/view/clipchannelspectrogramview.h
+++ b/src/spectrogram/view/clipchannelspectrogramview.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "internal/ispectrogrampainter.h"
+#include "ispectrogramservice.h"
 
 #include "context/iglobalcontext.h"
 
@@ -30,6 +31,7 @@ class ClipChannelSpectrogramView : public QQuickPaintedItem, public muse::async:
     Q_PROPERTY(
         double selectionEndFrequency READ selectionEndFrequency WRITE setSelectionEndFrequency NOTIFY selectionFrequencyChanged FINAL)
 
+    muse::Inject<ISpectrogramService> spectrogramService{ this };
     muse::Inject<ISpectrogramPainter> spectrogramPainter { this };
     muse::Inject<au::context::IGlobalContext> globalContext { this };
 

--- a/src/spectrogram/view/scalesectionparameterlistmodel.cpp
+++ b/src/spectrogram/view/scalesectionparameterlistmodel.cpp
@@ -11,7 +11,16 @@
 
 namespace au::spectrogram {
 ScaleSectionParameterListModel::ScaleSectionParameterListModel(QObject* parent)
-    : AbstractSectionParametersListModel(parent) {}
+    : AbstractSectionParametersListModel(parent), muse::Injectable(muse::iocCtxForQmlObject(this)) {}
+
+void ScaleSectionParameterListModel::setTrackId(int trackId)
+{
+    if (trackId == m_trackId) {
+        return;
+    }
+    m_trackId = trackId;
+    emit trackIdChanged();
+}
 
 void ScaleSectionParameterListModel::onSettingsModelSet(AbstractSpectrogramSettingsModel&)
 {
@@ -65,12 +74,12 @@ QString ScaleSectionParameterListModel::controlLabel(Control control) const
 
 int ScaleSectionParameterListModel::controlMinValue(Control) const
 {
-    return m_settingsModel ? m_settingsModel->frequencyHardMinimum() : 0;
+    return 0;
 }
 
 int ScaleSectionParameterListModel::controlMaxValue(Control) const
 {
-    return m_settingsModel ? m_settingsModel->frequencyHardMaximum() : 0;
+    return m_trackId == -1 ? 1e6 : spectrogramService()->frequencyHardMaximum(m_trackId);
 }
 
 int ScaleSectionParameterListModel::controlCurrentValue(Control control) const

--- a/src/spectrogram/view/scalesectionparameterlistmodel.h
+++ b/src/spectrogram/view/scalesectionparameterlistmodel.h
@@ -4,15 +4,31 @@
 #pragma once
 
 #include "abstractsectionparameterslistmodel.h"
+#include "ispectrogramservice.h"
+
+#include "framework/global/modularity/ioc.h"
 
 namespace au::spectrogram {
 class AbstractSpectrogramSettingsModel;
 
-class ScaleSectionParameterListModel : public AbstractSectionParametersListModel
+class ScaleSectionParameterListModel : public AbstractSectionParametersListModel, muse::Injectable
 {
+    Q_OBJECT
+
+protected:
+    muse::Inject<ISpectrogramService> spectrogramService{ this };
+
 public:
     explicit ScaleSectionParameterListModel(QObject* parent = nullptr);
     ~ScaleSectionParameterListModel() override = default;
+
+    Q_PROPERTY(int trackId READ trackId WRITE setTrackId NOTIFY trackIdChanged FINAL)
+
+    int trackId() const { return m_trackId; }
+    void setTrackId(int);
+
+signals:
+    void trackIdChanged();
 
 private:
     enum Control {
@@ -40,5 +56,7 @@ private:
     int controlMinValue(Control) const;
     int controlMaxValue(Control) const;
     int controlCurrentValue(Control) const;
+
+    int m_trackId = -1;
 };
 }

--- a/src/spectrogram/view/spectrogramchannelrulermodel.cpp
+++ b/src/spectrogram/view/spectrogramchannelrulermodel.cpp
@@ -106,5 +106,6 @@ void SpectrogramChannelRulerModel::zoomBy(double factor, double mousePos)
     config->setUseGlobalSettings(false);
 
     emit zoomChanged();
+    spectrogramService()->notifyAboutTrackSpectrogramConfigurationChanged(m_trackId);
 }
 }

--- a/src/spectrogram/view/spectrogramchannelrulermodel.cpp
+++ b/src/spectrogram/view/spectrogramchannelrulermodel.cpp
@@ -1,0 +1,110 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+#include "spectrogramchannelrulermodel.h"
+
+#include "framework/global/types/number.h"
+#include "framework/global/log.h"
+
+namespace au::spectrogram {
+SpectrogramChannelRulerModel::SpectrogramChannelRulerModel(QObject* parent)
+    : QObject(parent), muse::Injectable(muse::iocCtxForQmlObject(this))
+{
+}
+
+int SpectrogramChannelRulerModel::trackId() const
+{
+    return m_trackId;
+}
+
+void SpectrogramChannelRulerModel::setTrackId(int trackId)
+{
+    if (m_trackId == trackId) {
+        return;
+    }
+    m_trackId = trackId;
+    emit trackIdChanged();
+}
+
+double SpectrogramChannelRulerModel::channelHeight() const
+{
+    return m_channelHeight;
+}
+
+void SpectrogramChannelRulerModel::setChannelHeight(double height)
+{
+    if (muse::is_equal(m_channelHeight, height)) {
+        return;
+    }
+    m_channelHeight = height;
+    emit channelHeightChanged();
+}
+
+namespace {
+constexpr double ZOOM_FACTOR = 1.4142;     // sqrt(2)
+}
+
+void SpectrogramChannelRulerModel::zoomIn(double mouseY)
+{
+    zoomBy(1. / ZOOM_FACTOR, mouseY);
+}
+
+void SpectrogramChannelRulerModel::zoomOut(double mouseY)
+{
+    zoomBy(ZOOM_FACTOR, mouseY);
+}
+
+double SpectrogramChannelRulerModel::frequencyToPosition(double freq) const
+{
+    return spectrogramService()->frequencyToY(trackId(), freq, m_channelHeight);
+}
+
+double SpectrogramChannelRulerModel::positionToFrequency(double pos) const
+{
+    return spectrogramService()->yToFrequency(trackId(), pos, m_channelHeight);
+}
+
+void SpectrogramChannelRulerModel::zoomBy(double factor, double mousePos)
+{
+    const auto config = spectrogramService()->trackSpectrogramConfiguration(m_trackId);
+    IF_ASSERT_FAILED(config) {
+        return;
+    }
+
+    if (config->maxFreq() > config->minFreq()) {
+        // We do the calculations in the "positional" domain, where equal y steps mean equal steps on the chosen
+        // spectrogram scale (e.g. on the mel scale, 1 pixel may equal 0.1 mel).
+
+        // Hard maximum frequency -> "hard minimum" position (frequency and positional domains have opposite polarities).
+        const auto hardMinPos = frequencyToPosition(spectrogramService()->frequencyHardMaximum(m_trackId));
+
+        // If the mouse is say at 300px on a 400px ruler, the space above the mouse will change from 300 to 300 * factor.
+        const auto newSpaceAbove = mousePos * factor;
+
+        // Do as though we displaced top and bottom from [0, height] to [newBottom, newTop].
+        // Then calculate the corresponding frequencies. When setting them as min and max frequencies on the configuration,
+        // the spectrogram and ruler painting will rescale their content so that this new range fits in [0, height] again.
+
+        // Don't forget that the spectrogram display of a given track must be upper-bound to the track's frequency.
+        const auto newTop = std::max(hardMinPos, mousePos - newSpaceAbove);
+        const auto newBottom = newTop + m_channelHeight * factor;
+
+        const auto newMaxFreq = positionToFrequency(newTop);
+        const auto newMinFreq = std::max(0., positionToFrequency(newBottom));
+
+        config->setMaxFreq(newMaxFreq);
+        config->setMinFreq(newMinFreq);
+    } else {
+        // Special case: we are showing a spectrum slice and all positions map to the same frequency.
+        // Workaround: augment the range to 1Hz.
+        const auto newMinFreq = std::max(0, config->minFreq() - 1);
+        config->setMinFreq(newMinFreq);
+        config->setMaxFreq(newMinFreq + 1);
+    }
+
+    // Changing track spectrogram setting decouples it from the global spectrogram settings.
+    config->setUseGlobalSettings(false);
+
+    emit zoomChanged();
+}
+}

--- a/src/spectrogram/view/spectrogramchannelrulermodel.h
+++ b/src/spectrogram/view/spectrogramchannelrulermodel.h
@@ -1,0 +1,47 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+#pragma once
+
+#include "spectrogram/ispectrogramservice.h"
+
+#include "modularity/ioc.h"
+
+#include <QObject>
+
+namespace au::spectrogram {
+class SpectrogramChannelRulerModel : public QObject, public muse::Injectable
+{
+    Q_OBJECT
+
+    Q_PROPERTY(int trackId READ trackId WRITE setTrackId NOTIFY trackIdChanged FINAL)
+    Q_PROPERTY(double channelHeight READ channelHeight WRITE setChannelHeight NOTIFY channelHeightChanged FINAL)
+
+    muse::Inject<ISpectrogramService> spectrogramService{ this };
+
+public:
+    SpectrogramChannelRulerModel(QObject* parent = nullptr);
+
+    int trackId() const;
+    void setTrackId(int trackId);
+
+    double channelHeight() const;
+    void setChannelHeight(double height);
+
+    Q_INVOKABLE void zoomIn(double mouseY);
+    Q_INVOKABLE void zoomOut(double mouseY);
+
+signals:
+    void trackIdChanged();
+    void channelHeightChanged();
+    void zoomChanged();
+
+private:
+    void zoomBy(double factor, double centerPosition);
+    double frequencyToPosition(double freq) const;
+    double positionToFrequency(double pos) const;
+
+    int m_trackId = -1;
+    double m_channelHeight = 0.0;
+};
+} // namespace au::spectrogram

--- a/src/spectrogram/view/trackspectrogramsettingsmodel.cpp
+++ b/src/spectrogram/view/trackspectrogramsettingsmodel.cpp
@@ -34,7 +34,7 @@ static_assert(logTwo(8) == 3);
 }
 
 TrackSpectrogramSettingsModel::TrackSpectrogramSettingsModel(QObject* parent)
-    : AbstractSpectrogramSettingsModel(parent)
+    : AbstractSpectrogramSettingsModel(parent), muse::Injectable(muse::iocCtxForQmlObject(this))
 {}
 
 void TrackSpectrogramSettingsModel::aboutToDestroy()

--- a/src/spectrogram/view/trackspectrogramsettingsmodel.cpp
+++ b/src/spectrogram/view/trackspectrogramsettingsmodel.cpp
@@ -6,7 +6,7 @@
 
 #include "framework/global/log.h"
 
-namespace au::trackedit {
+namespace au::spectrogram {
 namespace {
 constexpr auto isPowerOfTwo(int x) -> bool
 {
@@ -34,7 +34,7 @@ static_assert(logTwo(8) == 3);
 }
 
 TrackSpectrogramSettingsModel::TrackSpectrogramSettingsModel(QObject* parent)
-    : spectrogram::AbstractSpectrogramSettingsModel(parent)
+    : AbstractSpectrogramSettingsModel(parent)
 {}
 
 void TrackSpectrogramSettingsModel::aboutToDestroy()
@@ -207,7 +207,7 @@ int TrackSpectrogramSettingsModel::colorScheme() const
 
 void TrackSpectrogramSettingsModel::setColorScheme(int value)
 {
-    const auto scheme = static_cast<spectrogram::SpectrogramColorScheme>(value);
+    const auto scheme = static_cast<SpectrogramColorScheme>(value);
     if (m_trackConfig->colorScheme() == scheme) {
         return;
     }
@@ -223,7 +223,7 @@ int TrackSpectrogramSettingsModel::scale() const
 
 void TrackSpectrogramSettingsModel::setScale(int value)
 {
-    const auto scale = static_cast<spectrogram::SpectrogramScale>(value);
+    const auto scale = static_cast<SpectrogramScale>(value);
     if (m_trackConfig->scale() == scale) {
         return;
     }
@@ -239,7 +239,7 @@ int TrackSpectrogramSettingsModel::algorithm() const
 
 void TrackSpectrogramSettingsModel::setAlgorithm(int value)
 {
-    const auto algorithm = static_cast<spectrogram::SpectrogramAlgorithm>(value);
+    const auto algorithm = static_cast<SpectrogramAlgorithm>(value);
     if (m_trackConfig->algorithm() == algorithm) {
         return;
     }
@@ -255,7 +255,7 @@ int TrackSpectrogramSettingsModel::windowType() const
 
 void TrackSpectrogramSettingsModel::setWindowType(int value)
 {
-    const auto windowType = static_cast<spectrogram::SpectrogramWindowType>(value);
+    const auto windowType = static_cast<SpectrogramWindowType>(value);
     if (m_trackConfig->windowType() == windowType) {
         return;
     }

--- a/src/spectrogram/view/trackspectrogramsettingsmodel.h
+++ b/src/spectrogram/view/trackspectrogramsettingsmodel.h
@@ -8,22 +8,21 @@
 #include "spectrogram/view/abstractspectrogramsettingsmodel.h"
 #include "spectrogram/iglobalspectrogramconfiguration.h"
 #include "spectrogram/ispectrogramservice.h"
-#include "context/iglobalcontext.h"
 
+#include "framework/global/async/asyncable.h"
 #include "framework/global/modularity/ioc.h"
 
-namespace au::trackedit {
-class TrackSpectrogramSettingsModel : public spectrogram::AbstractSpectrogramSettingsModel, public QQmlParserStatus,
-    public muse::async::Asyncable
+namespace au::spectrogram {
+class TrackSpectrogramSettingsModel : public AbstractSpectrogramSettingsModel, public QQmlParserStatus, public muse::async::Asyncable
 {
     Q_OBJECT
 
     Q_PROPERTY(int trackId READ trackId WRITE setTrackId NOTIFY trackIdChanged)
     Q_PROPERTY(bool useGlobalSettings READ useGlobalSettings WRITE setUseGlobalSettings NOTIFY useGlobalSettingsChanged)
 
-    muse::GlobalInject<spectrogram::IGlobalSpectrogramConfiguration> globalSpectrogramConfiguration;
+    muse::GlobalInject<IGlobalSpectrogramConfiguration> globalSpectrogramConfiguration;
 
-    muse::Inject<spectrogram::ISpectrogramService> spectrogramService { this };
+    muse::Inject<ISpectrogramService> spectrogramService { this };
 
 public:
     TrackSpectrogramSettingsModel(QObject* parent = nullptr);
@@ -84,7 +83,7 @@ private:
 
     int m_trackId = -1;
 
-    std::shared_ptr<spectrogram::ITrackSpectrogramConfiguration> m_trackConfig;
-    std::unique_ptr<spectrogram::ITrackSpectrogramConfiguration> m_initialTrackConfig;
+    std::shared_ptr<ITrackSpectrogramConfiguration> m_trackConfig;
+    std::unique_ptr<ITrackSpectrogramConfiguration> m_initialTrackConfig;
 };
 }

--- a/src/spectrogram/view/trackspectrogramsettingsmodel.h
+++ b/src/spectrogram/view/trackspectrogramsettingsmodel.h
@@ -13,7 +13,8 @@
 #include "framework/global/modularity/ioc.h"
 
 namespace au::spectrogram {
-class TrackSpectrogramSettingsModel : public AbstractSpectrogramSettingsModel, public QQmlParserStatus, public muse::async::Asyncable
+class TrackSpectrogramSettingsModel : public AbstractSpectrogramSettingsModel,  public QQmlParserStatus, public muse::Injectable,
+    public muse::async::Asyncable
 {
     Q_OBJECT
 

--- a/src/trackedit/CMakeLists.txt
+++ b/src/trackedit/CMakeLists.txt
@@ -89,6 +89,8 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/view/tracknavigationmodel.h
     ${CMAKE_CURRENT_LIST_DIR}/view/trackspectrogramsettingsmodel.cpp
     ${CMAKE_CURRENT_LIST_DIR}/view/trackspectrogramsettingsmodel.h
+    ${CMAKE_CURRENT_LIST_DIR}/view/trackspectrogramsettingsdialogmodel.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/view/trackspectrogramsettingsdialogmodel.h
     )
 
 # AU3

--- a/src/trackedit/CMakeLists.txt
+++ b/src/trackedit/CMakeLists.txt
@@ -35,7 +35,6 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/dom/wave.cpp
     ${CMAKE_CURRENT_LIST_DIR}/dom/wave.h
 
-    ${CMAKE_CURRENT_LIST_DIR}/internal/snapshotspectrogramconfiguration.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/trackspectrogramsettingsupdater.cpp
     ${CMAKE_CURRENT_LIST_DIR}/internal/trackspectrogramsettingsupdater.h
 
@@ -87,8 +86,6 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/view/pastebehaviorpanelmodel.h
     ${CMAKE_CURRENT_LIST_DIR}/view/tracknavigationmodel.cpp
     ${CMAKE_CURRENT_LIST_DIR}/view/tracknavigationmodel.h
-    ${CMAKE_CURRENT_LIST_DIR}/view/trackspectrogramsettingsmodel.cpp
-    ${CMAKE_CURRENT_LIST_DIR}/view/trackspectrogramsettingsmodel.h
     ${CMAKE_CURRENT_LIST_DIR}/view/trackspectrogramsettingsdialogmodel.cpp
     ${CMAKE_CURRENT_LIST_DIR}/view/trackspectrogramsettingsdialogmodel.h
     )

--- a/src/trackedit/internal/au3/au3projecthistory.cpp
+++ b/src/trackedit/internal/au3/au3projecthistory.cpp
@@ -96,7 +96,7 @@ void Au3ProjectHistory::endUserInteraction(bool modifyState)
 
 void Au3ProjectHistory::modifyState(bool autoSave)
 {
-    LOGI() << "modifyState(" << (autoSave ? "true" : "false") << ")";
+    LOGD() << "modifyState(" << (autoSave ? "true" : "false") << ")";
     if (m_interactionOngoing) {
         LOGW() << "Attempt to modify state during undoable action";
         return;
@@ -116,7 +116,7 @@ void Au3ProjectHistory::modifyState(const std::type_index& restorerType)
 
 void Au3ProjectHistory::markUnsaved()
 {
-    LOGI() << "markUnsaved()";
+    LOGD() << "markUnsaved()";
     auto& project = projectRef();
     ::UndoManager::Get(project).MarkUnsaved();
 }

--- a/src/trackedit/internal/trackeditactionscontroller.cpp
+++ b/src/trackedit/internal/trackeditactionscontroller.cpp
@@ -1868,6 +1868,7 @@ void TrackeditActionsController::openTrackSpectrogramSettings(const muse::action
 {
     muse::UriQuery spectrogramSettingsUri("audacity://trackedit/track_spectrogram_settings");
     spectrogramSettingsUri.addParam("trackId", muse::Val(q.param("trackId").toInt()));
+    spectrogramSettingsUri.addParam("trackTitle", muse::Val(q.param("trackTitle").toString()));
     interactive()->open(spectrogramSettingsUri);
 }
 

--- a/src/trackedit/internal/trackeditactionscontroller.cpp
+++ b/src/trackedit/internal/trackeditactionscontroller.cpp
@@ -1840,7 +1840,7 @@ void TrackeditActionsController::changeTrackViewToWaveformAndSpectrogram(const m
 
 void TrackeditActionsController::changeTrackView(const muse::actions::ActionQuery& q, TrackViewType trackView)
 {
-    IF_ASSERT_FAILED(q.params().size() == 1) {
+    IF_ASSERT_FAILED(q.params().size() >= 1) {
         return;
     }
     const auto trackId = q.param("trackId").toInt();

--- a/src/trackedit/qml/Audacity/TrackEdit/TrackSpectrogramScaleSection.qml
+++ b/src/trackedit/qml/Audacity/TrackEdit/TrackSpectrogramScaleSection.qml
@@ -47,6 +47,7 @@ TrackSpectrogramBaseSection {
 
         model: ScaleSectionParameterListModel {
             settingsModel: root.settingsModel
+            trackId: root.settingsModel.trackId
             columnWidth: root.prefsColumnWidth
         }
 

--- a/src/trackedit/qml/Audacity/TrackEdit/TrackSpectrogramSettingsDialog.qml
+++ b/src/trackedit/qml/Audacity/TrackEdit/TrackSpectrogramSettingsDialog.qml
@@ -26,7 +26,14 @@ StyledDialogView {
 
     property var settingsModel: TrackSpectrogramSettingsModel {
         trackId: root.trackId
+        onUpdateRequested: dialogModel.requestSpectrogramUpdate()
     }
+
+    property var dialogModel: TrackSpectrogramSettingsDialogModel {
+        trackId: root.trackId
+    }
+
+    Component.onDestruction: settingsModel.aboutToDestroy()
 
     QtObject {
         id: prv

--- a/src/trackedit/qml/Audacity/TrackEdit/TrackSpectrogramSettingsDialog.qml
+++ b/src/trackedit/qml/Audacity/TrackEdit/TrackSpectrogramSettingsDialog.qml
@@ -18,10 +18,11 @@ StyledDialogView {
         if (!root.settingsModel)
             return qsTrc("trackedit/preferences", "Spectrogram settings")
         else
-            return qsTrc("trackedit/preferences", "Spectrogram settings - %1").arg(root.settingsModel.trackTitle)
+            return qsTrc("trackedit/preferences", "Spectrogram settings - %1").arg(root.trackTitle)
     }
 
     property int trackId: -1
+    property string trackTitle: ""
 
     property var settingsModel: TrackSpectrogramSettingsModel {
         trackId: root.trackId

--- a/src/trackedit/qml/Audacity/TrackEdit/TrackSpectrogramSettingsDialog.qml
+++ b/src/trackedit/qml/Audacity/TrackEdit/TrackSpectrogramSettingsDialog.qml
@@ -5,6 +5,7 @@ import QtQuick
 import Muse.UiComponents
 import Audacity.TrackEdit
 import Audacity.Preferences
+import Audacity.Spectrogram
 
 import "."
 

--- a/src/trackedit/trackeditmodule.cpp
+++ b/src/trackedit/trackeditmodule.cpp
@@ -41,6 +41,7 @@
 #include "view/pastebehaviorpanelmodel.h"
 #include "view/tracknavigationmodel.h"
 #include "view/trackspectrogramsettingsmodel.h"
+#include "view/trackspectrogramsettingsdialogmodel.h"
 
 #include "internal/au3/au3trackeditproject.h"
 #include "internal/au3/au3selectioncontroller.h"
@@ -86,6 +87,7 @@ void TrackeditModule::registerUiTypes()
     qmlRegisterType<PasteBehaviorPanelModel>("Audacity.TrackEdit", 1, 0, "PasteBehaviorPanelModel");
     qmlRegisterType<TrackNavigationModel>("Audacity.TrackEdit", 1, 0, "TrackNavigationModel");
     qmlRegisterType<TrackSpectrogramSettingsModel>("Audacity.TrackEdit", 1, 0, "TrackSpectrogramSettingsModel");
+    qmlRegisterType<TrackSpectrogramSettingsDialogModel>("Audacity.TrackEdit", 1, 0, "TrackSpectrogramSettingsDialogModel");
 }
 
 void TrackeditModule::resolveImports()

--- a/src/trackedit/trackeditmodule.cpp
+++ b/src/trackedit/trackeditmodule.cpp
@@ -40,7 +40,6 @@
 #include "view/deletebehaviorpanelmodel.h"
 #include "view/pastebehaviorpanelmodel.h"
 #include "view/tracknavigationmodel.h"
-#include "view/trackspectrogramsettingsmodel.h"
 #include "view/trackspectrogramsettingsdialogmodel.h"
 
 #include "internal/au3/au3trackeditproject.h"
@@ -86,7 +85,6 @@ void TrackeditModule::registerUiTypes()
     qmlRegisterType<DeleteBehaviorPanelModel>("Audacity.TrackEdit", 1, 0, "DeleteBehaviorPanelModel");
     qmlRegisterType<PasteBehaviorPanelModel>("Audacity.TrackEdit", 1, 0, "PasteBehaviorPanelModel");
     qmlRegisterType<TrackNavigationModel>("Audacity.TrackEdit", 1, 0, "TrackNavigationModel");
-    qmlRegisterType<TrackSpectrogramSettingsModel>("Audacity.TrackEdit", 1, 0, "TrackSpectrogramSettingsModel");
     qmlRegisterType<TrackSpectrogramSettingsDialogModel>("Audacity.TrackEdit", 1, 0, "TrackSpectrogramSettingsDialogModel");
 }
 

--- a/src/trackedit/view/trackspectrogramsettingsdialogmodel.cpp
+++ b/src/trackedit/view/trackspectrogramsettingsdialogmodel.cpp
@@ -1,0 +1,33 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+#include "trackspectrogramsettingsdialogmodel.h"
+
+namespace au::trackedit {
+TrackSpectrogramSettingsDialogModel::TrackSpectrogramSettingsDialogModel(QObject* parent)
+    : QObject(parent), muse::Injectable(muse::iocCtxForQmlObject(this))
+{
+}
+
+void TrackSpectrogramSettingsDialogModel::setTrackId(int value)
+{
+    if (m_trackId == value) {
+        return;
+    }
+    m_trackId = value;
+    emit trackIdChanged();
+}
+
+void TrackSpectrogramSettingsDialogModel::requestSpectrogramUpdate()
+{
+    const ITrackeditProjectPtr project = globalContext()->currentTrackeditProject();
+    IF_ASSERT_FAILED(project) {
+        return;
+    }
+    const auto track = project->track(m_trackId);
+    IF_ASSERT_FAILED(track) {
+        return;
+    }
+    project->notifyAboutTrackChanged(*track);
+}
+}

--- a/src/trackedit/view/trackspectrogramsettingsdialogmodel.h
+++ b/src/trackedit/view/trackspectrogramsettingsdialogmodel.h
@@ -1,0 +1,35 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+#pragma once
+
+#include "context/iglobalcontext.h"
+
+#include "framework/global/modularity/ioc.h"
+
+#include <QObject>
+
+namespace au::trackedit {
+class TrackSpectrogramSettingsDialogModel : public QObject, public muse::Injectable
+{
+    Q_OBJECT
+
+    Q_PROPERTY(int trackId READ trackId WRITE setTrackId NOTIFY trackIdChanged)
+
+    muse::Inject<au::context::IGlobalContext> globalContext { this };
+public:
+
+    TrackSpectrogramSettingsDialogModel(QObject* parent = nullptr);
+
+    int trackId() const { return m_trackId; }
+    void setTrackId(int value);
+
+    Q_INVOKABLE void requestSpectrogramUpdate();
+
+signals:
+    void trackIdChanged();
+
+private:
+    int m_trackId = -1;
+};
+}

--- a/src/trackedit/view/trackspectrogramsettingsmodel.cpp
+++ b/src/trackedit/view/trackspectrogramsettingsmodel.cpp
@@ -104,15 +104,6 @@ void TrackSpectrogramSettingsModel::setTrackId(int value)
     emit trackIdChanged();
 }
 
-QString TrackSpectrogramSettingsModel::trackTitle() const
-{
-    const ITrackeditProjectPtr project = globalContext()->currentTrackeditProject();
-    if (!project) {
-        return QString();
-    }
-    return QString::fromStdString(project->trackName(m_trackId).value_or(""));
-}
-
 bool TrackSpectrogramSettingsModel::useGlobalSettings() const
 {
     return m_trackConfig ? m_trackConfig->useGlobalSettings() : false;

--- a/src/trackedit/view/trackspectrogramsettingsmodel.h
+++ b/src/trackedit/view/trackspectrogramsettingsmodel.h
@@ -23,14 +23,14 @@ class TrackSpectrogramSettingsModel : public spectrogram::AbstractSpectrogramSet
 
     muse::GlobalInject<spectrogram::IGlobalSpectrogramConfiguration> globalSpectrogramConfiguration;
 
-    muse::Inject<au::context::IGlobalContext> globalContext { this };
     muse::Inject<spectrogram::ISpectrogramService> spectrogramService { this };
 
 public:
     TrackSpectrogramSettingsModel(QObject* parent = nullptr);
-    ~TrackSpectrogramSettingsModel() override;
+    ~TrackSpectrogramSettingsModel() override = default;
 
     Q_INVOKABLE void accept();
+    Q_INVOKABLE void aboutToDestroy();
 
     int trackId() const { return m_trackId; }
     void setTrackId(int value);
@@ -74,13 +74,13 @@ public:
 signals:
     void trackIdChanged();
     void useGlobalSettingsChanged();
+    void updateRequested();
 
 private:
     void classBegin() override {}
     void componentComplete() override;
 
     void onSettingChanged();
-    void sendRepaintRequest();
 
     int m_trackId = -1;
 

--- a/src/trackedit/view/trackspectrogramsettingsmodel.h
+++ b/src/trackedit/view/trackspectrogramsettingsmodel.h
@@ -19,7 +19,6 @@ class TrackSpectrogramSettingsModel : public spectrogram::AbstractSpectrogramSet
     Q_OBJECT
 
     Q_PROPERTY(int trackId READ trackId WRITE setTrackId NOTIFY trackIdChanged)
-    Q_PROPERTY(QString trackTitle READ trackTitle NOTIFY trackIdChanged)
     Q_PROPERTY(bool useGlobalSettings READ useGlobalSettings WRITE setUseGlobalSettings NOTIFY useGlobalSettingsChanged)
 
     muse::GlobalInject<spectrogram::IGlobalSpectrogramConfiguration> globalSpectrogramConfiguration;
@@ -35,8 +34,6 @@ public:
 
     int trackId() const { return m_trackId; }
     void setTrackId(int value);
-
-    QString trackTitle() const;
 
     bool useGlobalSettings() const;
     void setUseGlobalSettings(bool value);


### PR DESCRIPTION
Spectrogram vertical zooming with mouse wheel

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [x] Works for mono and stereo tracks in spectrogram and multi view
- [x] In multi view (on stereo track), resizing the left/right channels on the waveform view also resizes on spectrogram view
- [x] Zoom works for all spectrogram scale types (Linear, Mel, ...)
- [x] Autobot test cases have been run
