### PR TITLE
#10471: Gave audio.com "Skip" button.

### DIFF
--- a/src/appshell/qml/Audacity/AppShell/FirstLaunchSetup/firstlaunchsetupmodel.cpp
+++ b/src/appshell/qml/Audacity/AppShell/FirstLaunchSetup/firstlaunchsetupmodel.cpp
@@ -25,11 +25,11 @@
 #include "global/async/async.h"
 
 namespace {
-const char * THEMES_PAGE = "ThemesPage.qml";
-const char * CLIP_VISUALIZATION_PAGE = "ClipVisualizationPage.qml";
-const char * WORKSPACE_LAYOUT_PAGE = "WorkspaceLayoutPage.qml";
-const char * SIGNIN_AUDIO_COM_PAGE = "SigninAudiocomPage.qml";
-const char * APP_UPDATES_AND_USAGE_INFO_PAGE = "AppUpdatesAndUsageInfoPage.qml";
+const char* THEMES_PAGE = "ThemesPage.qml";
+const char* CLIP_VISUALIZATION_PAGE = "ClipVisualizationPage.qml";
+const char* WORKSPACE_LAYOUT_PAGE = "WorkspaceLayoutPage.qml";
+const char* SIGNIN_AUDIO_COM_PAGE = "SigninAudiocomPage.qml";
+const char* APP_UPDATES_AND_USAGE_INFO_PAGE = "AppUpdatesAndUsageInfoPage.qml";
 }
 
 using namespace muse;


### PR DESCRIPTION
Resolves: #10471

Changed audio.com sign-in page to say "Skip" instead of next, as per the issue raised.
Possibly needs a "Continue" label when sign-in is successful, but I am unable to add that at this time as none of the sign-in options were functioning.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Autobot test cases have been run
