### PR TITLE
Share audio context brought in line with "Get Effects" and "Audio Setup" buttons

### DIFF
--- a/src/project/internal/projectuiactions.cpp
+++ b/src/project/internal/projectuiactions.cpp
@@ -744,8 +744,8 @@ const UiActionList ProjectUiActions::m_actions = {
              IconCode::Code::CLOUD_FILE
              ),
     UiAction("file-share-audio",
-             au::context::UiCtxAny,
-             au::context::CTX_ANY,
+             au::context::UiCtxProjectOpened,
+             au::context::CTX_PROJECT_FOCUSED,
              TranslatableString("action", "Share audio"),
              TranslatableString("action", "Share audio"),
              IconCode::Code::SHARE_AUDIO


### PR DESCRIPTION
Resolves: #10479 

"Share Audio" button context updated to project opened & focused context, disabling it with the rest of the nearby buttons when "Get Effects" is open, preferences, etc.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Autobot test cases have been run
