### PR TITLE
Replace trim icons

### DIFF
--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/ClipHandles.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/ClipHandles.qml
@@ -72,11 +72,10 @@ Item {
             id: leftArrow
             anchors.verticalCenter: leftTrimHandle.verticalCenter
             anchors.left: leftTrimHandle.left
-            // specific icon pivot
-            anchors.leftMargin: -5
+            anchors.leftMargin: 2
 
-            iconCode: IconCode.SMALL_ARROW_LEFT
-            font.pixelSize: 30
+            iconCode: IconCode.TRIM_HANDLE_LEFT
+            font.pixelSize: 17
             color: ui.theme.extra["black_color"]
             style: Text.Outline
             styleColor: ui.theme.extra["white_color"]
@@ -217,11 +216,10 @@ Item {
             id: rightArrow
             anchors.verticalCenter: rightTrimHandle.verticalCenter
             anchors.right: rightTrimHandle.right
-            // specific icon pivot
-            anchors.rightMargin: -5
+            anchors.rightMargin: 2
 
-            iconCode: IconCode.SMALL_ARROW_RIGHT
-            font.pixelSize: 30
+            iconCode: IconCode.TRIM_HANDLE_RIGHT
+            font.pixelSize: 17
             color: ui.theme.extra["black_color"]
             style: Text.Outline
             styleColor: ui.theme.extra["white_color"]
@@ -671,11 +669,11 @@ Item {
             when: leftTrimMa.containsMouse
             PropertyChanges {
                 target: leftArrow
-                font.pixelSize: 40
+                font.pixelSize: 22
             }
             PropertyChanges {
                 target: leftArrow
-                anchors.leftMargin: -10
+                anchors.leftMargin: -1
             }
         },
         State {
@@ -683,11 +681,11 @@ Item {
             when: rightTrimMa.containsMouse
             PropertyChanges {
                 target: rightArrow
-                font.pixelSize: 40
+                font.pixelSize: 22
             }
             PropertyChanges {
                 target: rightArrow
-                anchors.rightMargin: -10
+                anchors.rightMargin: -1
             }
         },
         State {


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/9521
Depends on: https://github.com/musescore/MuseScore/pull/32794

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Autobot test cases have been run
- [ ] Verify that icon is replaced, with proper size, and with animation on hover
