### PR TITLE
10365 Fix color check context menu

### DIFF
--- a/src/projectscene/view/tracksitemsview/clipcontextmenumodel.cpp
+++ b/src/projectscene/view/tracksitemsview/clipcontextmenumodel.cpp
@@ -124,7 +124,7 @@ void ClipContextMenuModel::updateColorCheckedState()
         ActionQuery query(action);
 
         if ((!clip.hasCustomColor && action == m_colorChangeActionCodeList.at(0))
-            || (clip.hasCustomColor && query.param("color").toString() == clip.color.toString())) {
+            || (clip.hasCustomColor && muse::draw::Color::fromString(query.param("color").toString()) == clip.color)) {
             auto state = item.state();
             state.checked = true;
             item.setState(state);

--- a/src/projectscene/view/tracksitemsview/clipcontextmenumodel.cpp
+++ b/src/projectscene/view/tracksitemsview/clipcontextmenumodel.cpp
@@ -57,6 +57,15 @@ void ClipContextMenuModel::load()
         makeItemWithArg("clip-render-pitch-speed"),
     };
 
+    trackedit::ITrackeditProjectPtr prj = globalContext()->currentTrackeditProject();
+    if (prj) {
+        prj->clipList(m_clipKey.trackId()).onItemChanged(this, [this](const trackedit::Clip& clip) {
+            if (clip.key == m_clipKey.key) {
+                load();
+            }
+        }, muse::async::Asyncable::Mode::SetReplace);
+    }
+
     setItems(items);
 
     updateColorCheckedState();

--- a/src/projectscene/view/trackspanel/trackcontextmenumodel.cpp
+++ b/src/projectscene/view/trackspanel/trackcontextmenumodel.cpp
@@ -270,9 +270,8 @@ void TrackContextMenuModel::updateColorCheckedState()
     for (const auto& action : m_colorChangeActionCodeList) {
         MenuItem& item = findItem(ActionCode(action));
         ActionQuery query(action);
-        track.value().color.toString();
 
-        if (query.param("color").toString() == track.value().color.toString()) {
+        if (muse::draw::Color::fromString(query.param("color").toString()) == track.value().color) {
             auto state = item.state();
             state.checked = true;
             item.setState(state);

--- a/src/trackedit/internal/trackeditactionscontroller.cpp
+++ b/src/trackedit/internal/trackeditactionscontroller.cpp
@@ -1711,7 +1711,7 @@ void TrackeditActionsController::moveCursorToClosestZeroCrossing()
 void TrackeditActionsController::setClipColor(const muse::actions::ActionQuery& q)
 {
     auto selectedClips = clipsForInteraction();
-    if (!selectedClips.empty()) {
+    if (selectedClips.empty()) {
         return;
     }
 


### PR DESCRIPTION
Resolves: #10365 

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Autobot test cases have been run
