### PR TITLE
Change FFmpeg location in the warning message

### DIFF
--- a/au3/modules/import-export/mod-ffmpeg/ExportFFmpeg.cpp
+++ b/au3/modules/import-export/mod-ffmpeg/ExportFFmpeg.cpp
@@ -1383,7 +1383,7 @@ bool FFmpegExportProcessor::Initialize(AudacityProject& project,
     context.t1 = t1;
 
     if (!FFmpegFunctions::Load()) {
-        throw ExportException(_("Properly configured FFmpeg is required to proceed.\nYou can configure it at Preferences > Libraries."));
+        throw ExportException(_("Properly configured FFmpeg is required to proceed.\nYou can configure it at Preferences > General."));
     }
     // subformat index may not correspond directly to fmts[] index, convert it
     const auto adjustedFormatIndex = AdjustFormatIndex(context.subformat);


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/10586

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated error message guidance for FFmpeg export to direct users to the correct preference location when library loading fails, improving user experience and reducing confusion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->