### PR TITLE
extract plugin registration self-test into separate CI jobs

### DIFF
--- a/.github/workflows/au4_build_linux.yml
+++ b/.github/workflows/au4_build_linux.yml
@@ -217,3 +217,9 @@ jobs:
         find ./build.install/bin/ -type f -exec chmod +x {} +
         APP_BIN=$(find "./build.install/bin/" -type f -name "audacity4portable*" -print -quit)
         QT_QPA_PLATFORM=minimal:enable_fonts "$APP_BIN" --plugin-registration-self-test
+
+    - name: Delete self-test artifact
+      if: always()
+      uses: geekyeggo/delete-artifact@176a747ab7e287e3ff4787bf8a148716375ca118 # v6.0.0
+      with:
+        name: selftest-build-linux

--- a/.github/workflows/au4_build_macos.yml
+++ b/.github/workflows/au4_build_macos.yml
@@ -229,3 +229,9 @@ jobs:
       run: |
         chmod +x ./build.install/audacity.app/Contents/MacOS/audacity
         ./build.install/audacity.app/Contents/MacOS/audacity --plugin-registration-self-test
+
+    - name: Delete self-test artifact
+      if: always()
+      uses: geekyeggo/delete-artifact@176a747ab7e287e3ff4787bf8a148716375ca118 # v6.0.0
+      with:
+        name: selftest-build-macos

--- a/.github/workflows/au4_build_windows.yml
+++ b/.github/workflows/au4_build_windows.yml
@@ -213,3 +213,9 @@ jobs:
       shell: bash
       run: |
         ./build.install/bin/Audacity4.exe --plugin-registration-self-test
+
+    - name: Delete self-test artifact
+      if: always()
+      uses: geekyeggo/delete-artifact@176a747ab7e287e3ff4787bf8a148716375ca118 # v6.0.0
+      with:
+        name: selftest-build-windows


### PR DESCRIPTION
Resolves: extract plugin registration self-test into separate CI jobs

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [ ] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Autobot test cases have been run
