### PR TITLE
Fix multiple crashes in track operations and context menus

### DIFF
--- a/src/automation/view/clipgainmodel.cpp
+++ b/src/automation/view/clipgainmodel.cpp
@@ -163,6 +163,13 @@ void ClipGainModel::reload()
 
     m_clipStartTime = clipsInteraction()->clipStartTime(m_clipKey.key);
     m_clipEndTime   = clipsInteraction()->clipEndTime(m_clipKey.key);
+
+    // Track/clip may have been deleted (e.g. after track removal + history notify)
+    if (m_clipStartTime < 0 || m_clipEndTime < 0) {
+        clear();
+        return;
+    }
+
     emit clipTimeChanged();
 
     auto points = clipGainInteraction()->clipGainPoints(m_clipKey.key);

--- a/src/projectscene/view/trackspanel/trackcontextmenumodel.cpp
+++ b/src/projectscene/view/trackspanel/trackcontextmenumodel.cpp
@@ -48,6 +48,9 @@ muse::actions::ActionQuery makeTrackRateChangeAction(uint64_t rate)
 MenuItem* TrackContextMenuModel::makeItemWithArg(const ActionCode& actionCode)
 {
     MenuItem* item = makeMenuItem(actionCode);
+    if (!item) {
+        return nullptr;
+    }
     item->setArgs(ActionData::make_arg1<trackedit::TrackId>(m_trackId));
     return item;
 }

--- a/src/trackedit/internal/trackeditactionscontroller.cpp
+++ b/src/trackedit/internal/trackeditactionscontroller.cpp
@@ -363,7 +363,11 @@ bool TrackeditActionsController::isFocusedItemClip() const
     }
 
     const ITrackeditProjectPtr prj = globalContext()->currentTrackeditProject();
-    return prj ? prj->track(focusedItemKey.trackId)->type != TrackType::Label : false;
+    if (!prj) {
+        return false;
+    }
+    auto t = prj->track(focusedItemKey.trackId);
+    return t ? t->type != TrackType::Label : false;
 }
 
 ClipKeyList TrackeditActionsController::clipsForInteraction() const
@@ -388,7 +392,11 @@ bool TrackeditActionsController::isFocusedItemLabel() const
     }
 
     const ITrackeditProjectPtr prj = globalContext()->currentTrackeditProject();
-    return prj ? prj->track(focusedItemKey.trackId)->type == TrackType::Label : false;
+    if (!prj) {
+        return false;
+    }
+    auto t = prj->track(focusedItemKey.trackId);
+    return t ? t->type == TrackType::Label : false;
 }
 
 LabelKeyList TrackeditActionsController::labelsForInteraction() const


### PR DESCRIPTION
## Summary

- **Fix crash on track deletion in ClipGainModel::reload()**: Fatal `IF_ASSERT_FAILED` when accessing a deleted track's clip times. Replace with graceful null checks since a missing track after deletion is expected.
- **Fix null MenuItem crash in track context menu submenus**: `makeMenuItem()` returns nullptr for unregistered actions, causing Qt to crash when creating QML delegates for null QObject* data. Add null filtering in `AbstractMenuModel::makeMenu()` and `setItems()`.
- **Fix crash in isFocusedItemClip/Label when track no longer exists**: Dereferenced an empty `std::optional<Track>` when the focused track was deleted during project compaction on close.

## Test plan

- [ ] Delete a wave track that has clip gain automation — should not crash
- [ ] Right-click wave track → hover submenus (Track Color, Format, Rate) — should not crash on null items
- [ ] Close a project with unsaved changes (click Don't Save) — should not crash