### PR TITLE
Avoid assert on debug mode when removing a clip

### DIFF
--- a/src/automation/view/clipgainmodel.cpp
+++ b/src/automation/view/clipgainmodel.cpp
@@ -10,7 +10,7 @@ using namespace au::projectscene;
 
 ClipGainModel::ClipGainModel(QObject* parent)
     : QAbstractListModel(parent)
-    , muse::Injectable(muse::modularity::ContextPtr())
+    , muse::Injectable(muse::iocCtxForQmlObject(this))
 {
 }
 
@@ -139,6 +139,18 @@ void ClipGainModel::setClipKey(const ClipKey& key)
     }
 
     m_clipKey = key;
+
+    if (m_clipKey.isValid()) {
+        if (auto prj = globalContext()->currentTrackeditProject()) {
+            prj->clipList(m_clipKey.key.trackId).onItemRemoved(this, [this](const trackedit::Clip& clip) {
+                if (clip.key == m_clipKey.key) {
+                    clear();
+                    m_clipKey = ClipKey {};
+                }
+            }, muse::async::Asyncable::Mode::SetReplace);
+        }
+    }
+
     reload();
 }
 

--- a/src/automation/view/clipgainmodel.h
+++ b/src/automation/view/clipgainmodel.h
@@ -11,6 +11,7 @@
 #include "async/asyncable.h"
 
 #include "modularity/ioc.h"
+#include "context/iglobalcontext.h"
 #include "automation/iclipgaininteraction.h"
 #include "trackedit/iclipsinteraction.h"
 #include "trackedit/iprojecthistory.h"
@@ -26,6 +27,7 @@ class ClipGainModel : public QAbstractListModel, public muse::async::Asyncable, 
     muse::Inject<IClipGainInteraction> clipGainInteraction{ this };
     muse::Inject<trackedit::IClipsInteraction> clipsInteraction{ this };
     muse::Inject<trackedit::IProjectHistory> projectHistory{ this };
+    muse::Inject<context::IGlobalContext> globalContext{ this };
 
     Q_PROPERTY(projectscene::ClipKey clipKey READ clipKey WRITE setClipKey NOTIFY clipKeyChanged FINAL)
 

--- a/src/trackedit/internal/au3/au3clipsinteraction.cpp
+++ b/src/trackedit/internal/au3/au3clipsinteraction.cpp
@@ -384,6 +384,7 @@ bool Au3ClipsInteraction::removeClips(const ClipKeyList& clipKeyList, bool moveC
         waveTrack->Clear(clip->Start(), clip->End(), moveClips);
 
         trackedit::ITrackeditProjectPtr prj = globalContext()->currentTrackeditProject();
+        prj->notifyAboutClipRemoved(DomConverter::clip(waveTrack, clip.get()));
         prj->notifyAboutTrackChanged(DomConverter::track(waveTrack));
     }
 


### PR DESCRIPTION
Resolves: *(direct link to the issue)*

When removing a clip, history changed is called on ClipGainModel triggering reload.
It tries to access data from the removed clip and crashes on debug mode.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Autobot test cases have been run
