### PR TITLE
10195 download audio from audiocom

### DIFF
--- a/au3/libraries/au3-cloud-audiocom/CloudSyncService.cpp
+++ b/au3/libraries/au3-cloud-audiocom/CloudSyncService.cpp
@@ -887,9 +887,9 @@ void CloudSyncService::DownloadAudio(const std::string& name, const std::string&
             const auto statusCode = context && context->Cancelled()
                                     ? DownloadAudioResult::StatusCode::Cancelled
                                     : DownloadAudioResult::StatusCode::Failed;
-            mDownloadInProcess.store(false);
             BasicUI::CallAfter([this, statusCode] {
                 mDownloadAudioPromise.set_value({ statusCode, {}, {} });
+                mDownloadInProcess.store(false);
             });
 
             return;

--- a/au3/libraries/au3-cloud-audiocom/CloudSyncService.cpp
+++ b/au3/libraries/au3-cloud-audiocom/CloudSyncService.cpp
@@ -41,6 +41,7 @@
 #include "au3-network-manager/NetworkManager.h"
 #include "au3-network-manager/Request.h"
 
+#include "au3-concurrency/concurrency/CancellationContext.h"
 namespace audacity::cloud::audiocom {
 namespace {
 std::mutex& GetResponsesMutex()
@@ -73,7 +74,9 @@ void RemovePendingRequest(audacity::network_manager::IResponse* request)
 
 void PerformProjectGetRequest(
     OAuthService& oAuthService, std::string url,
-    std::function<void(ResponseResult)> dataCallback)
+    std::function<void(ResponseResult)> dataCallback,
+    sync::ProgressCallback progressCallback = nullptr,
+    concurrency::CancellationContextPtr context = nullptr)
 {
     assert(oAuthService.HasAccessToken());
 
@@ -97,14 +100,31 @@ void PerformProjectGetRequest(
 
     auto response = NetworkManager::GetInstance().doGet(request);
 
+    if (context) {
+        context->OnCancelled(response);
+
+        if (progressCallback) {
+            response->setDownloadProgressCallback([context, progressCallback] (int64_t current, int64_t expected) {
+                if (!progressCallback(static_cast<double>(current) / expected)) {
+                    context->Cancel();
+                }
+            });
+        }
+    }
+
     response->setRequestFinishedCallback(
-        [dataCallback = std::move(dataCallback)](auto response)
+        [dataCallback = std::move(dataCallback), context](auto response)
     {
         BasicUI::CallAfter(
-            [dataCallback = std::move(dataCallback), response]
+            [dataCallback = std::move(dataCallback), response, context]
         {
             auto removeRequest
                 =finally([response] { RemovePendingRequest(response); });
+
+            if (context && context->Cancelled()) {
+                dataCallback({ SyncResultCode::Cancelled });
+                return;
+            }
 
             dataCallback(GetResponseResult(*response, true));
         });
@@ -667,7 +687,9 @@ void CloudSyncService::ReportUploadStats(
 void GetAudioInfo(
     OAuthService& oAuthService, const ServiceConfig& serviceConfig,
     std::string audioId,
-    std::function<void(sync::CloudAudioFullInfo, ResponseResult)> callback)
+    std::function<void(sync::CloudAudioFullInfo, ResponseResult)> callback,
+    sync::ProgressCallback progressCallback = nullptr,
+    concurrency::CancellationContextPtr context = nullptr)
 {
     assert(callback);
 
@@ -689,13 +711,15 @@ void GetAudioInfo(
         }
 
         callback(std::move(*audioInfo), std::move(result));
-    });
+    }, progressCallback, std::move(context));
 }
 
 void GetAudioDownloadInfo(
     OAuthService& oAuthService, const ServiceConfig& serviceConfig,
     std::string audioId,
-    std::function<void(sync::CloudAudioDownloadInfo, ResponseResult)> callback)
+    std::function<void(sync::CloudAudioDownloadInfo, ResponseResult)> callback,
+    sync::ProgressCallback progressCallback = nullptr,
+    concurrency::CancellationContextPtr context = nullptr)
 {
     assert(callback);
 
@@ -717,7 +741,7 @@ void GetAudioDownloadInfo(
         }
 
         callback(std::move(*downloadInfo), std::move(result));
-    });
+    }, progressCallback, std::move(context));
 }
 
 CloudSyncService::GetAudioInfoFuture GetAudioInfo(
@@ -821,7 +845,8 @@ CloudSyncService::GetAudioListFuture CloudSyncService::GetAudioList(
     return promise->get_future();
 }
 
-void CloudSyncService::DownloadAudio(const std::string& name, const std::string& format, const std::string& url)
+void CloudSyncService::DownloadAudio(const std::string& name, const std::string& format, const std::string& url,
+                                     concurrency::CancellationContextPtr context)
 {
     using namespace audacity::network_manager;
     using namespace sync;
@@ -829,25 +854,26 @@ void CloudSyncService::DownloadAudio(const std::string& name, const std::string&
     const Request request(url);
     auto response = NetworkManager::GetInstance().doGet(request);
 
+    if (context) {
+        context->OnCancelled(response);
+    }
+
     const auto filename = sync::MakeSafeFilePath(wxFileName::GetTempDir(), audacity::ToWXString(name), format);
     auto audioFile = std::make_shared<std::ofstream>(filename.ToStdString(), std::ios::binary);
 
-    response->setRequestFinishedCallback([response, this, filename, name, format, audioFile]
+    response->setRequestFinishedCallback([response, this, filename, name, format, audioFile, context]
                                          (IResponse*) {
         if (audioFile && audioFile->is_open()) {
             audioFile->close();
         }
 
         if (response->getError() != NetworkError::NoError) {
-            BasicUI::CallAfter([this] {
-                ShowErrorDialog({},
-                                XC("Error importing cloud audio", "cloud sync"),
-                                XC("Can't download cloud audio", "update dialog"),
-                                wxString(),
-                                BasicUI::ErrorDialogOptions { BasicUI::ErrorDialogType::ModalErrorReport });
-
-                mDownloadInProcess.store(false);
-                mDownloadAudioPromise.set_value({ DownloadAudioResult::StatusCode::Failed, {}, {} });
+            const auto statusCode = context && context->Cancelled()
+                                    ? DownloadAudioResult::StatusCode::Cancelled
+                                    : DownloadAudioResult::StatusCode::Failed;
+            mDownloadInProcess.store(false);
+            BasicUI::CallAfter([this, statusCode] {
+                mDownloadAudioPromise.set_value({ statusCode, {}, {} });
             });
 
             return;
@@ -867,7 +893,7 @@ void CloudSyncService::DownloadAudio(const std::string& name, const std::string&
                                          );
 
     // Called each time, since downloading for update progress status.
-    response->setDownloadProgressCallback([this]
+    response->setDownloadProgressCallback([this, context]
                                           (int64_t current, int64_t expected) {
         mDownloadProgress.store(static_cast<double>(current) / expected);
 
@@ -875,8 +901,14 @@ void CloudSyncService::DownloadAudio(const std::string& name, const std::string&
             return;
         }
 
-        BasicUI::CallAfter([this] {
-            mProgressCallback(mDownloadProgress.load());
+        BasicUI::CallAfter([this, context] {
+            if (mProgressCallback) {
+                if (!mProgressCallback(mDownloadProgress.load())) {
+                    if (context) {
+                        context->Cancel();
+                    }
+                }
+            }
             mAudioProgressUpdateQueued.store(false);
         });
     }
@@ -900,7 +932,8 @@ void CloudSyncService::DownloadAudio(const std::string& name, const std::string&
 
 CloudSyncService::DownloadAudioFuture CloudSyncService::DownloadCloudAudio(
     std::string_view audioId,
-    sync::ProgressCallback callback)
+    sync::ProgressCallback callback,
+    concurrency::CancellationContextPtr context)
 {
     if (mDownloadInProcess.exchange(true)) {
         auto blockedPromise = DownloadAudioPromise {};
@@ -927,12 +960,15 @@ CloudSyncService::DownloadAudioFuture CloudSyncService::DownloadCloudAudio(
     }
 
     GetAudioInfo(GetOAuthService(), GetServiceConfig(), std::string(audioId),
-                 [this](sync::CloudAudioFullInfo audioInfo, ResponseResult result)
+                 [this, context](sync::CloudAudioFullInfo audioInfo, ResponseResult result)
     {
         if (result.Code != SyncResultCode::Success) {
             mDownloadInProcess.store(false);
+            const auto statusCode = context && context->Cancelled()
+                                    ? sync::DownloadAudioResult::StatusCode::Cancelled
+                                    : sync::DownloadAudioResult::StatusCode::Failed;
             mDownloadAudioPromise.set_value(
-                { sync::DownloadAudioResult::StatusCode::Failed,
+                { statusCode,
                   std::move(result),
                   {} });
             return;
@@ -948,12 +984,15 @@ CloudSyncService::DownloadAudioFuture CloudSyncService::DownloadCloudAudio(
         }
 
         GetAudioDownloadInfo(GetOAuthService(), GetServiceConfig(), audioInfo.Id,
-                             [this, audioInfo](sync::CloudAudioDownloadInfo downloadInfo, ResponseResult result)
+                             [this, audioInfo, context](sync::CloudAudioDownloadInfo downloadInfo, ResponseResult result)
         {
             if (result.Code != SyncResultCode::Success) {
                 mDownloadInProcess.store(false);
+                const auto statusCode = context && context->Cancelled()
+                                        ? sync::DownloadAudioResult::StatusCode::Cancelled
+                                        : sync::DownloadAudioResult::StatusCode::Failed;
                 mDownloadAudioPromise.set_value(
-                    { sync::DownloadAudioResult::StatusCode::Failed,
+                    { statusCode,
                       std::move(result),
                       {} });
             } else {
@@ -976,12 +1015,12 @@ CloudSyncService::DownloadAudioFuture CloudSyncService::DownloadCloudAudio(
                 if (item == downloadInfo.Items.end()) {
                     item = downloadInfo.Items.begin();
                 }
-                DownloadAudio(audioInfo.Title, item->Format, item->Url);
+                DownloadAudio(audioInfo.Title, item->Format, item->Url, context);
             }
-        }
-                             );
-    }
-                 );
+            //The "real" progress is tracked in DownloadAudio
+            // but we need to update the progress to receive cancellation information
+        }, [this](double) { return mProgressCallback(0.0); }, context);
+    }, [this](double) { return mProgressCallback(0.0); }, context);
 
     return mDownloadAudioPromise.get_future();
 }

--- a/au3/libraries/au3-cloud-audiocom/CloudSyncService.cpp
+++ b/au3/libraries/au3-cloud-audiocom/CloudSyncService.cpp
@@ -105,7 +105,8 @@ void PerformProjectGetRequest(
 
         if (progressCallback) {
             response->setDownloadProgressCallback([context, progressCallback] (int64_t current, int64_t expected) {
-                if (!progressCallback(static_cast<double>(current) / expected)) {
+                const double progress = expected > 0 ? static_cast<double>(current) / expected : 0.0;
+                if (!progressCallback(progress)) {
                     context->Cancel();
                 }
             });
@@ -910,7 +911,8 @@ void CloudSyncService::DownloadAudio(const std::string& name, const std::string&
     // Called each time, since downloading for update progress status.
     response->setDownloadProgressCallback([this, context]
                                           (int64_t current, int64_t expected) {
-        mDownloadProgress.store(static_cast<double>(current) / expected);
+        const double progress = expected > 0 ? static_cast<double>(current) / expected : 0.0;
+        mDownloadProgress.store(progress);
 
         if (mAudioProgressUpdateQueued.exchange(true)) {
             return;

--- a/au3/libraries/au3-cloud-audiocom/CloudSyncService.cpp
+++ b/au3/libraries/au3-cloud-audiocom/CloudSyncService.cpp
@@ -902,8 +902,6 @@ CloudSyncService::DownloadAudioFuture CloudSyncService::DownloadCloudAudio(
     std::string_view audioId,
     sync::ProgressCallback callback)
 {
-    ASSERT_MAIN_THREAD();
-
     mDownloadAudioPromise = {};
 
     if (mDownloadInProcess.exchange(true)) {

--- a/au3/libraries/au3-cloud-audiocom/CloudSyncService.cpp
+++ b/au3/libraries/au3-cloud-audiocom/CloudSyncService.cpp
@@ -137,7 +137,9 @@ void PerformProjectGetRequest(
 void GetProjectInfo(
     OAuthService& oAuthService, const ServiceConfig& serviceConfig,
     std::string projectId,
-    std::function<void(sync::ProjectInfo, ResponseResult)> callback)
+    std::function<void(sync::ProjectInfo, ResponseResult)> callback,
+    sync::ProgressCallback progressCallback = nullptr,
+    concurrency::CancellationContextPtr context = nullptr)
 {
     assert(callback);
 
@@ -160,13 +162,15 @@ void GetProjectInfo(
         }
 
         callback(std::move(*projectInfo), std::move(result));
-    });
+    }, progressCallback, std::move(context));
 }
 
 void GetSnapshotInfo(
     OAuthService& oAuthService, const ServiceConfig& serviceConfig,
     std::string projectId, std::string snapshotId,
-    std::function<void(sync::SnapshotInfo, ResponseResult result)> callback)
+    std::function<void(sync::SnapshotInfo, ResponseResult result)> callback,
+    sync::ProgressCallback progressCallback = nullptr,
+    concurrency::CancellationContextPtr context = nullptr)
 {
     assert(callback);
 
@@ -189,7 +193,7 @@ void GetSnapshotInfo(
         }
 
         callback(std::move(*snapshotInfo), std::move(result));
-    });
+    }, progressCallback, std::move(context));
 }
 
 void GetSnapshotInfo(
@@ -197,7 +201,9 @@ void GetSnapshotInfo(
     std::string projectId, std::string snapshotId,
     std::function<
         void(sync::ProjectInfo, sync::SnapshotInfo, ResponseResult result)>
-    callback)
+    callback,
+    sync::ProgressCallback progressCallback = nullptr,
+    concurrency::CancellationContextPtr context = nullptr)
 {
     assert(callback);
 
@@ -205,7 +211,7 @@ void GetSnapshotInfo(
         oAuthService, serviceConfig, projectId,
         [callback   = std::move(callback), projectId,
          snapshotId = std::move(snapshotId), &oAuthService,
-         &serviceConfig](sync::ProjectInfo projectInfo, ResponseResult result)
+         &serviceConfig, progressCallback, context](sync::ProjectInfo projectInfo, ResponseResult result)
     {
         if (result.Code != SyncResultCode::Success) {
             callback({}, {}, std::move(result));
@@ -234,8 +240,8 @@ void GetSnapshotInfo(
             callback(
                 std::move(projectInfo), std::move(snapshotInfo),
                 std::move(result));
-        });
-    });
+        }, progressCallback, context);
+    }, progressCallback, context);
 }
 
 bool HasAutosave(const std::string& path)
@@ -357,7 +363,8 @@ CloudSyncService::GetProjectsFuture CloudSyncService::GetProjects(
 
 CloudSyncService::SyncFuture CloudSyncService::OpenFromCloud(
     std::string projectId, std::string snapshotId, SyncMode mode,
-    sync::ProgressCallback callback)
+    sync::ProgressCallback callback,
+    concurrency::CancellationContextPtr context)
 {
     if (mSyncInProcess.exchange(true)) {
         auto blockedPromise = SyncPromise {};
@@ -382,16 +389,20 @@ CloudSyncService::SyncFuture CloudSyncService::OpenFromCloud(
 
     GetSnapshotInfo(
         GetOAuthService(), GetServiceConfig(), projectId, snapshotId,
-        [this, mode](
+        [this, mode, context](
             sync::ProjectInfo projectInfo, sync::SnapshotInfo snapshotInfo,
             ResponseResult result)
     {
         if (result.Code != SyncResultCode::Success) {
-            FailSync(std::move(result));
+            if (context && context->Cancelled()) {
+                CompleteSync({ sync::ProjectSyncResult::StatusCode::Cancelled, {}, {} });
+            } else {
+                FailSync(std::move(result));
+            }
         } else {
             SyncCloudSnapshot(projectInfo, snapshotInfo, mode);
         }
-    });
+    }, [this](double) { return mProgressCallback(0.0); }, context);
 
     return mSyncPromise.get_future();
 }
@@ -494,7 +505,9 @@ CloudSyncService::GetProjectState(const std::string& projectId)
 }
 
 CloudSyncService::GetHeadSnapshotIDFuture
-CloudSyncService::GetHeadSnapshotID(std::string_view projectId)
+CloudSyncService::GetHeadSnapshotID(
+    std::string_view projectId, sync::ProgressCallback progressCallback,
+    concurrency::CancellationContextPtr context)
 {
     auto promise = std::make_shared<GetHeadSnapshotIDPromise>();
 
@@ -508,7 +521,7 @@ CloudSyncService::GetHeadSnapshotID(std::string_view projectId)
         } else {
             promise->set_value({ projectInfo.HeadSnapshot.Id });
         }
-    });
+    }, progressCallback, std::move(context));
 
     return promise->get_future();
 }
@@ -623,12 +636,14 @@ void CloudSyncService::SyncCloudSnapshot(
             / (state.BlocksTotal + 1.0));
 
         if (state.IsComplete()) {
-            const bool success = state.Result.Code == SyncResultCode::Success;
+            const auto statusCode
+                =state.Result.Code == SyncResultCode::Success
+                  ? sync::ProjectSyncResult::StatusCode::Succeeded
+                  : state.Result.Code == SyncResultCode::Cancelled
+                  ? sync::ProjectSyncResult::StatusCode::Cancelled
+                  : sync::ProjectSyncResult::StatusCode::Failed;
 
-            CompleteSync({ success
-                           ? sync::ProjectSyncResult::StatusCode::Succeeded
-                           : sync::ProjectSyncResult::StatusCode::Failed,
-                           std::move(state.Result), std::move(path) });
+            CompleteSync({ statusCode, std::move(state.Result), std::move(path) });
         }
     },
         mode == SyncMode::ForceNew);

--- a/au3/libraries/au3-cloud-audiocom/CloudSyncService.cpp
+++ b/au3/libraries/au3-cloud-audiocom/CloudSyncService.cpp
@@ -902,13 +902,15 @@ CloudSyncService::DownloadAudioFuture CloudSyncService::DownloadCloudAudio(
     std::string_view audioId,
     sync::ProgressCallback callback)
 {
-    mDownloadAudioPromise = {};
-
     if (mDownloadInProcess.exchange(true)) {
-        mDownloadAudioPromise.set_value(
+        auto blockedPromise = DownloadAudioPromise {};
+
+        blockedPromise.set_value(
             { sync::DownloadAudioResult::StatusCode::Blocked, {}, {} });
-        return mDownloadAudioPromise.get_future();
+        return blockedPromise.get_future();
     }
+
+    mDownloadAudioPromise = {};
 
     if (audioId.empty()) {
         mDownloadAudioPromise.set_value(

--- a/au3/libraries/au3-cloud-audiocom/CloudSyncService.h
+++ b/au3/libraries/au3-cloud-audiocom/CloudSyncService.h
@@ -57,6 +57,7 @@ struct DownloadAudioResult final
         Succeeded,
         Failed,
         Blocked,
+        Cancelled,
     };
 
     StatusCode Status { StatusCode::Failed };
@@ -126,7 +127,7 @@ public:
         concurrency::CancellationContextPtr context, int page, int pageSize, std::string_view searchString);
 
     [[nodiscard]] DownloadAudioFuture DownloadCloudAudio(
-        std::string_view audioId, sync::ProgressCallback callback);
+        std::string_view audioId, sync::ProgressCallback callback, concurrency::CancellationContextPtr context = nullptr);
 
     //! Open the project from the cloud. This operation is asynchronous.
     [[nodiscard]] SyncFuture OpenFromCloud(
@@ -157,7 +158,8 @@ private:
     void SyncCloudSnapshot(
         const sync::ProjectInfo& projectInfo, const sync::SnapshotInfo& snapshotInfo, SyncMode mode);
 
-    void DownloadAudio(const std::string& name, const std::string& format, const std::string& url);
+    void DownloadAudio(const std::string& name, const std::string& format, const std::string& url,
+                       concurrency::CancellationContextPtr context = nullptr);
 
     void UpdateDowloadProgress(double downloadProgress);
 

--- a/au3/libraries/au3-cloud-audiocom/CloudSyncService.h
+++ b/au3/libraries/au3-cloud-audiocom/CloudSyncService.h
@@ -42,6 +42,7 @@ struct ProjectSyncResult final
         Succeeded,
         Blocked,
         Failed,
+        Cancelled,
     };
 
     StatusCode Status { StatusCode::Failed };
@@ -131,7 +132,8 @@ public:
 
     //! Open the project from the cloud. This operation is asynchronous.
     [[nodiscard]] SyncFuture OpenFromCloud(
-        std::string projectId, std::string snapshotId, SyncMode mode, sync::ProgressCallback callback);
+        std::string projectId, std::string snapshotId, SyncMode mode, sync::ProgressCallback callback,
+        concurrency::CancellationContextPtr context = nullptr);
 
     [[nodiscard]] SyncFuture SyncProject(
         AudacityProject& project, const std::string& path, bool forceSync, sync::ProgressCallback callback);
@@ -146,7 +148,9 @@ public:
     };
     static ProjectState GetProjectState(const std::string& projectId);
 
-    GetHeadSnapshotIDFuture GetHeadSnapshotID(std::string_view projectId);
+    GetHeadSnapshotIDFuture GetHeadSnapshotID(
+        std::string_view projectId, sync::ProgressCallback progressCallback = nullptr,
+        concurrency::CancellationContextPtr context = nullptr);
 
 private:
     void FailSync(ResponseResult responseResult);

--- a/au3/libraries/au3-cloud-audiocom/sync/CloudSyncDTO.cpp
+++ b/au3/libraries/au3-cloud-audiocom/sync/CloudSyncDTO.cpp
@@ -269,6 +269,10 @@ bool Deserialize(const rapidjson::Value& value, ProjectInfo& projectInfo)
         return {};
     }
 
+    if (!Deserialize(value, "size", tempProject.Size)) {
+        return {};
+    }
+
     Deserialize(value, "head", tempProject.HeadSnapshot);
     Deserialize(
         value, "latest_synced_snapshot_id", tempProject.LastSyncedSnapshotId);

--- a/au3/libraries/au3-cloud-audiocom/sync/CloudSyncDTO.cpp
+++ b/au3/libraries/au3-cloud-audiocom/sync/CloudSyncDTO.cpp
@@ -468,6 +468,10 @@ bool Deserialize(const rapidjson::Value& value, CloudAudioInfo& audio)
         return {};
     }
 
+    if (value.HasMember("play") && value["play"].IsObject()) {
+        Deserialize(value["play"], "waveform", temp.WaveformUrl);
+    }
+
     audio = std::move(temp);
     return true;
 }

--- a/au3/libraries/au3-cloud-audiocom/sync/CloudSyncDTO.h
+++ b/au3/libraries/au3-cloud-audiocom/sync/CloudSyncDTO.h
@@ -143,6 +143,7 @@ struct CloudAudioInfo final
     std::string Slug;
     std::string Title;
     std::vector<std::string> Tags;
+    std::string WaveformUrl;
 
     int64_t FileSize {};
     int64_t Duration {};

--- a/au3/libraries/au3-cloud-audiocom/sync/CloudSyncDTO.h
+++ b/au3/libraries/au3-cloud-audiocom/sync/CloudSyncDTO.h
@@ -97,7 +97,7 @@ struct ProjectInfo final
     std::string Slug;
     std::string Name;
     std::string Details;
-    int64_t Size;
+    int64_t Size {};
 
     SnapshotInfo HeadSnapshot;
     std::string LastSyncedSnapshotId;

--- a/au3/libraries/au3-cloud-audiocom/sync/CloudSyncDTO.h
+++ b/au3/libraries/au3-cloud-audiocom/sync/CloudSyncDTO.h
@@ -97,6 +97,7 @@ struct ProjectInfo final
     std::string Slug;
     std::string Name;
     std::string Details;
+    int64_t Size;
 
     SnapshotInfo HeadSnapshot;
     std::string LastSyncedSnapshotId;

--- a/share/locale/audacity_en.ts
+++ b/share/locale/audacity_en.ts
@@ -17,285 +17,273 @@
 <context>
     <name>action</name>
     <message>
-        <location filename="../../src/appshell/internal/applicationuiactions.cpp" line="48"/>
-        <location filename="../../src/appshell/internal/applicationuiactions.cpp" line="49"/>
+        <location filename="../../src/appshell/internal/applicationuiactions.cpp" line="46"/>
+        <location filename="../../src/appshell/internal/applicationuiactions.cpp" line="47"/>
         <source>Exit</source>
         <translation type="unfinished">Exit</translation>
     </message>
     <message>
-        <location filename="../../src/appshell/internal/applicationuiactions.cpp" line="54"/>
+        <location filename="../../src/appshell/internal/applicationuiactions.cpp" line="52"/>
         <source>Restart</source>
         <translation type="unfinished">Restart</translation>
     </message>
     <message>
-        <location filename="../../src/appshell/internal/applicationuiactions.cpp" line="59"/>
+        <location filename="../../src/appshell/internal/applicationuiactions.cpp" line="57"/>
         <source>&amp;Full screen</source>
         <translation type="unfinished">&amp;Full screen</translation>
     </message>
     <message>
-        <location filename="../../src/appshell/internal/applicationuiactions.cpp" line="60"/>
+        <location filename="../../src/appshell/internal/applicationuiactions.cpp" line="58"/>
         <source>Full screen</source>
         <translation type="unfinished">Full screen</translation>
     </message>
     <message>
-        <location filename="../../src/appshell/internal/applicationuiactions.cpp" line="66"/>
         <source>&amp;About MuseScore…</source>
         <translation type="unfinished">&amp;About MuseScore…</translation>
     </message>
     <message>
-        <location filename="../../src/appshell/internal/applicationuiactions.cpp" line="71"/>
+        <location filename="../../src/appshell/internal/applicationuiactions.cpp" line="69"/>
         <source>About &amp;Qt…</source>
         <translation type="unfinished">About &amp;Qt…</translation>
     </message>
     <message>
-        <location filename="../../src/appshell/internal/applicationuiactions.cpp" line="76"/>
         <source>About &amp;MusicXML…</source>
         <translation type="unfinished">About &amp;MusicXML…</translation>
     </message>
     <message>
-        <location filename="../../src/appshell/internal/applicationuiactions.cpp" line="81"/>
+        <location filename="../../src/appshell/internal/applicationuiactions.cpp" line="74"/>
         <source>Online &amp;handbook</source>
         <translation type="unfinished">Online &amp;handbook</translation>
     </message>
     <message>
-        <location filename="../../src/appshell/internal/applicationuiactions.cpp" line="82"/>
+        <location filename="../../src/appshell/internal/applicationuiactions.cpp" line="75"/>
         <source>Open online handbook</source>
         <translation type="unfinished">Open online handbook</translation>
     </message>
     <message>
-        <location filename="../../src/appshell/internal/applicationuiactions.cpp" line="87"/>
+        <location filename="../../src/appshell/internal/applicationuiactions.cpp" line="80"/>
         <source>As&amp;k for help</source>
         <translation type="unfinished">As&amp;k for help</translation>
     </message>
     <message>
-        <location filename="../../src/appshell/internal/applicationuiactions.cpp" line="92"/>
+        <location filename="../../src/appshell/internal/applicationuiactions.cpp" line="85"/>
         <source>Revert to &amp;factory settings</source>
         <translation type="unfinished">Revert to &amp;factory settings</translation>
     </message>
     <message>
-        <location filename="../../src/appshell/internal/applicationuiactions.cpp" line="93"/>
+        <location filename="../../src/appshell/internal/applicationuiactions.cpp" line="86"/>
         <source>Revert to factory settings</source>
         <translation type="unfinished">Revert to factory settings</translation>
     </message>
     <message>
-        <location filename="../../src/appshell/internal/applicationuiactions.cpp" line="100"/>
+        <location filename="../../src/appshell/internal/applicationuiactions.cpp" line="93"/>
         <source>Restore the &amp;default layout</source>
         <translation type="unfinished">Restore the &amp;default layout</translation>
     </message>
     <message>
-        <location filename="../../src/appshell/internal/applicationuiactions.cpp" line="101"/>
+        <location filename="../../src/appshell/internal/applicationuiactions.cpp" line="94"/>
         <source>Restore the default layout</source>
         <translation type="unfinished">Restore the default layout</translation>
     </message>
     <message>
-        <location filename="../../src/appshell/internal/applicationuiactions.cpp" line="108"/>
+        <location filename="../../src/appshell/internal/applicationuiactions.cpp" line="101"/>
         <source>&amp;Playback controls</source>
         <translation type="unfinished">&amp;Playback controls</translation>
     </message>
     <message>
-        <location filename="../../src/appshell/internal/applicationuiactions.cpp" line="109"/>
+        <location filename="../../src/appshell/internal/applicationuiactions.cpp" line="102"/>
         <source>Show/hide playback controls</source>
         <translation type="unfinished">Show/hide playback controls</translation>
     </message>
     <message>
-        <location filename="../../src/appshell/internal/applicationuiactions.cpp" line="115"/>
         <source>&amp;Note input</source>
         <translation type="unfinished">&amp;Note input</translation>
     </message>
     <message>
-        <location filename="../../src/appshell/internal/applicationuiactions.cpp" line="116"/>
         <source>Show/hide note input toolbar</source>
         <translation type="unfinished">Show/hide note input toolbar</translation>
     </message>
     <message>
-        <location filename="../../src/appshell/internal/applicationuiactions.cpp" line="124"/>
+        <location filename="../../src/appshell/internal/applicationuiactions.cpp" line="109"/>
         <source>&amp;Tracks</source>
         <translation type="unfinished">&amp;Tracks</translation>
     </message>
     <message>
-        <location filename="../../src/appshell/internal/applicationuiactions.cpp" line="125"/>
+        <location filename="../../src/appshell/internal/applicationuiactions.cpp" line="110"/>
         <source>Show/hide tracks</source>
         <translation type="unfinished">Show/hide tracks</translation>
     </message>
     <message>
-        <location filename="../../src/appshell/internal/applicationuiactions.cpp" line="131"/>
         <source>Instr&amp;uments</source>
         <translation type="unfinished">Instr&amp;uments</translation>
     </message>
     <message>
-        <location filename="../../src/appshell/internal/applicationuiactions.cpp" line="132"/>
         <source>Open instruments dialog…</source>
         <translation type="unfinished">Open instruments dialog…</translation>
     </message>
     <message>
-        <location filename="../../src/appshell/internal/applicationuiactions.cpp" line="138"/>
         <source>Propert&amp;ies</source>
         <translation type="unfinished">Propert&amp;ies</translation>
     </message>
     <message>
-        <location filename="../../src/appshell/internal/applicationuiactions.cpp" line="139"/>
         <source>Show/hide properties</source>
         <translation type="unfinished">Show/hide properties</translation>
     </message>
     <message>
-        <location filename="../../src/appshell/internal/applicationuiactions.cpp" line="145"/>
         <source>Se&amp;lection filter</source>
         <translation type="unfinished">Se&amp;lection filter</translation>
     </message>
     <message>
-        <location filename="../../src/appshell/internal/applicationuiactions.cpp" line="146"/>
         <source>Show/hide selection filter</source>
         <translation type="unfinished">Show/hide selection filter</translation>
     </message>
     <message>
-        <location filename="../../src/appshell/internal/applicationuiactions.cpp" line="154"/>
         <source>&amp;Navigator</source>
         <translation type="unfinished">&amp;Navigator</translation>
     </message>
     <message>
-        <location filename="../../src/appshell/internal/applicationuiactions.cpp" line="155"/>
         <source>Show/hide navigator</source>
         <translation type="unfinished">Show/hide navigator</translation>
     </message>
     <message>
-        <location filename="../../src/appshell/internal/applicationuiactions.cpp" line="163"/>
         <source>&amp;Braille</source>
         <translation type="unfinished">&amp;Braille</translation>
     </message>
     <message>
-        <location filename="../../src/appshell/internal/applicationuiactions.cpp" line="164"/>
         <source>Show/hide braille panel</source>
         <translation type="unfinished">Show/hide braille panel</translation>
     </message>
     <message>
-        <location filename="../../src/appshell/internal/applicationuiactions.cpp" line="172"/>
         <source>Tim&amp;eline</source>
         <translation type="unfinished">Tim&amp;eline</translation>
     </message>
     <message>
-        <location filename="../../src/appshell/internal/applicationuiactions.cpp" line="173"/>
         <source>Show/hide timeline</source>
         <translation type="unfinished">Show/hide timeline</translation>
     </message>
     <message>
-        <location filename="../../src/appshell/internal/applicationuiactions.cpp" line="179"/>
         <source>Piano &amp;keyboard</source>
         <translation type="unfinished">Piano &amp;keyboard</translation>
     </message>
     <message>
-        <location filename="../../src/appshell/internal/applicationuiactions.cpp" line="180"/>
         <source>Show/hide piano keyboard</source>
         <translation type="unfinished">Show/hide piano keyboard</translation>
     </message>
     <message>
-        <location filename="../../src/appshell/internal/applicationuiactions.cpp" line="186"/>
         <source>Score comparison tool</source>
         <translation type="unfinished">Score comparison tool</translation>
     </message>
     <message>
-        <location filename="../../src/appshell/internal/applicationuiactions.cpp" line="194"/>
+        <location filename="../../src/appshell/internal/applicationuiactions.cpp" line="64"/>
+        <source>&amp;About Audacity…</source>
+        <translation type="unfinished">&amp;About Audacity…</translation>
+    </message>
+    <message>
+        <location filename="../../src/appshell/internal/applicationuiactions.cpp" line="117"/>
         <source>&amp;Status bar</source>
         <translation type="unfinished">&amp;Status bar</translation>
     </message>
     <message>
-        <location filename="../../src/appshell/internal/applicationuiactions.cpp" line="195"/>
+        <location filename="../../src/appshell/internal/applicationuiactions.cpp" line="118"/>
         <source>Show/hide status bar</source>
         <translation type="unfinished">Show/hide status bar</translation>
     </message>
     <message>
-        <location filename="../../src/appshell/internal/applicationuiactions.cpp" line="202"/>
+        <location filename="../../src/appshell/internal/applicationuiactions.cpp" line="125"/>
         <source>&amp;Preferences</source>
         <translation type="unfinished">&amp;Preferences</translation>
     </message>
     <message>
-        <location filename="../../src/appshell/internal/applicationuiactions.cpp" line="203"/>
+        <location filename="../../src/appshell/internal/applicationuiactions.cpp" line="126"/>
         <source>Preferences…</source>
         <translation type="unfinished">Preferences…</translation>
     </message>
     <message>
-        <location filename="../../src/appshell/internal/applicationuiactions.cpp" line="209"/>
-        <location filename="../../src/appshell/internal/applicationuiactions.cpp" line="210"/>
+        <location filename="../../src/appshell/internal/applicationuiactions.cpp" line="132"/>
+        <location filename="../../src/appshell/internal/applicationuiactions.cpp" line="133"/>
         <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="24"/>
         <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="25"/>
         <source>Copy</source>
         <translation type="unfinished">Copy</translation>
     </message>
     <message>
-        <location filename="../../src/appshell/internal/applicationuiactions.cpp" line="217"/>
-        <location filename="../../src/appshell/internal/applicationuiactions.cpp" line="218"/>
+        <location filename="../../src/appshell/internal/applicationuiactions.cpp" line="140"/>
+        <location filename="../../src/appshell/internal/applicationuiactions.cpp" line="141"/>
         <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="31"/>
         <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="32"/>
         <source>Cut</source>
         <translation type="unfinished">Cut</translation>
     </message>
     <message>
-        <location filename="../../src/appshell/internal/applicationuiactions.cpp" line="225"/>
-        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="235"/>
+        <location filename="../../src/appshell/internal/applicationuiactions.cpp" line="148"/>
+        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="256"/>
         <source>&amp;Paste</source>
         <translation type="unfinished">&amp;Paste</translation>
     </message>
     <message>
-        <location filename="../../src/appshell/internal/applicationuiactions.cpp" line="226"/>
-        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="236"/>
+        <location filename="../../src/appshell/internal/applicationuiactions.cpp" line="149"/>
+        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="257"/>
         <source>Paste</source>
         <translation type="unfinished">Paste</translation>
     </message>
     <message>
-        <location filename="../../src/appshell/internal/applicationuiactions.cpp" line="233"/>
+        <location filename="../../src/appshell/internal/applicationuiactions.cpp" line="156"/>
         <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="38"/>
         <source>&amp;Undo</source>
         <translation type="unfinished">&amp;Undo</translation>
     </message>
     <message>
-        <location filename="../../src/appshell/internal/applicationuiactions.cpp" line="234"/>
+        <location filename="../../src/appshell/internal/applicationuiactions.cpp" line="157"/>
         <location filename="../../src/appshell/qml/Audacity/AppShell/appmenumodel.cpp" line="167"/>
         <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="39"/>
         <source>Undo</source>
         <translation type="unfinished">Undo</translation>
     </message>
     <message>
-        <location filename="../../src/appshell/internal/applicationuiactions.cpp" line="241"/>
+        <location filename="../../src/appshell/internal/applicationuiactions.cpp" line="164"/>
         <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="45"/>
         <source>&amp;Redo</source>
         <translation type="unfinished">&amp;Redo</translation>
     </message>
     <message>
-        <location filename="../../src/appshell/internal/applicationuiactions.cpp" line="242"/>
+        <location filename="../../src/appshell/internal/applicationuiactions.cpp" line="165"/>
         <location filename="../../src/appshell/qml/Audacity/AppShell/appmenumodel.cpp" line="173"/>
         <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="46"/>
         <source>Redo</source>
         <translation type="unfinished">Redo</translation>
     </message>
     <message>
-        <location filename="../../src/appshell/internal/applicationuiactions.cpp" line="249"/>
+        <location filename="../../src/appshell/internal/applicationuiactions.cpp" line="172"/>
         <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="52"/>
         <source>De&amp;lete</source>
         <translation type="unfinished">De&amp;lete</translation>
     </message>
     <message>
-        <location filename="../../src/appshell/internal/applicationuiactions.cpp" line="250"/>
+        <location filename="../../src/appshell/internal/applicationuiactions.cpp" line="173"/>
+        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="174"/>
+        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="175"/>
         <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="53"/>
-        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="144"/>
+        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="165"/>
         <source>Delete</source>
         <translation type="unfinished">Delete</translation>
     </message>
     <message>
-        <location filename="../../src/appshell/internal/applicationuiactions.cpp" line="256"/>
+        <location filename="../../src/appshell/internal/applicationuiactions.cpp" line="179"/>
         <source>&amp;Cancel</source>
         <translation type="unfinished">&amp;Cancel</translation>
     </message>
     <message>
-        <location filename="../../src/appshell/internal/applicationuiactions.cpp" line="257"/>
+        <location filename="../../src/appshell/internal/applicationuiactions.cpp" line="180"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancel</translation>
     </message>
     <message>
-        <location filename="../../src/appshell/internal/applicationuiactions.cpp" line="263"/>
+        <location filename="../../src/appshell/internal/applicationuiactions.cpp" line="186"/>
         <source>&amp;Trigger</source>
         <translation type="unfinished">&amp;Trigger</translation>
     </message>
     <message>
-        <location filename="../../src/appshell/internal/applicationuiactions.cpp" line="264"/>
+        <location filename="../../src/appshell/internal/applicationuiactions.cpp" line="187"/>
         <source>Trigger</source>
         <translation type="unfinished">Trigger</translation>
     </message>
@@ -312,6 +300,12 @@
     <message>
         <location filename="../../src/au3cloud/internal/clouduiactions.cpp" line="15"/>
         <location filename="../../src/au3cloud/internal/clouduiactions.cpp" line="16"/>
+        <source>View project on audio.com</source>
+        <translation type="unfinished">View project on audio.com</translation>
+    </message>
+    <message>
+        <location filename="../../src/au3cloud/internal/clouduiactions.cpp" line="21"/>
+        <location filename="../../src/au3cloud/internal/clouduiactions.cpp" line="22"/>
         <source>View on audio.com</source>
         <translation type="unfinished">View on audio.com</translation>
     </message>
@@ -375,14 +369,14 @@
     <message>
         <location filename="../../src/playback/internal/playbackuiactions.cpp" line="42"/>
         <location filename="../../src/playback/internal/playbackuiactions.cpp" line="43"/>
-        <location filename="../../src/record/internal/recorduiactions.cpp" line="35"/>
         <location filename="../../src/record/internal/recorduiactions.cpp" line="36"/>
+        <location filename="../../src/record/internal/recorduiactions.cpp" line="37"/>
         <source>Pause</source>
         <translation type="unfinished">Pause</translation>
     </message>
     <message>
         <location filename="../../src/playback/internal/playbackuiactions.cpp" line="49"/>
-        <location filename="../../src/record/internal/recorduiactions.cpp" line="42"/>
+        <location filename="../../src/record/internal/recorduiactions.cpp" line="43"/>
         <source>Stop</source>
         <translation type="unfinished">Stop</translation>
     </message>
@@ -567,11 +561,19 @@
     </message>
     <message>
         <location filename="../../src/playback/internal/playbackuiactions.cpp" line="217"/>
+        <source>Pan automatically</source>
+        <translation type="unfinished">Pan automatically</translation>
+    </message>
+    <message>
+        <location filename="../../src/playback/internal/playbackuiactions.cpp" line="218"/>
+        <source>Pan automatically during playback</source>
+        <translation type="unfinished">Pan automatically during playback</translation>
+    </message>
+    <message>
         <source>Pan score automatically</source>
         <translation type="unfinished">Pan score automatically</translation>
     </message>
     <message>
-        <location filename="../../src/playback/internal/playbackuiactions.cpp" line="218"/>
         <source>Pan score automatically during playback</source>
         <translation type="unfinished">Pan score automatically during playback</translation>
     </message>
@@ -596,745 +598,723 @@
         <translation type="unfinished">Open…</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="35"/>
         <source>&amp;Open cloud project…</source>
         <translation type="unfinished">&amp;Open cloud project…</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="36"/>
         <source>Open cloud project…</source>
         <translation type="unfinished">Open cloud project…</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="41"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="35"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="36"/>
         <source>Open</source>
         <translation type="unfinished">Open</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="42"/>
         <source>Open cloud audio</source>
         <translation type="unfinished">Open cloud audio</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="47"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="41"/>
         <source>&amp;Clear recent files</source>
         <translation type="unfinished">&amp;Clear recent files</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="48"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="42"/>
         <source>Clear recent files</source>
         <translation type="unfinished">Clear recent files</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="53"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="54"/>
         <source>Import</source>
         <translation type="unfinished">Import</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="59"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="53"/>
         <source>&amp;Save project</source>
         <translation type="unfinished">&amp;Save project</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="60"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="54"/>
         <source>Save project</source>
         <translation type="unfinished">Save project</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="65"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="59"/>
         <source>Save &amp;as…</source>
         <translation type="unfinished">Save &amp;as…</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="66"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="60"/>
         <source>Save as…</source>
         <translation type="unfinished">Save as…</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="71"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="72"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="65"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="66"/>
         <source>Save backup</source>
         <translation type="unfinished">Save backup</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="77"/>
         <source>&amp;Export audio</source>
         <translation type="unfinished">&amp;Export audio</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="78"/>
         <source>Export audio</source>
         <translation type="unfinished">Export audio</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="83"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="77"/>
         <source>&amp;Export labels</source>
         <translation type="unfinished">&amp;Export labels</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="84"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="78"/>
         <source>Export labels</source>
         <translation type="unfinished">Export labels</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="89"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="83"/>
         <source>&amp;Export MIDI</source>
         <translation type="unfinished">&amp;Export MIDI</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="90"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="84"/>
         <source>Export MIDI</source>
         <translation type="unfinished">Export MIDI</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="95"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="89"/>
         <source>&amp;Close project</source>
         <translation type="unfinished">&amp;Close project</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="96"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="90"/>
         <source>Close project</source>
         <translation type="unfinished">Close project</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="103"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="104"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="423"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="424"/>
-        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="125"/>
-        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="126"/>
-        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="138"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="97"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="98"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="312"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="313"/>
+        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="146"/>
+        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="147"/>
+        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="159"/>
         <source>Duplicate</source>
         <translation type="unfinished">Duplicate</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="109"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="110"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="103"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="104"/>
         <source>Insert</source>
         <translation type="unfinished">Insert</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="115"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="116"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="109"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="110"/>
         <source>Rename item</source>
         <translation type="unfinished">Rename item</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="121"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="122"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="115"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="116"/>
         <source>Trim clip</source>
         <translation type="unfinished">Trim clip</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="127"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="128"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="121"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="122"/>
         <source>Split into new track</source>
         <translation type="unfinished">Split into new track</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="133"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="134"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="127"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="128"/>
         <source>Silence audio</source>
         <translation type="unfinished">Silence audio</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="139"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="140"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="133"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="134"/>
         <source>Paste new label</source>
         <translation type="unfinished">Paste new label</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="145"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="146"/>
         <source>Cut labels</source>
         <translation type="unfinished">Cut labels</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="151"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="152"/>
         <source>Cut labels and leave gap</source>
         <translation type="unfinished">Cut labels and leave gap</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="157"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="158"/>
         <source>Copy labels</source>
         <translation type="unfinished">Copy labels</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="163"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="164"/>
         <source>Delete labels</source>
         <translation type="unfinished">Delete labels</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="169"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="170"/>
         <source>Delete labels and leave gap</source>
         <translation type="unfinished">Delete labels and leave gap</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="175"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="176"/>
         <source>Split labels</source>
         <translation type="unfinished">Split labels</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="181"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="182"/>
         <source>Merge labels</source>
         <translation type="unfinished">Merge labels</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="187"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="188"/>
         <source>Silence labels</source>
         <translation type="unfinished">Silence labels</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="193"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="194"/>
         <source>Disjoin labels</source>
         <translation type="unfinished">Disjoin labels</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="199"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="200"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="139"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="140"/>
         <source>Manage labels</source>
         <translation type="unfinished">Manage labels</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="205"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="206"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="145"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="146"/>
         <source>Metadata editor</source>
         <translation type="unfinished">Metadata editor</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="213"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="214"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="153"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="154"/>
         <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="60"/>
         <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="61"/>
         <source>Select all</source>
         <translation type="unfinished">Select all</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="219"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="220"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="159"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="160"/>
         <source>Select all tracks</source>
         <translation type="unfinished">Select all tracks</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="225"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="226"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="165"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="166"/>
         <source>Left of playback position</source>
         <translation type="unfinished">Left of playback position</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="231"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="232"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="171"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="172"/>
         <source>Right of playback position</source>
         <translation type="unfinished">Right of playback position</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="237"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="238"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="177"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="178"/>
         <source>Track start to cursor</source>
         <translation type="unfinished">Track start to cursor</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="243"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="244"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="183"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="184"/>
         <source>Cursor to track end</source>
         <translation type="unfinished">Cursor to track end</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="249"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="250"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="189"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="190"/>
         <source>Track start to end</source>
         <translation type="unfinished">Track start to end</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="255"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="256"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="195"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="196"/>
         <source>Previous clip boundary to cursor</source>
         <translation type="unfinished">Previous clip boundary to cursor</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="261"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="262"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="201"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="202"/>
         <source>Cursor to next clip boundary</source>
         <translation type="unfinished">Cursor to next clip boundary</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="267"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="268"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="207"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="208"/>
         <source>Previous clip</source>
         <translation type="unfinished">Previous clip</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="273"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="274"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="213"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="214"/>
         <source>Next clip</source>
         <translation type="unfinished">Next clip</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="279"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="280"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="219"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="220"/>
         <source>Toggle spectral selection</source>
         <translation type="unfinished">Toggle spectral selection</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="285"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="286"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="225"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="226"/>
         <source>Move cursor to closest zero crossing</source>
         <translation type="unfinished">Move cursor to closest zero crossing</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="293"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="294"/>
-        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="43"/>
-        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="44"/>
+        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="36"/>
+        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="37"/>
         <source>Zoom in</source>
         <translation type="unfinished">Zoom in</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="300"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="301"/>
-        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="50"/>
-        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="51"/>
+        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="43"/>
+        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="44"/>
         <source>Zoom out</source>
         <translation type="unfinished">Zoom out</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="307"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="308"/>
+        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="50"/>
+        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="51"/>
+        <source>Zoom default</source>
+        <translation type="unfinished">Zoom default</translation>
+    </message>
+    <message>
+        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="56"/>
+        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="57"/>
         <source>Zoom to selection</source>
         <translation type="unfinished">Zoom to selection</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="314"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="315"/>
-        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="36"/>
-        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="37"/>
+        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="70"/>
+        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="71"/>
         <source>Zoom toggle</source>
         <translation type="unfinished">Zoom toggle</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="320"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="321"/>
         <source>Zoom reset</source>
         <translation type="unfinished">Zoom reset</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="326"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="327"/>
         <source>Fit project to window</source>
         <translation type="unfinished">Fit project to window</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="332"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="333"/>
         <source>Fit view to project</source>
         <translation type="unfinished">Fit view to project</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="338"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="339"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="233"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="234"/>
         <source>Collapse all tracks</source>
         <translation type="unfinished">Collapse all tracks</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="344"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="345"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="239"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="240"/>
         <source>Expand all tracks</source>
         <translation type="unfinished">Expand all tracks</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="350"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="351"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="245"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="246"/>
         <source>Skip to selection start</source>
         <translation type="unfinished">Skip to selection start</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="356"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="357"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="251"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="252"/>
         <source>Skip to selection end</source>
         <translation type="unfinished">Skip to selection end</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="362"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="363"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="257"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="258"/>
         <source>Show effects</source>
         <translation type="unfinished">Show effects</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="369"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="370"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="264"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="265"/>
         <source>Show metadata editor</source>
         <translation type="unfinished">Show metadata editor</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="376"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="377"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="271"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="272"/>
         <source>Show history</source>
         <translation type="unfinished">Show history</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="385"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="386"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="280"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="281"/>
         <source>Record on current track</source>
         <translation type="unfinished">Record on current track</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="391"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="392"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="286"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="287"/>
         <source>Record on new track</source>
         <translation type="unfinished">Record on new track</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="397"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="398"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="292"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="293"/>
         <source>Set up timed recording</source>
         <translation type="unfinished">Set up timed recording</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="403"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="404"/>
         <source>Punch and roll record</source>
         <translation type="unfinished">Punch and roll record</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="409"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="410"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="298"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="299"/>
         <source>Enable sound activating recording</source>
         <translation type="unfinished">Enable sound activating recording</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="415"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="416"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="304"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="305"/>
         <source>Set sound activation level</source>
         <translation type="unfinished">Set sound activation level</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="429"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="430"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="318"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="319"/>
         <source>Remove tracks</source>
         <translation type="unfinished">Remove tracks</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="435"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="436"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="324"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="325"/>
         <source>Mix-down to…</source>
         <translation type="unfinished">Mix-down to…</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="441"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="442"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="330"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="331"/>
         <source>Align end to end</source>
         <translation type="unfinished">Align end to end</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="447"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="448"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="336"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="337"/>
         <source>Align together</source>
         <translation type="unfinished">Align together</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="453"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="454"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="342"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="343"/>
         <source>Align start to zero</source>
         <translation type="unfinished">Align start to zero</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="459"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="460"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="348"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="349"/>
         <source>Align start to playhead</source>
         <translation type="unfinished">Align start to playhead</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="465"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="466"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="354"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="355"/>
         <source>Align start to selection end</source>
         <translation type="unfinished">Align start to selection end</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="471"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="472"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="360"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="361"/>
         <source>Align end to playhead</source>
         <translation type="unfinished">Align end to playhead</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="477"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="478"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="366"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="367"/>
         <source>Align end to selection end</source>
         <translation type="unfinished">Align end to selection end</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="483"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="484"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="372"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="373"/>
         <source>Sort by time</source>
         <translation type="unfinished">Sort by time</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="489"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="490"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="378"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="379"/>
         <source>Sort by name</source>
         <translation type="unfinished">Sort by name</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="495"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="496"/>
         <source>Keep tracks synchronised</source>
         <translation type="unfinished">Keep tracks synchronised</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="503"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="504"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="517"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="518"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="555"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="556"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="581"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="582"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="392"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="393"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="400"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="401"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="432"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="433"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="452"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="453"/>
         <source>Plugin manager</source>
         <translation type="unfinished">Plugin manager</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="509"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="510"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="573"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="574"/>
         <source>(Omitted)</source>
         <translation type="unfinished">(Omitted)</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="523"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="524"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="406"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="407"/>
         <source>Add realtime effects</source>
         <translation type="unfinished">Add realtime effects</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="529"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="530"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="412"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="413"/>
         <source>Fav effect #1</source>
         <translation type="unfinished">Fav effect #1</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="535"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="536"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="418"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="419"/>
         <source>Fav effect #2</source>
         <translation type="unfinished">Fav effect #2</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="541"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="542"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="424"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="425"/>
         <source>Fav effect #3</source>
         <translation type="unfinished">Fav effect #3</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="547"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="548"/>
         <source>(Plugins omitted)</source>
         <translation type="unfinished">(Plugins omitted)</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="561"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="562"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="47"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="48"/>
+        <source>Import…</source>
+        <translation type="unfinished">Import…</translation>
+    </message>
+    <message>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="71"/>
+        <source>&amp;Export audio…</source>
+        <translation type="unfinished">&amp;Export audio…</translation>
+    </message>
+    <message>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="72"/>
+        <source>Export audio…</source>
+        <translation type="unfinished">Export audio…</translation>
+    </message>
+    <message>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="384"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="385"/>
+        <source>Keep tracks synchronized</source>
+        <translation type="unfinished">Keep tracks synchronized</translation>
+    </message>
+    <message>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="438"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="439"/>
         <source>Contrast analyzer</source>
         <translation type="unfinished">Contrast analyzer</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="567"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="568"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="444"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="445"/>
         <source>Plot spectrum</source>
         <translation type="unfinished">Plot spectrum</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="587"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="588"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="458"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="459"/>
         <source>Manage macros</source>
         <translation type="unfinished">Manage macros</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="593"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="594"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="464"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="465"/>
         <source>Apply macros palette</source>
         <translation type="unfinished">Apply macros palette</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="599"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="600"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="470"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="471"/>
         <source>Macro fade ends</source>
         <translation type="unfinished">Macro fade ends</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="605"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="606"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="476"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="477"/>
         <source>Macro MP3 conversion</source>
         <translation type="unfinished">Macro MP3 conversion</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="611"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="612"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="482"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="483"/>
         <source>Nyquist plugin installer</source>
         <translation type="unfinished">Nyquist plugin installer</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="617"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="618"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="488"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="489"/>
         <source>Nyquist prompt</source>
         <translation type="unfinished">Nyquist prompt</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="623"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="624"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="494"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="495"/>
         <source>Sample data export</source>
         <translation type="unfinished">Sample data export</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="629"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="630"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="500"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="501"/>
         <source>Sample data import</source>
         <translation type="unfinished">Sample data import</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="635"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="636"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="506"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="507"/>
         <source>Raw data import</source>
         <translation type="unfinished">Raw data import</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="641"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="642"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="512"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="513"/>
         <source>Reset configuration</source>
         <translation type="unfinished">Reset configuration</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="649"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="650"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="520"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="521"/>
         <source>Previous window</source>
         <translation type="unfinished">Previous window</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="655"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="656"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="526"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="527"/>
         <source>Next window</source>
         <translation type="unfinished">Next window</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="661"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="662"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="532"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="533"/>
         <source>Benchmark</source>
         <translation type="unfinished">Benchmark</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="667"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="668"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="538"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="539"/>
         <source>Regular interval labels</source>
         <translation type="unfinished">Regular interval labels</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="675"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="676"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="546"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="547"/>
         <source>Tutorials</source>
         <translation type="unfinished">Tutorials</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="681"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="682"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="552"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="553"/>
         <source>Device info</source>
         <translation type="unfinished">Device info</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="687"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="688"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="558"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="559"/>
         <source>MIDI device info</source>
         <translation type="unfinished">MIDI device info</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="693"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="694"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="564"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="565"/>
         <source>Log</source>
         <translation type="unfinished">Log</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="699"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="700"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="570"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="571"/>
         <source>Crash report</source>
         <translation type="unfinished">Crash report</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="705"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="706"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="576"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="577"/>
         <source>Raise segfault</source>
         <translation type="unfinished">Raise segfault</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="711"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="712"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="582"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="583"/>
         <source>Throw exception</source>
         <translation type="unfinished">Throw exception</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="717"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="718"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="588"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="589"/>
         <source>Violate assertion</source>
         <translation type="unfinished">Violate assertion</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="723"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="724"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="594"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="595"/>
         <source>Menu tree</source>
         <translation type="unfinished">Menu tree</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="729"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="730"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="600"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="601"/>
         <source>Frame statistics</source>
         <translation type="unfinished">Frame statistics</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="735"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="736"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="606"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="607"/>
         <source>Link account</source>
         <translation type="unfinished">Link account</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="741"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="742"/>
         <source>Updates</source>
         <translation type="unfinished">Updates</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="747"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="748"/>
         <source>About Audacity</source>
         <translation type="unfinished">About Audacity</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="754"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="612"/>
         <source>Save to clo&amp;ud…</source>
         <translation type="unfinished">Save to clo&amp;ud…</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="755"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="613"/>
         <source>Save to cloud…</source>
         <translation type="unfinished">Save to cloud…</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="761"/>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="762"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="619"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="620"/>
         <source>Share audio</source>
         <translation type="unfinished">Share audio</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="769"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="627"/>
         <source>Project propert&amp;ies…</source>
         <translation type="unfinished">Project propert&amp;ies…</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectuiactions.cpp" line="770"/>
+        <location filename="../../src/project/internal/projectuiactions.cpp" line="628"/>
         <source>Project properties…</source>
         <translation type="unfinished">Project properties…</translation>
     </message>
@@ -1351,205 +1331,237 @@
         <translation type="unfinished">Split tool</translation>
     </message>
     <message>
-        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="57"/>
-        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="58"/>
         <source>Fit selection to width</source>
         <translation type="unfinished">Fit selection to width</translation>
     </message>
     <message>
+        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="63"/>
         <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="64"/>
-        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="65"/>
         <source>Zoom to fit project</source>
         <translation type="unfinished">Zoom to fit project</translation>
     </message>
     <message>
-        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="71"/>
-        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="72"/>
+        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="77"/>
+        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="78"/>
         <source>Center view on playhead</source>
         <translation type="unfinished">Center view on playhead</translation>
     </message>
     <message>
-        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="77"/>
-        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="78"/>
+        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="83"/>
+        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="84"/>
         <source>Toggle spectral view</source>
         <translation type="unfinished">Toggle spectral view</translation>
     </message>
     <message>
-        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="84"/>
-        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="85"/>
+        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="90"/>
         <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="91"/>
-        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="92"/>
+        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="97"/>
+        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="98"/>
         <source>Spectral box select</source>
         <translation type="unfinished">Spectral box select</translation>
     </message>
     <message>
-        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="98"/>
-        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="99"/>
+        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="104"/>
+        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="105"/>
         <source>Snapping</source>
         <translation type="unfinished">Snapping</translation>
     </message>
     <message>
-        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="105"/>
-        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="106"/>
+        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="111"/>
+        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="112"/>
         <source>Minutes &amp;&amp; seconds</source>
         <translation type="unfinished">Minutes &amp;&amp; seconds</translation>
     </message>
     <message>
-        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="112"/>
-        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="113"/>
+        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="118"/>
+        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="119"/>
         <source>Beats &amp;&amp; measures</source>
         <translation type="unfinished">Beats &amp;&amp; measures</translation>
     </message>
     <message>
-        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="119"/>
-        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="120"/>
+        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="125"/>
+        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="126"/>
         <source>Show vertical rulers</source>
         <translation type="unfinished">Show vertical rulers</translation>
     </message>
     <message>
-        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="126"/>
-        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="127"/>
+        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="132"/>
+        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="133"/>
         <source>Show master track</source>
         <translation type="unfinished">Show master track</translation>
     </message>
     <message>
-        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="133"/>
-        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="134"/>
+        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="139"/>
+        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="140"/>
         <source>Update display while playing</source>
         <translation type="unfinished">Update display while playing</translation>
     </message>
     <message>
-        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="140"/>
-        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="141"/>
+        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="146"/>
+        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="147"/>
         <source>Pinned play head</source>
         <translation type="unfinished">Pinned play head</translation>
     </message>
     <message>
-        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="147"/>
-        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="148"/>
+        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="153"/>
+        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="154"/>
         <source>Click ruler to start playback</source>
         <translation type="unfinished">Click ruler to start playback</translation>
     </message>
     <message>
-        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="155"/>
+        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="161"/>
         <source>Clip properties</source>
         <translation type="unfinished">Clip properties</translation>
     </message>
     <message>
-        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="156"/>
+        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="162"/>
         <source>Show clip properties</source>
         <translation type="unfinished">Show clip properties</translation>
     </message>
     <message>
-        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="161"/>
-        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="162"/>
+        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="167"/>
+        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="168"/>
         <source>Rename clip</source>
         <translation type="unfinished">Rename clip</translation>
     </message>
     <message>
-        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="168"/>
-        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="169"/>
+        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="182"/>
+        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="183"/>
         <source>Follow track color</source>
         <translation type="unfinished">Follow track color</translation>
     </message>
     <message>
-        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="175"/>
-        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="176"/>
+        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="189"/>
+        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="190"/>
         <source>Move play cursor left</source>
         <translation type="unfinished">Move play cursor left</translation>
     </message>
     <message>
-        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="181"/>
-        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="182"/>
+        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="195"/>
+        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="196"/>
         <source>Move play cursor right</source>
         <translation type="unfinished">Move play cursor right</translation>
     </message>
     <message>
-        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="187"/>
-        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="188"/>
-        <source>Pitch and speed</source>
-        <translation type="unfinished">Pitch and speed</translation>
-    </message>
-    <message>
-        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="193"/>
-        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="194"/>
-        <source>Show RMS in waveform</source>
-        <translation type="unfinished">Show RMS in waveform</translation>
-    </message>
-    <message>
-        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="200"/>
         <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="201"/>
-        <source>Show clipping in waveform</source>
-        <translation type="unfinished">Show clipping in waveform</translation>
+        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="202"/>
+        <source>Extend selection left</source>
+        <translation type="unfinished">Extend selection left</translation>
     </message>
     <message>
         <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="207"/>
         <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="208"/>
+        <source>Extend selection right</source>
+        <translation type="unfinished">Extend selection right</translation>
+    </message>
+    <message>
+        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="213"/>
+        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="214"/>
+        <source>Contract selection from left</source>
+        <translation type="unfinished">Contract selection from left</translation>
+    </message>
+    <message>
+        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="219"/>
+        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="220"/>
+        <source>Contract selection from right</source>
+        <translation type="unfinished">Contract selection from right</translation>
+    </message>
+    <message>
+        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="225"/>
+        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="226"/>
+        <source>Pitch and speed</source>
+        <translation type="unfinished">Pitch and speed</translation>
+    </message>
+    <message>
+        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="231"/>
+        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="232"/>
+        <source>Show RMS in waveform</source>
+        <translation type="unfinished">Show RMS in waveform</translation>
+    </message>
+    <message>
+        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="238"/>
+        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="239"/>
+        <source>Show clipping in waveform</source>
+        <translation type="unfinished">Show clipping in waveform</translation>
+    </message>
+    <message>
+        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="245"/>
+        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="246"/>
         <source>Half-wave</source>
         <translation type="unfinished">Half-wave</translation>
     </message>
     <message>
-        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="214"/>
-        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="215"/>
+        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="252"/>
+        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="253"/>
         <source>Show label editor</source>
         <translation type="unfinished">Show label editor</translation>
     </message>
     <message>
-        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="220"/>
-        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="221"/>
+        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="258"/>
+        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="259"/>
         <source>Move realtime effect up</source>
         <translation type="unfinished">Move realtime effect up</translation>
     </message>
     <message>
-        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="226"/>
-        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="227"/>
+        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="264"/>
+        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="265"/>
         <source>Move realtime effect down</source>
         <translation type="unfinished">Move realtime effect down</translation>
     </message>
     <message>
-        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="249"/>
-        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="250"/>
+        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="289"/>
+        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="290"/>
         <source>Change clip color</source>
         <translation type="unfinished">Change clip color</translation>
     </message>
     <message>
-        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="261"/>
-        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="262"/>
+        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="301"/>
+        <location filename="../../src/projectscene/internal/projectsceneuiactions.cpp" line="302"/>
         <source>Change track color</source>
         <translation type="unfinished">Change track color</translation>
     </message>
     <message>
-        <location filename="../../src/record/internal/recorduiactions.cpp" line="28"/>
         <location filename="../../src/record/internal/recorduiactions.cpp" line="29"/>
+        <location filename="../../src/record/internal/recorduiactions.cpp" line="30"/>
         <source>Record</source>
         <translation type="unfinished">Record</translation>
     </message>
     <message>
-        <location filename="../../src/record/internal/recorduiactions.cpp" line="43"/>
+        <location filename="../../src/record/internal/recorduiactions.cpp" line="44"/>
         <source>Stop record</source>
         <translation type="unfinished">Stop record</translation>
     </message>
     <message>
-        <location filename="../../src/record/internal/recorduiactions.cpp" line="49"/>
+        <location filename="../../src/record/internal/recorduiactions.cpp" line="50"/>
         <source>Record level</source>
         <translation type="unfinished">Record level</translation>
     </message>
     <message>
-        <location filename="../../src/record/internal/recorduiactions.cpp" line="50"/>
+        <location filename="../../src/record/internal/recorduiactions.cpp" line="51"/>
         <source>Set record level</source>
         <translation type="unfinished">Set record level</translation>
     </message>
     <message>
-        <location filename="../../src/record/internal/recorduiactions.cpp" line="56"/>
         <location filename="../../src/record/internal/recorduiactions.cpp" line="57"/>
+        <location filename="../../src/record/internal/recorduiactions.cpp" line="58"/>
         <source>Show mic metering</source>
         <translation type="unfinished">Show mic metering</translation>
     </message>
     <message>
-        <location filename="../../src/record/internal/recorduiactions.cpp" line="63"/>
         <location filename="../../src/record/internal/recorduiactions.cpp" line="64"/>
+        <location filename="../../src/record/internal/recorduiactions.cpp" line="65"/>
         <source>Turn on input monitoring</source>
         <translation type="unfinished">Turn on input monitoring</translation>
+    </message>
+    <message>
+        <location filename="../../src/record/internal/recorduiactions.cpp" line="71"/>
+        <source>Lead-in Recording</source>
+        <translation type="unfinished">Lead-in Recording</translation>
+    </message>
+    <message>
+        <location filename="../../src/record/internal/recorduiactions.cpp" line="72"/>
+        <source>Start lead-in recording</source>
+        <translation type="unfinished">Start lead-in recording</translation>
     </message>
     <message>
         <location filename="../../src/spectrogram/internal/spectrogramuiactions.cpp" line="18"/>
@@ -1566,248 +1578,276 @@
     <message>
         <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="72"/>
         <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="73"/>
-        <source>Cut and close gap (per clip)</source>
-        <translation type="unfinished">Cut and close gap (per clip)</translation>
+        <source>Cut and leave gap</source>
+        <translation type="unfinished">Cut and leave gap</translation>
     </message>
     <message>
         <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="79"/>
         <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="80"/>
-        <source>Cut and close gap (per track)</source>
-        <translation type="unfinished">Cut and close gap (per track)</translation>
+        <source>Cut and close gap (per clip)</source>
+        <translation type="unfinished">Cut and close gap (per clip)</translation>
     </message>
     <message>
         <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="86"/>
         <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="87"/>
-        <source>Cut and close gap (all tracks)</source>
-        <translation type="unfinished">Cut and close gap (all tracks)</translation>
+        <source>Cut and close gap (per track)</source>
+        <translation type="unfinished">Cut and close gap (per track)</translation>
     </message>
     <message>
         <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="93"/>
         <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="94"/>
-        <source>Delete and close gap (per track)</source>
-        <translation type="unfinished">Delete and close gap (per track)</translation>
+        <source>Cut and close gap (all tracks)</source>
+        <translation type="unfinished">Cut and close gap (all tracks)</translation>
     </message>
     <message>
         <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="100"/>
         <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="101"/>
-        <source>Delete and close gap (all tracks)</source>
-        <translation type="unfinished">Delete and close gap (all tracks)</translation>
+        <source>Delete and leave gap</source>
+        <translation type="unfinished">Delete and leave gap</translation>
     </message>
     <message>
         <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="107"/>
         <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="108"/>
+        <source>Delete and close gap (per clip)</source>
+        <translation type="unfinished">Delete and close gap (per clip)</translation>
+    </message>
+    <message>
+        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="114"/>
+        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="115"/>
+        <source>Delete and close gap (per track)</source>
+        <translation type="unfinished">Delete and close gap (per track)</translation>
+    </message>
+    <message>
+        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="121"/>
+        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="122"/>
+        <source>Delete and close gap (all tracks)</source>
+        <translation type="unfinished">Delete and close gap (all tracks)</translation>
+    </message>
+    <message>
+        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="128"/>
+        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="129"/>
         <source>Split</source>
         <translation type="unfinished">Split</translation>
     </message>
     <message>
-        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="113"/>
-        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="114"/>
+        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="134"/>
+        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="135"/>
         <source>Join selected clips</source>
         <translation type="unfinished">Join selected clips</translation>
     </message>
     <message>
-        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="119"/>
-        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="120"/>
+        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="140"/>
+        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="141"/>
         <source>Split clips at silences</source>
         <translation type="unfinished">Split clips at silences</translation>
     </message>
     <message>
-        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="132"/>
+        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="153"/>
         <source>Rename</source>
         <translation type="unfinished">Rename</translation>
     </message>
     <message>
-        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="133"/>
+        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="154"/>
         <source>Rename track</source>
         <translation type="unfinished">Rename track</translation>
     </message>
     <message>
-        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="139"/>
+        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="160"/>
         <source>Duplicate track</source>
         <translation type="unfinished">Duplicate track</translation>
     </message>
     <message>
-        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="145"/>
+        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="166"/>
         <source>Delete track</source>
         <translation type="unfinished">Delete track</translation>
     </message>
     <message>
-        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="150"/>
-        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="151"/>
+        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="171"/>
+        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="172"/>
         <source>Move track up</source>
         <translation type="unfinished">Move track up</translation>
     </message>
     <message>
-        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="156"/>
-        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="157"/>
+        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="177"/>
+        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="178"/>
         <source>Move track down</source>
         <translation type="unfinished">Move track down</translation>
     </message>
     <message>
-        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="162"/>
-        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="163"/>
+        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="183"/>
+        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="184"/>
         <source>Move track to top</source>
         <translation type="unfinished">Move track to top</translation>
     </message>
     <message>
-        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="168"/>
-        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="169"/>
+        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="189"/>
+        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="190"/>
         <source>Move track to bottom</source>
         <translation type="unfinished">Move track to bottom</translation>
     </message>
     <message>
-        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="174"/>
-        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="175"/>
+        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="195"/>
+        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="196"/>
         <source>Other…</source>
         <translation type="unfinished">Other…</translation>
     </message>
     <message>
-        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="181"/>
-        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="182"/>
+        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="202"/>
+        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="203"/>
         <source>Make stereo track</source>
         <translation type="unfinished">Make stereo track</translation>
     </message>
     <message>
-        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="187"/>
-        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="188"/>
+        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="208"/>
+        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="209"/>
         <source>Swap stereo channels</source>
         <translation type="unfinished">Swap stereo channels</translation>
     </message>
     <message>
-        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="193"/>
-        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="194"/>
+        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="214"/>
+        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="215"/>
         <source>Split stereo to L/R mono</source>
         <translation type="unfinished">Split stereo to L/R mono</translation>
     </message>
     <message>
-        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="199"/>
-        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="200"/>
+        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="220"/>
+        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="221"/>
         <source>Split stereo to center mono</source>
         <translation type="unfinished">Split stereo to center mono</translation>
     </message>
     <message>
-        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="205"/>
-        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="206"/>
+        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="226"/>
+        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="227"/>
         <source>Resample track…</source>
         <translation type="unfinished">Resample track…</translation>
     </message>
     <message>
-        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="211"/>
-        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="212"/>
+        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="232"/>
+        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="233"/>
         <source>Waveform</source>
         <translation type="unfinished">Waveform</translation>
     </message>
     <message>
-        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="219"/>
-        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="220"/>
+        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="240"/>
+        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="241"/>
+        <source>Spectrogram</source>
+        <translation type="unfinished">Spectrogram</translation>
+    </message>
+    <message>
+        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="453"/>
+        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="454"/>
+        <source>Above item</source>
+        <translation type="unfinished">Above item</translation>
+    </message>
+    <message>
+        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="459"/>
+        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="460"/>
+        <source>Below item</source>
+        <translation type="unfinished">Below item</translation>
+    </message>
+    <message>
         <source>Spectogram</source>
         <translation type="unfinished">Spectogram</translation>
     </message>
     <message>
-        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="227"/>
-        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="228"/>
+        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="248"/>
+        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="249"/>
         <source>Multi-view</source>
         <translation type="unfinished">Multi-view</translation>
     </message>
     <message>
-        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="242"/>
-        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="243"/>
+        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="263"/>
+        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="264"/>
         <source>Paste (pushes clips on selected track)</source>
         <translation type="unfinished">Paste (pushes clips on selected track)</translation>
     </message>
     <message>
-        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="249"/>
-        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="250"/>
+        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="270"/>
+        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="271"/>
         <source>Paste (overlaps other clips)</source>
         <translation type="unfinished">Paste (overlaps other clips)</translation>
     </message>
     <message>
-        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="256"/>
-        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="257"/>
+        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="277"/>
+        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="278"/>
         <source>Paste (preserves synchronization on all tracks)</source>
         <translation type="unfinished">Paste (preserves synchronization on all tracks)</translation>
     </message>
     <message>
-        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="263"/>
-        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="264"/>
+        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="284"/>
+        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="285"/>
         <source>Merge selected clips</source>
         <translation type="unfinished">Merge selected clips</translation>
     </message>
     <message>
-        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="269"/>
-        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="270"/>
+        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="290"/>
+        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="291"/>
         <source>Duplicate selected</source>
         <translation type="unfinished">Duplicate selected</translation>
     </message>
     <message>
-        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="275"/>
-        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="276"/>
+        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="296"/>
+        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="297"/>
         <source>Duplicate clip</source>
         <translation type="unfinished">Duplicate clip</translation>
     </message>
     <message>
-        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="281"/>
-        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="282"/>
+        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="302"/>
+        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="303"/>
         <source>Export clip</source>
         <translation type="unfinished">Export clip</translation>
     </message>
     <message>
-        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="287"/>
-        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="288"/>
+        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="308"/>
+        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="309"/>
         <source>Stretch with tempo changes</source>
         <translation type="unfinished">Stretch with tempo changes</translation>
     </message>
     <message>
-        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="294"/>
-        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="295"/>
+        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="315"/>
+        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="316"/>
         <source>Open pitch and speed dialog</source>
         <translation type="unfinished">Open pitch and speed dialog</translation>
     </message>
     <message>
-        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="300"/>
-        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="301"/>
+        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="321"/>
+        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="322"/>
         <source>Render pitch and speed</source>
         <translation type="unfinished">Render pitch and speed</translation>
     </message>
     <message>
-        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="306"/>
-        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="307"/>
+        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="327"/>
+        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="328"/>
         <source>New mono track</source>
         <translation type="unfinished">New mono track</translation>
     </message>
     <message>
-        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="312"/>
-        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="313"/>
+        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="333"/>
+        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="334"/>
         <source>New stereo track</source>
         <translation type="unfinished">New stereo track</translation>
     </message>
     <message>
-        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="318"/>
-        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="319"/>
+        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="339"/>
+        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="340"/>
         <source>New label track</source>
         <translation type="unfinished">New label track</translation>
     </message>
     <message>
-        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="324"/>
-        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="325"/>
+        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="345"/>
+        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="346"/>
         <source>Add label</source>
         <translation type="unfinished">Add label</translation>
     </message>
     <message>
-        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="330"/>
-        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="331"/>
         <source>Delete label</source>
         <translation type="unfinished">Delete label</translation>
     </message>
     <message>
-        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="337"/>
-        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="338"/>
         <source>Cut label</source>
         <translation type="unfinished">Cut label</translation>
     </message>
     <message>
-        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="344"/>
-        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="345"/>
         <source>Copy label</source>
         <translation type="unfinished">Copy label</translation>
     </message>
@@ -1908,68 +1948,64 @@
         <translation type="unfinished">Previous item</translation>
     </message>
     <message>
-        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="453"/>
-        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="454"/>
         <source>Next track</source>
         <translation type="unfinished">Next track</translation>
     </message>
     <message>
-        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="459"/>
-        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="460"/>
         <source>Previous track</source>
         <translation type="unfinished">Previous track</translation>
     </message>
     <message>
-        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="465"/>
         <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="466"/>
+        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="467"/>
         <source>First track</source>
         <translation type="unfinished">First track</translation>
     </message>
     <message>
-        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="471"/>
         <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="472"/>
+        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="473"/>
         <source>Last track</source>
         <translation type="unfinished">Last track</translation>
     </message>
     <message>
-        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="478"/>
         <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="479"/>
+        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="480"/>
         <source>Select track/track item</source>
         <translation type="unfinished">Select track/track item</translation>
     </message>
     <message>
-        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="484"/>
         <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="485"/>
+        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="486"/>
         <source>Track range selection</source>
         <translation type="unfinished">Track range selection</translation>
     </message>
     <message>
-        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="490"/>
         <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="491"/>
+        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="492"/>
         <source>Multi track selection previous</source>
         <translation type="unfinished">Multi track selection previous</translation>
     </message>
     <message>
-        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="496"/>
         <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="497"/>
+        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="498"/>
         <source>Multi track selection next</source>
         <translation type="unfinished">Multi track selection next</translation>
     </message>
     <message>
-        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="503"/>
         <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="504"/>
+        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="505"/>
         <source>Open item’s context menu</source>
         <translation type="unfinished">Open item’s context menu</translation>
     </message>
     <message>
-        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="524"/>
         <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="525"/>
+        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="526"/>
         <source>Change track format</source>
         <translation type="unfinished">Change track format</translation>
     </message>
     <message>
-        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="537"/>
         <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="538"/>
+        <location filename="../../src/trackedit/internal/trackedituiactions.cpp" line="539"/>
         <source>Change track sample rate</source>
         <translation type="unfinished">Change track sample rate</translation>
     </message>
@@ -1978,23 +2014,23 @@
     <name>appshell</name>
     <message>
         <location filename="../../src/appshell/qml/Audacity/AppShell/HomePage/AccountPage.qml" line="63"/>
-        <location filename="../../src/appshell/qml/Audacity/AppShell/HomePage/HomeMenu.qml" line="62"/>
+        <location filename="../../src/appshell/qml/Audacity/AppShell/HomePage/HomeMenu.qml" line="64"/>
         <source>Cloud account</source>
         <translation type="unfinished">Cloud account</translation>
     </message>
     <message>
-        <location filename="../../src/appshell/qml/Audacity/AppShell/HomePage/HomeMenu.qml" line="53"/>
+        <location filename="../../src/appshell/qml/Audacity/AppShell/HomePage/HomeMenu.qml" line="54"/>
         <source>Home menu</source>
         <translation type="unfinished">Home menu</translation>
     </message>
     <message>
-        <location filename="../../src/appshell/qml/Audacity/AppShell/HomePage/HomeMenu.qml" line="92"/>
+        <location filename="../../src/appshell/qml/Audacity/AppShell/HomePage/HomeMenu.qml" line="94"/>
         <location filename="../../src/appshell/qml/Audacity/AppShell/maintoolbarmodel.cpp" line="95"/>
         <source>Project</source>
         <translation type="unfinished">Project</translation>
     </message>
     <message>
-        <location filename="../../src/appshell/qml/Audacity/AppShell/HomePage/HomeMenu.qml" line="98"/>
+        <location filename="../../src/appshell/qml/Audacity/AppShell/HomePage/HomeMenu.qml" line="100"/>
         <source>Learn</source>
         <translation type="unfinished">Learn</translation>
     </message>
@@ -2021,7 +2057,6 @@
         <translation type="unfinished">All</translation>
     </message>
     <message>
-        <location filename="../../src/appshell/qml/Audacity/AppShell/Main.wasm.qml" line="36"/>
         <source>MuseScore</source>
         <translation type="unfinished">MuseScore</translation>
     </message>
@@ -2037,7 +2072,6 @@
         <translation type="unfinished">Application menu</translation>
     </message>
     <message>
-        <location filename="../../src/appshell/qml/Audacity/AppShell/platform/win/AppTitleBar.qml" line="92"/>
         <source>MuseScore 4</source>
         <translation type="unfinished">MuseScore 4</translation>
     </message>
@@ -2082,12 +2116,12 @@
         <translation type="unfinished">Produce MIDI 2.0 output if supported by the receiver</translation>
     </message>
     <message>
-        <location filename="../../src/appshell/internal/applicationactioncontroller.cpp" line="326"/>
+        <location filename="../../src/appshell/internal/applicationactioncontroller.cpp" line="324"/>
         <source>Are you sure you want to revert to factory settings?</source>
         <translation type="unfinished">Are you sure you want to revert to factory settings?</translation>
     </message>
     <message>
-        <location filename="../../src/appshell/internal/applicationactioncontroller.cpp" line="327"/>
+        <location filename="../../src/appshell/internal/applicationactioncontroller.cpp" line="325"/>
         <source>This action will reset all your app preferences and delete all custom palettes and custom shortcuts. The list of recent projects will also be cleared.
 
 This action will not delete any of your projects.</source>
@@ -2096,22 +2130,22 @@ This action will not delete any of your projects.</source>
 This action will not delete any of your projects.</translation>
     </message>
     <message>
-        <location filename="../../src/appshell/internal/applicationactioncontroller.cpp" line="336"/>
+        <location filename="../../src/appshell/internal/applicationactioncontroller.cpp" line="334"/>
         <source>Revert</source>
         <translation type="unfinished">Revert</translation>
     </message>
     <message>
-        <location filename="../../src/appshell/internal/applicationactioncontroller.cpp" line="348"/>
+        <location filename="../../src/appshell/internal/applicationactioncontroller.cpp" line="346"/>
         <source>Would you like to restart Audacity now?</source>
         <translation type="unfinished">Would you like to restart Audacity now?</translation>
     </message>
     <message>
-        <location filename="../../src/appshell/internal/applicationactioncontroller.cpp" line="349"/>
+        <location filename="../../src/appshell/internal/applicationactioncontroller.cpp" line="347"/>
         <source>Audacity needs to be restarted for these changes to take effect.</source>
         <translation type="unfinished">Audacity needs to be restarted for these changes to take effect.</translation>
     </message>
     <message>
-        <location filename="../../src/appshell/internal/applicationactioncontroller.cpp" line="354"/>
+        <location filename="../../src/appshell/internal/applicationactioncontroller.cpp" line="352"/>
         <source>Restart</source>
         <translation type="unfinished">Restart</translation>
     </message>
@@ -2141,32 +2175,32 @@ This action will not delete any of your projects.</translation>
         <translation type="unfinished">Loading project…‎</translation>
     </message>
     <message>
-        <location filename="../../src/appshell/internal/startupscenario.cpp" line="145"/>
+        <location filename="../../src/effects/effects_base/internal/effectsprovider.cpp" line="56"/>
         <source>Scanning audio plugins</source>
         <translation type="unfinished">Scanning audio plugins</translation>
     </message>
     <message>
-        <location filename="../../src/appshell/internal/startupscenario.cpp" line="146"/>
+        <location filename="../../src/effects/effects_base/internal/effectsprovider.cpp" line="57"/>
         <source>Audacity has found plugins that need to be scanned before use. Would you like to scan them now or skip?</source>
         <translation type="unfinished">Audacity has found plugins that need to be scanned before use. Would you like to scan them now or skip?</translation>
     </message>
     <message>
-        <location filename="../../src/appshell/internal/startupscenario.cpp" line="150"/>
+        <location filename="../../src/effects/effects_base/internal/effectsprovider.cpp" line="62"/>
         <source>Skip this time</source>
         <translation type="unfinished">Skip this time</translation>
     </message>
     <message>
-        <location filename="../../src/appshell/internal/startupscenario.cpp" line="153"/>
+        <location filename="../../src/effects/effects_base/internal/effectsprovider.cpp" line="65"/>
         <source>Scan plugins</source>
         <translation type="unfinished">Scan plugins</translation>
     </message>
     <message>
-        <location filename="../../src/appshell/internal/startupscenario.cpp" line="285"/>
+        <location filename="../../src/appshell/internal/startupscenario.cpp" line="282"/>
         <source>The previous session quit unexpectedly.</source>
         <translation type="unfinished">The previous session quit unexpectedly.</translation>
     </message>
     <message>
-        <location filename="../../src/appshell/internal/startupscenario.cpp" line="286"/>
+        <location filename="../../src/appshell/internal/startupscenario.cpp" line="283"/>
         <source>Do you want to restore the session?</source>
         <translation type="unfinished">Do you want to restore the session?</translation>
     </message>
@@ -2187,51 +2221,54 @@ This action will not delete any of your projects.</translation>
     </message>
     <message>
         <location filename="../../src/appshell/qml/Audacity/AppShell/mainwindowtitleprovider.cpp" line="101"/>
-        <location filename="../../src/appshell/qml/Audacity/AppShell/mainwindowtitleprovider.cpp" line="109"/>
+        <location filename="../../src/appshell/qml/Audacity/AppShell/mainwindowtitleprovider.cpp" line="110"/>
         <source>Audacity 4</source>
         <translation type="unfinished">Audacity 4</translation>
     </message>
     <message>
-        <location filename="../../src/appshell/qml/Audacity/AppShell/mainwindowtitleprovider.cpp" line="110"/>
+        <location filename="../../src/appshell/qml/Audacity/AppShell/mainwindowtitleprovider.cpp" line="111"/>
+        <source>%1 %2- Audacity 4</source>
+        <translation type="unfinished">%1 %2- Audacity 4</translation>
+    </message>
+    <message>
         <source>%1 - Audacity 4</source>
         <translation type="unfinished">%1 - Audacity 4</translation>
+    </message>
+    <message>
+        <location filename="../../src/appshell/qml/Audacity/AppShell/Main.wasm.qml" line="36"/>
+        <location filename="../../src/appshell/qml/Audacity/AppShell/platform/win/AppTitleBar.qml" line="92"/>
+        <source>Audacity</source>
+        <translation type="unfinished">Audacity</translation>
     </message>
 </context>
 <context>
     <name>appshell/about</name>
     <message>
-        <location filename="../../src/appshell/qml/Audacity/AppShell/AboutDialog.qml" line="32"/>
         <source>About MuseScore</source>
         <translation type="unfinished">About MuseScore</translation>
     </message>
     <message>
-        <location filename="../../src/appshell/qml/Audacity/AppShell/AboutDialog.qml" line="84"/>
         <source>Version:</source>
         <translation type="unfinished">Version:</translation>
     </message>
     <message>
-        <location filename="../../src/appshell/qml/Audacity/AppShell/AboutDialog.qml" line="94"/>
         <source>Revision:</source>
         <translation type="unfinished">Revision:</translation>
     </message>
     <message>
-        <location filename="../../src/appshell/qml/Audacity/AppShell/AboutDialog.qml" line="114"/>
         <source>Visit %1 for new versions and more information.</source>
         <extracomment>%1 will be a link to the MuseScore website</extracomment>
         <translation type="unfinished">Visit %1 for new versions and more information.</translation>
     </message>
     <message>
-        <location filename="../../src/appshell/qml/Audacity/AppShell/AboutDialog.qml" line="117"/>
         <source>Get &lt;a href=&quot;%1&quot;&gt;help&lt;/a&gt; with the program or &lt;a href=&quot;%2&quot;&gt;contribute&lt;/a&gt; to its development.</source>
         <translation type="unfinished">Get &lt;a href=&quot;%1&quot;&gt;help&lt;/a&gt; with the program or &lt;a href=&quot;%2&quot;&gt;contribute&lt;/a&gt; to its development.</translation>
     </message>
     <message>
-        <location filename="../../src/appshell/qml/Audacity/AppShell/AboutDialog.qml" line="130"/>
         <source>For privacy information, see our &lt;a href=&quot;%1&quot;&gt;privacy policy&lt;/a&gt;.</source>
         <translation type="unfinished">For privacy information, see our &lt;a href=&quot;%1&quot;&gt;privacy policy&lt;/a&gt;.</translation>
     </message>
     <message>
-        <location filename="../../src/appshell/qml/Audacity/AppShell/AboutDialog.qml" line="139"/>
         <source>Copyright © 1999-2024 MuseScore BVBA and others.
 Published under the &lt;a href=&quot;%1&quot;&gt;GNU General Public License version 3&lt;/a&gt;.</source>
         <translation type="unfinished">Copyright © 1999-2024 MuseScore BVBA and others.
@@ -2263,9 +2300,69 @@ Published under the &lt;a href=&quot;%1&quot;&gt;GNU General Public License vers
         <translation type="unfinished">Audacity 4</translation>
     </message>
     <message>
-        <location filename="../../src/appshell/qml/Audacity/AppShell/aboutmodel.cpp" line="42"/>
+        <location filename="../../src/appshell/qml/Audacity/AppShell/aboutmodel.cpp" line="272"/>
         <source>Unstable prerelease for %1</source>
         <translation type="unfinished">Unstable prerelease for %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/appshell/qml/Audacity/AppShell/aboutmodel.cpp" line="338"/>
+        <source>translator_credits</source>
+        <translation type="unfinished">translator_credits</translation>
+    </message>
+    <message>
+        <location filename="../../src/appshell/qml/Audacity/AppShell/AboutDialog.qml" line="15"/>
+        <source>About Audacity</source>
+        <translation type="unfinished">About Audacity</translation>
+    </message>
+    <message>
+        <location filename="../../src/appshell/qml/Audacity/AppShell/AboutDialog.qml" line="43"/>
+        <source>Audacity</source>
+        <translation type="unfinished">Audacity</translation>
+    </message>
+    <message>
+        <location filename="../../src/appshell/qml/Audacity/AppShell/AboutDialog.qml" line="47"/>
+        <source>Legal</source>
+        <translation type="unfinished">Legal</translation>
+    </message>
+    <message>
+        <location filename="../../src/appshell/qml/Audacity/AppShell/AboutDialogAudacityTab.qml" line="28"/>
+        <source>Audacity the free, open source, cross-platform software for recording and editing sounds.</source>
+        <translation type="unfinished">Audacity the free, open source, cross-platform software for recording and editing sounds.</translation>
+    </message>
+    <message>
+        <location filename="../../src/appshell/qml/Audacity/AppShell/AboutDialogAudacityTab.qml" line="109"/>
+        <source>Credits</source>
+        <translation type="unfinished">Credits</translation>
+    </message>
+    <message>
+        <location filename="../../src/appshell/qml/Audacity/AppShell/AboutDialogAudacityTab.qml" line="197"/>
+        <source>Audacity website: %1</source>
+        <translation type="unfinished">Audacity website: %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/appshell/qml/Audacity/AppShell/AboutDialogAudacityTab.qml" line="207"/>
+        <source>&lt;b&gt;Audacity®&lt;/b&gt; software is copyright © 1999-%1 Audacity Team.</source>
+        <translation type="unfinished">&lt;b&gt;Audacity®&lt;/b&gt; software is copyright © 1999-%1 Audacity Team.</translation>
+    </message>
+    <message>
+        <location filename="../../src/appshell/qml/Audacity/AppShell/AboutDialogAudacityTab.qml" line="212"/>
+        <source>The name &lt;b&gt;Audacity&lt;/b&gt; is a registered trademark.</source>
+        <translation type="unfinished">The name &lt;b&gt;Audacity&lt;/b&gt; is a registered trademark.</translation>
+    </message>
+    <message>
+        <location filename="../../src/appshell/qml/Audacity/AppShell/AboutDialogPrivacyTab.qml" line="27"/>
+        <source>Privacy</source>
+        <translation type="unfinished">Privacy</translation>
+    </message>
+    <message>
+        <location filename="../../src/appshell/qml/Audacity/AppShell/AboutDialogPrivacyTab.qml" line="28"/>
+        <source>App update checking and error reporting require network access. These features are optional.&lt;br&gt;See our %1 for more info.</source>
+        <translation type="unfinished">App update checking and error reporting require network access. These features are optional.&lt;br&gt;See our %1 for more info.</translation>
+    </message>
+    <message>
+        <location filename="../../src/appshell/qml/Audacity/AppShell/AboutDialogPrivacyTab.qml" line="54"/>
+        <source>privacy policy</source>
+        <translation type="unfinished">privacy policy</translation>
     </message>
 </context>
 <context>
@@ -2565,17 +2662,17 @@ Published under the &lt;a href=&quot;%1&quot;&gt;GNU General Public License vers
         <translation type="unfinished">Available option</translation>
     </message>
     <message>
-        <location filename="../../src/appshell/qml/Audacity/AppShell/FirstLaunchSetup/firstlaunchsetupmodel.cpp" line="113"/>
+        <location filename="../../src/appshell/qml/Audacity/AppShell/FirstLaunchSetup/firstlaunchsetupmodel.cpp" line="121"/>
         <source>Getting started</source>
         <translation type="unfinished">Getting started</translation>
     </message>
     <message>
-        <location filename="../../src/appshell/qml/Audacity/AppShell/FirstLaunchSetup/firstlaunchsetupmodel.cpp" line="131"/>
+        <location filename="../../src/appshell/qml/Audacity/AppShell/FirstLaunchSetup/firstlaunchsetupmodel.cpp" line="139"/>
         <source>Accept &amp; continue</source>
         <translation type="unfinished">Accept &amp; continue</translation>
     </message>
     <message>
-        <location filename="../../src/appshell/qml/Audacity/AppShell/FirstLaunchSetup/firstlaunchsetupmodel.cpp" line="137"/>
+        <location filename="../../src/appshell/qml/Audacity/AppShell/FirstLaunchSetup/firstlaunchsetupmodel.cpp" line="145"/>
         <source>%1 of %2</source>
         <extracomment>%1 is the current page number, %2 is the total number of pages</extracomment>
         <translation type="unfinished">%1 of %2</translation>
@@ -2751,12 +2848,12 @@ Published under the &lt;a href=&quot;%1&quot;&gt;GNU General Public License vers
         <translation type="unfinished">Preview of the selected workspace layout showing the arrangement of interface elements</translation>
     </message>
     <message>
-        <location filename="../../src/au3cloud/internal/au3cloudservice.cpp" line="50"/>
+        <location filename="../../src/au3cloud/internal/au3cloudservice.cpp" line="46"/>
         <source>Authorization failed</source>
         <translation type="unfinished">Authorization failed</translation>
     </message>
     <message>
-        <location filename="../../src/au3cloud/internal/au3cloudservice.cpp" line="58"/>
+        <location filename="../../src/au3cloud/internal/au3cloudservice.cpp" line="57"/>
         <source>No access token</source>
         <translation type="unfinished">No access token</translation>
     </message>
@@ -2801,7 +2898,6 @@ Published under the &lt;a href=&quot;%1&quot;&gt;GNU General Public License vers
 <context>
     <name>appshell/menu/audio-actions</name>
     <message>
-        <location filename="../../src/appshell/qml/Audacity/AppShell/appmenumodel.cpp" line="565"/>
         <source>Audio actions across labels</source>
         <translation type="unfinished">Audio actions across labels</translation>
     </message>
@@ -2814,7 +2910,7 @@ Published under the &lt;a href=&quot;%1&quot;&gt;GNU General Public License vers
         <translation type="unfinished">Clip</translation>
     </message>
     <message>
-        <location filename="../../src/appshell/qml/Audacity/AppShell/appmenumodel.cpp" line="545"/>
+        <location filename="../../src/appshell/qml/Audacity/AppShell/appmenumodel.cpp" line="535"/>
         <source>Rename clip</source>
         <translation type="unfinished">Rename clip</translation>
     </message>
@@ -2838,17 +2934,21 @@ Published under the &lt;a href=&quot;%1&quot;&gt;GNU General Public License vers
 <context>
     <name>appshell/menu/diagnostic</name>
     <message>
-        <location filename="../../src/appshell/qml/Audacity/AppShell/appmenumodel.cpp" line="726"/>
+        <location filename="../../src/appshell/qml/Audacity/AppShell/appmenumodel.cpp" line="694"/>
         <source>&amp;System</source>
         <translation type="unfinished">&amp;System</translation>
     </message>
     <message>
-        <location filename="../../src/appshell/qml/Audacity/AppShell/appmenumodel.cpp" line="736"/>
+        <location filename="../../src/appshell/qml/Audacity/AppShell/appmenumodel.cpp" line="704"/>
         <source>&amp;Accessibility</source>
         <translation type="unfinished">&amp;Accessibility</translation>
     </message>
     <message>
-        <location filename="../../src/appshell/qml/Audacity/AppShell/appmenumodel.cpp" line="743"/>
+        <location filename="../../src/appshell/qml/Audacity/AppShell/appmenumodel.cpp" line="711"/>
+        <source>Test&amp;flow</source>
+        <translation type="unfinished">Test&amp;flow</translation>
+    </message>
+    <message>
         <source>Auto&amp;bot</source>
         <translation type="unfinished">Auto&amp;bot</translation>
     </message>
@@ -2856,37 +2956,41 @@ Published under the &lt;a href=&quot;%1&quot;&gt;GNU General Public License vers
 <context>
     <name>appshell/menu/diagnostics</name>
     <message>
-        <location filename="../../src/appshell/qml/Audacity/AppShell/appmenumodel.cpp" line="424"/>
+        <location filename="../../src/appshell/qml/Audacity/AppShell/appmenumodel.cpp" line="417"/>
         <source>Diagnostics</source>
         <translation type="unfinished">Diagnostics</translation>
     </message>
     <message>
-        <location filename="../../src/appshell/qml/Audacity/AppShell/appmenumodel.cpp" line="454"/>
+        <location filename="../../src/appshell/qml/Audacity/AppShell/appmenumodel.cpp" line="444"/>
         <source>&amp;System</source>
         <translation type="unfinished">&amp;System</translation>
     </message>
     <message>
-        <location filename="../../src/appshell/qml/Audacity/AppShell/appmenumodel.cpp" line="476"/>
+        <location filename="../../src/appshell/qml/Audacity/AppShell/appmenumodel.cpp" line="466"/>
         <source>A&amp;ctions</source>
         <translation type="unfinished">A&amp;ctions</translation>
     </message>
     <message>
-        <location filename="../../src/appshell/qml/Audacity/AppShell/appmenumodel.cpp" line="477"/>
+        <location filename="../../src/appshell/qml/Audacity/AppShell/appmenumodel.cpp" line="467"/>
         <source>&amp;Accessibility</source>
         <translation type="unfinished">&amp;Accessibility</translation>
     </message>
     <message>
-        <location filename="../../src/appshell/qml/Audacity/AppShell/appmenumodel.cpp" line="478"/>
+        <location filename="../../src/appshell/qml/Audacity/AppShell/appmenumodel.cpp" line="468"/>
         <source>E&amp;xtensions</source>
         <translation type="unfinished">E&amp;xtensions</translation>
     </message>
     <message>
-        <location filename="../../src/appshell/qml/Audacity/AppShell/appmenumodel.cpp" line="479"/>
+        <location filename="../../src/appshell/qml/Audacity/AppShell/appmenumodel.cpp" line="469"/>
+        <source>Test&amp;flow</source>
+        <translation type="unfinished">Test&amp;flow</translation>
+    </message>
+    <message>
         <source>Auto&amp;bot</source>
         <translation type="unfinished">Auto&amp;bot</translation>
     </message>
     <message>
-        <location filename="../../src/appshell/qml/Audacity/AppShell/appmenumodel.cpp" line="484"/>
+        <location filename="../../src/appshell/qml/Audacity/AppShell/appmenumodel.cpp" line="474"/>
         <source>&amp;Diagnostics</source>
         <translation type="unfinished">&amp;Diagnostics</translation>
     </message>
@@ -2918,7 +3022,7 @@ Published under the &lt;a href=&quot;%1&quot;&gt;GNU General Public License vers
 <context>
     <name>appshell/menu/extra</name>
     <message>
-        <location filename="../../src/appshell/qml/Audacity/AppShell/appmenumodel.cpp" line="415"/>
+        <location filename="../../src/appshell/qml/Audacity/AppShell/appmenumodel.cpp" line="408"/>
         <source>&amp;Extra</source>
         <translation type="unfinished">&amp;Extra</translation>
     </message>
@@ -2979,7 +3083,7 @@ Published under the &lt;a href=&quot;%1&quot;&gt;GNU General Public License vers
 <context>
     <name>appshell/menu/help</name>
     <message>
-        <location filename="../../src/appshell/qml/Audacity/AppShell/appmenumodel.cpp" line="441"/>
+        <location filename="../../src/appshell/qml/Audacity/AppShell/appmenumodel.cpp" line="431"/>
         <source>&amp;Help</source>
         <translation type="unfinished">&amp;Help</translation>
     </message>
@@ -3003,7 +3107,7 @@ Published under the &lt;a href=&quot;%1&quot;&gt;GNU General Public License vers
 <context>
     <name>appshell/menu/macros</name>
     <message>
-        <location filename="../../src/appshell/qml/Audacity/AppShell/appmenumodel.cpp" line="872"/>
+        <location filename="../../src/appshell/qml/Audacity/AppShell/appmenumodel.cpp" line="840"/>
         <source>&amp;Macros</source>
         <translation type="unfinished">&amp;Macros</translation>
     </message>
@@ -3164,7 +3268,7 @@ Published under the &lt;a href=&quot;%1&quot;&gt;GNU General Public License vers
 <context>
     <name>appshell/preferences</name>
     <message>
-        <location filename="../../src/importexport/export/qml/Export/ExportDialog.qml" line="605"/>
+        <location filename="../../src/importexport/export/qml/Export/ExportDialog.qml" line="604"/>
         <source>Edit metadata</source>
         <translation type="unfinished">Edit metadata</translation>
     </message>
@@ -3184,7 +3288,6 @@ Published under the &lt;a href=&quot;%1&quot;&gt;GNU General Public License vers
         <translation type="unfinished">VBL</translation>
     </message>
     <message>
-        <location filename="../../src/preferences/qml/Audacity/Preferences/internal/AccentColorsSection.qml" line="64"/>
         <source>Accent color:</source>
         <translation type="unfinished">Accent color:</translation>
     </message>
@@ -3205,11 +3308,19 @@ Published under the &lt;a href=&quot;%1&quot;&gt;GNU General Public License vers
     </message>
     <message>
         <location filename="../../src/preferences/qml/Audacity/Preferences/internal/AutomaticUpdateSection.qml" line="44"/>
+        <source>Check to see if a new version of Audacity is available</source>
+        <translation type="unfinished">Check to see if a new version of Audacity is available</translation>
+    </message>
+    <message>
+        <location filename="../../src/preferences/qml/Audacity/Preferences/internal/AutomaticUpdateSection.qml" line="60"/>
+        <source>Update checking requires network access. In order to protect your privacy, Audacity does not store any personal information. See our &lt;a href=&quot;%1&quot;&gt;privacy policy&lt;/a&gt; for more info.</source>
+        <translation type="unfinished">Update checking requires network access. In order to protect your privacy, Audacity does not store any personal information. See our &lt;a href=&quot;%1&quot;&gt;privacy policy&lt;/a&gt; for more info.</translation>
+    </message>
+    <message>
         <source>Check to see if a new version of MuseScore is available</source>
         <translation type="unfinished">Check to see if a new version of MuseScore is available</translation>
     </message>
     <message>
-        <location filename="../../src/preferences/qml/Audacity/Preferences/internal/AutomaticUpdateSection.qml" line="60"/>
         <source>Update checking requires network access. In order to protect your privacy, MuseScore does not store any personal information. See our &lt;a href=&quot;%1&quot;&gt;privacy policy&lt;/a&gt; for more info.</source>
         <translation type="unfinished">Update checking requires network access. In order to protect your privacy, MuseScore does not store any personal information. See our &lt;a href=&quot;%1&quot;&gt;privacy policy&lt;/a&gt; for more info.</translation>
     </message>
@@ -3220,6 +3331,10 @@ Published under the &lt;a href=&quot;%1&quot;&gt;GNU General Public License vers
     </message>
     <message>
         <location filename="../../src/preferences/qml/Audacity/Preferences/internal/AutoSaveSection.qml" line="51"/>
+        <source>Auto save every</source>
+        <translation type="unfinished">Auto save every</translation>
+    </message>
+    <message>
         <source>Auto save every:</source>
         <translation type="unfinished">Auto save every:</translation>
     </message>
@@ -3297,11 +3412,19 @@ Published under the &lt;a href=&quot;%1&quot;&gt;GNU General Public License vers
     </message>
     <message>
         <location filename="../../src/preferences/qml/Audacity/Preferences/internal/MidiDevicesSection.qml" line="49"/>
+        <source>MIDI input</source>
+        <translation type="unfinished">MIDI input</translation>
+    </message>
+    <message>
+        <location filename="../../src/preferences/qml/Audacity/Preferences/internal/MidiDevicesSection.qml" line="65"/>
+        <source>MIDI output</source>
+        <translation type="unfinished">MIDI output</translation>
+    </message>
+    <message>
         <source>MIDI input:</source>
         <translation type="unfinished">MIDI input:</translation>
     </message>
     <message>
-        <location filename="../../src/preferences/qml/Audacity/Preferences/internal/MidiDevicesSection.qml" line="65"/>
         <source>MIDI output:</source>
         <translation type="unfinished">MIDI output:</translation>
     </message>
@@ -3411,12 +3534,10 @@ Published under the &lt;a href=&quot;%1&quot;&gt;GNU General Public License vers
         <translation type="unfinished">Choose starting project</translation>
     </message>
     <message>
-        <location filename="../../src/preferences/qml/Audacity/Preferences/internal/PublishMuseScoreComSection.qml" line="32"/>
         <source>Publish to MuseScore.com</source>
         <translation type="unfinished">Publish to MuseScore.com</translation>
     </message>
     <message>
-        <location filename="../../src/preferences/qml/Audacity/Preferences/internal/PublishMuseScoreComSection.qml" line="43"/>
         <source>Always prompt to share on Audio.com after publishing to MuseScore.com</source>
         <translation type="unfinished">Always prompt to share on Audio.com after publishing to MuseScore.com</translation>
     </message>
@@ -3474,6 +3595,121 @@ Published under the &lt;a href=&quot;%1&quot;&gt;GNU General Public License vers
         <location filename="../../src/preferences/qml/Audacity/Preferences/internal/ZoomSection.qml" line="96"/>
         <source>Mouse zoom precision:</source>
         <translation type="unfinished">Mouse zoom precision:</translation>
+    </message>
+    <message>
+        <location filename="../../src/preferences/qml/Audacity/Preferences/internal/AccentColorsSection.qml" line="64"/>
+        <source>Accent color</source>
+        <translation type="unfinished">Accent color</translation>
+    </message>
+    <message>
+        <location filename="../../src/preferences/qml/Audacity/Preferences/internal/UsageInfoSection.qml" line="14"/>
+        <source>Usage info</source>
+        <translation type="unfinished">Usage info</translation>
+    </message>
+    <message>
+        <location filename="../../src/preferences/qml/Audacity/Preferences/internal/UsageInfoSection.qml" line="25"/>
+        <source>Send anonymous usage info</source>
+        <translation type="unfinished">Send anonymous usage info</translation>
+    </message>
+    <message>
+        <location filename="../../src/preferences/qml/Audacity/Preferences/internal/UsageInfoSection.qml" line="39"/>
+        <source>To help us understand how often people use Audacity, we generate a random ID (UUID) for each installation. This ID does not contain any personally identifiable information. Want to know more? Check out our &lt;a href=&quot;%1&quot;&gt;privacy policy&lt;/a&gt;.</source>
+        <translation type="unfinished">To help us understand how often people use Audacity, we generate a random ID (UUID) for each installation. This ID does not contain any personally identifiable information. Want to know more? Check out our &lt;a href=&quot;%1&quot;&gt;privacy policy&lt;/a&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../../src/preferences/qml/Audacity/Preferences/internal/ZoomToggleSection.qml" line="14"/>
+        <source>Zoom toggle (magnifying glass)</source>
+        <translation type="unfinished">Zoom toggle (magnifying glass)</translation>
+    </message>
+    <message>
+        <location filename="../../src/preferences/qml/Audacity/Preferences/internal/ZoomToggleSection.qml" line="26"/>
+        <source>A special tool in the top bar that toggles between two different zoom states.</source>
+        <translation type="unfinished">A special tool in the top bar that toggles between two different zoom states.</translation>
+    </message>
+    <message>
+        <location filename="../../src/preferences/qml/Audacity/Preferences/internal/ZoomToggleSection.qml" line="34"/>
+        <source>Zoom state 1:</source>
+        <translation type="unfinished">Zoom state 1:</translation>
+    </message>
+    <message>
+        <location filename="../../src/preferences/qml/Audacity/Preferences/internal/ZoomToggleSection.qml" line="55"/>
+        <source>Zoom state 2:</source>
+        <translation type="unfinished">Zoom state 2:</translation>
+    </message>
+    <message>
+        <location filename="../../src/preferences/qml/Audacity/Preferences/editpreferencesmodel.cpp" line="246"/>
+        <source>Fit to Width</source>
+        <translation type="unfinished">Fit to Width</translation>
+    </message>
+    <message>
+        <location filename="../../src/preferences/qml/Audacity/Preferences/editpreferencesmodel.cpp" line="247"/>
+        <source>Zoom to Selection</source>
+        <translation type="unfinished">Zoom to Selection</translation>
+    </message>
+    <message>
+        <location filename="../../src/preferences/qml/Audacity/Preferences/editpreferencesmodel.cpp" line="248"/>
+        <source>Zoom Default</source>
+        <translation type="unfinished">Zoom Default</translation>
+    </message>
+    <message>
+        <location filename="../../src/preferences/qml/Audacity/Preferences/editpreferencesmodel.cpp" line="249"/>
+        <source>Minutes</source>
+        <translation type="unfinished">Minutes</translation>
+    </message>
+    <message>
+        <location filename="../../src/preferences/qml/Audacity/Preferences/editpreferencesmodel.cpp" line="250"/>
+        <source>Seconds</source>
+        <translation type="unfinished">Seconds</translation>
+    </message>
+    <message>
+        <location filename="../../src/preferences/qml/Audacity/Preferences/editpreferencesmodel.cpp" line="251"/>
+        <source>5ths of Seconds</source>
+        <translation type="unfinished">5ths of Seconds</translation>
+    </message>
+    <message>
+        <location filename="../../src/preferences/qml/Audacity/Preferences/editpreferencesmodel.cpp" line="252"/>
+        <source>10ths of Seconds</source>
+        <translation type="unfinished">10ths of Seconds</translation>
+    </message>
+    <message>
+        <location filename="../../src/preferences/qml/Audacity/Preferences/editpreferencesmodel.cpp" line="253"/>
+        <source>20ths of Seconds</source>
+        <translation type="unfinished">20ths of Seconds</translation>
+    </message>
+    <message>
+        <location filename="../../src/preferences/qml/Audacity/Preferences/editpreferencesmodel.cpp" line="254"/>
+        <source>50ths of Seconds</source>
+        <translation type="unfinished">50ths of Seconds</translation>
+    </message>
+    <message>
+        <location filename="../../src/preferences/qml/Audacity/Preferences/editpreferencesmodel.cpp" line="255"/>
+        <source>100ths of Seconds</source>
+        <translation type="unfinished">100ths of Seconds</translation>
+    </message>
+    <message>
+        <location filename="../../src/preferences/qml/Audacity/Preferences/editpreferencesmodel.cpp" line="256"/>
+        <source>500ths of Seconds</source>
+        <translation type="unfinished">500ths of Seconds</translation>
+    </message>
+    <message>
+        <location filename="../../src/preferences/qml/Audacity/Preferences/editpreferencesmodel.cpp" line="257"/>
+        <source>MilliSeconds</source>
+        <translation type="unfinished">MilliSeconds</translation>
+    </message>
+    <message>
+        <location filename="../../src/preferences/qml/Audacity/Preferences/editpreferencesmodel.cpp" line="258"/>
+        <source>Samples</source>
+        <translation type="unfinished">Samples</translation>
+    </message>
+    <message>
+        <location filename="../../src/preferences/qml/Audacity/Preferences/editpreferencesmodel.cpp" line="259"/>
+        <source>4 Pixels per Sample</source>
+        <translation type="unfinished">4 Pixels per Sample</translation>
+    </message>
+    <message>
+        <location filename="../../src/preferences/qml/Audacity/Preferences/editpreferencesmodel.cpp" line="260"/>
+        <source>Max Zoom</source>
+        <translation type="unfinished">Max Zoom</translation>
     </message>
 </context>
 <context>
@@ -3619,27 +3855,90 @@ Published under the &lt;a href=&quot;%1&quot;&gt;GNU General Public License vers
     </message>
 </context>
 <context>
+    <name>canvas</name>
+    <message>
+        <location filename="../../src/projectscene/view/tracksitemsview/canvascontextmenumodel.cpp" line="26"/>
+        <source>Paste and overlap</source>
+        <translation type="unfinished">Paste and overlap</translation>
+    </message>
+    <message>
+        <location filename="../../src/projectscene/view/tracksitemsview/canvascontextmenumodel.cpp" line="28"/>
+        <source>Paste and make room on this track</source>
+        <translation type="unfinished">Paste and make room on this track</translation>
+    </message>
+    <message>
+        <location filename="../../src/projectscene/view/tracksitemsview/canvascontextmenumodel.cpp" line="30"/>
+        <source>Paste and make room on all tracks</source>
+        <translation type="unfinished">Paste and make room on all tracks</translation>
+    </message>
+    <message>
+        <location filename="../../src/projectscene/view/tracksitemsview/canvascontextmenumodel.cpp" line="35"/>
+        <source>Paste and…</source>
+        <translation type="unfinished">Paste and…</translation>
+    </message>
+</context>
+<context>
     <name>clip</name>
     <message>
         <location filename="../../src/projectscene/view/tracksitemsview/clipcontextmenumodel.cpp" line="46"/>
+        <source>Cut and leave gap</source>
+        <translation type="unfinished">Cut and leave gap</translation>
+    </message>
+    <message>
+        <location filename="../../src/projectscene/view/tracksitemsview/clipcontextmenumodel.cpp" line="48"/>
+        <source>Cut and close gap on this track</source>
+        <translation type="unfinished">Cut and close gap on this track</translation>
+    </message>
+    <message>
+        <location filename="../../src/projectscene/view/tracksitemsview/clipcontextmenumodel.cpp" line="50"/>
+        <source>Cut and close gap on all tracks</source>
+        <translation type="unfinished">Cut and close gap on all tracks</translation>
+    </message>
+    <message>
+        <location filename="../../src/projectscene/view/tracksitemsview/clipcontextmenumodel.cpp" line="55"/>
+        <source>Delete and leave gap</source>
+        <translation type="unfinished">Delete and leave gap</translation>
+    </message>
+    <message>
+        <location filename="../../src/projectscene/view/tracksitemsview/clipcontextmenumodel.cpp" line="57"/>
+        <source>Delete and close gap on this track</source>
+        <translation type="unfinished">Delete and close gap on this track</translation>
+    </message>
+    <message>
+        <location filename="../../src/projectscene/view/tracksitemsview/clipcontextmenumodel.cpp" line="59"/>
+        <source>Delete and close gap on all tracks</source>
+        <translation type="unfinished">Delete and close gap on all tracks</translation>
+    </message>
+    <message>
+        <location filename="../../src/projectscene/view/tracksitemsview/clipcontextmenumodel.cpp" line="64"/>
         <source>Rename clip</source>
         <translation type="unfinished">Rename clip</translation>
     </message>
     <message>
-        <location filename="../../src/projectscene/view/tracksitemsview/clipcontextmenumodel.cpp" line="47"/>
+        <location filename="../../src/projectscene/view/tracksitemsview/clipcontextmenumodel.cpp" line="65"/>
         <source>Clip color</source>
         <translation type="unfinished">Clip color</translation>
+    </message>
+    <message>
+        <location filename="../../src/projectscene/view/tracksitemsview/clipcontextmenumodel.cpp" line="72"/>
+        <source>Cut and…</source>
+        <translation type="unfinished">Cut and…</translation>
+    </message>
+    <message>
+        <location filename="../../src/projectscene/view/tracksitemsview/clipcontextmenumodel.cpp" line="73"/>
+        <source>Delete and…</source>
+        <translation type="unfinished">Delete and…</translation>
     </message>
 </context>
 <context>
     <name>clips</name>
     <message>
-        <location filename="../../src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/ClipItem.qml" line="1059"/>
+        <location filename="../../src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/ClipItem.qml" line="1068"/>
         <source>Select</source>
         <translation type="unfinished">Select</translation>
     </message>
     <message>
-        <location filename="../../src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/ClipItem.qml" line="1059"/>
+        <location filename="../../src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/ClipItem.qml" line="1068"/>
         <source>Deselect</source>
         <translation type="unfinished">Deselect</translation>
     </message>
@@ -3685,8 +3984,8 @@ Published under the &lt;a href=&quot;%1&quot;&gt;GNU General Public License vers
     </message>
     <message>
         <location filename="../../src/project/qml/Audacity/Project/SaveToCloudDialog.qml" line="22"/>
-        <location filename="../../src/project/internal/projectactionscontroller.cpp" line="1195"/>
-        <location filename="../../src/project/internal/projectactionscontroller.cpp" line="1324"/>
+        <location filename="../../src/project/internal/opensaveprojectscenario.cpp" line="604"/>
+        <location filename="../../src/project/internal/opensaveprojectscenario.cpp" line="724"/>
         <source>Save</source>
         <translation type="unfinished">Save</translation>
     </message>
@@ -3696,29 +3995,40 @@ Published under the &lt;a href=&quot;%1&quot;&gt;GNU General Public License vers
         <translation type="unfinished">You are not signed in</translation>
     </message>
     <message>
-        <location filename="../../src/au3cloud/internal/au3audiocomservice.cpp" line="382"/>
-        <location filename="../../src/au3cloud/internal/au3audiocomservice.cpp" line="388"/>
-        <location filename="../../src/au3cloud/internal/au3audiocomservice.cpp" line="422"/>
+        <location filename="../../src/au3cloud/internal/au3audiocomservice.cpp" line="265"/>
+        <location filename="../../src/au3cloud/internal/au3audiocomservice.cpp" line="270"/>
+        <location filename="../../src/au3cloud/internal/au3audiocomservice.cpp" line="291"/>
         <source>Invalid project</source>
         <translation type="unfinished">Invalid project</translation>
     </message>
     <message>
-        <location filename="../../src/au3cloud/internal/au3audiocomservice.cpp" line="415"/>
+        <location filename="../../src/au3cloud/internal/au3audiocomservice.cpp" line="279"/>
+        <location filename="../../src/au3cloud/internal/au3audiocomservice.cpp" line="575"/>
+        <source>Service destroyed</source>
+        <translation type="unfinished">Service destroyed</translation>
+    </message>
+    <message>
+        <location filename="../../src/au3cloud/internal/au3audiocomservice.cpp" line="284"/>
         <source>Project was closed before upload started</source>
         <translation type="unfinished">Project was closed before upload started</translation>
     </message>
     <message>
-        <location filename="../../src/au3cloud/internal/au3audiocomservice.cpp" line="539"/>
+        <location filename="../../src/au3cloud/internal/au3audiocomservice.cpp" line="448"/>
+        <source>Invalid audio ID</source>
+        <translation type="unfinished">Invalid audio ID</translation>
+    </message>
+    <message>
+        <location filename="../../src/au3cloud/internal/au3audiocomservice.cpp" line="505"/>
         <source>Project not found in cloud database</source>
         <translation type="unfinished">Project not found in cloud database</translation>
     </message>
     <message>
-        <location filename="../../src/au3cloud/internal/au3audiocomservice.cpp" line="615"/>
+        <location filename="../../src/au3cloud/internal/au3audiocomservice.cpp" line="587"/>
         <source>No valid current project</source>
         <translation type="unfinished">No valid current project</translation>
     </message>
     <message>
-        <location filename="../../src/au3cloud/internal/au3audiocomservice.cpp" line="678"/>
+        <location filename="../../src/au3cloud/internal/au3audiocomservice.cpp" line="650"/>
         <source>Upload succeeded but payload is missing</source>
         <translation type="unfinished">Upload succeeded but payload is missing</translation>
     </message>
@@ -3728,42 +4038,52 @@ Published under the &lt;a href=&quot;%1&quot;&gt;GNU General Public License vers
         <translation type="unfinished">Sign in successful! You’re good to go back to Audacity.</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectactionscontroller.cpp" line="479"/>
-        <location filename="../../src/project/internal/projectactionscontroller.cpp" line="1017"/>
+        <location filename="../../src/project/internal/projectactionscontroller.cpp" line="506"/>
+        <location filename="../../src/project/internal/projectactionscontroller.cpp" line="1088"/>
         <source>View on audio.com</source>
         <translation type="unfinished">View on audio.com</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectactionscontroller.cpp" line="993"/>
+        <location filename="../../src/project/internal/projectactionscontroller.cpp" line="1060"/>
         <source>Track title</source>
         <translation type="unfinished">Track title</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectactionscontroller.cpp" line="994"/>
+        <location filename="../../src/project/internal/projectactionscontroller.cpp" line="1061"/>
         <source>Share audio</source>
         <translation type="unfinished">Share audio</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectactionscontroller.cpp" line="995"/>
+        <location filename="../../src/project/internal/projectactionscontroller.cpp" line="1062"/>
         <source>Share</source>
         <translation type="unfinished">Share</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectactionscontroller.cpp" line="1012"/>
+        <location filename="../../src/project/internal/projectactionscontroller.cpp" line="1083"/>
         <source>Audio shared to audio.com</source>
         <translation type="unfinished">Audio shared to audio.com</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectactionscontroller.cpp" line="1032"/>
+        <location filename="../../src/project/internal/projectactionscontroller.cpp" line="1103"/>
         <source>Sharing audio to audio.com…</source>
         <translation type="unfinished">Sharing audio to audio.com…</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectactionscontroller.cpp" line="1190"/>
-        <location filename="../../src/project/internal/projectactionscontroller.cpp" line="1293"/>
-        <location filename="../../src/project/internal/projectactionscontroller.cpp" line="1319"/>
+        <location filename="../../src/project/internal/projectactionscontroller.cpp" line="1162"/>
+        <source>Downloading audio from cloud…</source>
+        <translation type="unfinished">Downloading audio from cloud…</translation>
+    </message>
+    <message>
+        <location filename="../../src/project/internal/opensaveprojectscenario.cpp" line="599"/>
+        <location filename="../../src/project/internal/opensaveprojectscenario.cpp" line="706"/>
+        <location filename="../../src/project/internal/opensaveprojectscenario.cpp" line="719"/>
         <source>Save to audio.com</source>
         <translation type="unfinished">Save to audio.com</translation>
+    </message>
+    <message>
+        <location filename="../../src/project/internal/opensaveprojectscenario.cpp" line="796"/>
+        <source>Open audio from cloud</source>
+        <translation type="unfinished">Open audio from cloud</translation>
     </message>
 </context>
 <context>
@@ -3783,7 +4103,6 @@ Published under the &lt;a href=&quot;%1&quot;&gt;GNU General Public License vers
     </message>
     <message>
         <location filename="../../src/effects/builtin_collection/tonegen/ChirpView.qml" line="17"/>
-        <location filename="../../src/effects/builtin_collection/internal/builtineffectsloader.cpp" line="256"/>
         <source>Chirp</source>
         <translation type="unfinished">Chirp</translation>
     </message>
@@ -3810,10 +4129,14 @@ Published under the &lt;a href=&quot;%1&quot;&gt;GNU General Public License vers
         <translation type="unfinished">Unknown parameter type: %1</translation>
     </message>
     <message>
-        <location filename="../../src/effects/effects_base/qml/Audacity/Effects/PresetNameDialog.qml" line="13"/>
-        <location filename="../../src/effects/effects_base/internal/effectpresetsscenario.cpp" line="48"/>
         <source>Save Preset</source>
         <translation type="unfinished">Save Preset</translation>
+    </message>
+    <message>
+        <location filename="../../src/effects/effects_base/qml/Audacity/Effects/PresetNameDialog.qml" line="13"/>
+        <location filename="../../src/effects/effects_base/internal/effectpresetsscenario.cpp" line="48"/>
+        <source>Save preset</source>
+        <translation type="unfinished">Save preset</translation>
     </message>
     <message>
         <location filename="../../src/effects/effects_base/qml/Audacity/Effects/PresetNameDialog.qml" line="44"/>
@@ -3821,27 +4144,31 @@ Published under the &lt;a href=&quot;%1&quot;&gt;GNU General Public License vers
         <translation type="unfinished">Preset name</translation>
     </message>
     <message>
-        <location filename="../../src/effects/nyquist/nyquistprompt/NyquistPromptView.qml" line="54"/>
         <source>Enter Nyquist Command:</source>
         <translation type="unfinished">Enter Nyquist Command:</translation>
     </message>
     <message>
-        <location filename="../../src/effects/nyquist/nyquistprompt/NyquistPromptView.qml" line="60"/>
+        <location filename="../../src/effects/nyquist/nyquistprompt/NyquistPromptView.qml" line="63"/>
+        <source>Enter Nyquist command:</source>
+        <translation type="unfinished">Enter Nyquist command:</translation>
+    </message>
+    <message>
+        <location filename="../../src/effects/nyquist/nyquistprompt/NyquistPromptView.qml" line="69"/>
         <source>Debug</source>
         <translation type="unfinished">Debug</translation>
     </message>
     <message>
-        <location filename="../../src/effects/nyquist/nyquistprompt/NyquistPromptView.qml" line="77"/>
+        <location filename="../../src/effects/nyquist/nyquistprompt/NyquistPromptView.qml" line="93"/>
         <source>Enter Nyquist code here…</source>
         <translation type="unfinished">Enter Nyquist code here…</translation>
     </message>
     <message>
-        <location filename="../../src/effects/nyquist/nyquistprompt/NyquistPromptView.qml" line="90"/>
+        <location filename="../../src/effects/nyquist/nyquistprompt/NyquistPromptView.qml" line="106"/>
         <source>Load</source>
         <translation type="unfinished">Load</translation>
     </message>
     <message>
-        <location filename="../../src/effects/nyquist/nyquistprompt/NyquistPromptView.qml" line="97"/>
+        <location filename="../../src/effects/nyquist/nyquistprompt/NyquistPromptView.qml" line="117"/>
         <location filename="../../src/effects/effects_base/view/effectsavecontextmenu.cpp" line="76"/>
         <source>Save</source>
         <translation type="unfinished">Save</translation>
@@ -3910,163 +4237,130 @@ Published under the &lt;a href=&quot;%1&quot;&gt;GNU General Public License vers
         <translation type="unfinished">Output</translation>
     </message>
     <message>
-        <location filename="../../src/effects/builtin_collection/internal/builtineffectsloader.cpp" line="146"/>
         <source>Amplify</source>
         <translation type="unfinished">Amplify</translation>
     </message>
     <message>
-        <location filename="../../src/effects/builtin_collection/internal/builtineffectsloader.cpp" line="147"/>
         <source>Increases or decreases the volume of the audio you have selected</source>
         <translation type="unfinished">Increases or decreases the volume of the audio you have selected</translation>
     </message>
     <message>
-        <location filename="../../src/effects/builtin_collection/internal/builtineffectsloader.cpp" line="154"/>
         <source>Loudness normalization</source>
         <translation type="unfinished">Loudness normalization</translation>
     </message>
     <message>
-        <location filename="../../src/effects/builtin_collection/internal/builtineffectsloader.cpp" line="155"/>
         <source>Sets the loudness of one or more tracks</source>
         <translation type="unfinished">Sets the loudness of one or more tracks</translation>
     </message>
     <message>
-        <location filename="../../src/effects/builtin_collection/internal/builtineffectsloader.cpp" line="163"/>
         <source>Graphic EQ</source>
         <translation type="unfinished">Graphic EQ</translation>
     </message>
     <message>
-        <location filename="../../src/effects/builtin_collection/internal/builtineffectsloader.cpp" line="164"/>
         <source>Adjusts the balance between frequency components</source>
         <translation type="unfinished">Adjusts the balance between frequency components</translation>
     </message>
     <message>
-        <location filename="../../src/effects/builtin_collection/internal/builtineffectsloader.cpp" line="171"/>
         <source>Click removal</source>
         <translation type="unfinished">Click removal</translation>
     </message>
     <message>
-        <location filename="../../src/effects/builtin_collection/internal/builtineffectsloader.cpp" line="172"/>
         <source>Click removal is designed to remove clicks on audio tracks</source>
         <translation type="unfinished">Click removal is designed to remove clicks on audio tracks</translation>
     </message>
     <message>
-        <location filename="../../src/effects/builtin_collection/internal/builtineffectsloader.cpp" line="181"/>
         <source>Compressor</source>
         <translation type="unfinished">Compressor</translation>
     </message>
     <message>
-        <location filename="../../src/effects/builtin_collection/internal/builtineffectsloader.cpp" line="182"/>
         <source>Reduces “dynamic range”, or differences between loud and quiet parts</source>
         <translation type="unfinished">Reduces “dynamic range”, or differences between loud and quiet parts</translation>
     </message>
     <message>
-        <location filename="../../src/effects/builtin_collection/internal/builtineffectsloader.cpp" line="191"/>
         <source>Limiter</source>
         <translation type="unfinished">Limiter</translation>
     </message>
     <message>
-        <location filename="../../src/effects/builtin_collection/internal/builtineffectsloader.cpp" line="192"/>
         <source>Augments loudness while minimizing distortion</source>
         <translation type="unfinished">Augments loudness while minimizing distortion</translation>
     </message>
     <message>
-        <location filename="../../src/effects/builtin_collection/internal/builtineffectsloader.cpp" line="199"/>
         <source>Normalize</source>
         <translation type="unfinished">Normalize</translation>
     </message>
     <message>
-        <location filename="../../src/effects/builtin_collection/internal/builtineffectsloader.cpp" line="200"/>
-        <location filename="../../src/effects/builtin_collection/internal/builtineffectsloader.cpp" line="224"/>
         <source>Sets the peak amplitude of a one or more tracks</source>
         <translation type="unfinished">Sets the peak amplitude of a one or more tracks</translation>
     </message>
     <message>
-        <location filename="../../src/effects/builtin_collection/internal/builtineffectsloader.cpp" line="205"/>
         <source>Fade in</source>
         <translation type="unfinished">Fade in</translation>
     </message>
     <message>
-        <location filename="../../src/effects/builtin_collection/internal/builtineffectsloader.cpp" line="206"/>
         <source>Applies a linear fade-in to the selected audio</source>
         <translation type="unfinished">Applies a linear fade-in to the selected audio</translation>
     </message>
     <message>
-        <location filename="../../src/effects/builtin_collection/internal/builtineffectsloader.cpp" line="211"/>
         <source>Fade out</source>
         <translation type="unfinished">Fade out</translation>
     </message>
     <message>
-        <location filename="../../src/effects/builtin_collection/internal/builtineffectsloader.cpp" line="212"/>
         <source>Applies a linear fade-out to the selected audio</source>
         <translation type="unfinished">Applies a linear fade-out to the selected audio</translation>
     </message>
     <message>
-        <location filename="../../src/effects/builtin_collection/internal/builtineffectsloader.cpp" line="217"/>
         <source>Invert</source>
         <translation type="unfinished">Invert</translation>
     </message>
     <message>
-        <location filename="../../src/effects/builtin_collection/internal/builtineffectsloader.cpp" line="218"/>
         <source>Flips the audio samples upside-down, reversing their polarity</source>
         <translation type="unfinished">Flips the audio samples upside-down, reversing their polarity</translation>
     </message>
     <message>
-        <location filename="../../src/effects/builtin_collection/internal/builtineffectsloader.cpp" line="223"/>
         <source>Repair</source>
         <translation type="unfinished">Repair</translation>
     </message>
     <message>
-        <location filename="../../src/effects/builtin_collection/internal/builtineffectsloader.cpp" line="229"/>
         <source>Reverse</source>
         <translation type="unfinished">Reverse</translation>
     </message>
     <message>
-        <location filename="../../src/effects/builtin_collection/internal/builtineffectsloader.cpp" line="230"/>
         <source>Reverses the selected audio</source>
         <translation type="unfinished">Reverses the selected audio</translation>
     </message>
     <message>
-        <location filename="../../src/effects/builtin_collection/internal/builtineffectsloader.cpp" line="237"/>
         <source>Truncate silence</source>
         <translation type="unfinished">Truncate silence</translation>
     </message>
     <message>
-        <location filename="../../src/effects/builtin_collection/internal/builtineffectsloader.cpp" line="238"/>
         <source>Automatically reduces the length of passages where the volume is below a specified level</source>
         <translation type="unfinished">Automatically reduces the length of passages where the volume is below a specified level</translation>
     </message>
     <message>
-        <location filename="../../src/effects/builtin_collection/internal/builtineffectsloader.cpp" line="247"/>
         <source>Change pitch</source>
         <translation type="unfinished">Change pitch</translation>
     </message>
     <message>
-        <location filename="../../src/effects/builtin_collection/internal/builtineffectsloader.cpp" line="248"/>
         <source>Changes the pitch of a track without changing its tempo</source>
         <translation type="unfinished">Changes the pitch of a track without changing its tempo</translation>
     </message>
     <message>
-        <location filename="../../src/effects/builtin_collection/internal/builtineffectsloader.cpp" line="257"/>
         <source>Generates an ascending or descending tone of one of four types</source>
         <translation type="unfinished">Generates an ascending or descending tone of one of four types</translation>
     </message>
     <message>
-        <location filename="../../src/effects/builtin_collection/internal/builtineffectsloader.cpp" line="264"/>
         <source>Tone</source>
         <translation type="unfinished">Tone</translation>
     </message>
     <message>
-        <location filename="../../src/effects/builtin_collection/internal/builtineffectsloader.cpp" line="265"/>
         <source>Generates a constant frequency tone of one of four types</source>
         <translation type="unfinished">Generates a constant frequency tone of one of four types</translation>
     </message>
     <message>
-        <location filename="../../src/effects/builtin_collection/internal/builtineffectsloader.cpp" line="272"/>
         <source>Reverb</source>
         <translation type="unfinished">Reverb</translation>
     </message>
     <message>
-        <location filename="../../src/effects/builtin_collection/internal/builtineffectsloader.cpp" line="273"/>
         <source>Reverb effect</source>
         <translation type="unfinished">Reverb effect</translation>
     </message>
@@ -4116,7 +4410,7 @@ Published under the &lt;a href=&quot;%1&quot;&gt;GNU General Public License vers
         <translation type="unfinished">Preset mismatch</translation>
     </message>
     <message>
-        <location filename="../../src/effects/effects_base/internal/effectexecutionscenario.cpp" line="329"/>
+        <location filename="../../src/effects/effects_base/internal/effectexecutionscenario.cpp" line="385"/>
         <source>Applied effect: %1</source>
         <translation type="unfinished">Applied effect: %1</translation>
     </message>
@@ -4126,9 +4420,13 @@ Published under the &lt;a href=&quot;%1&quot;&gt;GNU General Public License vers
         <translation type="unfinished">Preset “%1” already exists, replace?</translation>
     </message>
     <message>
-        <location filename="../../src/effects/effects_base/internal/effectpresetsscenario.cpp" line="89"/>
         <source>Delete Preset</source>
         <translation type="unfinished">Delete Preset</translation>
+    </message>
+    <message>
+        <location filename="../../src/effects/effects_base/internal/effectpresetsscenario.cpp" line="89"/>
+        <source>Delete preset</source>
+        <translation type="unfinished">Delete preset</translation>
     </message>
     <message>
         <location filename="../../src/effects/effects_base/internal/effectpresetsscenario.cpp" line="90"/>
@@ -4142,6 +4440,15 @@ Published under the &lt;a href=&quot;%1&quot;&gt;GNU General Public License vers
     </message>
     <message>
         <location filename="../../src/effects/effects_base/internal/effectpresetsscenario.cpp" line="117"/>
+        <source>Import effect parameters</source>
+        <translation type="unfinished">Import effect parameters</translation>
+    </message>
+    <message>
+        <location filename="../../src/effects/effects_base/internal/effectpresetsscenario.cpp" line="148"/>
+        <source>Export effect parameters</source>
+        <translation type="unfinished">Export effect parameters</translation>
+    </message>
+    <message>
         <source>Import Effect Parameters</source>
         <translation type="unfinished">Import Effect Parameters</translation>
     </message>
@@ -4156,17 +4463,16 @@ Published under the &lt;a href=&quot;%1&quot;&gt;GNU General Public License vers
         <translation type="unfinished">%1: is for a different Effect, Generator or Analyzer.</translation>
     </message>
     <message>
-        <location filename="../../src/effects/effects_base/internal/effectpresetsscenario.cpp" line="148"/>
         <source>Export Effect Parameters</source>
         <translation type="unfinished">Export Effect Parameters</translation>
     </message>
     <message>
-        <location filename="../../src/effects/effects_base/internal/effectsprovider.cpp" line="369"/>
+        <location filename="../../src/effects/effects_base/internal/effectexecutionscenario.cpp" line="622"/>
         <source>Generating %1…</source>
         <translation type="unfinished">Generating %1…</translation>
     </message>
     <message>
-        <location filename="../../src/effects/effects_base/internal/effectsprovider.cpp" line="369"/>
+        <location filename="../../src/effects/effects_base/internal/effectexecutionscenario.cpp" line="622"/>
         <source>Applying %1…</source>
         <translation type="unfinished">Applying %1…</translation>
     </message>
@@ -4181,7 +4487,7 @@ Published under the &lt;a href=&quot;%1&quot;&gt;GNU General Public License vers
         <translation type="unfinished">Toggle between vendor UI and fallback UI</translation>
     </message>
     <message>
-        <location filename="../../src/effects/effects_base/internal/realtimeeffectservice.cpp" line="232"/>
+        <location filename="../../src/effects/effects_base/internal/realtimeeffectservice.cpp" line="233"/>
         <source>Master</source>
         <translation type="unfinished">Master</translation>
     </message>
@@ -4202,9 +4508,13 @@ Published under the &lt;a href=&quot;%1&quot;&gt;GNU General Public License vers
         <translation type="unfinished">Save as…</translation>
     </message>
     <message>
-        <location filename="../../src/effects/effects_base/view/generatedeffectviewermodel.cpp" line="54"/>
         <source>Unknown Effect</source>
         <translation type="unfinished">Unknown Effect</translation>
+    </message>
+    <message>
+        <location filename="../../src/effects/effects_base/view/generatedeffectviewermodel.cpp" line="54"/>
+        <source>Unknown effect</source>
+        <translation type="unfinished">Unknown effect</translation>
     </message>
     <message>
         <location filename="../../src/effects/effects_base/view/generatedeffectviewermodel.cpp" line="70"/>
@@ -4212,13 +4522,11 @@ Published under the &lt;a href=&quot;%1&quot;&gt;GNU General Public License vers
         <translation type="unfinished">No parameters available for this effect</translation>
     </message>
     <message>
-        <location filename="../../src/effects/nyquist/nyquistprompt/nyquistpromptloader.cpp" line="35"/>
         <location filename="../../src/effects/nyquist/nyquistprompt/nyquistpromptviewmodel.cpp" line="42"/>
         <source>Nyquist prompt</source>
         <translation type="unfinished">Nyquist prompt</translation>
     </message>
     <message>
-        <location filename="../../src/effects/nyquist/nyquistprompt/nyquistpromptloader.cpp" line="36"/>
         <source>Nyquist prompt effect</source>
         <translation type="unfinished">Nyquist prompt effect</translation>
     </message>
@@ -4253,6 +4561,10 @@ Published under the &lt;a href=&quot;%1&quot;&gt;GNU General Public License vers
     <message>
         <location filename="../../src/effects/nyquist/nyquistprompt/nyquistpromptviewmodel.cpp" line="163"/>
         <location filename="../../src/effects/nyquist/nyquistprompt/nyquistpromptviewmodel.cpp" line="168"/>
+        <source>Nyquist debug output</source>
+        <translation type="unfinished">Nyquist debug output</translation>
+    </message>
+    <message>
         <source>Nyquist Debug Output</source>
         <translation type="unfinished">Nyquist Debug Output</translation>
     </message>
@@ -4288,9 +4600,13 @@ Published under the &lt;a href=&quot;%1&quot;&gt;GNU General Public License vers
 <context>
     <name>effects/changepitch</name>
     <message>
-        <location filename="../../src/effects/builtin_collection/changepitch/changepitchviewmodel.cpp" line="22"/>
         <source>Change Pitch</source>
         <translation type="unfinished">Change Pitch</translation>
+    </message>
+    <message>
+        <location filename="../../src/effects/builtin_collection/changepitch/changepitchviewmodel.cpp" line="22"/>
+        <source>Change pitch</source>
+        <translation type="unfinished">Change pitch</translation>
     </message>
     <message>
         <location filename="../../src/effects/builtin_collection/changepitch/changepitchviewmodel.cpp" line="34"/>
@@ -4437,7 +4753,6 @@ Published under the &lt;a href=&quot;%1&quot;&gt;GNU General Public License vers
     <name>effects/dtmf</name>
     <message>
         <location filename="../../src/effects/builtin_collection/dtmfgen/DtmfView.qml" line="19"/>
-        <location filename="../../src/effects/builtin_collection/internal/builtineffectsloader.cpp" line="296"/>
         <source>DTMF tones</source>
         <translation type="unfinished">DTMF tones</translation>
     </message>
@@ -4493,7 +4808,6 @@ Published under the &lt;a href=&quot;%1&quot;&gt;GNU General Public License vers
         <translation type="unfinished">Silence duration</translation>
     </message>
     <message>
-        <location filename="../../src/effects/builtin_collection/internal/builtineffectsloader.cpp" line="297"/>
         <source>Generates DTMF signal</source>
         <translation type="unfinished">Generates DTMF signal</translation>
     </message>
@@ -4580,12 +4894,10 @@ Published under the &lt;a href=&quot;%1&quot;&gt;GNU General Public License vers
         <translation type="unfinished">Duration</translation>
     </message>
     <message>
-        <location filename="../../src/effects/builtin_collection/internal/builtineffectsloader.cpp" line="280"/>
         <source>Noise</source>
         <translation type="unfinished">Noise</translation>
     </message>
     <message>
-        <location filename="../../src/effects/builtin_collection/internal/builtineffectsloader.cpp" line="281"/>
         <source>Generates noise</source>
         <translation type="unfinished">Generates noise</translation>
     </message>
@@ -4611,7 +4923,6 @@ Published under the &lt;a href=&quot;%1&quot;&gt;GNU General Public License vers
 <context>
     <name>effects/noisereduction</name>
     <message>
-        <location filename="../../src/effects/builtin_collection/noisereduction/NoiseReductionView.qml" line="13"/>
         <source>Noise Reduction</source>
         <translation type="unfinished">Noise Reduction</translation>
     </message>
@@ -4641,8 +4952,8 @@ Published under the &lt;a href=&quot;%1&quot;&gt;GNU General Public License vers
         <translation type="unfinished">Select all of the audio you want filtered, choose how much noise you want filtered out, and then click “Apply” to reduce noise.</translation>
     </message>
     <message>
+        <location filename="../../src/effects/builtin_collection/noisereduction/NoiseReductionView.qml" line="13"/>
         <location filename="../../src/effects/builtin_collection/noisereduction/NoiseReductionView.qml" line="141"/>
-        <location filename="../../src/effects/builtin_collection/internal/builtineffectsloader.cpp" line="288"/>
         <source>Noise reduction</source>
         <translation type="unfinished">Noise reduction</translation>
     </message>
@@ -4677,7 +4988,6 @@ Published under the &lt;a href=&quot;%1&quot;&gt;GNU General Public License vers
         <translation type="unfinished">Noise only</translation>
     </message>
     <message>
-        <location filename="../../src/effects/builtin_collection/internal/builtineffectsloader.cpp" line="289"/>
         <source>Reduces noise in the audio</source>
         <translation type="unfinished">Reduces noise in the audio</translation>
     </message>
@@ -4789,12 +5099,10 @@ Published under the &lt;a href=&quot;%1&quot;&gt;GNU General Public License vers
 <context>
     <name>effects/silence</name>
     <message>
-        <location filename="../../src/effects/builtin_collection/internal/builtineffectsloader.cpp" line="304"/>
         <source>Silence</source>
         <translation type="unfinished">Silence</translation>
     </message>
     <message>
-        <location filename="../../src/effects/builtin_collection/internal/builtineffectsloader.cpp" line="305"/>
         <source>Generates silence</source>
         <translation type="unfinished">Generates silence</translation>
     </message>
@@ -5022,7 +5330,7 @@ Published under the &lt;a href=&quot;%1&quot;&gt;GNU General Public License vers
     </message>
     <message>
         <location filename="../../src/importexport/export/qml/Export/CustomMappingDialog.qml" line="16"/>
-        <location filename="../../src/importexport/export/qml/Export/ExportDialog.qml" line="356"/>
+        <location filename="../../src/importexport/export/qml/Export/ExportDialog.qml" line="355"/>
         <source>Edit mapping</source>
         <translation type="unfinished">Edit mapping</translation>
     </message>
@@ -5033,100 +5341,106 @@ Published under the &lt;a href=&quot;%1&quot;&gt;GNU General Public License vers
     </message>
     <message>
         <location filename="../../src/importexport/export/qml/Export/ExportDialog.qml" line="19"/>
+        <location filename="../../src/importexport/export/view/exportpreferencesmodel.cpp" line="465"/>
+        <location filename="../../src/importexport/export/view/exportpreferencesmodel.cpp" line="597"/>
         <source>Export audio</source>
         <translation type="unfinished">Export audio</translation>
     </message>
     <message>
-        <location filename="../../src/importexport/export/qml/Export/ExportDialog.qml" line="77"/>
+        <location filename="../../src/importexport/export/qml/Export/ExportDialog.qml" line="76"/>
         <source>Export</source>
         <translation type="unfinished">Export</translation>
     </message>
     <message>
-        <location filename="../../src/importexport/export/qml/Export/ExportDialog.qml" line="92"/>
+        <location filename="../../src/importexport/export/qml/Export/ExportDialog.qml" line="91"/>
         <source>Type</source>
         <translation type="unfinished">Type</translation>
     </message>
     <message>
-        <location filename="../../src/importexport/export/qml/Export/ExportDialog.qml" line="129"/>
+        <location filename="../../src/importexport/export/qml/Export/ExportDialog.qml" line="128"/>
         <location filename="../../src/importexport/labels/qml/Export/ExportLabelsDialog.qml" line="65"/>
         <source>File</source>
         <translation type="unfinished">File</translation>
     </message>
     <message>
-        <location filename="../../src/importexport/export/qml/Export/ExportDialog.qml" line="143"/>
+        <location filename="../../src/importexport/export/qml/Export/ExportDialog.qml" line="142"/>
         <location filename="../../src/importexport/labels/qml/Export/ExportLabelsDialog.qml" line="76"/>
         <source>File name</source>
         <translation type="unfinished">File name</translation>
     </message>
     <message>
-        <location filename="../../src/importexport/export/qml/Export/ExportDialog.qml" line="177"/>
+        <location filename="../../src/importexport/export/qml/Export/ExportDialog.qml" line="176"/>
         <location filename="../../src/importexport/labels/qml/Export/ExportLabelsDialog.qml" line="143"/>
         <source>Folder</source>
         <translation type="unfinished">Folder</translation>
     </message>
     <message>
-        <location filename="../../src/importexport/export/qml/Export/ExportDialog.qml" line="213"/>
+        <location filename="../../src/importexport/export/qml/Export/ExportDialog.qml" line="212"/>
         <source>Format</source>
         <translation type="unfinished">Format</translation>
     </message>
     <message>
-        <location filename="../../src/importexport/export/qml/Export/ExportDialog.qml" line="250"/>
+        <location filename="../../src/importexport/export/qml/Export/ExportDialog.qml" line="249"/>
         <source>Audio options</source>
         <translation type="unfinished">Audio options</translation>
     </message>
     <message>
-        <location filename="../../src/importexport/export/qml/Export/ExportDialog.qml" line="267"/>
+        <location filename="../../src/importexport/export/qml/Export/ExportDialog.qml" line="266"/>
         <source>Channels</source>
         <translation type="unfinished">Channels</translation>
     </message>
     <message>
-        <location filename="../../src/importexport/export/qml/Export/ExportDialog.qml" line="292"/>
+        <location filename="../../src/importexport/export/qml/Export/ExportDialog.qml" line="291"/>
         <source>Mono</source>
         <translation type="unfinished">Mono</translation>
     </message>
     <message>
-        <location filename="../../src/importexport/export/qml/Export/ExportDialog.qml" line="310"/>
+        <location filename="../../src/importexport/export/qml/Export/ExportDialog.qml" line="309"/>
         <source>Stereo</source>
         <translation type="unfinished">Stereo</translation>
     </message>
     <message>
-        <location filename="../../src/importexport/export/qml/Export/ExportDialog.qml" line="327"/>
+        <location filename="../../src/importexport/export/qml/Export/ExportDialog.qml" line="326"/>
         <source>Custom mapping</source>
         <translation type="unfinished">Custom mapping</translation>
     </message>
     <message>
-        <location filename="../../src/importexport/export/qml/Export/ExportDialog.qml" line="374"/>
+        <location filename="../../src/importexport/export/qml/Export/ExportDialog.qml" line="373"/>
         <location filename="../../src/importexport/export/qml/Export/internal/GeneralOptionsSection.qml" line="183"/>
         <source>Sample rate</source>
         <translation type="unfinished">Sample rate</translation>
     </message>
     <message>
-        <location filename="../../src/importexport/export/qml/Export/ExportDialog.qml" line="419"/>
+        <location filename="../../src/importexport/export/qml/Export/ExportDialog.qml" line="418"/>
         <source>Open custom FFmpeg format options</source>
         <translation type="unfinished">Open custom FFmpeg format options</translation>
     </message>
     <message>
-        <location filename="../../src/importexport/export/qml/Export/ExportDialog.qml" line="440"/>
+        <location filename="../../src/importexport/export/qml/Export/ExportDialog.qml" line="439"/>
         <source>Format:</source>
         <translation type="unfinished">Format:</translation>
     </message>
     <message>
-        <location filename="../../src/importexport/export/qml/Export/ExportDialog.qml" line="464"/>
+        <location filename="../../src/importexport/export/qml/Export/ExportDialog.qml" line="463"/>
         <source>Codec:</source>
         <translation type="unfinished">Codec:</translation>
     </message>
     <message>
-        <location filename="../../src/importexport/export/qml/Export/ExportDialog.qml" line="555"/>
+        <location filename="../../src/importexport/export/qml/Export/ExportDialog.qml" line="554"/>
+        <source>Effective bit rate may vary</source>
+        <translation type="unfinished">Effective bit rate may vary</translation>
+    </message>
+    <message>
         <source>Effective bitrate may vary</source>
         <translation type="unfinished">Effective bitrate may vary</translation>
     </message>
     <message>
-        <location filename="../../src/importexport/export/qml/Export/ExportDialog.qml" line="565"/>
+        <location filename="../../src/importexport/export/qml/Export/ExportDialog.qml" line="564"/>
         <source>Rendering</source>
         <translation type="unfinished">Rendering</translation>
     </message>
     <message>
-        <location filename="../../src/importexport/export/qml/Export/ExportDialog.qml" line="575"/>
+        <location filename="../../src/importexport/export/qml/Export/ExportDialog.qml" line="574"/>
         <source>Trim blank space before first clip</source>
         <translation type="unfinished">Trim blank space before first clip</translation>
     </message>
@@ -5223,6 +5537,16 @@ Published under the &lt;a href=&quot;%1&quot;&gt;GNU General Public License vers
     </message>
     <message>
         <location filename="../../src/importexport/export/qml/Export/internal/GeneralOptionsSection.qml" line="176"/>
+        <source>Bit rate (bits/second) - influences the resulting file size and quality
+Some codecs may only accept specific values (128k, 192k, 256k, etc.)
+0 - automatic
+192000 - recommended</source>
+        <translation type="unfinished">Bit rate (bits/second) - influences the resulting file size and quality
+Some codecs may only accept specific values (128k, 192k, 256k, etc.)
+0 - automatic
+192000 - recommended</translation>
+    </message>
+    <message>
         <source>Bit Rate (bits/second) - influences the resulting file size and quality
 Some codecs may only accept specific values (128k, 192k, 256k etc)
 0 - automatic
@@ -5334,53 +5658,51 @@ Recommended - 192000</translation>
         <translation type="unfinished">Export audio in loop region</translation>
     </message>
     <message>
-        <location filename="../../src/importexport/export/view/exportpreferencesmodel.cpp" line="173"/>
+        <location filename="../../src/importexport/export/view/exportpreferencesmodel.cpp" line="171"/>
         <source>No loop region</source>
         <translation type="unfinished">No loop region</translation>
     </message>
     <message>
-        <location filename="../../src/importexport/export/view/exportpreferencesmodel.cpp" line="174"/>
+        <location filename="../../src/importexport/export/view/exportpreferencesmodel.cpp" line="172"/>
         <source>Export audio in loop region requires a loop in the project. Please go back, create a loop and try again.</source>
         <translation type="unfinished">Export audio in loop region requires a loop in the project. Please go back, create a loop and try again.</translation>
     </message>
     <message>
-        <location filename="../../src/importexport/export/view/exportpreferencesmodel.cpp" line="185"/>
+        <location filename="../../src/importexport/export/view/exportpreferencesmodel.cpp" line="183"/>
         <source>No selected audio</source>
         <translation type="unfinished">No selected audio</translation>
     </message>
     <message>
-        <location filename="../../src/importexport/export/view/exportpreferencesmodel.cpp" line="186"/>
+        <location filename="../../src/importexport/export/view/exportpreferencesmodel.cpp" line="184"/>
         <source>Export selected audio requires a selection of audio data in the project. Please return to the project, make a selection and then try again.</source>
         <translation type="unfinished">Export selected audio requires a selection of audio data in the project. Please return to the project, make a selection and then try again.</translation>
     </message>
     <message>
-        <location filename="../../src/importexport/export/view/exportpreferencesmodel.cpp" line="467"/>
-        <location filename="../../src/importexport/export/view/exportpreferencesmodel.cpp" line="599"/>
         <source>Export Audio</source>
         <translation type="unfinished">Export Audio</translation>
     </message>
     <message>
-        <location filename="../../src/importexport/export/view/exportpreferencesmodel.cpp" line="467"/>
+        <location filename="../../src/importexport/export/view/exportpreferencesmodel.cpp" line="465"/>
         <source>Unable to create destination folder</source>
         <translation type="unfinished">Unable to create destination folder</translation>
     </message>
     <message>
-        <location filename="../../src/importexport/export/view/exportpreferencesmodel.cpp" line="523"/>
+        <location filename="../../src/importexport/export/view/exportpreferencesmodel.cpp" line="521"/>
         <source>Do you want to overwrite?</source>
         <translation type="unfinished">Do you want to overwrite?</translation>
     </message>
     <message>
-        <location filename="../../src/importexport/export/view/exportpreferencesmodel.cpp" line="524"/>
+        <location filename="../../src/importexport/export/view/exportpreferencesmodel.cpp" line="522"/>
         <source>Overwrite</source>
         <translation type="unfinished">Overwrite</translation>
     </message>
     <message>
-        <location filename="../../src/importexport/export/view/exportpreferencesmodel.cpp" line="536"/>
+        <location filename="../../src/importexport/export/view/exportpreferencesmodel.cpp" line="534"/>
         <source>Export error</source>
         <translation type="unfinished">Export error</translation>
     </message>
     <message>
-        <location filename="../../src/importexport/export/view/exportpreferencesmodel.cpp" line="600"/>
+        <location filename="../../src/importexport/export/view/exportpreferencesmodel.cpp" line="598"/>
         <source>To export with custom channel mapping, master effects must be turned off temporarily.
 
 Master effects will be turned back on after export.</source>
@@ -5400,10 +5722,10 @@ Master effects will be turned back on after export.</translation>
 <context>
     <name>global</name>
     <message>
-        <location filename="../../src/appshell/qml/Audacity/AppShell/AboutDialog.qml" line="156"/>
         <location filename="../../src/appshell/qml/Audacity/AppShell/AlphaWelcomePopup.qml" line="155"/>
         <location filename="../../src/appshell/qml/Audacity/AppShell/WelcomeDialog.qml" line="279"/>
         <location filename="../../src/importexport/export/qml/Export/CustomFFmpegDialog.qml" line="143"/>
+        <location filename="../../src/trackedit/qml/Audacity/TrackEdit/DeleteBehaviorOnboardingFollowupDialog.qml" line="100"/>
         <source>OK</source>
         <translation type="unfinished">OK</translation>
     </message>
@@ -5421,7 +5743,7 @@ Master effects will be turned back on after export.</translation>
         <location filename="../../src/effects/builtin_collection/tonegen/ChirpView.qml" line="179"/>
         <location filename="../../src/effects/builtin_collection/tonegen/ChirpView.qml" line="200"/>
         <location filename="../../src/effects/builtin_collection/tonegen/ToneView.qml" line="84"/>
-        <location filename="../../src/preferences/qml/Audacity/Preferences/internal/SampleRateSection.qml" line="77"/>
+        <location filename="../../src/preferences/qml/Audacity/Preferences/internal/SampleRateSection.qml" line="102"/>
         <location filename="../../src/trackedit/qml/Audacity/TrackEdit/CustomRateDialog.qml" line="23"/>
         <source>Hz</source>
         <translation type="unfinished">Hz</translation>
@@ -5430,33 +5752,35 @@ Master effects will be turned back on after export.</translation>
         <location filename="../../src/effects/effects_base/qml/Audacity/Effects/DestructiveEffectsViewerDialog.qml" line="327"/>
         <location filename="../../src/importexport/export/qml/Export/CustomFFmpegDialog.qml" line="131"/>
         <location filename="../../src/importexport/export/qml/Export/CustomMappingDialog.qml" line="94"/>
-        <location filename="../../src/importexport/export/qml/Export/ExportDialog.qml" line="621"/>
+        <location filename="../../src/importexport/export/qml/Export/ExportDialog.qml" line="620"/>
         <location filename="../../src/importexport/labels/qml/Export/ExportLabelsDialog.qml" line="240"/>
         <location filename="../../src/playback/qml/Audacity/Playback/dialogs/LoopRegionInOut.qml" line="159"/>
         <location filename="../../src/project/qml/Audacity/Project/NewProjectDialog.qml" line="117"/>
         <location filename="../../src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/labeleditor/AddNewLabelTrackDialog.qml" line="98"/>
-        <location filename="../../src/project/internal/opensaveprojectscenario.cpp" line="453"/>
-        <location filename="../../src/project/internal/opensaveprojectscenario.cpp" line="475"/>
+        <location filename="../../src/project/internal/opensaveprojectscenario.cpp" line="527"/>
+        <location filename="../../src/project/internal/opensaveprojectscenario.cpp" line="549"/>
+        <location filename="../../src/project/internal/opensaveprojectscenario.cpp" line="651"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancel</translation>
     </message>
     <message>
         <location filename="../../src/effects/effects_base/qml/Audacity/Effects/DestructiveEffectsViewerDialog.qml" line="344"/>
         <location filename="../../src/importexport/export/qml/Export/CustomMappingDialog.qml" line="105"/>
-        <location filename="../../src/importexport/export/qml/Export/MetadataDialog.qml" line="128"/>
+        <location filename="../../src/importexport/export/qml/Export/MetadataDialog.qml" line="127"/>
         <location filename="../../src/playback/qml/Audacity/Playback/dialogs/LoopRegionInOut.qml" line="171"/>
         <location filename="../../src/trackedit/qml/Audacity/TrackEdit/DeleteBehaviorOnboardingDialog.qml" line="93"/>
         <source>Apply</source>
         <translation type="unfinished">Apply</translation>
     </message>
     <message>
-        <location filename="../../src/importexport/export/qml/Export/ExportDialog.qml" line="638"/>
+        <location filename="../../src/importexport/export/qml/Export/ExportDialog.qml" line="637"/>
         <location filename="../../src/importexport/labels/qml/Export/ExportLabelsDialog.qml" line="255"/>
         <source>Export</source>
         <translation type="unfinished">Export</translation>
     </message>
     <message>
-        <location filename="../../src/importexport/export/qml/Export/MetadataDialog.qml" line="116"/>
+        <location filename="../../src/appshell/qml/Audacity/AppShell/AboutDialog.qml" line="80"/>
+        <location filename="../../src/importexport/export/qml/Export/MetadataDialog.qml" line="115"/>
         <location filename="../../src/project/qml/Audacity/Project/ProjectUploadedDialog.qml" line="266"/>
         <source>Close</source>
         <translation type="unfinished">Close</translation>
@@ -5478,8 +5802,9 @@ Master effects will be turned back on after export.</translation>
         <translation type="unfinished">min</translation>
     </message>
     <message>
-        <location filename="../../src/preferences/qml/Audacity/Preferences/internal/BufferAndLatencySection.qml" line="57"/>
-        <location filename="../../src/preferences/qml/Audacity/Preferences/internal/BufferAndLatencySection.qml" line="97"/>
+        <location filename="../../src/preferences/qml/Audacity/Preferences/internal/BufferAndLatencySection.qml" line="64"/>
+        <location filename="../../src/preferences/qml/Audacity/Preferences/internal/BufferAndLatencySection.qml" line="101"/>
+        <location filename="../../src/preferences/qml/Audacity/Preferences/internal/LeadInRecordingSection.qml" line="60"/>
         <location filename="../../src/preferences/qml/Audacity/Preferences/internal/NoteInputPlaySection.qml" line="69"/>
         <location filename="../../src/preferences/qml/Audacity/Preferences/internal/NoteInputSection.qml" line="98"/>
         <source>ms</source>
@@ -5489,6 +5814,7 @@ Master effects will be turned back on after export.</translation>
     <message>
         <location filename="../../src/preferences/qml/Audacity/Preferences/internal/CursorSection.qml" line="31"/>
         <location filename="../../src/preferences/qml/Audacity/Preferences/internal/CursorSection.qml" line="51"/>
+        <location filename="../../src/preferences/qml/Audacity/Preferences/internal/LeadInRecordingSection.qml" line="35"/>
         <source>seconds</source>
         <translation type="unfinished">seconds</translation>
     </message>
@@ -5505,49 +5831,49 @@ Master effects will be turned back on after export.</translation>
     </message>
     <message>
         <location filename="../../src/project/qml/Audacity/Project/internal/NewProject/TitleListView.qml" line="123"/>
-        <location filename="../../src/project/qml/Audacity/Project/internal/ProjectsPage/ProjectGridItem.qml" line="294"/>
-        <location filename="../../src/project/qml/Audacity/Project/ProjectsGridView.qml" line="210"/>
-        <location filename="../../src/project/qml/Audacity/Project/ProjectsListView.qml" line="284"/>
+        <location filename="../../src/project/qml/Audacity/Project/internal/ProjectsPage/ProjectGridItem.qml" line="293"/>
+        <location filename="../../src/project/qml/Audacity/Project/ProjectsGridView.qml" line="208"/>
+        <location filename="../../src/project/qml/Audacity/Project/ProjectsListView.qml" line="294"/>
         <source>No results found</source>
         <translation type="unfinished">No results found</translation>
     </message>
     <message>
-        <location filename="../../src/project/qml/Audacity/Project/internal/ProjectsPage/CloudAudioFilesView.qml" line="210"/>
+        <location filename="../../src/project/qml/Audacity/Project/internal/ProjectsPage/CloudAudioFilesView.qml" line="216"/>
         <source>Duration</source>
         <comment>file duration</comment>
         <translation type="unfinished">Duration</translation>
     </message>
     <message>
-        <location filename="../../src/project/qml/Audacity/Project/internal/ProjectsPage/CloudAudioFilesView.qml" line="231"/>
-        <location filename="../../src/project/qml/Audacity/Project/internal/ProjectsPage/CloudAudioFilesView.qml" line="269"/>
-        <location filename="../../src/project/qml/Audacity/Project/internal/ProjectsPage/CloudProjectsView.qml" line="232"/>
-        <location filename="../../src/project/qml/Audacity/Project/internal/ProjectsPage/RecentProjectsView.qml" line="167"/>
+        <location filename="../../src/project/qml/Audacity/Project/internal/ProjectsPage/CloudAudioFilesView.qml" line="237"/>
+        <location filename="../../src/project/qml/Audacity/Project/internal/ProjectsPage/CloudAudioFilesView.qml" line="275"/>
+        <location filename="../../src/project/qml/Audacity/Project/internal/ProjectsPage/CloudProjectsView.qml" line="236"/>
+        <location filename="../../src/project/qml/Audacity/Project/internal/ProjectsPage/RecentProjectsView.qml" line="171"/>
         <source>Unknown</source>
         <translation type="unfinished">Unknown</translation>
     </message>
     <message>
-        <location filename="../../src/project/qml/Audacity/Project/internal/ProjectsPage/CloudAudioFilesView.qml" line="248"/>
-        <location filename="../../src/project/qml/Audacity/Project/internal/ProjectsPage/CloudProjectsView.qml" line="211"/>
-        <location filename="../../src/project/qml/Audacity/Project/internal/ProjectsPage/RecentProjectsView.qml" line="146"/>
+        <location filename="../../src/project/qml/Audacity/Project/internal/ProjectsPage/CloudAudioFilesView.qml" line="254"/>
+        <location filename="../../src/project/qml/Audacity/Project/internal/ProjectsPage/CloudProjectsView.qml" line="215"/>
+        <location filename="../../src/project/qml/Audacity/Project/internal/ProjectsPage/RecentProjectsView.qml" line="150"/>
         <source>Size</source>
         <comment>file size</comment>
         <translation type="unfinished">Size</translation>
     </message>
     <message>
-        <location filename="../../src/project/qml/Audacity/Project/internal/ProjectsPage/CloudAudioFilesView.qml" line="334"/>
-        <location filename="../../src/project/qml/Audacity/Project/internal/ProjectsPage/CloudProjectsView.qml" line="266"/>
+        <location filename="../../src/project/qml/Audacity/Project/internal/ProjectsPage/CloudAudioFilesView.qml" line="342"/>
+        <location filename="../../src/project/qml/Audacity/Project/internal/ProjectsPage/CloudProjectsView.qml" line="270"/>
         <source>Please check your internet connection or try again later.</source>
         <translation type="unfinished">Please check your internet connection or try again later.</translation>
     </message>
     <message>
         <location filename="../../src/project/qml/Audacity/Project/NewProjectDialog.qml" line="127"/>
-        <location filename="../../src/appshell/qml/Audacity/AppShell/FirstLaunchSetup/firstlaunchsetupmodel.cpp" line="118"/>
+        <location filename="../../src/appshell/qml/Audacity/AppShell/FirstLaunchSetup/firstlaunchsetupmodel.cpp" line="126"/>
         <source>Back</source>
         <translation type="unfinished">Back</translation>
     </message>
     <message>
         <location filename="../../src/project/qml/Audacity/Project/NewProjectDialog.qml" line="138"/>
-        <location filename="../../src/appshell/qml/Audacity/AppShell/FirstLaunchSetup/firstlaunchsetupmodel.cpp" line="131"/>
+        <location filename="../../src/appshell/qml/Audacity/AppShell/FirstLaunchSetup/firstlaunchsetupmodel.cpp" line="139"/>
         <source>Next</source>
         <translation type="unfinished">Next</translation>
     </message>
@@ -5562,12 +5888,11 @@ Master effects will be turned back on after export.</translation>
         <translation type="unfinished">Success!</translation>
     </message>
     <message>
-        <location filename="../../src/trackedit/qml/Audacity/TrackEdit/DeleteBehaviorOnboardingFollowupDialog.qml" line="100"/>
         <source>Ok</source>
         <translation type="unfinished">Ok</translation>
     </message>
     <message>
-        <location filename="../../src/appshell/qml/Audacity/AppShell/FirstLaunchSetup/firstlaunchsetupmodel.cpp" line="128"/>
+        <location filename="../../src/appshell/qml/Audacity/AppShell/FirstLaunchSetup/firstlaunchsetupmodel.cpp" line="136"/>
         <source>Skip</source>
         <translation type="unfinished">Skip</translation>
     </message>
@@ -5587,13 +5912,13 @@ Master effects will be turned back on after export.</translation>
         <translation type="unfinished">All files</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectactionscontroller.cpp" line="472"/>
-        <location filename="../../src/project/internal/projectactionscontroller.cpp" line="1011"/>
+        <location filename="../../src/project/internal/projectactionscontroller.cpp" line="499"/>
+        <location filename="../../src/project/internal/projectactionscontroller.cpp" line="1082"/>
         <source>Success</source>
         <translation type="unfinished">Success</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectactionscontroller.cpp" line="1016"/>
+        <location filename="../../src/project/internal/projectactionscontroller.cpp" line="1087"/>
         <source>Dismiss</source>
         <translation type="unfinished">Dismiss</translation>
     </message>
@@ -5606,6 +5931,42 @@ Master effects will be turned back on after export.</translation>
         <location filename="../../src/projectscene/view/tracksitemsview/labeleditor/labelstableviewmodel.cpp" line="635"/>
         <source>Open</source>
         <translation type="unfinished">Open</translation>
+    </message>
+</context>
+<context>
+    <name>import</name>
+    <message>
+        <location filename="../../src/importexport/import/internal/au3/tempodetection.cpp" line="134"/>
+        <location filename="../../src/importexport/import/internal/au3/tempodetection.cpp" line="168"/>
+        <source>Loop tempo detected at %1 BPM. What would you like to do?</source>
+        <translation type="unfinished">Loop tempo detected at %1 BPM. What would you like to do?</translation>
+    </message>
+    <message>
+        <location filename="../../src/importexport/import/internal/au3/tempodetection.cpp" line="138"/>
+        <source>Match project tempo to loop</source>
+        <translation type="unfinished">Match project tempo to loop</translation>
+    </message>
+    <message>
+        <location filename="../../src/importexport/import/internal/au3/tempodetection.cpp" line="139"/>
+        <source>Match loop to project tempo</source>
+        <translation type="unfinished">Match loop to project tempo</translation>
+    </message>
+    <message>
+        <location filename="../../src/importexport/import/internal/au3/tempodetection.cpp" line="140"/>
+        <location filename="../../src/importexport/import/internal/au3/tempodetection.cpp" line="173"/>
+        <source>Do nothing</source>
+        <translation type="unfinished">Do nothing</translation>
+    </message>
+    <message>
+        <location filename="../../src/importexport/import/internal/au3/tempodetection.cpp" line="144"/>
+        <location filename="../../src/importexport/import/internal/au3/tempodetection.cpp" line="177"/>
+        <source>Loop Tempo Detected</source>
+        <translation type="unfinished">Loop Tempo Detected</translation>
+    </message>
+    <message>
+        <location filename="../../src/importexport/import/internal/au3/tempodetection.cpp" line="172"/>
+        <source>Stretch loop to project tempo</source>
+        <translation type="unfinished">Stretch loop to project tempo</translation>
     </message>
 </context>
 <context>
@@ -5629,20 +5990,80 @@ Master effects will be turned back on after export.</translation>
 <context>
     <name>label</name>
     <message>
-        <location filename="../../src/projectscene/view/tracksitemsview/labelcontextmenumodel.cpp" line="26"/>
+        <location filename="../../src/projectscene/view/tracksitemsview/labelcontextmenumodel.cpp" line="27"/>
+        <source>Cut and leave gap</source>
+        <translation type="unfinished">Cut and leave gap</translation>
+    </message>
+    <message>
+        <location filename="../../src/projectscene/view/tracksitemsview/labelcontextmenumodel.cpp" line="29"/>
+        <source>Cut and close gap on this track</source>
+        <translation type="unfinished">Cut and close gap on this track</translation>
+    </message>
+    <message>
+        <location filename="../../src/projectscene/view/tracksitemsview/labelcontextmenumodel.cpp" line="31"/>
+        <source>Cut and close gap on all tracks</source>
+        <translation type="unfinished">Cut and close gap on all tracks</translation>
+    </message>
+    <message>
+        <location filename="../../src/projectscene/view/tracksitemsview/labelcontextmenumodel.cpp" line="36"/>
+        <source>Paste and overlap</source>
+        <translation type="unfinished">Paste and overlap</translation>
+    </message>
+    <message>
+        <location filename="../../src/projectscene/view/tracksitemsview/labelcontextmenumodel.cpp" line="38"/>
+        <source>Paste and make room on this track</source>
+        <translation type="unfinished">Paste and make room on this track</translation>
+    </message>
+    <message>
+        <location filename="../../src/projectscene/view/tracksitemsview/labelcontextmenumodel.cpp" line="40"/>
+        <source>Paste and make room on all tracks</source>
+        <translation type="unfinished">Paste and make room on all tracks</translation>
+    </message>
+    <message>
+        <location filename="../../src/projectscene/view/tracksitemsview/labelcontextmenumodel.cpp" line="45"/>
+        <source>Delete and leave gap</source>
+        <translation type="unfinished">Delete and leave gap</translation>
+    </message>
+    <message>
+        <location filename="../../src/projectscene/view/tracksitemsview/labelcontextmenumodel.cpp" line="47"/>
+        <source>Delete and close gap on this track</source>
+        <translation type="unfinished">Delete and close gap on this track</translation>
+    </message>
+    <message>
+        <location filename="../../src/projectscene/view/tracksitemsview/labelcontextmenumodel.cpp" line="49"/>
+        <source>Delete and close gap on all tracks</source>
+        <translation type="unfinished">Delete and close gap on all tracks</translation>
+    </message>
+    <message>
+        <location filename="../../src/projectscene/view/tracksitemsview/labelcontextmenumodel.cpp" line="53"/>
         <source>Rename label</source>
         <translation type="unfinished">Rename label</translation>
+    </message>
+    <message>
+        <location filename="../../src/projectscene/view/tracksitemsview/labelcontextmenumodel.cpp" line="59"/>
+        <source>Cut and…</source>
+        <translation type="unfinished">Cut and…</translation>
+    </message>
+    <message>
+        <location filename="../../src/projectscene/view/tracksitemsview/labelcontextmenumodel.cpp" line="60"/>
+        <source>Paste and…</source>
+        <translation type="unfinished">Paste and…</translation>
+    </message>
+    <message>
+        <location filename="../../src/projectscene/view/tracksitemsview/labelcontextmenumodel.cpp" line="61"/>
+        <source>Delete and…</source>
+        <translation type="unfinished">Delete and…</translation>
     </message>
 </context>
 <context>
     <name>metadata</name>
     <message>
-        <location filename="../../src/importexport/export/qml/Export/MetadataDialog.qml" line="71"/>
+        <location filename="../../src/importexport/export/qml/Export/MetadataDialog.qml" line="70"/>
         <source>tag</source>
         <translation type="unfinished">tag</translation>
     </message>
     <message>
-        <location filename="../../src/importexport/export/qml/Export/MetadataDialog.qml" line="73"/>
+        <location filename="../../src/importexport/export/qml/Export/MetadataDialog.qml" line="72"/>
         <source>value</source>
         <translation type="unfinished">value</translation>
     </message>
@@ -5745,6 +6166,49 @@ Master effects will be turned back on after export.</translation>
         <location filename="../../src/project/types/projectmeta.h" line="104"/>
         <source>Comments</source>
         <translation type="unfinished">Comments</translation>
+    </message>
+</context>
+<context>
+    <name>multiclip</name>
+    <message>
+        <location filename="../../src/projectscene/view/tracksitemsview/multiclipcontextmenumodel.cpp" line="26"/>
+        <source>Cut and leave gap</source>
+        <translation type="unfinished">Cut and leave gap</translation>
+    </message>
+    <message>
+        <location filename="../../src/projectscene/view/tracksitemsview/multiclipcontextmenumodel.cpp" line="28"/>
+        <source>Cut and close gap on this track</source>
+        <translation type="unfinished">Cut and close gap on this track</translation>
+    </message>
+    <message>
+        <location filename="../../src/projectscene/view/tracksitemsview/multiclipcontextmenumodel.cpp" line="30"/>
+        <source>Cut and close gap on all tracks</source>
+        <translation type="unfinished">Cut and close gap on all tracks</translation>
+    </message>
+    <message>
+        <location filename="../../src/projectscene/view/tracksitemsview/multiclipcontextmenumodel.cpp" line="35"/>
+        <source>Delete and leave gap</source>
+        <translation type="unfinished">Delete and leave gap</translation>
+    </message>
+    <message>
+        <location filename="../../src/projectscene/view/tracksitemsview/multiclipcontextmenumodel.cpp" line="37"/>
+        <source>Delete and close gap on this track</source>
+        <translation type="unfinished">Delete and close gap on this track</translation>
+    </message>
+    <message>
+        <location filename="../../src/projectscene/view/tracksitemsview/multiclipcontextmenumodel.cpp" line="39"/>
+        <source>Delete and close gap on all tracks</source>
+        <translation type="unfinished">Delete and close gap on all tracks</translation>
+    </message>
+    <message>
+        <location filename="../../src/projectscene/view/tracksitemsview/multiclipcontextmenumodel.cpp" line="47"/>
+        <source>Cut and…</source>
+        <translation type="unfinished">Cut and…</translation>
+    </message>
+    <message>
+        <location filename="../../src/projectscene/view/tracksitemsview/multiclipcontextmenumodel.cpp" line="48"/>
+        <source>Delete and…</source>
+        <translation type="unfinished">Delete and…</translation>
     </message>
 </context>
 <context>
@@ -5881,12 +6345,12 @@ Master effects will be turned back on after export.</translation>
 <context>
     <name>preferences</name>
     <message>
-        <location filename="../../src/preferences/qml/Audacity/Preferences/AdvancedPreferencesPage.qml" line="66"/>
+        <location filename="../../src/preferences/qml/Audacity/Preferences/AdvancedPreferencesPage.qml" line="72"/>
         <source>Preference</source>
         <translation type="unfinished">Preference</translation>
     </message>
     <message>
-        <location filename="../../src/preferences/qml/Audacity/Preferences/AdvancedPreferencesPage.qml" line="68"/>
+        <location filename="../../src/preferences/qml/Audacity/Preferences/AdvancedPreferencesPage.qml" line="74"/>
         <source>Value</source>
         <translation type="unfinished">Value</translation>
     </message>
@@ -5914,16 +6378,19 @@ Master effects will be turned back on after export.</translation>
     </message>
     <message>
         <location filename="../../src/preferences/qml/Audacity/Preferences/internal/AsymmetricStereoHeightsSection.qml" line="73"/>
+        <location filename="../../src/preferences/qml/Audacity/Preferences/MusicPreferencesPage.qml" line="61"/>
         <source>Always</source>
         <translation type="unfinished">Always</translation>
     </message>
     <message>
         <location filename="../../src/preferences/qml/Audacity/Preferences/internal/AsymmetricStereoHeightsSection.qml" line="88"/>
+        <location filename="../../src/preferences/qml/Audacity/Preferences/MusicPreferencesPage.qml" line="76"/>
         <source>Depending on workspace</source>
         <translation type="unfinished">Depending on workspace</translation>
     </message>
     <message>
         <location filename="../../src/preferences/qml/Audacity/Preferences/internal/AsymmetricStereoHeightsSection.qml" line="114"/>
+        <location filename="../../src/preferences/qml/Audacity/Preferences/MusicPreferencesPage.qml" line="102"/>
         <source>Never</source>
         <translation type="unfinished">Never</translation>
     </message>
@@ -5933,7 +6400,7 @@ Master effects will be turned back on after export.</translation>
         <translation type="unfinished">Inputs and outputs</translation>
     </message>
     <message>
-        <location filename="../../src/preferences/qml/Audacity/Preferences/internal/AudioApiSection.qml" line="54"/>
+        <location filename="../../src/preferences/qml/Audacity/Preferences/internal/AudioApiSection.qml" line="58"/>
         <source>Host</source>
         <translation type="unfinished">Host</translation>
     </message>
@@ -5943,17 +6410,17 @@ Master effects will be turned back on after export.</translation>
         <translation type="unfinished">Buffer and latency</translation>
     </message>
     <message>
-        <location filename="../../src/preferences/qml/Audacity/Preferences/internal/BufferAndLatencySection.qml" line="47"/>
+        <location filename="../../src/preferences/qml/Audacity/Preferences/internal/BufferAndLatencySection.qml" line="54"/>
         <source>Buffer length</source>
         <translation type="unfinished">Buffer length</translation>
     </message>
     <message>
-        <location filename="../../src/preferences/qml/Audacity/Preferences/internal/BufferAndLatencySection.qml" line="69"/>
+        <location filename="../../src/preferences/qml/Audacity/Preferences/internal/BufferAndLatencySection.qml" line="82"/>
         <source>Latency compensation</source>
         <translation type="unfinished">Latency compensation</translation>
     </message>
     <message>
-        <location filename="../../src/preferences/qml/Audacity/Preferences/internal/BufferAndLatencySection.qml" line="80"/>
+        <location filename="../../src/preferences/qml/Audacity/Preferences/internal/BufferAndLatencySection.qml" line="116"/>
         <source>Automatic</source>
         <translation type="unfinished">Automatic</translation>
     </message>
@@ -5973,17 +6440,17 @@ Master effects will be turned back on after export.</translation>
         <translation type="unfinished">Classic</translation>
     </message>
     <message>
-        <location filename="../../src/preferences/qml/Audacity/Preferences/internal/CommonAudioApiConfiguration.qml" line="47"/>
+        <location filename="../../src/preferences/qml/Audacity/Preferences/internal/AudioApiSection.qml" line="101"/>
         <source>Playback device</source>
         <translation type="unfinished">Playback device</translation>
     </message>
     <message>
-        <location filename="../../src/preferences/qml/Audacity/Preferences/internal/CommonAudioApiConfiguration.qml" line="63"/>
+        <location filename="../../src/preferences/qml/Audacity/Preferences/internal/AudioApiSection.qml" line="77"/>
         <source>Recording device</source>
         <translation type="unfinished">Recording device</translation>
     </message>
     <message>
-        <location filename="../../src/preferences/qml/Audacity/Preferences/internal/CommonAudioApiConfiguration.qml" line="79"/>
+        <location filename="../../src/preferences/qml/Audacity/Preferences/internal/AudioApiSection.qml" line="120"/>
         <source>Recording channels</source>
         <translation type="unfinished">Recording channels</translation>
     </message>
@@ -6068,7 +6535,7 @@ Master effects will be turned back on after export.</translation>
         <translation type="unfinished">Mono &amp; stereo conversion</translation>
     </message>
     <message>
-        <location filename="../../src/preferences/qml/Audacity/Preferences/internal/MonoStereoConversionSection.qml" line="25"/>
+        <location filename="../../src/preferences/qml/Audacity/Preferences/internal/MonoStereoConversionSection.qml" line="27"/>
         <source>Always convert to mono without prompt</source>
         <translation type="unfinished">Always convert to mono without prompt</translation>
     </message>
@@ -6128,9 +6595,19 @@ Master effects will be turned back on after export.</translation>
         <translation type="unfinished">Default sample rate</translation>
     </message>
     <message>
-        <location filename="../../src/preferences/qml/Audacity/Preferences/internal/SampleRateSection.qml" line="91"/>
+        <location filename="../../src/preferences/qml/Audacity/Preferences/internal/SampleRateSection.qml" line="69"/>
         <source>Default sample format</source>
         <translation type="unfinished">Default sample format</translation>
+    </message>
+    <message>
+        <location filename="../../src/preferences/qml/Audacity/Preferences/internal/SampleRateSection.qml" line="93"/>
+        <source>Custom sample rate</source>
+        <translation type="unfinished">Custom sample rate</translation>
+    </message>
+    <message>
+        <location filename="../../src/preferences/qml/Audacity/Preferences/internal/SampleRateSection.qml" line="116"/>
+        <source>Default sample rates and formats apply to newly created tracks only. Recording into existing tracks will use the track’s sample rate and format instead.</source>
+        <translation type="unfinished">Default sample rates and formats apply to newly created tracks only. Recording into existing tracks will use the track’s sample rate and format instead.</translation>
     </message>
     <message>
         <location filename="../../src/preferences/qml/Audacity/Preferences/internal/SoloButtonSection.qml" line="15"/>
@@ -6173,14 +6650,22 @@ Master effects will be turned back on after export.</translation>
         <translation type="unfinished">Invert project</translation>
     </message>
     <message>
-        <location filename="../../src/preferences/qml/Audacity/Preferences/internal/ThemesSection.qml" line="34"/>
         <source>High contrast themes</source>
         <translation type="unfinished">High contrast themes</translation>
     </message>
     <message>
-        <location filename="../../src/preferences/qml/Audacity/Preferences/internal/ThemesSection.qml" line="34"/>
         <source>Themes</source>
         <translation type="unfinished">Themes</translation>
+    </message>
+    <message>
+        <location filename="../../src/preferences/qml/Audacity/Preferences/internal/ThemesSection.qml" line="34"/>
+        <source>High-contrast theme</source>
+        <translation type="unfinished">High-contrast theme</translation>
+    </message>
+    <message>
+        <location filename="../../src/preferences/qml/Audacity/Preferences/internal/ThemesSection.qml" line="34"/>
+        <source>Theme</source>
+        <translation type="unfinished">Theme</translation>
     </message>
     <message>
         <location filename="../../src/preferences/qml/Audacity/Preferences/internal/ThemesSection.qml" line="80"/>
@@ -6199,21 +6684,37 @@ Master effects will be turned back on after export.</translation>
     </message>
     <message>
         <location filename="../../src/preferences/qml/Audacity/Preferences/internal/UiColorsSection.qml" line="49"/>
+        <source>Accent color</source>
+        <translation type="unfinished">Accent color</translation>
+    </message>
+    <message>
+        <location filename="../../src/preferences/qml/Audacity/Preferences/internal/UiColorsSection.qml" line="50"/>
+        <source>Text and icons</source>
+        <translation type="unfinished">Text and icons</translation>
+    </message>
+    <message>
+        <location filename="../../src/preferences/qml/Audacity/Preferences/internal/UiColorsSection.qml" line="51"/>
+        <source>Disabled text</source>
+        <translation type="unfinished">Disabled text</translation>
+    </message>
+    <message>
+        <location filename="../../src/preferences/qml/Audacity/Preferences/internal/UiColorsSection.qml" line="52"/>
+        <source>Border color</source>
+        <translation type="unfinished">Border color</translation>
+    </message>
+    <message>
         <source>Accent color:</source>
         <translation type="unfinished">Accent color:</translation>
     </message>
     <message>
-        <location filename="../../src/preferences/qml/Audacity/Preferences/internal/UiColorsSection.qml" line="50"/>
         <source>Text and icons:</source>
         <translation type="unfinished">Text and icons:</translation>
     </message>
     <message>
-        <location filename="../../src/preferences/qml/Audacity/Preferences/internal/UiColorsSection.qml" line="51"/>
         <source>Disabled text:</source>
         <translation type="unfinished">Disabled text:</translation>
     </message>
     <message>
-        <location filename="../../src/preferences/qml/Audacity/Preferences/internal/UiColorsSection.qml" line="52"/>
         <source>Border color:</source>
         <translation type="unfinished">Border color:</translation>
     </message>
@@ -6225,11 +6726,19 @@ Master effects will be turned back on after export.</translation>
     </message>
     <message>
         <location filename="../../src/preferences/qml/Audacity/Preferences/internal/UiFontSection.qml" line="44"/>
+        <source>Font face</source>
+        <translation type="unfinished">Font face</translation>
+    </message>
+    <message>
+        <location filename="../../src/preferences/qml/Audacity/Preferences/internal/UiFontSection.qml" line="59"/>
+        <source>Body text size</source>
+        <translation type="unfinished">Body text size</translation>
+    </message>
+    <message>
         <source>Font face:</source>
         <translation type="unfinished">Font face:</translation>
     </message>
     <message>
-        <location filename="../../src/preferences/qml/Audacity/Preferences/internal/UiFontSection.qml" line="59"/>
         <source>Body text size:</source>
         <translation type="unfinished">Body text size:</translation>
     </message>
@@ -6359,24 +6868,59 @@ Master effects will be turned back on after export.</translation>
         <translation type="unfinished">Music</translation>
     </message>
     <message>
-        <location filename="../../src/preferences/qml/Audacity/Preferences/preferencesmodel.cpp" line="179"/>
+        <location filename="../../src/preferences/qml/Audacity/Preferences/preferencesmodel.cpp" line="180"/>
         <source>Cloud</source>
         <translation type="unfinished">Cloud</translation>
     </message>
     <message>
-        <location filename="../../src/preferences/qml/Audacity/Preferences/preferencesmodel.cpp" line="181"/>
+        <location filename="../../src/preferences/qml/Audacity/Preferences/preferencesmodel.cpp" line="182"/>
         <source>Shortcuts</source>
         <translation type="unfinished">Shortcuts</translation>
     </message>
     <message>
-        <location filename="../../src/preferences/qml/Audacity/Preferences/preferencesmodel.cpp" line="184"/>
+        <location filename="../../src/preferences/qml/Audacity/Preferences/preferencesmodel.cpp" line="185"/>
         <source>Plugins</source>
         <translation type="unfinished">Plugins</translation>
     </message>
     <message>
-        <location filename="../../src/preferences/qml/Audacity/Preferences/preferencesmodel.cpp" line="187"/>
+        <location filename="../../src/preferences/qml/Audacity/Preferences/preferencesmodel.cpp" line="188"/>
         <source>Advanced options</source>
         <translation type="unfinished">Advanced options</translation>
+    </message>
+    <message>
+        <location filename="../../src/preferences/qml/Audacity/Preferences/internal/LeadInRecordingSection.qml" line="14"/>
+        <source>Recording lead-in time</source>
+        <translation type="unfinished">Recording lead-in time</translation>
+    </message>
+    <message>
+        <location filename="../../src/preferences/qml/Audacity/Preferences/internal/LeadInRecordingSection.qml" line="22"/>
+        <source>Lead-in time before recording starts</source>
+        <translation type="unfinished">Lead-in time before recording starts</translation>
+    </message>
+    <message>
+        <location filename="../../src/preferences/qml/Audacity/Preferences/internal/LeadInRecordingSection.qml" line="47"/>
+        <source>Crossfade</source>
+        <translation type="unfinished">Crossfade</translation>
+    </message>
+    <message>
+        <location filename="../../src/preferences/qml/Audacity/Preferences/MusicPreferencesPage.qml" line="29"/>
+        <source>Music imports</source>
+        <translation type="unfinished">Music imports</translation>
+    </message>
+    <message>
+        <location filename="../../src/preferences/qml/Audacity/Preferences/MusicPreferencesPage.qml" line="45"/>
+        <source>Detect tempo in imported files:</source>
+        <translation type="unfinished">Detect tempo in imported files:</translation>
+    </message>
+    <message>
+        <location filename="../../src/preferences/qml/Audacity/Preferences/MusicPreferencesPage.qml" line="121"/>
+        <source>When Audacity detects music in imported file</source>
+        <translation type="unfinished">When Audacity detects music in imported file</translation>
+    </message>
+    <message>
+        <location filename="../../src/preferences/qml/Audacity/Preferences/MusicPreferencesPage.qml" line="135"/>
+        <source>Ask me each time</source>
+        <translation type="unfinished">Ask me each time</translation>
     </message>
 </context>
 <context>
@@ -6451,41 +6995,41 @@ Master effects will be turned back on after export.</translation>
         <translation type="unfinished">Copyright</translation>
     </message>
     <message>
-        <location filename="../../src/project/qml/Audacity/Project/internal/ProjectsPage/CloudAudioFilesView.qml" line="141"/>
+        <location filename="../../src/project/qml/Audacity/Project/internal/ProjectsPage/CloudAudioFilesView.qml" line="142"/>
         <source>Cloud audio files grid</source>
         <translation type="unfinished">Cloud audio files grid</translation>
     </message>
     <message>
-        <location filename="../../src/project/qml/Audacity/Project/internal/ProjectsPage/CloudAudioFilesView.qml" line="172"/>
-        <location filename="../../src/project/qml/Audacity/Project/internal/ProjectsPage/CloudProjectsView.qml" line="173"/>
-        <location filename="../../src/project/qml/Audacity/Project/internal/ProjectsPage/RecentProjectsView.qml" line="108"/>
+        <location filename="../../src/project/qml/Audacity/Project/internal/ProjectsPage/CloudAudioFilesView.qml" line="178"/>
+        <location filename="../../src/project/qml/Audacity/Project/internal/ProjectsPage/CloudProjectsView.qml" line="177"/>
+        <location filename="../../src/project/qml/Audacity/Project/internal/ProjectsPage/RecentProjectsView.qml" line="112"/>
         <source>Modified</source>
         <extracomment>Stands for &quot;Last time that this project was modified&quot;. Used as the header of this column in the scores list.</extracomment>
         <translation type="unfinished">Modified</translation>
     </message>
     <message>
-        <location filename="../../src/project/qml/Audacity/Project/internal/ProjectsPage/CloudAudioFilesView.qml" line="333"/>
+        <location filename="../../src/project/qml/Audacity/Project/internal/ProjectsPage/CloudAudioFilesView.qml" line="341"/>
         <source>Unable to load online files</source>
         <translation type="unfinished">Unable to load online files</translation>
     </message>
     <message>
-        <location filename="../../src/project/qml/Audacity/Project/internal/ProjectsPage/CloudAudioFilesView.qml" line="353"/>
+        <location filename="../../src/project/qml/Audacity/Project/internal/ProjectsPage/CloudAudioFilesView.qml" line="361"/>
         <source>You don’t have any online files yet</source>
         <translation type="unfinished">You don’t have any online files yet</translation>
     </message>
     <message>
-        <location filename="../../src/project/qml/Audacity/Project/internal/ProjectsPage/CloudAudioFilesView.qml" line="354"/>
+        <location filename="../../src/project/qml/Audacity/Project/internal/ProjectsPage/CloudAudioFilesView.qml" line="362"/>
         <source>Files will appear here when you save a file to the cloud, or publish a project</source>
         <translation type="unfinished">Files will appear here when you save a file to the cloud, or publish a project</translation>
     </message>
     <message>
-        <location filename="../../src/project/qml/Audacity/Project/internal/ProjectsPage/CloudAudioFilesView.qml" line="373"/>
-        <location filename="../../src/project/qml/Audacity/Project/internal/ProjectsPage/CloudProjectsView.qml" line="305"/>
+        <location filename="../../src/project/qml/Audacity/Project/internal/ProjectsPage/CloudAudioFilesView.qml" line="381"/>
+        <location filename="../../src/project/qml/Audacity/Project/internal/ProjectsPage/CloudProjectsView.qml" line="309"/>
         <source>You are not signed in</source>
         <translation type="unfinished">You are not signed in</translation>
     </message>
     <message>
-        <location filename="../../src/project/qml/Audacity/Project/internal/ProjectsPage/CloudAudioFilesView.qml" line="374"/>
+        <location filename="../../src/project/qml/Audacity/Project/internal/ProjectsPage/CloudAudioFilesView.qml" line="382"/>
         <source>Please sign in to view your online files</source>
         <translation type="unfinished">Please sign in to view your online files</translation>
     </message>
@@ -6500,32 +7044,32 @@ Master effects will be turned back on after export.</translation>
         <translation type="unfinished">Download project</translation>
     </message>
     <message>
-        <location filename="../../src/project/qml/Audacity/Project/internal/ProjectsPage/CloudProjectsView.qml" line="137"/>
+        <location filename="../../src/project/qml/Audacity/Project/internal/ProjectsPage/CloudProjectsView.qml" line="138"/>
         <source>Cloud projects grid</source>
         <translation type="unfinished">Cloud projects grid</translation>
     </message>
     <message>
-        <location filename="../../src/project/qml/Audacity/Project/internal/ProjectsPage/CloudProjectsView.qml" line="162"/>
+        <location filename="../../src/project/qml/Audacity/Project/internal/ProjectsPage/CloudProjectsView.qml" line="165"/>
         <source>Cloud projects list</source>
         <translation type="unfinished">Cloud projects list</translation>
     </message>
     <message>
-        <location filename="../../src/project/qml/Audacity/Project/internal/ProjectsPage/CloudProjectsView.qml" line="265"/>
+        <location filename="../../src/project/qml/Audacity/Project/internal/ProjectsPage/CloudProjectsView.qml" line="269"/>
         <source>Unable to load online projects</source>
         <translation type="unfinished">Unable to load online projects</translation>
     </message>
     <message>
-        <location filename="../../src/project/qml/Audacity/Project/internal/ProjectsPage/CloudProjectsView.qml" line="285"/>
+        <location filename="../../src/project/qml/Audacity/Project/internal/ProjectsPage/CloudProjectsView.qml" line="289"/>
         <source>You don’t have any online projects yet</source>
         <translation type="unfinished">You don’t have any online projects yet</translation>
     </message>
     <message>
-        <location filename="../../src/project/qml/Audacity/Project/internal/ProjectsPage/CloudProjectsView.qml" line="286"/>
+        <location filename="../../src/project/qml/Audacity/Project/internal/ProjectsPage/CloudProjectsView.qml" line="290"/>
         <source>Projects will appear here when you publish a project</source>
         <translation type="unfinished">Projects will appear here when you publish a project</translation>
     </message>
     <message>
-        <location filename="../../src/project/qml/Audacity/Project/internal/ProjectsPage/CloudProjectsView.qml" line="306"/>
+        <location filename="../../src/project/qml/Audacity/Project/internal/ProjectsPage/CloudProjectsView.qml" line="310"/>
         <source>Please sign in to view your online projects</source>
         <translation type="unfinished">Please sign in to view your online projects</translation>
     </message>
@@ -6541,7 +7085,7 @@ Master effects will be turned back on after export.</translation>
     </message>
     <message>
         <location filename="../../src/project/qml/Audacity/Project/NewProjectDialog.qml" line="34"/>
-        <location filename="../../src/project/qml/Audacity/Project/ProjectsListView.qml" line="108"/>
+        <location filename="../../src/project/qml/Audacity/Project/ProjectsListView.qml" line="113"/>
         <location filename="../../src/project/view/recentprojectsmodel.cpp" line="66"/>
         <source>New project</source>
         <translation type="unfinished">New project</translation>
@@ -6557,12 +7101,12 @@ Master effects will be turned back on after export.</translation>
         <translation type="unfinished">Projects grid</translation>
     </message>
     <message>
-        <location filename="../../src/project/qml/Audacity/Project/ProjectsListView.qml" line="82"/>
+        <location filename="../../src/project/qml/Audacity/Project/ProjectsListView.qml" line="85"/>
         <source>Projects list</source>
         <translation type="unfinished">Projects list</translation>
     </message>
     <message>
-        <location filename="../../src/project/qml/Audacity/Project/ProjectsListView.qml" line="156"/>
+        <location filename="../../src/project/qml/Audacity/Project/ProjectsListView.qml" line="161"/>
         <source>Name</source>
         <translation type="unfinished">Name</translation>
     </message>
@@ -6593,48 +7137,48 @@ Master effects will be turned back on after export.</translation>
         <translation type="unfinished">Cloud projects</translation>
     </message>
     <message>
-        <location filename="../../src/project/qml/Audacity/Project/ProjectsPage.qml" line="170"/>
+        <location filename="../../src/project/qml/Audacity/Project/ProjectsPage.qml" line="171"/>
         <source>Cloud audio files</source>
         <translation type="unfinished">Cloud audio files</translation>
     </message>
     <message>
-        <location filename="../../src/project/qml/Audacity/Project/ProjectsPage.qml" line="185"/>
+        <location filename="../../src/project/qml/Audacity/Project/ProjectsPage.qml" line="187"/>
         <source>View buttons</source>
         <translation type="unfinished">View buttons</translation>
     </message>
     <message>
-        <location filename="../../src/project/qml/Audacity/Project/ProjectsPage.qml" line="197"/>
+        <location filename="../../src/project/qml/Audacity/Project/ProjectsPage.qml" line="199"/>
         <source>Refresh</source>
         <translation type="unfinished">Refresh</translation>
     </message>
     <message>
-        <location filename="../../src/project/qml/Audacity/Project/ProjectsPage.qml" line="211"/>
+        <location filename="../../src/project/qml/Audacity/Project/ProjectsPage.qml" line="213"/>
         <source>Grid view</source>
         <translation type="unfinished">Grid view</translation>
     </message>
     <message>
-        <location filename="../../src/project/qml/Audacity/Project/ProjectsPage.qml" line="216"/>
+        <location filename="../../src/project/qml/Audacity/Project/ProjectsPage.qml" line="218"/>
         <source>List view</source>
         <translation type="unfinished">List view</translation>
     </message>
     <message>
-        <location filename="../../src/project/qml/Audacity/Project/ProjectsPage.qml" line="364"/>
+        <location filename="../../src/project/qml/Audacity/Project/ProjectsPage.qml" line="384"/>
         <source>Projects actions</source>
         <extracomment>accessibility name for the panel at the bottom of the &quot;Projects&quot; page</extracomment>
         <translation type="unfinished">Projects actions</translation>
     </message>
     <message>
-        <location filename="../../src/project/qml/Audacity/Project/ProjectsPage.qml" line="379"/>
+        <location filename="../../src/project/qml/Audacity/Project/ProjectsPage.qml" line="399"/>
         <source>Project manager (online)</source>
         <translation type="unfinished">Project manager (online)</translation>
     </message>
     <message>
-        <location filename="../../src/project/qml/Audacity/Project/ProjectsPage.qml" line="398"/>
+        <location filename="../../src/project/qml/Audacity/Project/ProjectsPage.qml" line="418"/>
         <source>New</source>
         <translation type="unfinished">New</translation>
     </message>
     <message>
-        <location filename="../../src/project/qml/Audacity/Project/ProjectsPage.qml" line="410"/>
+        <location filename="../../src/project/qml/Audacity/Project/ProjectsPage.qml" line="430"/>
         <source>Open other…</source>
         <translation type="unfinished">Open other…</translation>
     </message>
@@ -6684,19 +7228,19 @@ Master effects will be turned back on after export.</translation>
         <translation type="unfinished">Accent color</translation>
     </message>
     <message>
-        <location filename="../../src/au3cloud/internal/au3audiocomservice.cpp" line="473"/>
+        <location filename="../../src/au3cloud/internal/au3audiocomservice.cpp" line="374"/>
         <source>Could not save project locally</source>
         <translation type="unfinished">Could not save project locally</translation>
     </message>
     <message>
-        <location filename="../../src/au3wrap/internal/au3project.cpp" line="139"/>
+        <location filename="../../src/au3wrap/internal/au3project.cpp" line="151"/>
         <source>Project loading failed</source>
         <translation type="unfinished">Project loading failed</translation>
     </message>
     <message>
-        <location filename="../../src/importexport/export/view/exportpreferencesmodel.cpp" line="477"/>
-        <location filename="../../src/project/internal/projectactionscontroller.cpp" line="554"/>
-        <location filename="../../src/project/internal/projectactionscontroller.cpp" line="601"/>
+        <location filename="../../src/importexport/export/view/exportpreferencesmodel.cpp" line="475"/>
+        <location filename="../../src/project/internal/projectactionscontroller.cpp" line="578"/>
+        <location filename="../../src/project/internal/projectactionscontroller.cpp" line="625"/>
         <source>All supported files</source>
         <translation type="unfinished">All supported files</translation>
     </message>
@@ -6721,134 +7265,156 @@ Master effects will be turned back on after export.</translation>
         <translation type="unfinished">Imported multiple files</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/opensaveprojectscenario.cpp" line="107"/>
         <source>Audacity4 files</source>
         <translation type="unfinished">Audacity4 files</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectactionscontroller.cpp" line="235"/>
+        <location filename="../../src/project/internal/projectactionscontroller.cpp" line="240"/>
         <source>Error opening file</source>
         <translation type="unfinished">Error opening file</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectactionscontroller.cpp" line="236"/>
+        <location filename="../../src/project/internal/projectactionscontroller.cpp" line="241"/>
         <source>Could not open file: %1</source>
         <translation type="unfinished">Could not open file: %1</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectactionscontroller.cpp" line="473"/>
         <source>All saved changes will now update to the cloud. 
 You can manage this file from your updated projects page on audio.com</source>
         <translation type="unfinished">All saved changes will now update to the cloud. 
 You can manage this file from your updated projects page on audio.com</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectactionscontroller.cpp" line="478"/>
+        <location filename="../../src/project/internal/projectactionscontroller.cpp" line="505"/>
         <source>Dismiss</source>
         <translation type="unfinished">Dismiss</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectactionscontroller.cpp" line="494"/>
+        <location filename="../../src/project/internal/projectactionscontroller.cpp" line="518"/>
         <source>Upload project to audio.com…</source>
         <translation type="unfinished">Upload project to audio.com…</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectactionscontroller.cpp" line="555"/>
+        <location filename="../../src/project/internal/projectactionscontroller.cpp" line="579"/>
         <source>Audacity project files</source>
         <translation type="unfinished">Audacity project files</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectactionscontroller.cpp" line="556"/>
+        <location filename="../../src/project/internal/projectactionscontroller.cpp" line="580"/>
         <source>Audacity 3 files</source>
         <translation type="unfinished">Audacity 3 files</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectactionscontroller.cpp" line="557"/>
+        <location filename="../../src/project/internal/opensaveprojectscenario.cpp" line="181"/>
+        <location filename="../../src/project/internal/projectactionscontroller.cpp" line="581"/>
         <source>Audacity 4 files</source>
         <translation type="unfinished">Audacity 4 files</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectactionscontroller.cpp" line="558"/>
+        <location filename="../../src/project/internal/opensaveprojectscenario.cpp" line="652"/>
+        <location filename="../../src/project/internal/opensaveprojectscenario.cpp" line="670"/>
+        <source>Visit audio.com</source>
+        <translation type="unfinished">Visit audio.com</translation>
+    </message>
+    <message>
+        <location filename="../../src/project/internal/opensaveprojectscenario.cpp" line="654"/>
+        <source>Load latest</source>
+        <translation type="unfinished">Load latest</translation>
+    </message>
+    <message>
+        <location filename="../../src/project/internal/projectactionscontroller.cpp" line="500"/>
+        <source>All saved changes will now update to the cloud.
+You can manage this file from your updated projects page on audio.com</source>
+        <translation type="unfinished">All saved changes will now update to the cloud.
+You can manage this file from your updated projects page on audio.com</translation>
+    </message>
+    <message>
+        <location filename="../../src/project/internal/projectactionscontroller.cpp" line="582"/>
         <source>Importable audio and media files</source>
         <translation type="unfinished">Importable audio and media files</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectactionscontroller.cpp" line="571"/>
-        <location filename="../../src/project/internal/projectactionscontroller.cpp" line="620"/>
+        <location filename="../../src/project/internal/projectactionscontroller.cpp" line="595"/>
+        <location filename="../../src/project/internal/projectactionscontroller.cpp" line="644"/>
         <source>Open</source>
         <translation type="unfinished">Open</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectactionscontroller.cpp" line="602"/>
+        <location filename="../../src/project/internal/projectactionscontroller.cpp" line="626"/>
         <source>Audio files</source>
         <translation type="unfinished">Audio files</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectactionscontroller.cpp" line="603"/>
+        <location filename="../../src/project/internal/projectactionscontroller.cpp" line="627"/>
         <source>Video files</source>
         <translation type="unfinished">Video files</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectactionscontroller.cpp" line="604"/>
+        <location filename="../../src/project/internal/projectactionscontroller.cpp" line="628"/>
         <source>Game media files</source>
         <translation type="unfinished">Game media files</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectactionscontroller.cpp" line="605"/>
+        <location filename="../../src/project/internal/projectactionscontroller.cpp" line="629"/>
         <source>Streaming files</source>
         <translation type="unfinished">Streaming files</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectactionscontroller.cpp" line="606"/>
+        <location filename="../../src/project/internal/projectactionscontroller.cpp" line="630"/>
         <source>Animation and image files</source>
         <translation type="unfinished">Animation and image files</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectactionscontroller.cpp" line="607"/>
+        <location filename="../../src/project/internal/projectactionscontroller.cpp" line="631"/>
         <source>Raw files</source>
         <translation type="unfinished">Raw files</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectactionscontroller.cpp" line="633"/>
+        <location filename="../../src/project/internal/projectactionscontroller.cpp" line="660"/>
+        <source>Do you want to save changes to the project before closing?</source>
+        <translation type="unfinished">Do you want to save changes to the project before closing?</translation>
+    </message>
+    <message>
+        <location filename="../../src/project/internal/projectactionscontroller.cpp" line="662"/>
         <source>Do you want to save changes to the project “%1” before closing?</source>
         <translation type="unfinished">Do you want to save changes to the project “%1” before closing?</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectactionscontroller.cpp" line="636"/>
+        <location filename="../../src/project/internal/projectactionscontroller.cpp" line="666"/>
         <source>Your changes will be lost if you don’t save them.</source>
         <translation type="unfinished">Your changes will be lost if you don’t save them.</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectactionscontroller.cpp" line="827"/>
+        <location filename="../../src/project/internal/projectactionscontroller.cpp" line="872"/>
         <source>Resuming sync to audio.com…</source>
         <translation type="unfinished">Resuming sync to audio.com…</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectactionscontroller.cpp" line="837"/>
+        <location filename="../../src/project/internal/projectactionscontroller.cpp" line="882"/>
         <source>Syncing project from cloud…</source>
         <translation type="unfinished">Syncing project from cloud…</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectactionscontroller.cpp" line="980"/>
+        <location filename="../../src/project/internal/projectactionscontroller.cpp" line="1042"/>
         <location filename="../../src/project/projecterrors.cpp" line="32"/>
         <location filename="../../src/project/projecterrors.cpp" line="51"/>
         <source>Cannot read file %1</source>
         <translation type="unfinished">Cannot read file %1</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectactionscontroller.cpp" line="985"/>
+        <location filename="../../src/project/internal/projectactionscontroller.cpp" line="1047"/>
         <source>An error occurred while reading this file.</source>
         <translation type="unfinished">An error occurred while reading this file.</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectactionscontroller.cpp" line="1187"/>
-        <location filename="../../src/project/internal/projectactionscontroller.cpp" line="1316"/>
-        <location filename="../../src/project/internal/projectactionscontroller.cpp" line="1372"/>
+        <location filename="../../src/project/internal/opensaveprojectscenario.cpp" line="597"/>
+        <location filename="../../src/project/internal/opensaveprojectscenario.cpp" line="701"/>
+        <location filename="../../src/project/internal/opensaveprojectscenario.cpp" line="717"/>
+        <location filename="../../src/project/internal/opensaveprojectscenario.cpp" line="756"/>
         <source>Save to computer</source>
         <translation type="unfinished">Save to computer</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/projectactionscontroller.cpp" line="1286"/>
         <source>Save to Computer</source>
         <translation type="unfinished">Save to Computer</translation>
     </message>
@@ -6942,28 +7508,20 @@ Please remove the write protection by checking the file’s properties, ensuring
         <translation type="unfinished">Remember my choice</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/opensaveprojectscenario.cpp" line="506"/>
-        <location filename="../../src/project/internal/opensaveprojectscenario.cpp" line="512"/>
-        <location filename="../../src/project/internal/opensaveprojectscenario.cpp" line="518"/>
-        <location filename="../../src/project/internal/opensaveprojectscenario.cpp" line="524"/>
-        <location filename="../../src/project/internal/opensaveprojectscenario.cpp" line="530"/>
         <source>MuseScore.com returned an error code: %1.</source>
         <extracomment>%1 will be replaced with the error code that MuseScore.com returned; this might contain english text that is deliberately not translated</extracomment>
         <translation type="unfinished">MuseScore.com returned an error code: %1.</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/opensaveprojectscenario.cpp" line="536"/>
         <source>MuseScore.com returned an unknown error code: %1.</source>
         <extracomment>%1 will be replaced with the error code that MuseScore.com returned, which is a number.</extracomment>
         <translation type="unfinished">MuseScore.com returned an unknown error code: %1.</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/opensaveprojectscenario.cpp" line="539"/>
         <source>MuseScore.com returned an unknown error code.</source>
         <translation type="unfinished">MuseScore.com returned an unknown error code.</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/opensaveprojectscenario.cpp" line="545"/>
         <source>Please try again later, or get help for this problem on musescore.org.</source>
         <translation type="unfinished">Please try again later, or get help for this problem on musescore.org.</translation>
     </message>
@@ -6992,34 +7550,49 @@ Please remove the write protection by checking the file’s properties, ensuring
 <context>
     <name>project/open</name>
     <message>
-        <location filename="../../src/project/internal/opensaveprojectscenario.cpp" line="406"/>
+        <location filename="../../src/project/internal/opensaveprojectscenario.cpp" line="480"/>
         <source>Legacy project file</source>
         <translation type="unfinished">Legacy project file</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/opensaveprojectscenario.cpp" line="407"/>
+        <location filename="../../src/project/internal/opensaveprojectscenario.cpp" line="481"/>
         <source>You have opened an Audacity 3 project. It must be converted before you can use it in Audacity 4.</source>
         <translation type="unfinished">You have opened an Audacity 3 project. It must be converted before you can use it in Audacity 4.</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/opensaveprojectscenario.cpp" line="412"/>
+        <location filename="../../src/project/internal/opensaveprojectscenario.cpp" line="486"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancel</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/opensaveprojectscenario.cpp" line="415"/>
+        <location filename="../../src/project/internal/opensaveprojectscenario.cpp" line="489"/>
         <source>Save as new project</source>
         <translation type="unfinished">Save as new project</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/opensaveprojectscenario.cpp" line="442"/>
+        <location filename="../../src/project/internal/opensaveprojectscenario.cpp" line="516"/>
         <source>The project was saved as “%1”</source>
         <translation type="unfinished">The project was saved as “%1”</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/opensaveprojectscenario.cpp" line="445"/>
+        <location filename="../../src/project/internal/opensaveprojectscenario.cpp" line="519"/>
         <source>Continue</source>
         <translation type="unfinished">Continue</translation>
+    </message>
+    <message>
+        <location filename="../../src/project/internal/projectactionscontroller.cpp" line="908"/>
+        <source>Time Track not supported</source>
+        <translation type="unfinished">Time Track not supported</translation>
+    </message>
+    <message>
+        <location filename="../../src/project/internal/projectactionscontroller.cpp" line="909"/>
+        <source>The project contains a time track, which is not yet supported in Audacity 4, and will need to be removed. This does not affect your original Audacity 3 project.</source>
+        <translation type="unfinished">The project contains a time track, which is not yet supported in Audacity 4, and will need to be removed. This does not affect your original Audacity 3 project.</translation>
+    </message>
+    <message>
+        <location filename="../../src/project/internal/projectactionscontroller.cpp" line="913"/>
+        <source>Ok</source>
+        <translation type="unfinished">Ok</translation>
     </message>
 </context>
 <context>
@@ -7068,7 +7641,6 @@ Please remove the write protection by checking the file’s properties, ensuring
         <translation type="unfinished">How would you like to save?</translation>
     </message>
     <message>
-        <location filename="../../src/project/qml/Audacity/Project/AskSaveLocationTypeDialog.qml" line="78"/>
         <source>Save to the Cloud (free)</source>
         <translation type="unfinished">Save to the Cloud (free)</translation>
     </message>
@@ -7083,6 +7655,7 @@ Please remove the write protection by checking the file’s properties, ensuring
         <translation type="unfinished">Save to cloud</translation>
     </message>
     <message>
+        <location filename="../../src/project/qml/Audacity/Project/AskSaveLocationTypeDialog.qml" line="78"/>
         <location filename="../../src/project/qml/Audacity/Project/AskSaveLocationTypeDialog.qml" line="86"/>
         <source>Save to the cloud (free)</source>
         <translation type="unfinished">Save to the cloud (free)</translation>
@@ -7099,7 +7672,7 @@ Please remove the write protection by checking the file’s properties, ensuring
     </message>
     <message>
         <location filename="../../src/project/qml/Audacity/Project/AskSaveLocationTypeDialog.qml" line="97"/>
-        <location filename="../../src/project/internal/opensaveprojectscenario.cpp" line="476"/>
+        <location filename="../../src/project/internal/opensaveprojectscenario.cpp" line="550"/>
         <source>Save to computer</source>
         <translation type="unfinished">Save to computer</translation>
     </message>
@@ -7109,62 +7682,62 @@ Please remove the write protection by checking the file’s properties, ensuring
         <translation type="unfinished">Save on your computer</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/opensaveprojectscenario.cpp" line="93"/>
+        <location filename="../../src/project/internal/opensaveprojectscenario.cpp" line="167"/>
         <source>Save project</source>
         <translation type="unfinished">Save project</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/opensaveprojectscenario.cpp" line="98"/>
+        <location filename="../../src/project/internal/opensaveprojectscenario.cpp" line="172"/>
         <source>copy</source>
         <comment>a copy of a file</comment>
         <extracomment>used to form a filename suggestion, like &quot;originalFile - copy&quot;</extracomment>
         <translation type="unfinished">copy</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/opensaveprojectscenario.cpp" line="101"/>
+        <location filename="../../src/project/internal/opensaveprojectscenario.cpp" line="175"/>
         <source>selection</source>
         <extracomment>used to form a filename suggestion, like &quot;originalFile - selection&quot;</extracomment>
         <translation type="unfinished">selection</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/opensaveprojectscenario.cpp" line="190"/>
+        <location filename="../../src/project/internal/opensaveprojectscenario.cpp" line="264"/>
         <source>Log in or create a new account on Audio.com to share your music.</source>
         <translation type="unfinished">Log in or create a new account on Audio.com to share your music.</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/opensaveprojectscenario.cpp" line="454"/>
+        <location filename="../../src/project/internal/opensaveprojectscenario.cpp" line="528"/>
         <source>Publish</source>
         <translation type="unfinished">Publish</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/opensaveprojectscenario.cpp" line="458"/>
+        <location filename="../../src/project/internal/opensaveprojectscenario.cpp" line="532"/>
         <source>Publish changes online?</source>
         <translation type="unfinished">Publish changes online?</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/opensaveprojectscenario.cpp" line="459"/>
+        <location filename="../../src/project/internal/opensaveprojectscenario.cpp" line="533"/>
         <source>Your saved changes will be publicly visible. We will also need to generate a new MP3 for public playback.</source>
         <translation type="unfinished">Your saved changes will be publicly visible. We will also need to generate a new MP3 for public playback.</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/opensaveprojectscenario.cpp" line="469"/>
         <source>Unable to connect to MuseScore.com</source>
         <translation type="unfinished">Unable to connect to MuseScore.com</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/opensaveprojectscenario.cpp" line="470"/>
-        <location filename="../../src/project/internal/opensaveprojectscenario.cpp" line="480"/>
-        <location filename="../../src/project/internal/opensaveprojectscenario.cpp" line="494"/>
+        <location filename="../../src/project/internal/opensaveprojectscenario.cpp" line="544"/>
+        <location filename="../../src/project/internal/opensaveprojectscenario.cpp" line="554"/>
+        <location filename="../../src/project/internal/opensaveprojectscenario.cpp" line="568"/>
         <source>Please check your internet connection or try again later.</source>
         <translation type="unfinished">Please check your internet connection or try again later.</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/opensaveprojectscenario.cpp" line="479"/>
+        <location filename="../../src/project/internal/opensaveprojectscenario.cpp" line="543"/>
+        <location filename="../../src/project/internal/opensaveprojectscenario.cpp" line="553"/>
         <source>Unable to connect to the cloud</source>
         <translation type="unfinished">Unable to connect to the cloud</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/opensaveprojectscenario.cpp" line="493"/>
+        <location filename="../../src/project/internal/opensaveprojectscenario.cpp" line="567"/>
         <source>Unable to connect to Audio.com</source>
         <translation type="unfinished">Unable to connect to Audio.com</translation>
     </message>
@@ -7172,34 +7745,34 @@ Please remove the write protection by checking the file’s properties, ensuring
 <context>
     <name>project/share</name>
     <message>
-        <location filename="../../src/project/internal/opensaveprojectscenario.cpp" line="703"/>
+        <location filename="../../src/project/internal/opensaveprojectscenario.cpp" line="805"/>
         <source>Your audio could not be shared</source>
         <translation type="unfinished">Your audio could not be shared</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/opensaveprojectscenario.cpp" line="711"/>
+        <location filename="../../src/project/internal/opensaveprojectscenario.cpp" line="813"/>
         <source>Your audio.com account needs to be verified first. Please activate your account via the link in the activation email.</source>
         <translation type="unfinished">Your audio.com account needs to be verified first. Please activate your account via the link in the activation email.</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/opensaveprojectscenario.cpp" line="717"/>
+        <location filename="../../src/project/internal/opensaveprojectscenario.cpp" line="819"/>
         <source>Audio.com returned an unknown error code: %1.</source>
         <extracomment>%1 will be replaced with the error code that audio.com returned, which is a number.</extracomment>
         <translation type="unfinished">Audio.com returned an unknown error code: %1.</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/opensaveprojectscenario.cpp" line="720"/>
+        <location filename="../../src/project/internal/opensaveprojectscenario.cpp" line="822"/>
         <source>Audio.com returned an unknown error code.</source>
         <translation type="unfinished">Audio.com returned an unknown error code.</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/opensaveprojectscenario.cpp" line="722"/>
-        <location filename="../../src/project/internal/opensaveprojectscenario.cpp" line="729"/>
+        <location filename="../../src/project/internal/opensaveprojectscenario.cpp" line="824"/>
+        <location filename="../../src/project/internal/opensaveprojectscenario.cpp" line="831"/>
         <source>Please try again later, or get help for this problem on audio.com.</source>
         <translation type="unfinished">Please try again later, or get help for this problem on audio.com.</translation>
     </message>
     <message>
-        <location filename="../../src/project/internal/opensaveprojectscenario.cpp" line="725"/>
+        <location filename="../../src/project/internal/opensaveprojectscenario.cpp" line="827"/>
         <source>Could not connect to audio.com. Please check your internet connection or try again later.</source>
         <translation type="unfinished">Could not connect to audio.com. Please check your internet connection or try again later.</translation>
     </message>
@@ -7221,11 +7794,19 @@ Please remove the write protection by checking the file’s properties, ensuring
     </message>
     <message>
         <location filename="../../src/projectscene/qml/Audacity/ProjectScene/statusbar/SelectionStatus.qml" line="50"/>
+        <source>Selection start</source>
+        <translation type="unfinished">Selection start</translation>
+    </message>
+    <message>
+        <location filename="../../src/projectscene/qml/Audacity/ProjectScene/statusbar/SelectionStatus.qml" line="51"/>
+        <source>Selection end</source>
+        <translation type="unfinished">Selection end</translation>
+    </message>
+    <message>
         <source>Selection Start</source>
         <translation type="unfinished">Selection Start</translation>
     </message>
     <message>
-        <location filename="../../src/projectscene/qml/Audacity/ProjectScene/statusbar/SelectionStatus.qml" line="51"/>
         <source>Selection End</source>
         <translation type="unfinished">Selection End</translation>
     </message>
@@ -7542,21 +8123,42 @@ Please remove the write protection by checking the file’s properties, ensuring
     </message>
     <message>
         <location filename="../../src/projectscene/view/toolbars/snaptoolbaritem.cpp" line="230"/>
+        <source>Video frames (24 fps)</source>
+        <translation type="unfinished">Video frames (24 fps)</translation>
+    </message>
+    <message>
+        <location filename="../../src/projectscene/view/toolbars/snaptoolbaritem.cpp" line="231"/>
+        <source>NTSC frames (29.97 fps)</source>
+        <translation type="unfinished">NTSC frames (29.97 fps)</translation>
+    </message>
+    <message>
+        <location filename="../../src/projectscene/view/toolbars/snaptoolbaritem.cpp" line="232"/>
+        <source>NTSC frames (30 fps)</source>
+        <translation type="unfinished">NTSC frames (30 fps)</translation>
+    </message>
+    <message>
+        <location filename="../../src/projectscene/view/toolbars/snaptoolbaritem.cpp" line="233"/>
+        <source>PAL frames (25 fps)</source>
+        <translation type="unfinished">PAL frames (25 fps)</translation>
+    </message>
+    <message>
+        <location filename="../../src/projectscene/view/toolbars/snaptoolbaritem.cpp" line="242"/>
+        <source>CDDA frames (75 fps)</source>
+        <translation type="unfinished">CDDA frames (75 fps)</translation>
+    </message>
+    <message>
         <source>Video Frames (24 fps)</source>
         <translation type="unfinished">Video Frames (24 fps)</translation>
     </message>
     <message>
-        <location filename="../../src/projectscene/view/toolbars/snaptoolbaritem.cpp" line="231"/>
         <source>NTSC Frames (29.97 fps)</source>
         <translation type="unfinished">NTSC Frames (29.97 fps)</translation>
     </message>
     <message>
-        <location filename="../../src/projectscene/view/toolbars/snaptoolbaritem.cpp" line="232"/>
         <source>NTSC Frames (30 fps)</source>
         <translation type="unfinished">NTSC Frames (30 fps)</translation>
     </message>
     <message>
-        <location filename="../../src/projectscene/view/toolbars/snaptoolbaritem.cpp" line="233"/>
         <source>PAL Frames (25 fps)</source>
         <translation type="unfinished">PAL Frames (25 fps)</translation>
     </message>
@@ -7566,7 +8168,6 @@ Please remove the write protection by checking the file’s properties, ensuring
         <translation type="unfinished">Video frames</translation>
     </message>
     <message>
-        <location filename="../../src/projectscene/view/toolbars/snaptoolbaritem.cpp" line="242"/>
         <source>CDDA Frames (75 fps)</source>
         <translation type="unfinished">CDDA Frames (75 fps)</translation>
     </message>
@@ -7660,45 +8261,137 @@ Please remove the write protection by checking the file’s properties, ensuring
         <translation type="unfinished">Show mic metering when not recording</translation>
     </message>
     <message>
-        <location filename="../../src/record/internal/au3/au3record.cpp" line="706"/>
         <source>Recorded Audio</source>
         <translation type="unfinished">Recorded Audio</translation>
     </message>
     <message>
-        <location filename="../../src/record/internal/au3/au3record.cpp" line="706"/>
+        <location filename="../../src/record/internal/au3/au3record.cpp" line="919"/>
         <source>Record</source>
         <translation type="unfinished">Record</translation>
     </message>
     <message>
-        <location filename="../../src/record/internal/recordcontroller.cpp" line="94"/>
-        <location filename="../../src/record/internal/recordcontroller.cpp" line="109"/>
-        <location filename="../../src/record/internal/recordcontroller.cpp" line="124"/>
+        <location filename="../../src/record/internal/au3/au3record.cpp" line="919"/>
+        <source>Recorded audio</source>
+        <translation type="unfinished">Recorded audio</translation>
+    </message>
+    <message>
+        <location filename="../../src/record/internal/recordcontroller.cpp" line="104"/>
+        <location filename="../../src/record/internal/recordcontroller.cpp" line="119"/>
+        <location filename="../../src/record/internal/recordcontroller.cpp" line="134"/>
         <source>Recording error</source>
         <translation type="unfinished">Recording error</translation>
     </message>
     <message>
-        <location filename="../../src/record/recorderrors.h" line="32"/>
+        <location filename="../../src/record/internal/recordcontroller.cpp" line="154"/>
+        <source>Lead-in Recording error</source>
+        <translation type="unfinished">Lead-in Recording error</translation>
+    </message>
+    <message>
+        <location filename="../../src/record/recorderrors.h" line="35"/>
         <source>Error opening recording device.
 Error code: %1</source>
         <translation type="unfinished">Error opening recording device.
 Error code: %1</translation>
     </message>
     <message>
-        <location filename="../../src/record/recorderrors.h" line="33"/>
+        <location filename="../../src/record/recorderrors.h" line="36"/>
         <source>Cannot stop recording</source>
         <translation type="unfinished">Cannot stop recording</translation>
     </message>
     <message>
-        <location filename="../../src/record/recorderrors.h" line="35"/>
+        <location filename="../../src/record/recorderrors.h" line="38"/>
         <source>The tracks selected for recording must all have the same sampling rate</source>
         <translation type="unfinished">The tracks selected for recording must all have the same sampling rate</translation>
     </message>
     <message>
-        <location filename="../../src/record/recorderrors.h" line="38"/>
+        <location filename="../../src/record/recorderrors.h" line="41"/>
         <source>Too few tracks are selected for recording at this sample rate.
 (Audacity requires two channels at the same sample rate foreach stereo track)</source>
         <translation type="unfinished">Too few tracks are selected for recording at this sample rate.
 (Audacity requires two channels at the same sample rate foreach stereo track)</translation>
+    </message>
+    <message>
+        <location filename="../../src/record/recorderrors.h" line="45"/>
+        <source>Please select a time within a clip.</source>
+        <translation type="unfinished">Please select a time within a clip.</translation>
+    </message>
+    <message>
+        <location filename="../../src/record/recorderrors.h" line="48"/>
+        <source>Please select a track for lead-in recording.</source>
+        <translation type="unfinished">Please select a track for lead-in recording.</translation>
+    </message>
+</context>
+<context>
+    <name>selection</name>
+    <message>
+        <location filename="../../src/projectscene/view/tracksitemsview/selectioncontextmenumodel.cpp" line="26"/>
+        <source>Cut and leave gap</source>
+        <translation type="unfinished">Cut and leave gap</translation>
+    </message>
+    <message>
+        <location filename="../../src/projectscene/view/tracksitemsview/selectioncontextmenumodel.cpp" line="28"/>
+        <source>Cut and close gap</source>
+        <translation type="unfinished">Cut and close gap</translation>
+    </message>
+    <message>
+        <location filename="../../src/projectscene/view/tracksitemsview/selectioncontextmenumodel.cpp" line="30"/>
+        <source>Cut and close gap on this track</source>
+        <translation type="unfinished">Cut and close gap on this track</translation>
+    </message>
+    <message>
+        <location filename="../../src/projectscene/view/tracksitemsview/selectioncontextmenumodel.cpp" line="32"/>
+        <source>Cut and close gap on all tracks</source>
+        <translation type="unfinished">Cut and close gap on all tracks</translation>
+    </message>
+    <message>
+        <location filename="../../src/projectscene/view/tracksitemsview/selectioncontextmenumodel.cpp" line="37"/>
+        <source>Paste and overlap</source>
+        <translation type="unfinished">Paste and overlap</translation>
+    </message>
+    <message>
+        <location filename="../../src/projectscene/view/tracksitemsview/selectioncontextmenumodel.cpp" line="39"/>
+        <source>Paste and make room on this track</source>
+        <translation type="unfinished">Paste and make room on this track</translation>
+    </message>
+    <message>
+        <location filename="../../src/projectscene/view/tracksitemsview/selectioncontextmenumodel.cpp" line="41"/>
+        <source>Paste and make room on all tracks</source>
+        <translation type="unfinished">Paste and make room on all tracks</translation>
+    </message>
+    <message>
+        <location filename="../../src/projectscene/view/tracksitemsview/selectioncontextmenumodel.cpp" line="46"/>
+        <source>Delete and leave gap</source>
+        <translation type="unfinished">Delete and leave gap</translation>
+    </message>
+    <message>
+        <location filename="../../src/projectscene/view/tracksitemsview/selectioncontextmenumodel.cpp" line="48"/>
+        <source>Delete and close gap</source>
+        <translation type="unfinished">Delete and close gap</translation>
+    </message>
+    <message>
+        <location filename="../../src/projectscene/view/tracksitemsview/selectioncontextmenumodel.cpp" line="50"/>
+        <source>Delete and close gap on this track</source>
+        <translation type="unfinished">Delete and close gap on this track</translation>
+    </message>
+    <message>
+        <location filename="../../src/projectscene/view/tracksitemsview/selectioncontextmenumodel.cpp" line="52"/>
+        <source>Delete and close gap on all tracks</source>
+        <translation type="unfinished">Delete and close gap on all tracks</translation>
+    </message>
+    <message>
+        <location filename="../../src/projectscene/view/tracksitemsview/selectioncontextmenumodel.cpp" line="62"/>
+        <source>Cut and…</source>
+        <translation type="unfinished">Cut and…</translation>
+    </message>
+    <message>
+        <location filename="../../src/projectscene/view/tracksitemsview/selectioncontextmenumodel.cpp" line="63"/>
+        <source>Paste and…</source>
+        <translation type="unfinished">Paste and…</translation>
+    </message>
+    <message>
+        <location filename="../../src/projectscene/view/tracksitemsview/selectioncontextmenumodel.cpp" line="64"/>
+        <source>Delete and…</source>
+        <translation type="unfinished">Delete and…</translation>
     </message>
 </context>
 <context>
@@ -7884,6 +8577,10 @@ Error code: %1</translation>
     </message>
     <message>
         <location filename="../../src/spectrogram/view/colorsectionparameterlistmodel.cpp" line="97"/>
+        <source>High boost</source>
+        <translation type="unfinished">High boost</translation>
+    </message>
+    <message>
         <source>High Boost</source>
         <translation type="unfinished">High Boost</translation>
     </message>
@@ -7922,6 +8619,10 @@ Error code: %1</translation>
     </message>
     <message>
         <location filename="../../src/spectrogram/qml/Audacity/Spectrogram/TrackSpectrogramSettingsDialog.qml" line="132"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
         <source>Ok</source>
         <translation type="unfinished">Ok</translation>
     </message>
@@ -7976,29 +8677,29 @@ Error code: %1</translation>
 <context>
     <name>trackedit</name>
     <message>
-        <location filename="../../src/automation/internal/au3/au3clipgaininteraction.cpp" line="189"/>
+        <location filename="../../src/automation/internal/au3/au3clipgaininteraction.cpp" line="191"/>
         <source>Added enveloped point</source>
         <translation type="unfinished">Added enveloped point</translation>
     </message>
     <message>
-        <location filename="../../src/automation/internal/au3/au3clipgaininteraction.cpp" line="189"/>
-        <location filename="../../src/automation/internal/au3/au3clipgaininteraction.cpp" line="219"/>
-        <location filename="../../src/automation/internal/au3/au3clipgaininteraction.cpp" line="339"/>
+        <location filename="../../src/automation/internal/au3/au3clipgaininteraction.cpp" line="191"/>
+        <location filename="../../src/automation/internal/au3/au3clipgaininteraction.cpp" line="224"/>
+        <location filename="../../src/automation/internal/au3/au3clipgaininteraction.cpp" line="345"/>
         <source>Clip envelope edit</source>
         <translation type="unfinished">Clip envelope edit</translation>
     </message>
     <message>
-        <location filename="../../src/automation/internal/au3/au3clipgaininteraction.cpp" line="219"/>
+        <location filename="../../src/automation/internal/au3/au3clipgaininteraction.cpp" line="224"/>
         <source>Removed enveloped point</source>
         <translation type="unfinished">Removed enveloped point</translation>
     </message>
     <message>
-        <location filename="../../src/automation/internal/au3/au3clipgaininteraction.cpp" line="339"/>
+        <location filename="../../src/automation/internal/au3/au3clipgaininteraction.cpp" line="345"/>
         <source>Dragged enveloped point</source>
         <translation type="unfinished">Dragged enveloped point</translation>
     </message>
     <message>
-        <location filename="../../src/playback/internal/playbackcontroller.cpp" line="601"/>
+        <location filename="../../src/playback/internal/playbackcontroller.cpp" line="631"/>
         <source>Set looping region in/out</source>
         <translation type="unfinished">Set looping region in/out</translation>
     </message>
@@ -8042,40 +8743,46 @@ This causes any realtime effects to be applied to the waveform and hidden data t
 Do you wish to continue?</translation>
     </message>
     <message>
-        <location filename="../../src/trackedit/internal/trackeditactionscontroller.cpp" line="638"/>
-        <location filename="../../src/trackedit/internal/trackeditactionscontroller.cpp" line="666"/>
-        <location filename="../../src/trackedit/internal/trackeditactionscontroller.cpp" line="689"/>
+        <location filename="../../src/trackedit/internal/trackeditactionscontroller.cpp" line="663"/>
+        <location filename="../../src/trackedit/internal/trackeditactionscontroller.cpp" line="697"/>
         <location filename="../../src/trackedit/internal/trackeditactionscontroller.cpp" line="720"/>
+        <location filename="../../src/trackedit/internal/trackeditactionscontroller.cpp" line="743"/>
+        <location filename="../../src/trackedit/internal/trackeditactionscontroller.cpp" line="774"/>
         <source>No audio selected</source>
         <translation type="unfinished">No audio selected</translation>
     </message>
     <message>
-        <location filename="../../src/trackedit/internal/trackeditactionscontroller.cpp" line="639"/>
-        <location filename="../../src/trackedit/internal/trackeditactionscontroller.cpp" line="667"/>
-        <location filename="../../src/trackedit/internal/trackeditactionscontroller.cpp" line="690"/>
-        <location filename="../../src/trackedit/internal/trackeditactionscontroller.cpp" line="721"/>
         <source>Select the audio for Delete then try again.</source>
         <translation type="unfinished">Select the audio for Delete then try again.</translation>
     </message>
     <message>
-        <location filename="../../src/trackedit/internal/trackeditactionscontroller.cpp" line="1120"/>
-        <location filename="../../src/trackedit/internal/trackeditactionscontroller.cpp" line="1134"/>
-        <location filename="../../src/trackedit/internal/trackeditactionscontroller.cpp" line="1148"/>
+        <location filename="../../src/trackedit/internal/trackeditactionscontroller.cpp" line="664"/>
+        <location filename="../../src/trackedit/internal/trackeditactionscontroller.cpp" line="698"/>
+        <location filename="../../src/trackedit/internal/trackeditactionscontroller.cpp" line="721"/>
+        <location filename="../../src/trackedit/internal/trackeditactionscontroller.cpp" line="744"/>
+        <location filename="../../src/trackedit/internal/trackeditactionscontroller.cpp" line="775"/>
+        <source>Select the audio to delete and try again.</source>
+        <translation type="unfinished">Select the audio to delete and try again.</translation>
+    </message>
+    <message>
+        <location filename="../../src/trackedit/internal/trackeditactionscontroller.cpp" line="1139"/>
+        <location filename="../../src/trackedit/internal/trackeditactionscontroller.cpp" line="1153"/>
+        <location filename="../../src/trackedit/internal/trackeditactionscontroller.cpp" line="1167"/>
         <source>Paste error</source>
         <translation type="unfinished">Paste error</translation>
     </message>
     <message>
-        <location filename="../../src/trackedit/internal/trackeditactionscontroller.cpp" line="1587"/>
+        <location filename="../../src/trackedit/internal/trackeditactionscontroller.cpp" line="1606"/>
         <source>Applying</source>
         <translation type="unfinished">Applying</translation>
     </message>
     <message>
-        <location filename="../../src/trackedit/internal/trackeditactionscontroller.cpp" line="1795"/>
+        <location filename="../../src/trackedit/internal/trackeditactionscontroller.cpp" line="1847"/>
         <source>Set rate</source>
         <translation type="unfinished">Set rate</translation>
     </message>
     <message>
-        <location filename="../../src/trackedit/internal/trackeditactionscontroller.cpp" line="1952"/>
+        <location filename="../../src/trackedit/internal/trackeditactionscontroller.cpp" line="2004"/>
         <source>Resample</source>
         <translation type="unfinished">Resample</translation>
     </message>
@@ -8108,9 +8815,13 @@ Do you wish to continue?</translation>
         <translation type="unfinished">Delete preference</translation>
     </message>
     <message>
-        <location filename="../../src/trackedit/qml/Audacity/TrackEdit/DeleteBehaviorOnboardingFollowupDialog.qml" line="45"/>
         <source>Your delete behaviour has been set</source>
         <translation type="unfinished">Your delete behaviour has been set</translation>
+    </message>
+    <message>
+        <location filename="../../src/trackedit/qml/Audacity/TrackEdit/DeleteBehaviorOnboardingFollowupDialog.qml" line="45"/>
+        <source>Your delete behavior has been set</source>
+        <translation type="unfinished">Your delete behavior has been set</translation>
     </message>
     <message>
         <location filename="../../src/trackedit/qml/Audacity/TrackEdit/DeleteBehaviorOnboardingFollowupDialog.qml" line="57"/>
@@ -8129,6 +8840,10 @@ Do you wish to continue?</translation>
     </message>
     <message>
         <location filename="../../src/trackedit/qml/Audacity/TrackEdit/DeleteBehaviorOnboardingFollowupDialog.qml" line="61"/>
+        <source>There are also a variety of new shortcuts that let you quickly access different delete behaviors. Go to %2 to learn more.</source>
+        <translation type="unfinished">There are also a variety of new shortcuts that let you quickly access different delete behaviors. Go to %2 to learn more.</translation>
+    </message>
+    <message>
         <source>There are also a variety of new shortcuts that let you quickly access different delete behaviours. Go to %2 to learn more.</source>
         <translation type="unfinished">There are also a variety of new shortcuts that let you quickly access different delete behaviours. Go to %2 to learn more.</translation>
     </message>

--- a/src/app/cmdoptions.h
+++ b/src/app/cmdoptions.h
@@ -25,6 +25,7 @@ struct AudacityCmdOptions : public muse::CmdOptions {
         std::optional<QString> projectDisplayNameOverride;
         std::optional<QString> cloudProjectId;
         muse::io::paths_t mediaFiles;
+        bool removeMediaFilesAfterImport = false;
     } startup;
 
     struct Testflow {

--- a/src/app/commandlineparser.cpp
+++ b/src/app/commandlineparser.cpp
@@ -57,6 +57,7 @@ void CommandLineParser::init()
 
     m_parser.addOption(QCommandLineOption("session-type", "Startup with given session type", "type"));
     m_parser.addOption(internalCommandLineOption("import-media-file", "Import media file on startup", "path"));
+    m_parser.addOption(internalCommandLineOption("remove-media-after-import", "Remove imported media files after import"));
     m_parser.addOption(internalCommandLineOption("project-display-name-override", "Display name override", "name"));
     m_parser.addOption(internalCommandLineOption("cloud-project-id", "Cloud project id", "id"));
 
@@ -132,6 +133,10 @@ void CommandLineParser::parse(int argc, char** argv)
         for (const QString& file : m_parser.values("import-media-file")) {
             m_options->startup.mediaFiles.emplace_back(fromUserInputPath(file));
         }
+    }
+
+    if (m_parser.isSet("remove-media-after-import")) {
+        m_options->startup.removeMediaFilesAfterImport = true;
     }
 
     if (m_parser.isSet("F")) {

--- a/src/app/guiapp.cpp
+++ b/src/app/guiapp.cpp
@@ -88,6 +88,7 @@ void GuiApp::doStartupScenario(const muse::modularity::ContextPtr& ctxId)
     startupScenario->setStartupType(options->startup.type);
     startupScenario->setStartupProjectFile(projectFile);
     startupScenario->setStartupMediaFiles(options->startup.mediaFiles);
+    startupScenario->setRemoveMediaFilesAfterImport(options->startup.removeMediaFilesAfterImport);
 
     startupScenario->runOnSplashScreen();
 

--- a/src/appshell/internal/startupscenario.cpp
+++ b/src/appshell/internal/startupscenario.cpp
@@ -100,6 +100,16 @@ void StartupScenario::setStartupMediaFiles(const muse::io::paths_t& files)
     m_startupMediaFiles = files;
 }
 
+bool StartupScenario::removeMediaFilesAfterImport() const
+{
+    return m_removeMediaFilesAfterImport;
+}
+
+void StartupScenario::setRemoveMediaFilesAfterImport(bool remove)
+{
+    m_removeMediaFilesAfterImport = remove;
+}
+
 muse::async::Promise<muse::Ret> StartupScenario::runOnSplashScreen()
 {
     return muse::async::make_promise<muse::Ret>([this](auto resolve, auto) {
@@ -184,7 +194,8 @@ void StartupScenario::onStartupPageOpened(StartupModeType modeType)
             files << file.toQString();
         }
 
-        dispatcher()->dispatch("project-import-startup-media", ActionData::make_arg1<QStringList>(files));
+        dispatcher()->dispatch("project-import-startup-media",
+                               ActionData::make_arg2<QStringList, bool>(files, m_removeMediaFilesAfterImport));
         return;
     }
 

--- a/src/appshell/internal/startupscenario.h
+++ b/src/appshell/internal/startupscenario.h
@@ -69,6 +69,8 @@ public:
     void setStartupProjectFile(const std::optional<au::project::ProjectFile>& file) override;
     const muse::io::paths_t& startupMediaFiles() const override;
     void setStartupMediaFiles(const muse::io::paths_t& files) override;
+    bool removeMediaFilesAfterImport() const override;
+    void setRemoveMediaFilesAfterImport(bool remove) override;
 
     muse::async::Promise<muse::Ret> runOnSplashScreen() override;
     void runAfterSplashScreen() override;
@@ -92,6 +94,7 @@ private:
     std::string m_startupTypeStr;
     au::project::ProjectFile m_startupProjectFile;
     muse::io::paths_t m_startupMediaFiles;
+    bool m_removeMediaFilesAfterImport = false;
     bool m_startupCompleted = false;
     QTimer m_updateCheckTimer;
 };

--- a/src/appshell/istartupscenario.h
+++ b/src/appshell/istartupscenario.h
@@ -45,6 +45,8 @@ public:
     virtual void setStartupProjectFile(const std::optional<project::ProjectFile>& file) = 0;
     virtual const muse::io::paths_t& startupMediaFiles() const = 0;
     virtual void setStartupMediaFiles(const muse::io::paths_t& files) = 0;
+    virtual bool removeMediaFilesAfterImport() const = 0;
+    virtual void setRemoveMediaFilesAfterImport(bool remove) = 0;
 
     virtual muse::async::Promise<muse::Ret> runOnSplashScreen() = 0;
     virtual void runAfterSplashScreen() = 0;

--- a/src/appshell/qml/Audacity/AppShell/FirstLaunchSetup/signinaudiocompagemodel.cpp
+++ b/src/appshell/qml/Audacity/AppShell/FirstLaunchSetup/signinaudiocompagemodel.cpp
@@ -14,7 +14,6 @@ SigninAudiocomPageModel::SigninAudiocomPageModel(QObject* parent)
 
 void SigninAudiocomPageModel::init()
 {
-    authorization()->signOut();
     authorization()->authState().ch.onReceive(this, [this](au::au3cloud::AuthState newState) {
         if (std::holds_alternative<au3cloud::NotAuthorized>(newState)) {
             const std::string& error = std::get<au3cloud::NotAuthorized>(newState).error;

--- a/src/au3cloud/CMakeLists.txt
+++ b/src/au3cloud/CMakeLists.txt
@@ -33,6 +33,8 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/internal/oauthhttpserverreplyhandler.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/au3audiocomtypeconv.cpp
     ${CMAKE_CURRENT_LIST_DIR}/internal/au3audiocomtypeconv.h
+    ${CMAKE_CURRENT_LIST_DIR}/internal/downloadmanager.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/internal/downloadmanager.h
 
     ${CMAKE_CURRENT_LIST_DIR}/view/accountinfomodel.cpp
     ${CMAKE_CURRENT_LIST_DIR}/view/accountinfomodel.h

--- a/src/au3cloud/CMakeLists.txt
+++ b/src/au3cloud/CMakeLists.txt
@@ -31,6 +31,8 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/internal/au3cloudservice.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/oauthhttpserverreplyhandler.cpp
     ${CMAKE_CURRENT_LIST_DIR}/internal/oauthhttpserverreplyhandler.h
+    ${CMAKE_CURRENT_LIST_DIR}/internal/au3audiocomtypeconv.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/internal/au3audiocomtypeconv.h
 
     ${CMAKE_CURRENT_LIST_DIR}/view/accountinfomodel.cpp
     ${CMAKE_CURRENT_LIST_DIR}/view/accountinfomodel.h

--- a/src/au3cloud/au3clouderrors.h
+++ b/src/au3cloud/au3clouderrors.h
@@ -60,6 +60,7 @@ enum class Err {
     // downloadAudioFile
     DownloadAudioResultCancelled,
     DownloadAudioResultFailed,
+    DownloadAudioResultBlocked,
 
     // openCloudProject
     OpenProjectCancelled,

--- a/src/au3cloud/au3clouderrors.h
+++ b/src/au3cloud/au3clouderrors.h
@@ -57,7 +57,7 @@ enum class Err {
     SyncResultSyncImpossible,
     SyncResultUnknownError,
 
-    // openAudioFile
+    // downloadAudioFile
     DownloadAudioResultCancelled,
 
     // openCloudProject

--- a/src/au3cloud/au3clouderrors.h
+++ b/src/au3cloud/au3clouderrors.h
@@ -55,6 +55,9 @@ enum class Err {
     SyncResultInternalServerError,
     SyncResultSyncImpossible,
     SyncResultUnknownError,
+
+    // openAudioFile
+    DownloadAudioResultCancel,
 };
 
 inline muse::Ret make_ret(Err e)

--- a/src/au3cloud/au3clouderrors.h
+++ b/src/au3cloud/au3clouderrors.h
@@ -59,6 +59,7 @@ enum class Err {
 
     // downloadAudioFile
     DownloadAudioResultCancelled,
+    DownloadAudioResultFailed,
 
     // openCloudProject
     OpenProjectCancelled,

--- a/src/au3cloud/au3clouderrors.h
+++ b/src/au3cloud/au3clouderrors.h
@@ -12,6 +12,7 @@ static constexpr int AU3_CLOUD_FIRST = 6000;
 enum class Err {
     Undefined    = int(muse::Ret::Code::Undefined),
     NoError      = int(muse::Ret::Code::Ok),
+    Cancelled    = int(muse::Ret::Code::Cancel),
     UnknownError = AU3_CLOUD_FIRST,
 
     NoExportPlugin,
@@ -58,6 +59,9 @@ enum class Err {
 
     // openAudioFile
     DownloadAudioResultCancel,
+
+    // openCloudProject
+    OpenProjectCancelled,
 };
 
 inline muse::Ret make_ret(Err e)

--- a/src/au3cloud/au3clouderrors.h
+++ b/src/au3cloud/au3clouderrors.h
@@ -58,7 +58,7 @@ enum class Err {
     SyncResultUnknownError,
 
     // openAudioFile
-    DownloadAudioResultCancel,
+    DownloadAudioResultCancelled,
 
     // openCloudProject
     OpenProjectCancelled,

--- a/src/au3cloud/au3clouderrors.h
+++ b/src/au3cloud/au3clouderrors.h
@@ -63,6 +63,8 @@ enum class Err {
 
     // openCloudProject
     OpenProjectCancelled,
+    CloudProjectNotFullySynced,
+    CloudProjectNeverSynced,
 };
 
 inline muse::Ret make_ret(Err e)

--- a/src/au3cloud/au3cloudmodule.cpp
+++ b/src/au3cloud/au3cloudmodule.cpp
@@ -41,6 +41,7 @@ void Au3CloudModule::registerExports()
 void Au3CloudModule::onInit(const muse::IApplication::RunMode&)
 {
     m_cloudService->init();
+    m_cloudConfiguration->init();
 }
 
 void Au3CloudModule::onDeinit()

--- a/src/au3cloud/au3cloudmodule.h
+++ b/src/au3cloud/au3cloudmodule.h
@@ -44,6 +44,5 @@ private:
     std::shared_ptr<Au3AudioComService> m_audioComService;
     std::shared_ptr<Au3CloudActionsController> m_actionsController;
     std::shared_ptr<CloudUiActions> m_uiActions;
-    std::shared_ptr<DownloadManager> m_downloadManager;
 };
 }

--- a/src/au3cloud/au3cloudmodule.h
+++ b/src/au3cloud/au3cloudmodule.h
@@ -11,6 +11,7 @@ class Au3CloudService;
 class Au3AudioComService;
 class Au3CloudActionsController;
 class CloudUiActions;
+class DownloadManager;
 
 class Au3CloudModule : public muse::modularity::IModuleSetup
 {
@@ -43,5 +44,6 @@ private:
     std::shared_ptr<Au3AudioComService> m_audioComService;
     std::shared_ptr<Au3CloudActionsController> m_actionsController;
     std::shared_ptr<CloudUiActions> m_uiActions;
+    std::shared_ptr<DownloadManager> m_downloadManager;
 };
 }

--- a/src/au3cloud/au3cloudmodule.h
+++ b/src/au3cloud/au3cloudmodule.h
@@ -11,7 +11,6 @@ class Au3CloudService;
 class Au3AudioComService;
 class Au3CloudActionsController;
 class CloudUiActions;
-class DownloadManager;
 
 class Au3CloudModule : public muse::modularity::IModuleSetup
 {

--- a/src/au3cloud/cloudtypes.h
+++ b/src/au3cloud/cloudtypes.h
@@ -75,4 +75,10 @@ struct AudioList {
         int itemsPerBatch = 0;
     } meta;
 };
+
+struct DownloadRequest {
+    std::string id;
+    std::string url;
+    muse::io::path_t localPath;
+};
 }

--- a/src/au3cloud/cloudtypes.h
+++ b/src/au3cloud/cloudtypes.h
@@ -40,6 +40,7 @@ struct ProjectList {
 
         int64_t created {};
         int64_t updated {};
+        int64_t headSnapshotSynced {};
     };
 
     std::vector<Item> items;

--- a/src/au3cloud/cloudtypes.h
+++ b/src/au3cloud/cloudtypes.h
@@ -4,6 +4,8 @@
 #include <string>
 #include <vector>
 
+#include "framework/global/io/path.h"
+
 namespace au::au3cloud {
 struct NotAuthorized {
     std::string error;
@@ -57,6 +59,7 @@ struct AudioList {
         std::string slug;
         std::string title;
         std::vector<std::string> tags;
+        muse::io::path_t waveformPath;
 
         int64_t fileSize {};
         int64_t duration {};

--- a/src/au3cloud/iau3audiocomservice.h
+++ b/src/au3cloud/iau3audiocomservice.h
@@ -45,11 +45,13 @@ public:
 
     virtual muse::ProgressPtr uploadProject(au::project::IAudacityProjectPtr project, const std::string& name,
                                             std::function<bool()> projectSaveCallback = nullptr, bool forceOverwrite = false) = 0;
-    virtual muse::ProgressPtr shareAudio(const std::string& title) = 0;
 
     virtual muse::ProgressPtr openCloudProject(const muse::io::path_t& localPath, const std::string& projectId = {},
                                                bool forceOverwrite = false) = 0;
     virtual muse::ProgressPtr resumeProjectSync(au::project::IAudacityProjectPtr project) = 0;
+
+    virtual muse::ProgressPtr shareAudio(const std::string& title) = 0;
+    virtual muse::ProgressPtr openAudioFile(const std::string& audioId) = 0;
 
     virtual std::string getCloudProjectPage(const std::string& slug) = 0;
     virtual std::string getCloudAudioPage(const std::string& slug) = 0;

--- a/src/au3cloud/iau3audiocomservice.h
+++ b/src/au3cloud/iau3audiocomservice.h
@@ -6,6 +6,7 @@
 #include <functional>
 #include <optional>
 #include <chrono>
+#include <string>
 
 #include "framework/global/modularity/imoduleinterface.h"
 #include "framework/global/async/promise.h"
@@ -49,6 +50,9 @@ public:
     virtual muse::ProgressPtr openCloudProject(const muse::io::path_t& localPath, const std::string& projectId = {},
                                                bool forceOverwrite = false) = 0;
     virtual muse::ProgressPtr resumeProjectSync(au::project::IAudacityProjectPtr project) = 0;
+
+    virtual std::string getCloudProjectPage(const std::string& slug) = 0;
+    virtual std::string getCloudAudioPage(const std::string& slug) = 0;
 
     virtual void deinit() = 0;
 };

--- a/src/au3cloud/iau3audiocomservice.h
+++ b/src/au3cloud/iau3audiocomservice.h
@@ -12,6 +12,7 @@
 #include "framework/global/async/promise.h"
 #include "framework/global/progress.h"
 #include "framework/global/io/path.h"
+#include "framework/global/async/channel.h"
 
 #include "project/iaudacityproject.h"
 #include "cloudtypes.h"
@@ -55,8 +56,8 @@ public:
     virtual muse::ProgressPtr shareAudio(const std::string& title) = 0;
     virtual muse::ProgressPtr openAudioFile(const std::string& audioId) = 0;
 
-    virtual std::string getCloudProjectPage(const std::string& slug) = 0;
-    virtual std::string getCloudAudioPage(const std::string& slug) = 0;
+    virtual std::string getCloudProjectPage(const std::string& slug) const = 0;
+    virtual std::string getCloudAudioPage(const std::string& slug) const = 0;
 
     virtual void deinit() = 0;
 };

--- a/src/au3cloud/iau3audiocomservice.h
+++ b/src/au3cloud/iau3audiocomservice.h
@@ -11,6 +11,7 @@
 #include "framework/global/modularity/imoduleinterface.h"
 #include "framework/global/async/promise.h"
 #include "framework/global/progress.h"
+#include "framework/global/io/path.h"
 
 #include "project/iaudacityproject.h"
 #include "cloudtypes.h"
@@ -42,6 +43,7 @@ public:
     virtual muse::async::Promise<AudioList> downloadAudioList(size_t audiosPerBatch, size_t batchNumber,
                                                               const FetchOptions& options = {}) = 0;
     virtual void clearAudioListCache() = 0;
+    virtual muse::async::Channel<std::string, muse::io::path_t> audioThumbnailFileUpdated() const = 0;
 
     virtual muse::ProgressPtr uploadProject(au::project::IAudacityProjectPtr project, const std::string& name,
                                             std::function<bool()> projectSaveCallback = nullptr, bool forceOverwrite = false) = 0;

--- a/src/au3cloud/iau3audiocomservice.h
+++ b/src/au3cloud/iau3audiocomservice.h
@@ -46,15 +46,16 @@ public:
     virtual void clearAudioListCache() = 0;
     virtual muse::async::Channel<std::string, muse::io::path_t> audioThumbnailFileUpdated() const = 0;
 
-    virtual muse::ProgressPtr uploadProject(au::project::IAudacityProjectPtr project, const std::string& name,
-                                            std::function<bool()> projectSaveCallback = nullptr, bool forceOverwrite = false) = 0;
+    virtual muse::RetVal<muse::ProgressPtr> uploadProject(au::project::IAudacityProjectPtr project, const std::string& name,
+                                                          std::function<bool()> projectSaveCallback = nullptr,
+                                                          bool forceOverwrite = false) = 0;
 
-    virtual muse::ProgressPtr openCloudProject(const muse::io::path_t& localPath, const std::string& projectId = {},
-                                               bool forceOverwrite = false) = 0;
-    virtual muse::ProgressPtr resumeProjectSync(au::project::IAudacityProjectPtr project) = 0;
+    virtual muse::RetVal<muse::ProgressPtr> openCloudProject(const muse::io::path_t& localPath, const std::string& projectId = {},
+                                                             bool forceOverwrite = false) = 0;
+    virtual muse::RetVal<muse::ProgressPtr> resumeProjectSync(au::project::IAudacityProjectPtr project) = 0;
 
-    virtual muse::ProgressPtr shareAudio(const std::string& title) = 0;
-    virtual muse::ProgressPtr downloadAudioFile(const std::string& audioId) = 0;
+    virtual muse::RetVal<muse::ProgressPtr> shareAudio(const std::string& title) = 0;
+    virtual muse::RetVal<muse::ProgressPtr> downloadAudioFile(const std::string& audioId) = 0;
 
     virtual std::string getCloudProjectPage(const std::string& slug) const = 0;
     virtual std::string getCloudAudioPage(const std::string& slug) const = 0;

--- a/src/au3cloud/iau3audiocomservice.h
+++ b/src/au3cloud/iau3audiocomservice.h
@@ -54,7 +54,7 @@ public:
     virtual muse::ProgressPtr resumeProjectSync(au::project::IAudacityProjectPtr project) = 0;
 
     virtual muse::ProgressPtr shareAudio(const std::string& title) = 0;
-    virtual muse::ProgressPtr openAudioFile(const std::string& audioId) = 0;
+    virtual muse::ProgressPtr downloadAudioFile(const std::string& audioId) = 0;
 
     virtual std::string getCloudProjectPage(const std::string& slug) const = 0;
     virtual std::string getCloudAudioPage(const std::string& slug) const = 0;

--- a/src/au3cloud/iau3cloudconfiguration.h
+++ b/src/au3cloud/iau3cloudconfiguration.h
@@ -22,5 +22,8 @@ public:
 
     virtual std::vector<std::string> preferredAudioFormats() const = 0;
     virtual std::string exportConfig(const std::string& mimeType) const = 0;
+
+    virtual bool shouldWarnOnSyncError() const = 0;
+    virtual void setWarnOnSyncError(bool warn) = 0;
 };
 }

--- a/src/au3cloud/internal/au3audiocomservice.cpp
+++ b/src/au3cloud/internal/au3audiocomservice.cpp
@@ -411,7 +411,7 @@ muse::ProgressPtr Au3AudioComService::resumeProjectSync(au::project::IAudacityPr
     return progress;
 }
 
-std::string Au3AudioComService::getCloudProjectPage(au::project::IAudacityProjectPtr project)
+std::string Au3AudioComService::getCloudProjectPage(au::project::IAudacityProjectPtr project) const
 {
     au::au3::Au3Project* au3Project = reinterpret_cast<au::au3::Au3Project*>(project->au3ProjectPtr());
 
@@ -419,7 +419,7 @@ std::string Au3AudioComService::getCloudProjectPage(au::project::IAudacityProjec
     return projectCloudExtension.GetCloudProjectPage(AudiocomTrace::SaveProjectSaveToCloudMenu);
 }
 
-std::string Au3AudioComService::getCloudProjectPage(const std::string& slug)
+std::string Au3AudioComService::getCloudProjectPage(const std::string& slug) const
 {
     auto& oauthService = GetOAuthService();
     const auto& serviceConfig = GetServiceConfig();
@@ -430,7 +430,7 @@ std::string Au3AudioComService::getCloudProjectPage(const std::string& slug)
     return oauthService.MakeAudioComAuthorizeURL(userId, projectPage);
 }
 
-std::string Au3AudioComService::getCloudAudioPage(const std::string& slug)
+std::string Au3AudioComService::getCloudAudioPage(const std::string& slug) const
 {
     auto& oauthService = GetOAuthService();
     const auto& serviceConfig = GetServiceConfig();
@@ -472,7 +472,7 @@ muse::ProgressPtr Au3AudioComService::openAudioFile(const std::string& audioId)
 
         if (result.Status != sync::DownloadAudioResult::StatusCode::Succeeded) {
             if (result.Status == sync::DownloadAudioResult::StatusCode::Cancelled) {
-                progress->finish(make_ret(Err::DownloadAudioResultCancel));
+                progress->finish(make_ret(Err::DownloadAudioResultCancelled));
             } else {
                 progress->finish(make_ret(Err::UnknownError));
             }

--- a/src/au3cloud/internal/au3audiocomservice.cpp
+++ b/src/au3cloud/internal/au3audiocomservice.cpp
@@ -515,6 +515,16 @@ muse::ProgressPtr Au3AudioComService::openCloudProject(const muse::io::path_t& l
         }
     }
 
+    if (!forceOverwrite) {
+        const auto unsyncedRet = checkUnsyncedProject(cloudProjectId);
+        if (!unsyncedRet) {
+            muse::async::Async::call(this, [progress, unsyncedRet]() {
+                progress->finish(unsyncedRet);
+            });
+            return progress;
+        }
+    }
+
     auto progressCallback = [progress](double p) -> bool {
         if (progress->isCanceled()) {
             return false;
@@ -703,6 +713,35 @@ std::optional<std::string> Au3AudioComService::getHeadSnapshotID(
     }
 
     return std::nullopt;
+}
+
+std::optional<ProjectList::Item> Au3AudioComService::findCachedProject(const std::string& projectId) const
+{
+    std::lock_guard guard(m_cacheMutex);
+    for (const auto& [_, cached] : m_projectListCache) {
+        for (const auto& item : cached.projectList.items) {
+            if (item.id == projectId) {
+                return item;
+            }
+        }
+    }
+    return std::nullopt;
+}
+
+muse::Ret Au3AudioComService::checkUnsyncedProject(const std::string& cloudProjectId) const
+{
+    const auto cachedProject = findCachedProject(cloudProjectId);
+    if (!cachedProject || cachedProject->headSnapshotSynced != 0) {
+        return muse::make_ok();
+    }
+
+    const auto localState = CloudSyncService::GetProjectState(cloudProjectId);
+    if (localState == CloudSyncService::ProjectState::PendingSync) {
+        return muse::make_ok();
+    }
+
+    const bool hasValidSnapshot = !cachedProject->lastSyncedSnapshotId.empty();
+    return make_ret(hasValidSnapshot ? Err::CloudProjectNotFullySynced : Err::CloudProjectNeverSynced);
 }
 
 void Au3AudioComService::deinit()

--- a/src/au3cloud/internal/au3audiocomservice.cpp
+++ b/src/au3cloud/internal/au3audiocomservice.cpp
@@ -506,35 +506,38 @@ muse::ProgressPtr Au3AudioComService::openCloudProject(const muse::io::path_t& l
         }
     }
 
-    std::thread([weak = weak_from_this(), progress, dbProjectData, path = localPath.toStdString(), cloudProjectId, forceOverwrite]() {
+    auto progressCallback = [progress](double p) -> bool {
+        if (progress->isCanceled()) {
+            return false;
+        }
+
+        progress->progress(static_cast<int64_t>(p * 100), 100);
+        return true;
+    };
+
+    auto cancellationContext = audacity::concurrency::CancellationContext::Create();
+
+    std::thread([weak = weak_from_this(), progress, dbProjectData, cloudProjectId, forceOverwrite,
+                 cancellationContext, progressCallback = std::move(progressCallback)]() mutable {
         auto self = weak.lock();
         if (!self) {
             return;
         }
 
-        if (!forceOverwrite && self->isSnapshotUpToDate(dbProjectData)) {
+        auto cancelCheck = [progress](double) -> bool { return !progress->isCanceled(); };
+        if (!forceOverwrite && self->isSnapshotUpToDate(dbProjectData, cancelCheck, cancellationContext)) {
             progress->finish(muse::make_ok());
             return;
         }
 
-        auto progressCallback = [progress](double p) -> bool {
-            if (progress->isCanceled()) {
-                return false;
-            }
-
-            progress->progress(static_cast<int64_t>(p * 100), 100);
-            return true;
-        };
-
         const auto syncMode = forceOverwrite
                               ? CloudSyncService::SyncMode::ForceOverwrite
                               : CloudSyncService::SyncMode::Normal;
-        auto result = CloudSyncService::Get().OpenFromCloud(
-            cloudProjectId, {},
-            syncMode,
-            std::move(progressCallback)).get();
+        const auto result = CloudSyncService::Get().OpenFromCloud(
+            cloudProjectId, {}, syncMode, std::move(progressCallback), cancellationContext).get();
 
-        if (progress->isCanceled()) {
+        if (result.Status == sync::ProjectSyncResult::StatusCode::Cancelled) {
+            progress->finish(make_ret(Err::OpenProjectCancelled));
             return;
         }
 
@@ -543,7 +546,7 @@ muse::ProgressPtr Au3AudioComService::openCloudProject(const muse::io::path_t& l
         } else {
             const auto err = syncResultCodeToErr(result.Result.Code);
             if (err == Err::SyncResultNotFound) {
-                removeProjectFromDatabase(result.ProjectPath);
+                self->removeProjectFromDatabase(result.ProjectPath);
             }
 
             progress->finish(make_ret(err));
@@ -659,13 +662,17 @@ void Au3AudioComService::removeProjectFromDatabase(const muse::io::path_t& local
     }
 }
 
-bool Au3AudioComService::isSnapshotUpToDate(const std::optional<sync::DBProjectData>& dbProjectData)
+bool Au3AudioComService::isSnapshotUpToDate(
+    const std::optional<sync::DBProjectData>& dbProjectData,
+    sync::ProgressCallback progressCallback,
+    CancellationContextPtr context)
 {
     if (!dbProjectData.has_value()) {
         return false;
     }
 
-    std::optional<std::string> headSnapshotId = getHeadSnapshotID(dbProjectData->ProjectId);
+    std::optional<std::string> headSnapshotId
+        = getHeadSnapshotID(dbProjectData->ProjectId, progressCallback, context);
     if (!headSnapshotId.has_value()) {
         return false;
     }
@@ -675,9 +682,13 @@ bool Au3AudioComService::isSnapshotUpToDate(const std::optional<sync::DBProjectD
     return snapshotsMatch && fullyDownloaded;
 }
 
-std::optional<std::string> Au3AudioComService::getHeadSnapshotID(const std::string& projectId)
+std::optional<std::string> Au3AudioComService::getHeadSnapshotID(
+    const std::string& projectId,
+    sync::ProgressCallback progressCallback,
+    CancellationContextPtr context)
 {
-    const auto headResult = CloudSyncService::Get().GetHeadSnapshotID(projectId).get();
+    const auto headResult
+        = CloudSyncService::Get().GetHeadSnapshotID(projectId, progressCallback, std::move(context)).get();
     if (const auto* snapshotId = std::get_if<std::string>(&headResult)) {
         return *snapshotId;
     }

--- a/src/au3cloud/internal/au3audiocomservice.cpp
+++ b/src/au3cloud/internal/au3audiocomservice.cpp
@@ -27,6 +27,7 @@
 #include "au3-import-export/ExportUtils.h"
 #include "au3-project-rate/ProjectRate.h"
 
+#include "au3audiocomtypeconv.h"
 #include "au3cloud/au3clouderrors.h"
 #include "au3cloud/cloudtypes.h"
 #include "au3wrap/au3types.h"
@@ -44,67 +45,6 @@ bool Au3AudioComService::enabled() const
 }
 
 namespace {
-au::au3cloud::ProjectList convertFromAu3PaginatedProject(const sync::PaginatedProjectsResponse& paginatedResponse)
-{
-    au::au3cloud::ProjectList projectList;
-
-    for (size_t i = 0; i < paginatedResponse.Items.size(); i++) {
-        const auto& projectInfo = paginatedResponse.Items[i];
-
-        au::au3cloud::ProjectList::Item item;
-        item.id = projectInfo.Id;
-        item.name = projectInfo.Name;
-        item.slug = projectInfo.Slug;
-        item.authorName = projectInfo.AuthorName;
-        item.username = projectInfo.Username;
-        item.details = projectInfo.Details;
-        item.lastSyncedSnapshotId = projectInfo.LastSyncedSnapshotId;
-        item.created = projectInfo.Created;
-        item.updated = projectInfo.Updated;
-        item.fileSize = projectInfo.HeadSnapshot.FileSize;
-
-        projectList.items.push_back(std::move(item));
-    }
-
-    projectList.meta.total = paginatedResponse.Pagination.TotalCount;
-    projectList.meta.batches = paginatedResponse.Pagination.PagesCount;
-    projectList.meta.thisBatchNumber = paginatedResponse.Pagination.CurrentPage;
-    projectList.meta.itemsPerBatch = paginatedResponse.Pagination.PageSize;
-
-    return projectList;
-}
-
-au::au3cloud::AudioList convertFromAu3CloudAudio(const sync::PaginatedAudioResponse& paginatedResponse,
-                                                 const muse::io::path_t& thumnailCacheDir)
-{
-    au::au3cloud::AudioList audioList;
-
-    for (size_t i = 0; i < paginatedResponse.Items.size(); i++) {
-        const auto& audioInfo = paginatedResponse.Items[i];
-
-        au::au3cloud::AudioList::Item item;
-        item.id = audioInfo.Id;
-        item.username = audioInfo.Username;
-        item.authorName = audioInfo.AuthorName;
-        item.slug = audioInfo.Slug;
-        item.title = audioInfo.Title;
-        item.tags = audioInfo.Tags;
-        item.created = audioInfo.Created;
-        item.fileSize = audioInfo.FileSize;
-        item.duration = audioInfo.Duration;
-        item.waveformPath = thumnailCacheDir.appendingComponent(audioInfo.Id).appendingSuffix("json");
-
-        audioList.items.push_back(std::move(item));
-    }
-
-    audioList.meta.total = paginatedResponse.Pagination.TotalCount;
-    audioList.meta.batches = paginatedResponse.Pagination.PagesCount;
-    audioList.meta.thisBatchNumber = paginatedResponse.Pagination.CurrentPage;
-    audioList.meta.itemsPerBatch = paginatedResponse.Pagination.PageSize;
-
-    return audioList;
-}
-
 muse::io::path_t getTempFileName(const muse::io::path_t tempDir, const std::string& ext)
 {
     auto timestamp = std::chrono::system_clock::now().time_since_epoch().count();
@@ -114,104 +54,6 @@ muse::io::path_t getTempFileName(const muse::io::path_t tempDir, const std::stri
     return tempDir
            .appendingComponent(oss.str())
            .appendingSuffix(ext);
-}
-
-au::au3cloud::Err cloudSyncErrorToErr(const std::optional<sync::CloudSyncError>& error)
-{
-    if (!error.has_value()) {
-        return Err::UnknownError;
-    }
-
-    using ErrorType = sync::CloudSyncError::ErrorType;
-    switch (error->Type) {
-    case ErrorType::None:
-        return Err::UnknownError;
-    case ErrorType::Authorization:
-        return Err::ProjectForbidden;
-    case ErrorType::ProjectLimitReached:
-        return Err::ProjectLimitReached;
-    case ErrorType::ProjectStorageLimitReached:
-        return Err::ProjectStorageLimitReached;
-    case ErrorType::ProjectVersionConflict:
-        return Err::ProjectVersionConflict;
-    case ErrorType::ProjectNotFound:
-        return Err::ProjectNotFound;
-    case ErrorType::DataUploadFailed:
-        return Err::DataUploadFailed;
-    case ErrorType::Network:
-        return Err::NetworkError;
-    case ErrorType::Server:
-        return Err::ServerError;
-    case ErrorType::Cancelled:
-        return Err::SyncCancelled;
-    case ErrorType::Aborted:
-        return Err::SyncAborted;
-    case ErrorType::ClientFailure:
-        return Err::ClientFailure;
-    }
-
-    return Err::UnknownError;
-}
-
-au::au3cloud::Err uploadResultToErr(UploadOperationCompleted::Result result)
-{
-    using Result = UploadOperationCompleted::Result;
-    switch (result) {
-    case Result::Success:
-        return Err::NoError;
-    case Result::Aborted:
-        return Err::UploadAborted;
-    case Result::FileNotFound:
-        return Err::UploadFileNotFound;
-    case Result::Unauthorized:
-        return Err::UploadUnauthorized;
-    case Result::InvalidData:
-        return Err::UploadInvalidData;
-    case Result::UnexpectedResponse:
-        return Err::UploadUnexpectedResponse;
-    case Result::UploadFailed:
-        return Err::UploadFailed;
-    }
-
-    return Err::UnknownError;
-}
-
-au::au3cloud::Err syncResultCodeToErr(audacity::cloud::audiocom::SyncResultCode code)
-{
-    switch (code) {
-    case SyncResultCode::Success:
-        return Err::NoError;
-    case SyncResultCode::Cancelled:
-        return Err::SyncResultCancelled;
-    case SyncResultCode::Expired:
-        return Err::SyncResultExpired;
-    case SyncResultCode::Conflict:
-        return Err::SyncResultConflict;
-    case SyncResultCode::ConnectionFailed:
-        return Err::SyncResultConnectionFailed;
-    case SyncResultCode::PaymentRequired:
-        return Err::SyncResultPaymentRequired;
-    case SyncResultCode::TooLarge:
-        return Err::SyncResultTooLarge;
-    case SyncResultCode::Unauthorized:
-        return Err::SyncResultUnauthorized;
-    case SyncResultCode::Forbidden:
-        return Err::SyncResultForbidden;
-    case SyncResultCode::NotFound:
-        return Err::SyncResultNotFound;
-    case SyncResultCode::UnexpectedResponse:
-        return Err::SyncResultUnexpectedResponse;
-    case SyncResultCode::InternalClientError:
-        return Err::SyncResultInternalClientError;
-    case SyncResultCode::InternalServerError:
-        return Err::SyncResultInternalServerError;
-    case SyncResultCode::SyncImpossible:
-        return Err::SyncResultSyncImpossible;
-    case SyncResultCode::UnknownError:
-        return Err::UnknownError;
-    }
-
-    return Err::UnknownError;
 }
 
 std::optional<sync::DBProjectData> getProjectDataFromDatabase(const muse::io::path_t& localPath)

--- a/src/au3cloud/internal/au3audiocomservice.cpp
+++ b/src/au3cloud/internal/au3audiocomservice.cpp
@@ -565,6 +565,51 @@ std::string Au3AudioComService::getCloudAudioPage(const std::string& slug)
     return oauthService.MakeAudioComAuthorizeURL(userId, audioPage);
 }
 
+muse::ProgressPtr Au3AudioComService::openAudioFile(const std::string& audioId)
+{
+    muse::ProgressPtr progress = std::make_shared<muse::Progress>();
+
+    std::thread([this, audioId, progress]() {
+        auto progressCallback = [progress](double p) -> bool {
+            if (progress->isCanceled()) {
+                return false;
+            }
+
+            progress->progress(static_cast<int64_t>(p * 100), 100);
+            return true;
+        };
+
+        using DownloadFuture = CloudSyncService::DownloadAudioFuture;
+        auto downloadFuturePromise = std::make_shared<std::promise<DownloadFuture> >();
+        std::future<DownloadFuture> downloadFutureResult = downloadFuturePromise->get_future();
+
+        muse::async::Async::call(this, [downloadFuturePromise, audioId,
+                                        progressCallback = std::move(progressCallback)]() mutable {
+            // Important: CloudSyncService does not control access by locking but by calling convention,
+            // We must ensure all operations on this service to be called on the main thread
+            downloadFuturePromise->set_value(
+                CloudSyncService::Get().DownloadCloudAudio(audioId, std::move(progressCallback)));
+        }, muse::runtime::mainThreadId());
+
+        auto result = downloadFutureResult.get().get();
+
+        if (progress->isCanceled()) {
+            return;
+        }
+
+        if (result.Status != sync::DownloadAudioResult::StatusCode::Succeeded) {
+            progress->finish(muse::make_ret(muse::Ret::Code::UnknownError, result.Result.Content));
+            return;
+        }
+
+        muse::async::Async::call(this, [this, progress, audioPath = result.AudioPath]() {
+            progress->finish(muse::RetVal<muse::Val>::make_ok(muse::Val(muse::io::path_t(audioPath))));
+        }, muse::runtime::mainThreadId());
+    }).detach();
+
+    return progress;
+}
+
 muse::ProgressPtr Au3AudioComService::openCloudProject(const muse::io::path_t& localPath, const std::string& projectId,
                                                        bool forceOverwrite)
 {

--- a/src/au3cloud/internal/au3audiocomservice.cpp
+++ b/src/au3cloud/internal/au3audiocomservice.cpp
@@ -480,6 +480,8 @@ muse::ProgressPtr Au3AudioComService::downloadAudioFile(const std::string& audio
         if (result.Status != sync::DownloadAudioResult::StatusCode::Succeeded) {
             if (result.Status == sync::DownloadAudioResult::StatusCode::Cancelled) {
                 progress->finish(make_ret(Err::DownloadAudioResultCancelled));
+            } else if (result.Status == sync::DownloadAudioResult::StatusCode::Failed) {
+                progress->finish(make_ret(Err::DownloadAudioResultFailed));
             } else {
                 progress->finish(make_ret(Err::UnknownError));
             }

--- a/src/au3cloud/internal/au3audiocomservice.cpp
+++ b/src/au3cloud/internal/au3audiocomservice.cpp
@@ -262,21 +262,19 @@ void Au3AudioComService::clearAudioListCache()
     m_audiosPerBatch = 0;
 }
 
-muse::ProgressPtr Au3AudioComService::uploadProject(au::project::IAudacityProjectPtr project, const std::string& name,
-                                                    std::function<bool()> projectSaveCallback, bool forceOverwrite)
+muse::RetVal<muse::ProgressPtr> Au3AudioComService::uploadProject(au::project::IAudacityProjectPtr project, const std::string& name,
+                                                                  std::function<bool()> projectSaveCallback, bool forceOverwrite)
 {
-    muse::ProgressPtr progress = std::make_shared<muse::Progress>();
-
     if (!project) {
-        progress->finish(muse::make_ret(muse::Ret::Code::InternalError, muse::trc("cloud", "Invalid project")));
-        return progress;
+        return muse::RetVal<muse::ProgressPtr>::make_ret(muse::Ret::Code::InternalError, muse::trc("cloud", "Invalid project"));
     }
 
     au::au3::Au3Project* au3Project = reinterpret_cast<au::au3::Au3Project*>(project->au3ProjectPtr());
     if (!au3Project) {
-        progress->finish(muse::make_ret(muse::Ret::Code::InternalError, muse::trc("cloud", "Invalid project")));
-        return progress;
+        return muse::RetVal<muse::ProgressPtr>::make_ret(muse::Ret::Code::InternalError, muse::trc("cloud", "Invalid project"));
     }
+
+    muse::ProgressPtr progress = std::make_shared<muse::Progress>();
 
     std::thread([weak = weak_from_this(), project, progress, name, forceOverwrite, projectSaveCallback = std::move(
                      projectSaveCallback)]() mutable {
@@ -382,10 +380,10 @@ muse::ProgressPtr Au3AudioComService::uploadProject(au::project::IAudacityProjec
         }
     }).detach();
 
-    return progress;
+    return muse::RetVal<muse::ProgressPtr>::make_ok(progress);
 }
 
-muse::ProgressPtr Au3AudioComService::resumeProjectSync(au::project::IAudacityProjectPtr project)
+muse::RetVal<muse::ProgressPtr> Au3AudioComService::resumeProjectSync(au::project::IAudacityProjectPtr project)
 {
     au::au3::Au3Project* au3Project = reinterpret_cast<au::au3::Au3Project*>(project->au3ProjectPtr());
     auto& projectCloudExtension = audacity::cloud::audiocom::sync::ProjectCloudExtension::Get(*au3Project);
@@ -394,7 +392,7 @@ muse::ProgressPtr Au3AudioComService::resumeProjectSync(au::project::IAudacityPr
         projectCloudExtension.GetCloudProjectId());
 
     if (pendingSnapshots.empty()) {
-        return nullptr;
+        return muse::RetVal<muse::ProgressPtr>::make_ok(nullptr);
     }
 
     auto progress = std::make_shared<muse::Progress>();
@@ -415,7 +413,7 @@ muse::ProgressPtr Au3AudioComService::resumeProjectSync(au::project::IAudacityPr
 
     audacity::cloud::audiocom::sync::ResumeProjectUpload(projectCloudExtension, {});
 
-    return progress;
+    return muse::RetVal<muse::ProgressPtr>::make_ok(progress);
 }
 
 std::string Au3AudioComService::getCloudProjectPage(au::project::IAudacityProjectPtr project) const
@@ -448,14 +446,13 @@ std::string Au3AudioComService::getCloudAudioPage(const std::string& slug) const
     return oauthService.MakeAudioComAuthorizeURL(userId, audioPage);
 }
 
-muse::ProgressPtr Au3AudioComService::downloadAudioFile(const std::string& audioId)
+muse::RetVal<muse::ProgressPtr> Au3AudioComService::downloadAudioFile(const std::string& audioId)
 {
-    muse::ProgressPtr progress = std::make_shared<muse::Progress>();
-
     if (audioId.empty()) {
-        progress->finish(muse::make_ret(muse::Ret::Code::UnknownError, muse::trc("cloud", "Invalid audio ID")));
-        return progress;
+        return muse::RetVal<muse::ProgressPtr>::make_ret(muse::Ret::Code::UnknownError, muse::trc("cloud", "Invalid audio ID"));
     }
+
+    muse::ProgressPtr progress = std::make_shared<muse::Progress>();
 
     auto progressCallback = [progress](double p) -> bool {
         if (progress->isCanceled()) {
@@ -471,7 +468,7 @@ muse::ProgressPtr Au3AudioComService::downloadAudioFile(const std::string& audio
 
     // Blocked is resolved synchronously (another download is already in progress)
     if (future.wait_for(std::chrono::seconds(0)) == std::future_status::ready) {
-        return nullptr;
+        return muse::RetVal<muse::ProgressPtr>::make_ok(nullptr);
     }
 
     std::thread([future = std::move(future), progress]() mutable {
@@ -491,14 +488,12 @@ muse::ProgressPtr Au3AudioComService::downloadAudioFile(const std::string& audio
         progress->finish(muse::RetVal<muse::Val>::make_ok(muse::Val(muse::io::path_t(result.AudioPath))));
     }).detach();
 
-    return progress;
+    return muse::RetVal<muse::ProgressPtr>::make_ok(progress);
 }
 
-muse::ProgressPtr Au3AudioComService::openCloudProject(const muse::io::path_t& localPath, const std::string& projectId,
-                                                       bool forceOverwrite)
+muse::RetVal<muse::ProgressPtr> Au3AudioComService::openCloudProject(const muse::io::path_t& localPath, const std::string& projectId,
+                                                                     bool forceOverwrite)
 {
-    muse::ProgressPtr progress = std::make_shared<muse::Progress>();
-
     const auto dbProjectData = getProjectDataFromDatabase(localPath);
     if (dbProjectData.has_value() && !filesystem()->exists(localPath)) {
         removeProjectFromDatabase(localPath);
@@ -510,20 +505,19 @@ muse::ProgressPtr Au3AudioComService::openCloudProject(const muse::io::path_t& l
         cloudProjectId = dbProjectData ? dbProjectData->ProjectId : "";
 
         if (cloudProjectId.empty()) {
-            progress->finish(muse::make_ret(muse::Ret::Code::UnknownError, muse::trc("cloud", "Project not found in cloud database")));
-            return progress;
+            return muse::RetVal<muse::ProgressPtr>::make_ret(
+                muse::Ret::Code::UnknownError, muse::trc("cloud", "Project not found in cloud database"));
         }
     }
 
     if (!forceOverwrite) {
         const auto unsyncedRet = checkUnsyncedProject(cloudProjectId);
         if (!unsyncedRet) {
-            muse::async::Async::call(this, [progress, unsyncedRet]() {
-                progress->finish(unsyncedRet);
-            });
-            return progress;
+            return muse::RetVal<muse::ProgressPtr>::make_ret(unsyncedRet);
         }
     }
+
+    muse::ProgressPtr progress = std::make_shared<muse::Progress>();
 
     auto progressCallback = [progress](double p) -> bool {
         if (progress->isCanceled()) {
@@ -572,10 +566,10 @@ muse::ProgressPtr Au3AudioComService::openCloudProject(const muse::io::path_t& l
         }
     }).detach();
 
-    return progress;
+    return muse::RetVal<muse::ProgressPtr>::make_ok(progress);
 }
 
-muse::ProgressPtr Au3AudioComService::shareAudio(const std::string& title)
+muse::RetVal<muse::ProgressPtr> Au3AudioComService::shareAudio(const std::string& title)
 {
     muse::ProgressPtr progress = std::make_shared<muse::Progress>();
 
@@ -670,7 +664,7 @@ muse::ProgressPtr Au3AudioComService::shareAudio(const std::string& title)
         },
             AudiocomTrace::ShareAudioButton);
     }).detach();
-    return progress;
+    return muse::RetVal<muse::ProgressPtr>::make_ok(progress);
 }
 
 void Au3AudioComService::removeProjectFromDatabase(const muse::io::path_t& localPath)

--- a/src/au3cloud/internal/au3audiocomservice.cpp
+++ b/src/au3cloud/internal/au3audiocomservice.cpp
@@ -270,28 +270,8 @@ muse::ProgressPtr Au3AudioComService::uploadProject(au::project::IAudacityProjec
         return progress;
     }
 
-    auto& projectCloudExtension = audacity::cloud::audiocom::sync::ProjectCloudExtension::Get(*au3Project);
-    m_projectUploadSubscription = projectCloudExtension.SubscribeStatusChanged(
-        [this, project, progress](const audacity::cloud::audiocom::sync::CloudStatusChangedMessage& message) {
-        if (message.Status == audacity::cloud::audiocom::sync::ProjectSyncStatus::Syncing) {
-            progress->progress(message.Progress * 100, 100);
-        }
-
-        if (message.Status == audacity::cloud::audiocom::sync::ProjectSyncStatus::Synced) {
-            progress->finish(muse::RetVal<muse::Val>::make_ok(muse::Val(getCloudProjectPage(project))));
-        }
-
-        if (message.Status == audacity::cloud::audiocom::sync::ProjectSyncStatus::Failed) {
-            progress->finish(make_ret(cloudSyncErrorToErr(message.Error)));
-        }
-    }, false);
-
-    const bool isSyncing = projectCloudExtension.IsSyncing();
-    const std::string currentSnapshotId = projectCloudExtension.GetSnapshotId();
-    const std::string cloudProjectId = projectCloudExtension.GetCloudProjectId();
-
-    std::thread([weak = weak_from_this(), project, progress, name, isSyncing, currentSnapshotId, cloudProjectId, forceOverwrite,
-                 projectSaveCallback = std::move(projectSaveCallback)]() mutable {
+    std::thread([weak = weak_from_this(), project, progress, name, forceOverwrite, projectSaveCallback = std::move(
+                     projectSaveCallback)]() mutable {
         auto self = weak.lock();
         if (!self) {
             progress->finish(muse::make_ret(muse::Ret::Code::InternalError, muse::trc("cloud", "Service destroyed")));
@@ -324,18 +304,18 @@ muse::ProgressPtr Au3AudioComService::uploadProject(au::project::IAudacityProjec
 
         auto done = std::make_shared<std::atomic<bool> >(false);
         {
-            std::lock_guard guard(m_uploadSubscriptionsMutex);
+            std::lock_guard guard(self->m_uploadSubscriptionsMutex);
 
-            m_projectUploadSubscriptions.erase(
+            self->m_projectUploadSubscriptions.erase(
                 std::remove_if(
-                    m_projectUploadSubscriptions.begin(),
-                    m_projectUploadSubscriptions.end(),
+                    self->m_projectUploadSubscriptions.begin(),
+                    self->m_projectUploadSubscriptions.end(),
                     [](const UploadSubscriptionEntry& e) { return e.done->load(); }),
-                m_projectUploadSubscriptions.end());
+                self->m_projectUploadSubscriptions.end());
 
-            m_projectUploadSubscriptions.push_back(
+            self->m_projectUploadSubscriptions.push_back(
                 { projectCloudExtension.SubscribeStatusChanged(
-                      [this, project, progress, done](
+                      [self, project, progress, done](
                           const audacity::cloud::audiocom::sync::CloudStatusChangedMessage& message) {
                     if (done->load()) {
                         return;
@@ -347,7 +327,7 @@ muse::ProgressPtr Au3AudioComService::uploadProject(au::project::IAudacityProjec
 
                     if (message.Status == audacity::cloud::audiocom::sync::ProjectSyncStatus::Synced) {
                         done->store(true);
-                        progress->finish(muse::RetVal<muse::Val>::make_ok(muse::Val(getCloudProjectPage(project))));
+                        progress->finish(muse::RetVal<muse::Val>::make_ok(muse::Val(self->getCloudProjectPage(project))));
                     }
 
                     if (message.Status == audacity::cloud::audiocom::sync::ProjectSyncStatus::Failed) {

--- a/src/au3cloud/internal/au3audiocomservice.cpp
+++ b/src/au3cloud/internal/au3audiocomservice.cpp
@@ -88,6 +88,10 @@ void Au3AudioComService::init()
         });
     });
 
+    m_downloadManager->downloadCompleted().onReceive(this, [this](const std::string& audioId, const muse::io::path_t& path) {
+        m_audioThumbnailFileUpdatedChannel.send(audioId, path);
+    });
+
     appshellConfiguration()->aboutToRevertToFactorySettings().onNotify(this, []() {
         audacity::cloud::audiocom::sync::CloudProjectsDatabase::Get().CloseConnection();
     });
@@ -161,6 +165,11 @@ void Au3AudioComService::clearProjectListCache()
     m_projectsPerBatch = 0;
 }
 
+muse::async::Channel<std::string, muse::io::path_t> Au3AudioComService::audioThumbnailFileUpdated() const
+{
+    return m_audioThumbnailFileUpdatedChannel;
+}
+
 muse::async::Promise<AudioList> Au3AudioComService::downloadAudioList(size_t audiosPerBatch, size_t batchNumber,
                                                                       const FetchOptions& options)
 {
@@ -211,6 +220,9 @@ muse::async::Promise<AudioList> Au3AudioComService::downloadAudioList(size_t aud
                     std::lock_guard guard(m_cacheMutex);
                     m_audioListCache[batchNumber] = CachedAudioItem { audioList, std::chrono::system_clock::now() };
                 }
+
+                m_downloadManager->scheduleDownloads(convertToDownloadRequests(*paginatedResponse,
+                                                                               projectConfiguration()->cloudProjectsPath()));
 
                 (void)resolve(audioList);
             } else {

--- a/src/au3cloud/internal/au3audiocomservice.cpp
+++ b/src/au3cloud/internal/au3audiocomservice.cpp
@@ -15,6 +15,7 @@
 
 #include "au3-cloud-audiocom/CloudSyncService.h"
 #include "au3-cloud-audiocom/OAuthService.h"
+#include "au3-cloud-audiocom/UserService.h"
 #include "au3-cloud-audiocom/ServiceConfig.h"
 #include "au3-cloud-audiocom/sync/CloudSyncDTO.h"
 #include "au3-cloud-audiocom/sync/CloudProjectsDatabase.h"
@@ -540,6 +541,28 @@ std::string Au3AudioComService::getCloudProjectPage(au::project::IAudacityProjec
 
     auto& projectCloudExtension = audacity::cloud::audiocom::sync::ProjectCloudExtension::Get(*au3Project);
     return projectCloudExtension.GetCloudProjectPage(AudiocomTrace::SaveProjectSaveToCloudMenu);
+}
+
+std::string Au3AudioComService::getCloudProjectPage(const std::string& slug)
+{
+    auto& oauthService = GetOAuthService();
+    const auto& serviceConfig = GetServiceConfig();
+
+    const auto userId = GetUserService().GetUserId().ToStdString();
+    const auto userslug = GetUserService().GetUserSlug().ToStdString();
+    const auto projectPage = serviceConfig.GetProjectPagePath(userslug, slug, AudiocomTrace::OpenFromCloudMenu);
+    return oauthService.MakeAudioComAuthorizeURL(userId, projectPage);
+}
+
+std::string Au3AudioComService::getCloudAudioPage(const std::string& slug)
+{
+    auto& oauthService = GetOAuthService();
+    const auto& serviceConfig = GetServiceConfig();
+
+    const auto userId = GetUserService().GetUserId().ToStdString();
+    const auto userslug = GetUserService().GetUserSlug().ToStdString();
+    const auto audioPage = serviceConfig.GetAudioPagePath(userslug, slug, AudiocomTrace::OpenFromCloudMenu);
+    return oauthService.MakeAudioComAuthorizeURL(userId, audioPage);
 }
 
 muse::ProgressPtr Au3AudioComService::openCloudProject(const muse::io::path_t& localPath, const std::string& projectId,

--- a/src/au3cloud/internal/au3audiocomservice.cpp
+++ b/src/au3cloud/internal/au3audiocomservice.cpp
@@ -468,7 +468,12 @@ muse::RetVal<muse::ProgressPtr> Au3AudioComService::downloadAudioFile(const std:
 
     // Blocked is resolved synchronously (another download is already in progress)
     if (future.wait_for(std::chrono::seconds(0)) == std::future_status::ready) {
-        return muse::RetVal<muse::ProgressPtr>::make_ok(nullptr);
+        const auto result = future.get();
+        if (result.Status == sync::DownloadAudioResult::StatusCode::Blocked) {
+            return muse::RetVal<muse::ProgressPtr>::make_ret(static_cast<int>(Err::DownloadAudioResultBlocked),
+                                                             "Download already in progress");
+        }
+        return muse::RetVal<muse::ProgressPtr>::make_ret(muse::Ret::Code::UnknownError, "Failed to start audio download");
     }
 
     std::thread([future = std::move(future), progress]() mutable {

--- a/src/au3cloud/internal/au3audiocomservice.cpp
+++ b/src/au3cloud/internal/au3audiocomservice.cpp
@@ -93,6 +93,13 @@ void Au3AudioComService::init()
         m_audioThumbnailFileUpdatedChannel.send(audioId, path);
     });
 
+    authorization()->authState().ch.onReceive(this, [this](const AuthState& authState) {
+        if (std::holds_alternative<NotAuthorized>(authState)) {
+            clearAudioListCache();
+            clearProjectListCache();
+        }
+    });
+
     appshellConfiguration()->aboutToRevertToFactorySettings().onNotify(this, []() {
         audacity::cloud::audiocom::sync::CloudProjectsDatabase::Get().CloseConnection();
     });

--- a/src/au3cloud/internal/au3audiocomservice.cpp
+++ b/src/au3cloud/internal/au3audiocomservice.cpp
@@ -74,7 +74,8 @@ au::au3cloud::ProjectList convertFromAu3PaginatedProject(const sync::PaginatedPr
     return projectList;
 }
 
-au::au3cloud::AudioList convertFromAu3CloudAudio(const sync::PaginatedAudioResponse& paginatedResponse)
+au::au3cloud::AudioList convertFromAu3CloudAudio(const sync::PaginatedAudioResponse& paginatedResponse,
+                                                 const muse::io::path_t& thumnailCacheDir)
 {
     au::au3cloud::AudioList audioList;
 
@@ -91,6 +92,7 @@ au::au3cloud::AudioList convertFromAu3CloudAudio(const sync::PaginatedAudioRespo
         item.created = audioInfo.Created;
         item.fileSize = audioInfo.FileSize;
         item.duration = audioInfo.Duration;
+        item.waveformPath = thumnailCacheDir.appendingComponent(audioInfo.Id).appendingSuffix("json");
 
         audioList.items.push_back(std::move(item));
     }
@@ -362,7 +364,7 @@ muse::async::Promise<AudioList> Au3AudioComService::downloadAudioList(size_t aud
 
             const auto* paginatedResponse = std::get_if<sync::PaginatedAudioResponse>(&result);
             if (paginatedResponse) {
-                const auto audioList = convertFromAu3CloudAudio(*paginatedResponse);
+                const auto audioList = convertFromAu3CloudAudio(*paginatedResponse, projectConfiguration()->cloudProjectsPath());
                 {
                     std::lock_guard guard(m_cacheMutex);
                     m_audioListCache[batchNumber] = CachedAudioItem { audioList, std::chrono::system_clock::now() };

--- a/src/au3cloud/internal/au3audiocomservice.cpp
+++ b/src/au3cloud/internal/au3audiocomservice.cpp
@@ -499,6 +499,9 @@ muse::ProgressPtr Au3AudioComService::openAudioFile(const std::string& audioId)
         auto result = downloadFutureResult.get().get();
 
         if (progress->isCanceled()) {
+            if (!result.AudioPath.empty()) {
+                self->filesystem()->remove(muse::io::path_t(result.AudioPath));
+            }
             return;
         }
 

--- a/src/au3cloud/internal/au3audiocomservice.cpp
+++ b/src/au3cloud/internal/au3audiocomservice.cpp
@@ -464,19 +464,7 @@ muse::ProgressPtr Au3AudioComService::openAudioFile(const std::string& audioId)
             return true;
         };
 
-        using DownloadFuture = CloudSyncService::DownloadAudioFuture;
-        auto downloadFuturePromise = std::make_shared<std::promise<DownloadFuture> >();
-        std::future<DownloadFuture> downloadFutureResult = downloadFuturePromise->get_future();
-
-        muse::async::Async::call(self.get(), [downloadFuturePromise, audioId,
-                                              progressCallback = std::move(progressCallback)]() mutable {
-            // Important: CloudSyncService does not control access by locking but by calling convention,
-            // We must ensure all operations on this service to be called on the main thread
-            downloadFuturePromise->set_value(
-                CloudSyncService::Get().DownloadCloudAudio(audioId, std::move(progressCallback)));
-        }, muse::runtime::mainThreadId());
-
-        auto result = downloadFutureResult.get().get();
+        auto result = CloudSyncService::Get().DownloadCloudAudio(audioId, std::move(progressCallback)).get();
 
         if (progress->isCanceled()) {
             if (!result.AudioPath.empty()) {
@@ -485,14 +473,12 @@ muse::ProgressPtr Au3AudioComService::openAudioFile(const std::string& audioId)
             return;
         }
 
-        muse::async::Async::call(self.get(), [progress, result]() {
-            if (result.Status != sync::DownloadAudioResult::StatusCode::Succeeded) {
-                progress->finish(muse::make_ret(muse::Ret::Code::UnknownError, result.Result.Content));
-                return;
-            }
+        if (result.Status != sync::DownloadAudioResult::StatusCode::Succeeded) {
+            progress->finish(muse::make_ret(muse::Ret::Code::UnknownError, result.Result.Content));
+            return;
+        }
 
-            progress->finish(muse::RetVal<muse::Val>::make_ok(muse::Val(muse::io::path_t(result.AudioPath))));
-        }, muse::runtime::mainThreadId());
+        progress->finish(muse::RetVal<muse::Val>::make_ok(muse::Val(muse::io::path_t(result.AudioPath))));
     }).detach();
 
     return progress;

--- a/src/au3cloud/internal/au3audiocomservice.cpp
+++ b/src/au3cloud/internal/au3audiocomservice.cpp
@@ -441,7 +441,7 @@ std::string Au3AudioComService::getCloudAudioPage(const std::string& slug) const
     return oauthService.MakeAudioComAuthorizeURL(userId, audioPage);
 }
 
-muse::ProgressPtr Au3AudioComService::openAudioFile(const std::string& audioId)
+muse::ProgressPtr Au3AudioComService::downloadAudioFile(const std::string& audioId)
 {
     muse::ProgressPtr progress = std::make_shared<muse::Progress>();
 

--- a/src/au3cloud/internal/au3audiocomservice.cpp
+++ b/src/au3cloud/internal/au3audiocomservice.cpp
@@ -569,6 +569,11 @@ muse::ProgressPtr Au3AudioComService::openAudioFile(const std::string& audioId)
 {
     muse::ProgressPtr progress = std::make_shared<muse::Progress>();
 
+    if (audioId.empty()) {
+        progress->finish(muse::make_ret(muse::Ret::Code::UnknownError, muse::trc("cloud", "Invalid audio ID")));
+        return progress;
+    }
+
     std::thread([this, audioId, progress]() {
         auto progressCallback = [progress](double p) -> bool {
             if (progress->isCanceled()) {

--- a/src/au3cloud/internal/au3audiocomservice.cpp
+++ b/src/au3cloud/internal/au3audiocomservice.cpp
@@ -8,6 +8,7 @@
 #include <chrono>
 #include <cstdint>
 #include <thread>
+#include <utility>
 
 #include "framework/global/async/async.h"
 #include "framework/global/runtime.h"
@@ -449,32 +450,32 @@ muse::ProgressPtr Au3AudioComService::openAudioFile(const std::string& audioId)
         return progress;
     }
 
-    std::thread([weak = weak_from_this(), audioId, progress]() {
-        auto self = weak.lock();
-        if (!self) {
-            return;
-        }
-
-        auto progressCallback = [progress](double p) -> bool {
-            if (progress->isCanceled()) {
-                return false;
-            }
-
-            progress->progress(static_cast<int64_t>(p * 100), 100);
-            return true;
-        };
-
-        auto result = CloudSyncService::Get().DownloadCloudAudio(audioId, std::move(progressCallback)).get();
-
+    auto progressCallback = [progress](double p) -> bool {
         if (progress->isCanceled()) {
-            if (!result.AudioPath.empty()) {
-                self->filesystem()->remove(muse::io::path_t(result.AudioPath));
-            }
-            return;
+            return false;
         }
+
+        progress->progress(static_cast<int64_t>(p * 100), 100);
+        return true;
+    };
+
+    auto cancellationContext = audacity::concurrency::CancellationContext::Create();
+    auto future = CloudSyncService::Get().DownloadCloudAudio(audioId, std::move(progressCallback), cancellationContext);
+
+    // Blocked is resolved synchronously (another download is already in progress)
+    if (future.wait_for(std::chrono::seconds(0)) == std::future_status::ready) {
+        return nullptr;
+    }
+
+    std::thread([future = std::move(future), progress]() mutable {
+        const auto result = future.get();
 
         if (result.Status != sync::DownloadAudioResult::StatusCode::Succeeded) {
-            progress->finish(muse::make_ret(muse::Ret::Code::UnknownError, result.Result.Content));
+            if (result.Status == sync::DownloadAudioResult::StatusCode::Cancelled) {
+                progress->finish(make_ret(Err::DownloadAudioResultCancel));
+            } else {
+                progress->finish(make_ret(Err::UnknownError));
+            }
             return;
         }
 

--- a/src/au3cloud/internal/au3audiocomservice.cpp
+++ b/src/au3cloud/internal/au3audiocomservice.cpp
@@ -133,8 +133,15 @@ muse::async::Promise<ProjectList> Au3AudioComService::downloadProjectList(size_t
         }
     }
 
-    return muse::async::Promise<ProjectList>([this, projectsPerBatch, batchNumber](const auto& resolve, const auto& reject) {
-        std::thread([this, projectsPerBatch, batchNumber, resolve, reject]() {
+    return muse::async::Promise<ProjectList>([weak = weak_from_this(), projectsPerBatch, batchNumber](const auto& resolve,
+                                                                                                      const auto& reject) {
+        std::thread([weak, projectsPerBatch, batchNumber, resolve, reject]() {
+            auto self = weak.lock();
+            if (!self) {
+                (void)reject(static_cast<int>(muse::Ret::Code::UnknownError), "Service destroyed");
+                return;
+            }
+
             auto& cloudSyncService = CloudSyncService::Get();
             auto cancellationContext = audacity::concurrency::CancellationContext::Create();
             auto future = cloudSyncService.GetProjects(cancellationContext, batchNumber, projectsPerBatch, "");
@@ -144,8 +151,8 @@ muse::async::Promise<ProjectList> Au3AudioComService::downloadProjectList(size_t
             if (paginatedResponse) {
                 const auto projects = convertFromAu3PaginatedProject(*paginatedResponse);
                 {
-                    std::lock_guard guard(m_cacheMutex);
-                    m_projectListCache[batchNumber] = CachedProjectItem { projects, std::chrono::system_clock::now() };
+                    std::lock_guard guard(self->m_cacheMutex);
+                    self->m_projectListCache[batchNumber] = CachedProjectItem { projects, std::chrono::system_clock::now() };
                 }
 
                 (void)resolve(projects);
@@ -206,8 +213,14 @@ muse::async::Promise<AudioList> Au3AudioComService::downloadAudioList(size_t aud
         }
     }
 
-    return muse::async::Promise<AudioList>([this, audiosPerBatch, batchNumber](const auto& resolve, const auto& reject) {
-        std::thread([this, audiosPerBatch, batchNumber, resolve, reject]() {
+    return muse::async::Promise<AudioList>([weak = weak_from_this(), audiosPerBatch, batchNumber](const auto& resolve, const auto& reject) {
+        std::thread([weak, audiosPerBatch, batchNumber, resolve, reject]() {
+            auto self = weak.lock();
+            if (!self) {
+                (void)reject(static_cast<int>(muse::Ret::Code::UnknownError), "Service destroyed");
+                return;
+            }
+
             auto& cloudSyncService = CloudSyncService::Get();
             auto cancellationContext = audacity::concurrency::CancellationContext::Create();
             auto future = cloudSyncService.GetAudioList(cancellationContext, batchNumber, audiosPerBatch, "");
@@ -215,14 +228,14 @@ muse::async::Promise<AudioList> Au3AudioComService::downloadAudioList(size_t aud
 
             const auto* paginatedResponse = std::get_if<sync::PaginatedAudioResponse>(&result);
             if (paginatedResponse) {
-                const auto audioList = convertFromAu3CloudAudio(*paginatedResponse, projectConfiguration()->cloudProjectsPath());
+                const auto audioList = convertFromAu3CloudAudio(*paginatedResponse, self->projectConfiguration()->cloudProjectsPath());
                 {
-                    std::lock_guard guard(m_cacheMutex);
-                    m_audioListCache[batchNumber] = CachedAudioItem { audioList, std::chrono::system_clock::now() };
+                    std::lock_guard guard(self->m_cacheMutex);
+                    self->m_audioListCache[batchNumber] = CachedAudioItem { audioList, std::chrono::system_clock::now() };
                 }
 
-                m_downloadManager->scheduleDownloads(convertToDownloadRequests(*paginatedResponse,
-                                                                               projectConfiguration()->cloudProjectsPath()));
+                self->m_downloadManager->scheduleDownloads(convertToDownloadRequests(*paginatedResponse,
+                                                                                     self->projectConfiguration()->cloudProjectsPath()));
 
                 (void)resolve(audioList);
             } else {
@@ -257,8 +270,34 @@ muse::ProgressPtr Au3AudioComService::uploadProject(au::project::IAudacityProjec
         return progress;
     }
 
-    std::thread([this, project, progress, name, forceOverwrite,
+    auto& projectCloudExtension = audacity::cloud::audiocom::sync::ProjectCloudExtension::Get(*au3Project);
+    m_projectUploadSubscription = projectCloudExtension.SubscribeStatusChanged(
+        [this, project, progress](const audacity::cloud::audiocom::sync::CloudStatusChangedMessage& message) {
+        if (message.Status == audacity::cloud::audiocom::sync::ProjectSyncStatus::Syncing) {
+            progress->progress(message.Progress * 100, 100);
+        }
+
+        if (message.Status == audacity::cloud::audiocom::sync::ProjectSyncStatus::Synced) {
+            progress->finish(muse::RetVal<muse::Val>::make_ok(muse::Val(getCloudProjectPage(project))));
+        }
+
+        if (message.Status == audacity::cloud::audiocom::sync::ProjectSyncStatus::Failed) {
+            progress->finish(make_ret(cloudSyncErrorToErr(message.Error)));
+        }
+    }, false);
+
+    const bool isSyncing = projectCloudExtension.IsSyncing();
+    const std::string currentSnapshotId = projectCloudExtension.GetSnapshotId();
+    const std::string cloudProjectId = projectCloudExtension.GetCloudProjectId();
+
+    std::thread([weak = weak_from_this(), project, progress, name, isSyncing, currentSnapshotId, cloudProjectId, forceOverwrite,
                  projectSaveCallback = std::move(projectSaveCallback)]() mutable {
+        auto self = weak.lock();
+        if (!self) {
+            progress->finish(muse::make_ret(muse::Ret::Code::InternalError, muse::trc("cloud", "Service destroyed")));
+            return;
+        }
+
         if (!project) {
             progress->finish(muse::make_ret(muse::Ret::Code::InternalError, muse::trc("cloud",
                                                                                       "Project was closed before upload started")));
@@ -335,7 +374,7 @@ muse::ProgressPtr Au3AudioComService::uploadProject(au::project::IAudacityProjec
         }
 
         if (projectSaveCallback) {
-            muse::async::Async::call(this, [project, projectSaveCallback = std::move(projectSaveCallback)]() {
+            muse::async::Async::call(self.get(), [project, projectSaveCallback = std::move(projectSaveCallback)]() {
                 bool ret = projectSaveCallback();
                 if (ret) {
                     return;
@@ -430,7 +469,12 @@ muse::ProgressPtr Au3AudioComService::openAudioFile(const std::string& audioId)
         return progress;
     }
 
-    std::thread([this, audioId, progress]() {
+    std::thread([weak = weak_from_this(), audioId, progress]() {
+        auto self = weak.lock();
+        if (!self) {
+            return;
+        }
+
         auto progressCallback = [progress](double p) -> bool {
             if (progress->isCanceled()) {
                 return false;
@@ -444,8 +488,8 @@ muse::ProgressPtr Au3AudioComService::openAudioFile(const std::string& audioId)
         auto downloadFuturePromise = std::make_shared<std::promise<DownloadFuture> >();
         std::future<DownloadFuture> downloadFutureResult = downloadFuturePromise->get_future();
 
-        muse::async::Async::call(this, [downloadFuturePromise, audioId,
-                                        progressCallback = std::move(progressCallback)]() mutable {
+        muse::async::Async::call(self.get(), [downloadFuturePromise, audioId,
+                                              progressCallback = std::move(progressCallback)]() mutable {
             // Important: CloudSyncService does not control access by locking but by calling convention,
             // We must ensure all operations on this service to be called on the main thread
             downloadFuturePromise->set_value(
@@ -458,13 +502,13 @@ muse::ProgressPtr Au3AudioComService::openAudioFile(const std::string& audioId)
             return;
         }
 
-        if (result.Status != sync::DownloadAudioResult::StatusCode::Succeeded) {
-            progress->finish(muse::make_ret(muse::Ret::Code::UnknownError, result.Result.Content));
-            return;
-        }
+        muse::async::Async::call(self.get(), [progress, result]() {
+            if (result.Status != sync::DownloadAudioResult::StatusCode::Succeeded) {
+                progress->finish(muse::make_ret(muse::Ret::Code::UnknownError, result.Result.Content));
+                return;
+            }
 
-        muse::async::Async::call(this, [this, progress, audioPath = result.AudioPath]() {
-            progress->finish(muse::RetVal<muse::Val>::make_ok(muse::Val(muse::io::path_t(audioPath))));
+            progress->finish(muse::RetVal<muse::Val>::make_ok(muse::Val(muse::io::path_t(result.AudioPath))));
         }, muse::runtime::mainThreadId());
     }).detach();
 
@@ -492,8 +536,13 @@ muse::ProgressPtr Au3AudioComService::openCloudProject(const muse::io::path_t& l
         }
     }
 
-    std::thread([this, progress, dbProjectData, path = localPath.toStdString(), cloudProjectId, forceOverwrite]() {
-        if (!forceOverwrite && isSnapshotUpToDate(dbProjectData)) {
+    std::thread([weak = weak_from_this(), progress, dbProjectData, path = localPath.toStdString(), cloudProjectId, forceOverwrite]() {
+        auto self = weak.lock();
+        if (!self) {
+            return;
+        }
+
+        if (!forceOverwrite && self->isSnapshotUpToDate(dbProjectData)) {
             progress->finish(muse::make_ok());
             return;
         }
@@ -538,14 +587,20 @@ muse::ProgressPtr Au3AudioComService::shareAudio(const std::string& title)
 {
     muse::ProgressPtr progress = std::make_shared<muse::Progress>();
 
-    std::thread([this, title, progress]() {
-        const auto preferredFormats = exporter()->cloudPreferredAudioFormats();
+    std::thread([weak = weak_from_this(), title, progress]() {
+        auto self = weak.lock();
+        if (!self) {
+            progress->finish(muse::make_ret(muse::Ret::Code::InternalError, muse::trc("cloud", "Service destroyed")));
+            return;
+        }
+
+        const auto preferredFormats = self->exporter()->cloudPreferredAudioFormats();
         if (preferredFormats.empty()) {
             progress->finish(make_ret(Err::NoExportPlugin));
             return;
         }
 
-        auto project = globalContext()->currentProject();
+        auto project = self->globalContext()->currentProject();
         if (!project) {
             progress->finish(muse::make_ret(muse::Ret::Code::InternalError, muse::trc("cloud", "No valid current project")));
             return;
@@ -555,7 +610,7 @@ muse::ProgressPtr Au3AudioComService::shareAudio(const std::string& title)
         const std::string format = preferredFormats[0];
 
         muse::ValList paramsList;
-        for (const auto& [id, val] : exporter()->cloudExportParameters(format)) {
+        for (const auto& [id, val] : self->exporter()->cloudExportParameters(format)) {
             muse::ValMap entry;
             entry["id"] = muse::Val(id);
             entry["value"] = std::visit([](auto v) -> muse::Val { return muse::Val(v); }, val);
@@ -572,18 +627,18 @@ muse::ProgressPtr Au3AudioComService::shareAudio(const std::string& title)
             = muse::Val(static_cast<int>(ProjectRate::Get(*au3Project).GetRate()));
         options[importexport::IExporter::OptionKey::Parameters] = muse::Val(paramsList);
 
-        const auto extensions = exporter()->formatExtensions(format);
+        const auto extensions = self->exporter()->formatExtensions(format);
         if (extensions.empty()) {
             progress->finish(make_ret(Err::NoExtensions));
             return;
         }
 
         const muse::io::path_t tempPath
-            = getTempFileName(projectConfiguration()->temporaryDir(), extensions.front());
+            = getTempFileName(self->projectConfiguration()->temporaryDir(), extensions.front());
 
-        const auto exportRet = exporter()->exportData(muse::io::path_t(tempPath), options, progress);
+        const auto exportRet = self->exporter()->exportData(muse::io::path_t(tempPath), options, progress);
         if (!exportRet) {
-            filesystem()->remove(tempPath);
+            self->filesystem()->remove(tempPath);
             progress->finish(exportRet);
             return;
         }
@@ -603,7 +658,7 @@ muse::ProgressPtr Au3AudioComService::shareAudio(const std::string& title)
             tempPath.toStdString(),
             title,
             isPublic,
-            [op, progress, tempPath, filesystem = filesystem()](const audacity::cloud::audiocom::UploadOperationCompleted& result) {
+            [op, progress, tempPath, filesystem = self->filesystem()](const audacity::cloud::audiocom::UploadOperationCompleted& result) {
             filesystem->remove(tempPath);
 
             if (result.result == audacity::cloud::audiocom::UploadOperationCompleted::Result::Success) {

--- a/src/au3cloud/internal/au3audiocomservice.h
+++ b/src/au3cloud/internal/au3audiocomservice.h
@@ -22,7 +22,9 @@
 #include "importexport/export/iexporter.h"
 #include "context/iglobalcontext.h"
 
+#include "au3-cloud-audiocom/CloudSyncService.h"
 #include "au3-cloud-audiocom/sync/CloudProjectsDatabase.h"
+#include "au3-concurrency/concurrency/CancellationContext.h"
 #include "au3-utility/Observer.h"
 
 #include "au3cloud/cloudtypes.h"
@@ -76,8 +78,12 @@ private:
     std::string getCloudProjectPage(au::project::IAudacityProjectPtr project);
 
     static void removeProjectFromDatabase(const muse::io::path_t& localPath);
-    bool isSnapshotUpToDate(const std::optional<audacity::cloud::audiocom::sync::DBProjectData>& dbProjectData);
-    std::optional<std::string> getHeadSnapshotID(const std::string& projectId);
+    bool isSnapshotUpToDate(
+        const std::optional<audacity::cloud::audiocom::sync::DBProjectData>& dbProjectData,
+        audacity::cloud::audiocom::sync::ProgressCallback progressCallback, audacity::concurrency::CancellationContextPtr context);
+    std::optional<std::string> getHeadSnapshotID(
+        const std::string& projectId, audacity::cloud::audiocom::sync::ProgressCallback progressCallback,
+        audacity::concurrency::CancellationContextPtr context);
 
     struct CachedProjectItem {
         ProjectList projectList;

--- a/src/au3cloud/internal/au3audiocomservice.h
+++ b/src/au3cloud/internal/au3audiocomservice.h
@@ -60,16 +60,16 @@ public:
     void clearAudioListCache() override;
     muse::async::Channel<std::string, muse::io::path_t> audioThumbnailFileUpdated() const override;
 
-    muse::ProgressPtr uploadProject(au::project::IAudacityProjectPtr project, const std::string& name,
-                                    std::function<bool()> projectSaveCallback, bool forceOverwrite = false) override;
+    muse::RetVal<muse::ProgressPtr> uploadProject(au::project::IAudacityProjectPtr project, const std::string& name,
+                                                  std::function<bool()> projectSaveCallback, bool forceOverwrite = false) override;
 
-    muse::ProgressPtr openCloudProject(const muse::io::path_t& localPath, const std::string& projectId = {},
-                                       bool forceOverwrite = false) override;
+    muse::RetVal<muse::ProgressPtr> openCloudProject(const muse::io::path_t& localPath, const std::string& projectId = {},
+                                                     bool forceOverwrite = false) override;
 
-    muse::ProgressPtr resumeProjectSync(au::project::IAudacityProjectPtr project) override;
+    muse::RetVal<muse::ProgressPtr> resumeProjectSync(au::project::IAudacityProjectPtr project) override;
 
-    muse::ProgressPtr shareAudio(const std::string& title) override;
-    muse::ProgressPtr downloadAudioFile(const std::string& audioId) override;
+    muse::RetVal<muse::ProgressPtr> shareAudio(const std::string& title) override;
+    muse::RetVal<muse::ProgressPtr> downloadAudioFile(const std::string& audioId) override;
 
     std::string getCloudProjectPage(const std::string& slug) const override;
     std::string getCloudAudioPage(const std::string& slug) const override;

--- a/src/au3cloud/internal/au3audiocomservice.h
+++ b/src/au3cloud/internal/au3audiocomservice.h
@@ -86,6 +86,8 @@ private:
     std::optional<std::string> getHeadSnapshotID(
         const std::string& projectId, audacity::cloud::audiocom::sync::ProgressCallback progressCallback,
         audacity::concurrency::CancellationContextPtr context);
+    std::optional<ProjectList::Item> findCachedProject(const std::string& projectId) const;
+    muse::Ret checkUnsyncedProject(const std::string& cloudProjectId) const;
 
     struct CachedProjectItem {
         ProjectList projectList;
@@ -102,7 +104,7 @@ private:
     std::map<size_t, CachedAudioItem> m_audioListCache;
     size_t m_audiosPerBatch = 0;
 
-    std::mutex m_cacheMutex;
+    mutable std::mutex m_cacheMutex;
 
     struct UploadSubscriptionEntry {
         Observer::Subscription subscription;

--- a/src/au3cloud/internal/au3audiocomservice.h
+++ b/src/au3cloud/internal/au3audiocomservice.h
@@ -29,7 +29,8 @@
 #include "au3cloud/iau3audiocomservice.h"
 
 namespace au::au3cloud {
-class Au3AudioComService : public IAu3AudioComService, public muse::async::Asyncable, public muse::Contextable
+class Au3AudioComService : public IAu3AudioComService, public muse::async::Asyncable, public muse::Contextable,
+    public std::enable_shared_from_this<Au3AudioComService>
 {
     muse::GlobalInject<muse::io::IFileSystem> filesystem;
     muse::GlobalInject<project::IProjectConfiguration> projectConfiguration;

--- a/src/au3cloud/internal/au3audiocomservice.h
+++ b/src/au3cloud/internal/au3audiocomservice.h
@@ -5,10 +5,12 @@
 #pragma once
 
 #include <map>
+#include <memory>
 #include <mutex>
 #include <optional>
 #include <string>
 
+#include "au3cloud/internal/downloadmanager.h"
 #include "framework/global/async/asyncable.h"
 #include "framework/global/async/promise.h"
 
@@ -38,7 +40,8 @@ class Au3AudioComService : public IAu3AudioComService, public muse::async::Async
 
 public:
     Au3AudioComService(const muse::modularity::ContextPtr& ctx)
-        : muse::Contextable(ctx) {}
+        : muse::Contextable(ctx), m_downloadManager(std::make_unique<DownloadManager>())
+    {}
 
     void init();
 
@@ -50,6 +53,7 @@ public:
 
     muse::async::Promise<AudioList> downloadAudioList(size_t audiosPerBatch, size_t batchNumber, const FetchOptions& options) override;
     void clearAudioListCache() override;
+    muse::async::Channel<std::string, muse::io::path_t> audioThumbnailFileUpdated() const override;
 
     muse::ProgressPtr uploadProject(au::project::IAudacityProjectPtr project, const std::string& name,
                                     std::function<bool()> projectSaveCallback, bool forceOverwrite = false) override;
@@ -99,5 +103,8 @@ private:
     std::mutex m_uploadSubscriptionsMutex;
 
     Observer::Subscription m_resumeSyncSubscription;
+
+    std::unique_ptr<DownloadManager> m_downloadManager;
+    muse::async::Channel<std::string, muse::io::path_t> m_audioThumbnailFileUpdatedChannel;
 };
 }

--- a/src/au3cloud/internal/au3audiocomservice.h
+++ b/src/au3cloud/internal/au3audiocomservice.h
@@ -7,6 +7,7 @@
 #include <map>
 #include <mutex>
 #include <optional>
+#include <string>
 
 #include "framework/global/async/asyncable.h"
 #include "framework/global/async/promise.h"
@@ -58,6 +59,9 @@ public:
                                        bool forceOverwrite = false) override;
 
     muse::ProgressPtr resumeProjectSync(au::project::IAudacityProjectPtr project) override;
+
+    std::string getCloudProjectPage(const std::string& slug) override;
+    std::string getCloudAudioPage(const std::string& slug) override;
 
     void deinit() override;
 

--- a/src/au3cloud/internal/au3audiocomservice.h
+++ b/src/au3cloud/internal/au3audiocomservice.h
@@ -19,6 +19,7 @@
 
 #include "appshell/iappshellconfiguration.h"
 #include "project/iprojectconfiguration.h"
+#include "au3cloud/iauthorization.h"
 #include "importexport/export/iexporter.h"
 #include "context/iglobalcontext.h"
 
@@ -37,6 +38,7 @@ class Au3AudioComService : public IAu3AudioComService, public muse::async::Async
     muse::GlobalInject<muse::io::IFileSystem> filesystem;
     muse::GlobalInject<project::IProjectConfiguration> projectConfiguration;
     muse::GlobalInject<appshell::IAppShellConfiguration> appshellConfiguration;
+    muse::GlobalInject<au::au3cloud::IAuthorization> authorization;
 
     muse::ContextInject<importexport::IExporter> exporter{ this };
     muse::ContextInject<context::IGlobalContext> globalContext { this };

--- a/src/au3cloud/internal/au3audiocomservice.h
+++ b/src/au3cloud/internal/au3audiocomservice.h
@@ -67,7 +67,7 @@ public:
     muse::ProgressPtr resumeProjectSync(au::project::IAudacityProjectPtr project) override;
 
     muse::ProgressPtr shareAudio(const std::string& title) override;
-    muse::ProgressPtr openAudioFile(const std::string& audioId) override;
+    muse::ProgressPtr downloadAudioFile(const std::string& audioId) override;
 
     std::string getCloudProjectPage(const std::string& slug) const override;
     std::string getCloudAudioPage(const std::string& slug) const override;

--- a/src/au3cloud/internal/au3audiocomservice.h
+++ b/src/au3cloud/internal/au3audiocomservice.h
@@ -53,12 +53,14 @@ public:
 
     muse::ProgressPtr uploadProject(au::project::IAudacityProjectPtr project, const std::string& name,
                                     std::function<bool()> projectSaveCallback, bool forceOverwrite = false) override;
-    muse::ProgressPtr shareAudio(const std::string& title) override;
 
     muse::ProgressPtr openCloudProject(const muse::io::path_t& localPath, const std::string& projectId = {},
                                        bool forceOverwrite = false) override;
 
     muse::ProgressPtr resumeProjectSync(au::project::IAudacityProjectPtr project) override;
+
+    muse::ProgressPtr shareAudio(const std::string& title) override;
+    muse::ProgressPtr openAudioFile(const std::string& audioId) override;
 
     std::string getCloudProjectPage(const std::string& slug) override;
     std::string getCloudAudioPage(const std::string& slug) override;

--- a/src/au3cloud/internal/au3audiocomservice.h
+++ b/src/au3cloud/internal/au3audiocomservice.h
@@ -69,13 +69,13 @@ public:
     muse::ProgressPtr shareAudio(const std::string& title) override;
     muse::ProgressPtr openAudioFile(const std::string& audioId) override;
 
-    std::string getCloudProjectPage(const std::string& slug) override;
-    std::string getCloudAudioPage(const std::string& slug) override;
+    std::string getCloudProjectPage(const std::string& slug) const override;
+    std::string getCloudAudioPage(const std::string& slug) const override;
 
     void deinit() override;
 
 private:
-    std::string getCloudProjectPage(au::project::IAudacityProjectPtr project);
+    std::string getCloudProjectPage(au::project::IAudacityProjectPtr project) const;
 
     static void removeProjectFromDatabase(const muse::io::path_t& localPath);
     bool isSnapshotUpToDate(

--- a/src/au3cloud/internal/au3audiocomtypeconv.cpp
+++ b/src/au3cloud/internal/au3audiocomtypeconv.cpp
@@ -176,6 +176,10 @@ std::vector<DownloadRequest> convertToDownloadRequests(const audacity::cloud::au
     for (size_t i = 0; i < paginatedResponse.Items.size(); i++) {
         const auto& audioInfo = paginatedResponse.Items[i];
 
+        if (audioInfo.Id.empty()) {
+            continue;
+        }
+
         DownloadRequest request;
         request.id = audioInfo.Id;
         request.url = audioInfo.WaveformUrl;

--- a/src/au3cloud/internal/au3audiocomtypeconv.cpp
+++ b/src/au3cloud/internal/au3audiocomtypeconv.cpp
@@ -23,6 +23,7 @@ ProjectList convertFromAu3PaginatedProject(const audacity::cloud::audiocom::sync
         item.created = projectInfo.Created;
         item.updated = projectInfo.Updated;
         item.fileSize = projectInfo.Size;
+        item.headSnapshotSynced = projectInfo.HeadSnapshot.Synced;
 
         projectList.items.push_back(std::move(item));
     }

--- a/src/au3cloud/internal/au3audiocomtypeconv.cpp
+++ b/src/au3cloud/internal/au3audiocomtypeconv.cpp
@@ -22,7 +22,7 @@ ProjectList convertFromAu3PaginatedProject(const audacity::cloud::audiocom::sync
         item.lastSyncedSnapshotId = projectInfo.LastSyncedSnapshotId;
         item.created = projectInfo.Created;
         item.updated = projectInfo.Updated;
-        item.fileSize = projectInfo.HeadSnapshot.FileSize;
+        item.fileSize = projectInfo.Size;
 
         projectList.items.push_back(std::move(item));
     }

--- a/src/au3cloud/internal/au3audiocomtypeconv.cpp
+++ b/src/au3cloud/internal/au3audiocomtypeconv.cpp
@@ -1,0 +1,165 @@
+/*
+* Audacity: A Digital Audio Editor
+*/
+#include "au3audiocomtypeconv.h"
+
+namespace au::au3cloud {
+ProjectList convertFromAu3PaginatedProject(const audacity::cloud::audiocom::sync::PaginatedProjectsResponse& paginatedResponse)
+{
+    ProjectList projectList;
+
+    for (size_t i = 0; i < paginatedResponse.Items.size(); i++) {
+        const auto& projectInfo = paginatedResponse.Items[i];
+
+        ProjectList::Item item;
+        item.id = projectInfo.Id;
+        item.name = projectInfo.Name;
+        item.slug = projectInfo.Slug;
+        item.authorName = projectInfo.AuthorName;
+        item.username = projectInfo.Username;
+        item.details = projectInfo.Details;
+        item.lastSyncedSnapshotId = projectInfo.LastSyncedSnapshotId;
+        item.created = projectInfo.Created;
+        item.updated = projectInfo.Updated;
+        item.fileSize = projectInfo.HeadSnapshot.FileSize;
+
+        projectList.items.push_back(std::move(item));
+    }
+
+    projectList.meta.total = paginatedResponse.Pagination.TotalCount;
+    projectList.meta.batches = paginatedResponse.Pagination.PagesCount;
+    projectList.meta.thisBatchNumber = paginatedResponse.Pagination.CurrentPage;
+    projectList.meta.itemsPerBatch = paginatedResponse.Pagination.PageSize;
+
+    return projectList;
+}
+
+AudioList convertFromAu3CloudAudio(const audacity::cloud::audiocom::sync::PaginatedAudioResponse& paginatedResponse,
+                                   const muse::io::path_t& thumnailCacheDir)
+{
+    AudioList audioList;
+
+    for (size_t i = 0; i < paginatedResponse.Items.size(); i++) {
+        const auto& audioInfo = paginatedResponse.Items[i];
+
+        AudioList::Item item;
+        item.id = audioInfo.Id;
+        item.username = audioInfo.Username;
+        item.authorName = audioInfo.AuthorName;
+        item.slug = audioInfo.Slug;
+        item.title = audioInfo.Title;
+        item.tags = audioInfo.Tags;
+        item.created = audioInfo.Created;
+        item.fileSize = audioInfo.FileSize;
+        item.duration = audioInfo.Duration;
+        item.waveformPath = thumnailCacheDir.appendingComponent(audioInfo.Id).appendingSuffix("json");
+
+        audioList.items.push_back(std::move(item));
+    }
+
+    audioList.meta.total = paginatedResponse.Pagination.TotalCount;
+    audioList.meta.batches = paginatedResponse.Pagination.PagesCount;
+    audioList.meta.thisBatchNumber = paginatedResponse.Pagination.CurrentPage;
+    audioList.meta.itemsPerBatch = paginatedResponse.Pagination.PageSize;
+
+    return audioList;
+}
+
+Err cloudSyncErrorToErr(const std::optional<audacity::cloud::audiocom::sync::CloudSyncError>& error)
+{
+    if (!error.has_value()) {
+        return Err::UnknownError;
+    }
+
+    using ErrorType = audacity::cloud::audiocom::sync::CloudSyncError::ErrorType;
+    switch (error->Type) {
+    case ErrorType::None:
+        return Err::UnknownError;
+    case ErrorType::Authorization:
+        return Err::ProjectForbidden;
+    case ErrorType::ProjectLimitReached:
+        return Err::ProjectLimitReached;
+    case ErrorType::ProjectStorageLimitReached:
+        return Err::ProjectStorageLimitReached;
+    case ErrorType::ProjectVersionConflict:
+        return Err::ProjectVersionConflict;
+    case ErrorType::ProjectNotFound:
+        return Err::ProjectNotFound;
+    case ErrorType::DataUploadFailed:
+        return Err::DataUploadFailed;
+    case ErrorType::Network:
+        return Err::NetworkError;
+    case ErrorType::Server:
+        return Err::ServerError;
+    case ErrorType::Cancelled:
+        return Err::SyncCancelled;
+    case ErrorType::Aborted:
+        return Err::SyncAborted;
+    case ErrorType::ClientFailure:
+        return Err::ClientFailure;
+    }
+
+    return Err::UnknownError;
+}
+
+Err uploadResultToErr(audacity::cloud::audiocom::UploadOperationCompleted::Result result)
+{
+    using Result = audacity::cloud::audiocom::UploadOperationCompleted::Result;
+    switch (result) {
+    case Result::Success:
+        return Err::NoError;
+    case Result::Aborted:
+        return Err::UploadAborted;
+    case Result::FileNotFound:
+        return Err::UploadFileNotFound;
+    case Result::Unauthorized:
+        return Err::UploadUnauthorized;
+    case Result::InvalidData:
+        return Err::UploadInvalidData;
+    case Result::UnexpectedResponse:
+        return Err::UploadUnexpectedResponse;
+    case Result::UploadFailed:
+        return Err::UploadFailed;
+    }
+
+    return Err::UnknownError;
+}
+
+Err syncResultCodeToErr(audacity::cloud::audiocom::SyncResultCode code)
+{
+    switch (code) {
+    case audacity::cloud::audiocom::SyncResultCode::Success:
+        return Err::NoError;
+    case audacity::cloud::audiocom::SyncResultCode::Cancelled:
+        return Err::SyncResultCancelled;
+    case audacity::cloud::audiocom::SyncResultCode::Expired:
+        return Err::SyncResultExpired;
+    case audacity::cloud::audiocom::SyncResultCode::Conflict:
+        return Err::SyncResultConflict;
+    case audacity::cloud::audiocom::SyncResultCode::ConnectionFailed:
+        return Err::SyncResultConnectionFailed;
+    case audacity::cloud::audiocom::SyncResultCode::PaymentRequired:
+        return Err::SyncResultPaymentRequired;
+    case audacity::cloud::audiocom::SyncResultCode::TooLarge:
+        return Err::SyncResultTooLarge;
+    case audacity::cloud::audiocom::SyncResultCode::Unauthorized:
+        return Err::SyncResultUnauthorized;
+    case audacity::cloud::audiocom::SyncResultCode::Forbidden:
+        return Err::SyncResultForbidden;
+    case audacity::cloud::audiocom::SyncResultCode::NotFound:
+        return Err::SyncResultNotFound;
+    case audacity::cloud::audiocom::SyncResultCode::UnexpectedResponse:
+        return Err::SyncResultUnexpectedResponse;
+    case audacity::cloud::audiocom::SyncResultCode::InternalClientError:
+        return Err::SyncResultInternalClientError;
+    case audacity::cloud::audiocom::SyncResultCode::InternalServerError:
+        return Err::SyncResultInternalServerError;
+    case audacity::cloud::audiocom::SyncResultCode::SyncImpossible:
+        return Err::SyncResultSyncImpossible;
+    case audacity::cloud::audiocom::SyncResultCode::UnknownError:
+        return Err::UnknownError;
+    }
+
+    return Err::UnknownError;
+}
+}

--- a/src/au3cloud/internal/au3audiocomtypeconv.cpp
+++ b/src/au3cloud/internal/au3audiocomtypeconv.cpp
@@ -8,6 +8,7 @@ ProjectList convertFromAu3PaginatedProject(const audacity::cloud::audiocom::sync
 {
     ProjectList projectList;
 
+    projectList.items.reserve(paginatedResponse.Items.size());
     for (size_t i = 0; i < paginatedResponse.Items.size(); i++) {
         const auto& projectInfo = paginatedResponse.Items[i];
 
@@ -39,6 +40,7 @@ AudioList convertFromAu3CloudAudio(const audacity::cloud::audiocom::sync::Pagina
 {
     AudioList audioList;
 
+    audioList.items.reserve(paginatedResponse.Items.size());
     for (size_t i = 0; i < paginatedResponse.Items.size(); i++) {
         const auto& audioInfo = paginatedResponse.Items[i];
 
@@ -52,7 +54,8 @@ AudioList convertFromAu3CloudAudio(const audacity::cloud::audiocom::sync::Pagina
         item.created = audioInfo.Created;
         item.fileSize = audioInfo.FileSize;
         item.duration = audioInfo.Duration;
-        item.waveformPath = thumbnailCacheDir.appendingComponent(audioInfo.Id).appendingSuffix("json");
+        item.waveformPath = audioInfo.Id.empty() ? muse::io::path_t() : thumbnailCacheDir.appendingComponent(audioInfo.Id).appendingSuffix(
+            "json");
 
         audioList.items.push_back(std::move(item));
     }
@@ -74,7 +77,7 @@ Err cloudSyncErrorToErr(const std::optional<audacity::cloud::audiocom::sync::Clo
     using ErrorType = audacity::cloud::audiocom::sync::CloudSyncError::ErrorType;
     switch (error->Type) {
     case ErrorType::None:
-        return Err::UnknownError;
+        return Err::NoError;
     case ErrorType::Authorization:
         return Err::ProjectForbidden;
     case ErrorType::ProjectLimitReached:
@@ -168,6 +171,7 @@ std::vector<DownloadRequest> convertToDownloadRequests(const audacity::cloud::au
 {
     std::vector<DownloadRequest> requests;
 
+    requests.reserve(paginatedResponse.Items.size());
     for (size_t i = 0; i < paginatedResponse.Items.size(); i++) {
         const auto& audioInfo = paginatedResponse.Items[i];
 

--- a/src/au3cloud/internal/au3audiocomtypeconv.cpp
+++ b/src/au3cloud/internal/au3audiocomtypeconv.cpp
@@ -35,7 +35,7 @@ ProjectList convertFromAu3PaginatedProject(const audacity::cloud::audiocom::sync
 }
 
 AudioList convertFromAu3CloudAudio(const audacity::cloud::audiocom::sync::PaginatedAudioResponse& paginatedResponse,
-                                   const muse::io::path_t& thumnailCacheDir)
+                                   const muse::io::path_t& thumbnailCacheDir)
 {
     AudioList audioList;
 
@@ -52,7 +52,7 @@ AudioList convertFromAu3CloudAudio(const audacity::cloud::audiocom::sync::Pagina
         item.created = audioInfo.Created;
         item.fileSize = audioInfo.FileSize;
         item.duration = audioInfo.Duration;
-        item.waveformPath = thumnailCacheDir.appendingComponent(audioInfo.Id).appendingSuffix("json");
+        item.waveformPath = thumbnailCacheDir.appendingComponent(audioInfo.Id).appendingSuffix("json");
 
         audioList.items.push_back(std::move(item));
     }

--- a/src/au3cloud/internal/au3audiocomtypeconv.cpp
+++ b/src/au3cloud/internal/au3audiocomtypeconv.cpp
@@ -162,4 +162,23 @@ Err syncResultCodeToErr(audacity::cloud::audiocom::SyncResultCode code)
 
     return Err::UnknownError;
 }
+
+std::vector<DownloadRequest> convertToDownloadRequests(const audacity::cloud::audiocom::sync::PaginatedAudioResponse& paginatedResponse,
+                                                       const muse::io::path_t& thumbnailCacheDir)
+{
+    std::vector<DownloadRequest> requests;
+
+    for (size_t i = 0; i < paginatedResponse.Items.size(); i++) {
+        const auto& audioInfo = paginatedResponse.Items[i];
+
+        DownloadRequest request;
+        request.id = audioInfo.Id;
+        request.url = audioInfo.WaveformUrl;
+        request.localPath = thumbnailCacheDir.appendingComponent(audioInfo.Id).appendingSuffix("json");
+
+        requests.push_back(std::move(request));
+    }
+
+    return requests;
+}
 }

--- a/src/au3cloud/internal/au3audiocomtypeconv.h
+++ b/src/au3cloud/internal/au3audiocomtypeconv.h
@@ -1,0 +1,28 @@
+/*
+* Audacity: A Digital Audio Editor
+*/
+
+#pragma once
+
+#include "framework/global/io/path.h"
+
+#include "au3-cloud-audiocom/sync/CloudSyncDTO.h"
+#include "au3-cloud-audiocom/sync/CloudSyncError.h"
+#include "au3-cloud-audiocom/UploadService.h"
+#include "au3-cloud-audiocom/NetworkUtils.h"
+
+#include "au3cloud/cloudtypes.h"
+#include "au3cloud/au3clouderrors.h"
+
+namespace au::au3cloud {
+ProjectList convertFromAu3PaginatedProject(const audacity::cloud::audiocom::sync::PaginatedProjectsResponse& paginatedResponse);
+
+AudioList convertFromAu3CloudAudio(const audacity::cloud::audiocom::sync::PaginatedAudioResponse& paginatedResponse,
+                                   const muse::io::path_t& thumnailCacheDir);
+
+Err cloudSyncErrorToErr(const std::optional<audacity::cloud::audiocom::sync::CloudSyncError>& error);
+
+Err uploadResultToErr(audacity::cloud::audiocom::UploadOperationCompleted::Result result);
+
+Err syncResultCodeToErr(audacity::cloud::audiocom::SyncResultCode code);
+}

--- a/src/au3cloud/internal/au3audiocomtypeconv.h
+++ b/src/au3cloud/internal/au3audiocomtypeconv.h
@@ -18,7 +18,7 @@ namespace au::au3cloud {
 ProjectList convertFromAu3PaginatedProject(const audacity::cloud::audiocom::sync::PaginatedProjectsResponse& paginatedResponse);
 
 AudioList convertFromAu3CloudAudio(const audacity::cloud::audiocom::sync::PaginatedAudioResponse& paginatedResponse,
-                                   const muse::io::path_t& thumnailCacheDir);
+                                   const muse::io::path_t& thumbnailCacheDir);
 
 Err cloudSyncErrorToErr(const std::optional<audacity::cloud::audiocom::sync::CloudSyncError>& error);
 

--- a/src/au3cloud/internal/au3audiocomtypeconv.h
+++ b/src/au3cloud/internal/au3audiocomtypeconv.h
@@ -25,4 +25,7 @@ Err cloudSyncErrorToErr(const std::optional<audacity::cloud::audiocom::sync::Clo
 Err uploadResultToErr(audacity::cloud::audiocom::UploadOperationCompleted::Result result);
 
 Err syncResultCodeToErr(audacity::cloud::audiocom::SyncResultCode code);
+
+std::vector<DownloadRequest> convertToDownloadRequests(const audacity::cloud::audiocom::sync::PaginatedAudioResponse& paginatedResponse,
+                                                       const muse::io::path_t& thumbnailCacheDir);
 }

--- a/src/au3cloud/internal/au3cloudactionscontroller.cpp
+++ b/src/au3cloud/internal/au3cloudactionscontroller.cpp
@@ -58,24 +58,32 @@ void Au3CloudActionsController::openCloudProjectPage(const muse::actions::Action
 {
     const auto slug = query.param("slug").toString();
     if (slug.empty()) {
+        LOGE() << "Cannot open cloud project page: empty slug";
         return;
     }
 
     const auto url = audioComService()->getCloudProjectPage(slug);
-    if (!url.empty()) {
-        platformInteractive()->openUrl(url);
+    if (url.empty()) {
+        LOGE() << "Cannot open cloud project page: empty URL";
+        return;
     }
+
+    platformInteractive()->openUrl(url);
 }
 
 void Au3CloudActionsController::openCloudAudioPage(const muse::actions::ActionQuery& query)
 {
     const auto slug = query.param("slug").toString();
     if (slug.empty()) {
+        LOGE() << "Cannot open cloud audio page: empty slug";
         return;
     }
 
     const auto url = audioComService()->getCloudAudioPage(slug);
-    if (!url.empty()) {
-        platformInteractive()->openUrl(url);
+    if (url.empty()) {
+        LOGE() << "Cannot open cloud audio page: empty URL";
+        return;
     }
+
+    platformInteractive()->openUrl(url);
 }

--- a/src/au3cloud/internal/au3cloudactionscontroller.cpp
+++ b/src/au3cloud/internal/au3cloudactionscontroller.cpp
@@ -10,6 +10,8 @@ const muse::Uri SIGNIN_URI("audacity://signin/audiocom");
 const char* TOUR_PAGE_URL { "https://audio.com/tour?mtm_campaign=audacitydesktop&mtm_content=app_launch_reg" };
 
 const muse::actions::ActionQuery OPEN_SIGNIN_DIALOG_ACTION("audacity://cloud/open-signin-dialog");
+const muse::actions::ActionQuery OPEN_CLOUD_PROJECT_PAGE_ACTION("audacity://cloud/open-project-page");
+const muse::actions::ActionQuery OPEN_CLOUD_AUDIO_PAGE_ACTION("audacity://cloud/open-audio-page");
 }
 
 Au3CloudActionsController::Au3CloudActionsController(muse::modularity::ContextPtr ctx)
@@ -20,6 +22,8 @@ Au3CloudActionsController::Au3CloudActionsController(muse::modularity::ContextPt
 void Au3CloudActionsController::init()
 {
     dispatcher()->reg(this, OPEN_SIGNIN_DIALOG_ACTION, this, &Au3CloudActionsController::openSignInDialog);
+    dispatcher()->reg(this, OPEN_CLOUD_PROJECT_PAGE_ACTION, this, &Au3CloudActionsController::openCloudProjectPage);
+    dispatcher()->reg(this, OPEN_CLOUD_AUDIO_PAGE_ACTION, this, &Au3CloudActionsController::openCloudAudioPage);
 }
 
 bool Au3CloudActionsController::canReceiveAction(const muse::actions::ActionCode&) const
@@ -47,5 +51,25 @@ void Au3CloudActionsController::openSignInDialog(const muse::actions::ActionQuer
 
     if (showTourPage) {
         platformInteractive()->openUrl(TOUR_PAGE_URL);
+    }
+}
+
+void Au3CloudActionsController::openCloudProjectPage(const muse::actions::ActionQuery& query)
+{
+    const auto slug = query.param("slug").toString();
+
+    const auto url = audioComService()->getCloudProjectPage(slug);
+    if (!url.empty()) {
+        platformInteractive()->openUrl(url);
+    }
+}
+
+void Au3CloudActionsController::openCloudAudioPage(const muse::actions::ActionQuery& query)
+{
+    const auto slug = query.param("slug").toString();
+
+    const auto url = audioComService()->getCloudAudioPage(slug);
+    if (!url.empty()) {
+        platformInteractive()->openUrl(url);
     }
 }

--- a/src/au3cloud/internal/au3cloudactionscontroller.cpp
+++ b/src/au3cloud/internal/au3cloudactionscontroller.cpp
@@ -57,6 +57,9 @@ void Au3CloudActionsController::openSignInDialog(const muse::actions::ActionQuer
 void Au3CloudActionsController::openCloudProjectPage(const muse::actions::ActionQuery& query)
 {
     const auto slug = query.param("slug").toString();
+    if (slug.empty()) {
+        return;
+    }
 
     const auto url = audioComService()->getCloudProjectPage(slug);
     if (!url.empty()) {
@@ -67,6 +70,9 @@ void Au3CloudActionsController::openCloudProjectPage(const muse::actions::Action
 void Au3CloudActionsController::openCloudAudioPage(const muse::actions::ActionQuery& query)
 {
     const auto slug = query.param("slug").toString();
+    if (slug.empty()) {
+        return;
+    }
 
     const auto url = audioComService()->getCloudAudioPage(slug);
     if (!url.empty()) {

--- a/src/au3cloud/internal/au3cloudactionscontroller.h
+++ b/src/au3cloud/internal/au3cloudactionscontroller.h
@@ -32,5 +32,7 @@ public:
 
 private:
     void openSignInDialog(const muse::actions::ActionQuery& query);
+    void openCloudProjectPage(const muse::actions::ActionQuery& query);
+    void openCloudAudioPage(const muse::actions::ActionQuery& query);
 };
 }

--- a/src/au3cloud/internal/au3cloudactionscontroller.h
+++ b/src/au3cloud/internal/au3cloudactionscontroller.h
@@ -9,9 +9,10 @@
 
 #include "framework/global/modularity/ioc.h"
 #include "framework/interactive/iplatforminteractive.h"
-#include "framework/actions/iactionsdispatcher.h"
 #include "au3cloud/iauthorization.h"
+#include "framework/actions/iactionsdispatcher.h"
 #include "au3cloud/iau3audiocomservice.h"
+#include "framework/interactive/iinteractive.h"
 
 namespace au::au3cloud {
 class Au3CloudActionsController : public muse::actions::Actionable, public muse::async::Asyncable, public muse::Contextable

--- a/src/au3cloud/internal/au3cloudactionscontroller.h
+++ b/src/au3cloud/internal/au3cloudactionscontroller.h
@@ -5,22 +5,23 @@
 
 #include "framework/actions/actionable.h"
 #include "framework/actions/actiontypes.h"
+#include "framework/global/async/asyncable.h"
 
 #include "framework/global/modularity/ioc.h"
-#include "framework/actions/iactionsdispatcher.h"
-#include "framework/interactive/iinteractive.h"
 #include "framework/interactive/iplatforminteractive.h"
+#include "framework/actions/iactionsdispatcher.h"
 #include "au3cloud/iauthorization.h"
 #include "au3cloud/iau3audiocomservice.h"
 
 namespace au::au3cloud {
-class Au3CloudActionsController : public muse::actions::Actionable, public muse::Contextable
+class Au3CloudActionsController : public muse::actions::Actionable, public muse::async::Asyncable, public muse::Contextable
 {
     muse::GlobalInject<muse::IPlatformInteractive> platformInteractive;
     muse::GlobalInject<IAuthorization> authorization;
 
     muse::ContextInject<muse::actions::IActionsDispatcher> dispatcher { this };
     muse::ContextInject<muse::IInteractive> interactive { this };
+    muse::ContextInject<IAuthorization> authorization { this };
     muse::ContextInject<IAu3AudioComService> audioComService { this };
 
 public:

--- a/src/au3cloud/internal/au3cloudactionscontroller.h
+++ b/src/au3cloud/internal/au3cloudactionscontroller.h
@@ -21,7 +21,6 @@ class Au3CloudActionsController : public muse::actions::Actionable, public muse:
 
     muse::ContextInject<muse::actions::IActionsDispatcher> dispatcher { this };
     muse::ContextInject<muse::IInteractive> interactive { this };
-    muse::ContextInject<IAuthorization> authorization { this };
     muse::ContextInject<IAu3AudioComService> audioComService { this };
 
 public:

--- a/src/au3cloud/internal/au3cloudconfiguration.cpp
+++ b/src/au3cloud/internal/au3cloudconfiguration.cpp
@@ -4,11 +4,21 @@
 #include "au3cloudconfiguration.h"
 
 #include "framework/global/io/dir.h"
+#include "framework/global/settings.h"
 
 #include "au3-cloud-audiocom/CloudLibrarySettings.h"
 #include "au3-cloud-audiocom/ServiceConfig.h"
 
 using namespace au::au3cloud;
+
+namespace {
+const muse::Settings::Key WARN_ON_SYNC_ERROR("cloud", "cloud/warnOnSyncError");
+}
+
+void Au3CloudConfiguration::init()
+{
+    muse::settings()->setDefaultValue(WARN_ON_SYNC_ERROR, muse::Val(true));
+}
 
 muse::io::path_t Au3CloudConfiguration::cloudProjectsPath() const
 {
@@ -28,4 +38,14 @@ std::vector<std::string> Au3CloudConfiguration::preferredAudioFormats() const
 std::string Au3CloudConfiguration::exportConfig(const std::string& mimeType) const
 {
     return audacity::cloud::audiocom::GetServiceConfig().GetExportConfig(mimeType);
+}
+
+bool Au3CloudConfiguration::shouldWarnOnSyncError() const
+{
+    return muse::settings()->value(WARN_ON_SYNC_ERROR).toBool();
+}
+
+void Au3CloudConfiguration::setWarnOnSyncError(bool warn)
+{
+    muse::settings()->setSharedValue(WARN_ON_SYNC_ERROR, muse::Val(warn));
 }

--- a/src/au3cloud/internal/au3cloudconfiguration.h
+++ b/src/au3cloud/internal/au3cloudconfiguration.h
@@ -9,10 +9,15 @@ namespace au::au3cloud {
 class Au3CloudConfiguration : public IAu3CloudConfiguration
 {
 public:
+    void init();
+
     muse::io::path_t cloudProjectsPath() const override;
     void setCloudProjectsPath(const muse::io::path_t& path) override;
 
     std::vector<std::string> preferredAudioFormats() const override;
     std::string exportConfig(const std::string& mimeType) const override;
+
+    bool shouldWarnOnSyncError() const override;
+    void setWarnOnSyncError(bool warn) override;
 };
 }

--- a/src/au3cloud/internal/au3cloudservice.cpp
+++ b/src/au3cloud/internal/au3cloudservice.cpp
@@ -51,8 +51,12 @@ void Au3CloudService::init()
     });
 
     auto& oauthService = audacity::cloud::audiocom::GetOAuthService();
-    const auto NO_ACCESS_TOKEN = muse::qtrc("appshell/gettingstarted", "No access token");
-    m_authState.set(AuthState(NotAuthorized(NO_ACCESS_TOKEN.toStdString())));
+    if (oauthService.HasRefreshToken()) {
+        m_authState.set(AuthState(Authorizing()));
+    } else {
+        const auto NO_ACCESS_TOKEN = muse::qtrc("appshell/gettingstarted", "No access token");
+        m_authState.set(AuthState(NotAuthorized(NO_ACCESS_TOKEN.toStdString())));
+    }
     oauthService.ValidateAuth(nullptr, AudiocomTrace::ignore, true);
     m_authSubscription
         = oauthService.Subscribe([this](const audacity::cloud::audiocom::AuthStateChangedMessage& message)

--- a/src/au3cloud/internal/au3cloudservice.cpp
+++ b/src/au3cloud/internal/au3cloudservice.cpp
@@ -57,7 +57,6 @@ void Au3CloudService::init()
         const auto NO_ACCESS_TOKEN = muse::qtrc("appshell/gettingstarted", "No access token");
         m_authState.set(AuthState(NotAuthorized(NO_ACCESS_TOKEN.toStdString())));
     }
-    oauthService.ValidateAuth(nullptr, AudiocomTrace::ignore, true);
     m_authSubscription
         = oauthService.Subscribe([this](const audacity::cloud::audiocom::AuthStateChangedMessage& message)
     {
@@ -76,6 +75,7 @@ void Au3CloudService::init()
             service.ClearUserData();
         }
     });
+    oauthService.ValidateAuth(nullptr, AudiocomTrace::ignore, true);
 
     auto& userService = audacity::cloud::audiocom::GetUserService();
     m_userDataSubscription

--- a/src/au3cloud/internal/clouduiactions.cpp
+++ b/src/au3cloud/internal/clouduiactions.cpp
@@ -9,17 +9,17 @@
 using namespace au::au3cloud;
 
 const muse::ui::UiActionList CloudUiActions::m_actions = {
-    muse::ui::UiAction("cloud-open-project-page",
+    muse::ui::UiAction("audacity://cloud/open-project-page",
                        au::context::UiCtxAny,
                        au::context::CTX_ANY,
-                       muse::TranslatableString("action", "Open project page on audio.com"),
-                       muse::TranslatableString("action", "Open project page on audio.com")
+                       muse::TranslatableString("action", "View project on audio.com"),
+                       muse::TranslatableString("action", "View project on audio.com")
                        ),
-    muse::ui::UiAction("cloud-open-audio-page",
+    muse::ui::UiAction("audacity://cloud/open-audio-page",
                        au::context::UiCtxAny,
                        au::context::CTX_ANY,
-                       muse::TranslatableString("action", "Open audio page on audio.com"),
-                       muse::TranslatableString("action", "Open audio page on audio.com")
+                       muse::TranslatableString("action", "View in audio.com"),
+                       muse::TranslatableString("action", "View in audio.com")
                        )
 };
 

--- a/src/au3cloud/internal/clouduiactions.cpp
+++ b/src/au3cloud/internal/clouduiactions.cpp
@@ -9,11 +9,17 @@
 using namespace au::au3cloud;
 
 const muse::ui::UiActionList CloudUiActions::m_actions = {
-    muse::ui::UiAction("audio-view-on-audiocom",
+    muse::ui::UiAction("cloud-open-project-page",
                        au::context::UiCtxAny,
                        au::context::CTX_ANY,
-                       muse::TranslatableString("action", "View on audio.com"),
-                       muse::TranslatableString("action", "View on audio.com")
+                       muse::TranslatableString("action", "Open project page on audio.com"),
+                       muse::TranslatableString("action", "Open project page on audio.com")
+                       ),
+    muse::ui::UiAction("cloud-open-audio-page",
+                       au::context::UiCtxAny,
+                       au::context::CTX_ANY,
+                       muse::TranslatableString("action", "Open audio page on audio.com"),
+                       muse::TranslatableString("action", "Open audio page on audio.com")
                        )
 };
 

--- a/src/au3cloud/internal/clouduiactions.cpp
+++ b/src/au3cloud/internal/clouduiactions.cpp
@@ -18,8 +18,8 @@ const muse::ui::UiActionList CloudUiActions::m_actions = {
     muse::ui::UiAction("audacity://cloud/open-audio-page",
                        au::context::UiCtxAny,
                        au::context::CTX_ANY,
-                       muse::TranslatableString("action", "View in audio.com"),
-                       muse::TranslatableString("action", "View in audio.com")
+                       muse::TranslatableString("action", "View on audio.com"),
+                       muse::TranslatableString("action", "View on audio.com")
                        )
 };
 

--- a/src/au3cloud/internal/downloadmanager.cpp
+++ b/src/au3cloud/internal/downloadmanager.cpp
@@ -1,0 +1,87 @@
+/*
+* Audacity: A Digital Audio Editor
+*/
+#include "downloadmanager.h"
+
+#include <QBuffer>
+#include <QString>
+#include <QUrl>
+
+#include "framework/global/async/async.h"
+#include "framework/global/runtime.h"
+#include "framework/global/types/bytearray.h"
+
+#include "au3cloud/cloudtypes.h"
+
+using namespace au::au3cloud;
+
+void DownloadManager::scheduleDownloads(const std::vector<DownloadRequest>& requests)
+{
+    for (const auto& req : requests) {
+        if (req.url.empty()) {
+            continue;
+        }
+
+        if (filesystem()->exists(req.localPath)) {
+            continue;
+        }
+
+        {
+            std::lock_guard lock(m_mutex);
+            if (!m_inProgressIds.insert(req.id).second) {
+                //Already in progress
+                continue;
+            }
+        }
+
+        muse::async::Async::call(this, [this, id = req.id, url = req.url, path = req.localPath]() {
+            startDownload(id, url, path);
+        }, muse::runtime::mainThreadId());
+    }
+}
+
+muse::async::Channel<std::string, muse::io::path_t> DownloadManager::downloadCompleted() const
+{
+    return m_downloadCompleted;
+}
+
+void DownloadManager::startDownload(const std::string& id, const std::string& url, const muse::io::path_t& destPath)
+{
+    auto manager = networkManagerCreator()->makeNetworkManager();
+    auto buffer = std::make_shared<QBuffer>();
+
+    muse::network::RequestHeaders headers;
+    headers.rawHeaders["User-Agent"] = "Audacity";
+
+    auto retVal = manager->get(QUrl(QString::fromStdString(url)),
+                               std::static_pointer_cast<QIODevice>(buffer),
+                               headers);
+
+    if (!retVal.ret) {
+        std::lock_guard lock(m_mutex);
+        m_inProgressIds.erase(id);
+        return;
+    }
+
+    m_activeManagers[id] = std::move(manager);
+
+    retVal.val.finished().onReceive(this,
+                                    [this, id, destPath, buffer](const muse::ProgressResult& res) {
+        m_activeManagers.erase(id);
+
+        {
+            std::lock_guard lock(m_mutex);
+            m_inProgressIds.erase(id);
+        }
+
+        if (!res.ret) {
+            return;
+        }
+
+        const muse::ByteArray data = muse::ByteArray::fromQByteArray(buffer->data());
+        const muse::Ret writeRet = filesystem()->writeFile(destPath, data);
+        if (writeRet) {
+            m_downloadCompleted.send(id, destPath);
+        }
+    });
+}

--- a/src/au3cloud/internal/downloadmanager.cpp
+++ b/src/au3cloud/internal/downloadmanager.cpp
@@ -12,6 +12,7 @@
 #include "framework/global/types/bytearray.h"
 
 #include "au3cloud/cloudtypes.h"
+#include "thirdparty/kors_logger/src/log_base.h"
 
 using namespace au::au3cloud;
 
@@ -57,24 +58,27 @@ void DownloadManager::startDownload(const std::string& id, const std::string& ur
                                std::static_pointer_cast<QIODevice>(buffer),
                                headers);
 
-    if (!retVal.ret) {
+    {
         std::lock_guard lock(m_mutex);
-        m_inProgressIds.erase(id);
-        return;
-    }
 
-    m_activeManagers[id] = std::move(manager);
+        if (!retVal.ret) {
+            m_inProgressIds.erase(id);
+            return;
+        }
+
+        m_activeManagers[id] = std::move(manager);
+    }
 
     retVal.val.finished().onReceive(this,
                                     [this, id, destPath, buffer](const muse::ProgressResult& res) {
-        m_activeManagers.erase(id);
-
         {
             std::lock_guard lock(m_mutex);
+            m_activeManagers.erase(id);
             m_inProgressIds.erase(id);
         }
 
         if (!res.ret) {
+            LOGE() << "Download failed for id " << id;
             return;
         }
 
@@ -82,6 +86,8 @@ void DownloadManager::startDownload(const std::string& id, const std::string& ur
         const muse::Ret writeRet = filesystem()->writeFile(destPath, data);
         if (writeRet) {
             m_downloadCompleted.send(id, destPath);
+        } else {
+            LOGE() << "Failed to write downloaded file for id " << id;
         }
     });
 }

--- a/src/au3cloud/internal/downloadmanager.h
+++ b/src/au3cloud/internal/downloadmanager.h
@@ -1,0 +1,42 @@
+/*
+* Audacity: A Digital Audio Editor
+*/
+
+#pragma once
+
+#include <map>
+#include <mutex>
+#include <set>
+#include <string>
+
+#include "framework/global/async/asyncable.h"
+#include "framework/global/async/channel.h"
+#include "framework/global/io/ifilesystem.h"
+#include "framework/global/io/path.h"
+#include "framework/global/modularity/ioc.h"
+#include "framework/network/inetworkmanagercreator.h"
+
+#include "au3cloud/cloudtypes.h"
+
+namespace au::au3cloud {
+class DownloadManager : public muse::async::Asyncable
+{
+    muse::GlobalInject<muse::network::INetworkManagerCreator> networkManagerCreator;
+    muse::GlobalInject<muse::io::IFileSystem> filesystem;
+
+public:
+    void scheduleDownloads(const std::vector<DownloadRequest>& requests);
+
+    muse::async::Channel<std::string, muse::io::path_t> downloadCompleted() const;
+
+private:
+    void startDownload(const std::string& id, const std::string& url, const muse::io::path_t& destPath);
+
+    muse::async::Channel<std::string, muse::io::path_t> m_downloadCompleted;
+
+    std::map<std::string, muse::network::INetworkManagerPtr> m_activeManagers;
+
+    std::set<std::string> m_inProgressIds;
+    std::mutex m_mutex;
+};
+}

--- a/src/importexport/import/CMakeLists.txt
+++ b/src/importexport/import/CMakeLists.txt
@@ -31,7 +31,7 @@ set(MODULE_SRC
 
 # Loop Tempo Estimator (fetched automatically during configure)
 if(NOT TARGET loop-tempo-estimator)
-    set(LTE_VERSION "v0.0.3")
+    set(LTE_VERSION "v0.0.4")
 
     include(FetchContent)
     FetchContent_Declare(

--- a/src/project/CMakeLists.txt
+++ b/src/project/CMakeLists.txt
@@ -102,6 +102,8 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/view/cloudprojectstatuswatcher.h
     ${CMAKE_CURRENT_LIST_DIR}/view/projectthumbnailloader.cpp
     ${CMAKE_CURRENT_LIST_DIR}/view/projectthumbnailloader.h
+    ${CMAKE_CURRENT_LIST_DIR}/view/thumbnailloader.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/view/thumbnailloader.h
     ${CMAKE_CURRENT_LIST_DIR}/view/pixmapprojectthumbnailview.cpp
     ${CMAKE_CURRENT_LIST_DIR}/view/pixmapprojectthumbnailview.h
     ${CMAKE_CURRENT_LIST_DIR}/view/newprojectmodel.cpp

--- a/src/project/internal/iopensaveprojectscenario.h
+++ b/src/project/internal/iopensaveprojectscenario.h
@@ -56,6 +56,8 @@ public:
     static constexpr int RET_CODE_CLOSE_AND_OPEN_CLOUD_FORCE = 1242;
     static constexpr int RET_CODE_SAVE_LOCALLY_AND_REMOVE_CACHE = 1243;
     static constexpr int RET_CODE_SAVE_TO_CLOUD_FORCE = 1244;
+    static constexpr int RET_CODE_OPEN_ON_AUDIOCOM = 1245;
+    static constexpr int RET_CODE_LOAD_LATEST_SYNCED = 1246;
 
     virtual muse::Ret showCloudOpenError(const muse::Ret& ret, const muse::io::path_t& localPath) const = 0;
     virtual muse::Ret showCloudSaveError(const muse::Ret& ret) const = 0;

--- a/src/project/internal/iopensaveprojectscenario.h
+++ b/src/project/internal/iopensaveprojectscenario.h
@@ -49,9 +49,17 @@ public:
     static constexpr int RET_CODE_CONFLICT_RESPONSE_PUBLISH_AS_NEW_SCORE = 1236;
     static constexpr int RET_CODE_CONFLICT_RESPONSE_REPLACE = 1237;
 
-    virtual void showCloudOpenError(const muse::Ret& ret) const = 0;
-    virtual muse::Ret showCloudSaveError(const muse::Ret& ret, const CloudProjectInfo& info, bool publishMode,
-                                         bool alreadyAttempted) const = 0;
+    static constexpr int RET_CODE_OPEN_LOCAL = 1238;
+    static constexpr int RET_CODE_SAVE_LOCALLY = 1239;
+    static constexpr int RET_CODE_SAVE_TO_CLOUD = 1240;
+    static constexpr int RET_CODE_OPEN_CLOUD_FORCE = 1241;
+    static constexpr int RET_CODE_CLOSE_AND_OPEN_CLOUD_FORCE = 1242;
+    static constexpr int RET_CODE_SAVE_LOCALLY_AND_REMOVE_CACHE = 1243;
+    static constexpr int RET_CODE_SAVE_TO_CLOUD_FORCE = 1244;
+
+    virtual muse::Ret showCloudOpenError(const muse::Ret& ret, const muse::io::path_t& localPath) const = 0;
+    virtual muse::Ret showCloudSaveError(const muse::Ret& ret) const = 0;
+    virtual muse::Ret showCloudAudioOpenError(const muse::Ret& ret) const = 0;
     virtual muse::Ret showAudioCloudShareError(const muse::Ret& ret) const = 0;
 };
 }

--- a/src/project/internal/opensaveprojectscenario.cpp
+++ b/src/project/internal/opensaveprojectscenario.cpp
@@ -73,9 +73,10 @@ const char* SAVE_FORBIDDEN_TITLE = "Access denied";
 const char* SAVE_FORBIDDEN_MESSAGE
     = "You don't have permission to save this project to the cloud. It may belong to a different account.";
 
-const char* PRJ_SIZE_EXCEEDED_TITLE = "Project size limit exceeded";
-const char* PRJ_SIZE_EXCEEDED_TEXT
-    = "Your project exceeds the maximum size of 10GB. Please consider reducing its size or save it to your computer.";
+const char* PRJ_STORAGE_LIMIT_TITLE = "Your project storage limit has been reached";
+const char* PRJ_STORAGE_LIMIT_TEXT
+    =
+        "You may need to remove your older projects to make space available. For more options, visit audio.com.\n\nYou can also save this project locally to avoid losing changes.";
 
 const char* PRJ_LIMIT_REACHED_TITLE = "Your project limit has been reached";
 const char* PRJ_LIMIT_REACHED_TEXT
@@ -686,10 +687,10 @@ Ret OpenSaveProjectScenario::showCloudOpenError(const Ret& error, const muse::io
     return muse::make_ok();
 }
 
-Ret OpenSaveProjectScenario::showCloudSaveError(const Ret& error) const
+Ret OpenSaveProjectScenario::showCloudSaveError(const Ret& ret) const
 {
     using Err = au::au3cloud::Err;
-    const auto err = static_cast<Err>(error.code());
+    const auto err = static_cast<Err>(ret.code());
 
     switch (err) {
     case Err::ProjectLimitReached:
@@ -699,8 +700,8 @@ Ret OpenSaveProjectScenario::showCloudSaveError(const Ret& error) const
             interactive()->buttonData(IInteractive::Button::Cancel),
             IInteractive::ButtonData(saveLocallyBtn, trc("project", "Save to computer"), /*accent=*/ true),
         };
-        const char* title = err == Err::ProjectLimitReached ? PRJ_LIMIT_REACHED_TITLE : PRJ_SIZE_EXCEEDED_TITLE;
-        const char* text = err == Err::ProjectLimitReached ? PRJ_LIMIT_REACHED_TEXT : PRJ_SIZE_EXCEEDED_TEXT;
+        const char* title = err == Err::ProjectLimitReached ? PRJ_LIMIT_REACHED_TITLE : PRJ_STORAGE_LIMIT_TITLE;
+        const char* text = err == Err::ProjectLimitReached ? PRJ_LIMIT_REACHED_TEXT : PRJ_STORAGE_LIMIT_TEXT;
         IInteractive::Result result = interactive()->infoSync(title, text, buttons, saveLocallyBtn, {},
                                                               trc("cloud", "Save to audio.com"));
         if (result.isButton(IInteractive::Button::Save)) {

--- a/src/project/internal/opensaveprojectscenario.cpp
+++ b/src/project/internal/opensaveprojectscenario.cpp
@@ -770,8 +770,19 @@ Ret OpenSaveProjectScenario::showCloudSaveError(const Ret& ret) const
     case Err::ClientFailure:
     case Err::UploadFailed:
     case Err::SyncCancelled:
-        interactive()->infoSync(DEFAULT_SYNC_ERROR_TITLE, DEFAULT_SYNC_ERROR_TEXT);
+    {
+        if (cloudConfiguration()->shouldWarnOnSyncError()) {
+            const IInteractive::ButtonData okBtn = interactive()->buttonData(IInteractive::Button::Ok);
+            const auto result = interactive()->infoSync(DEFAULT_SYNC_ERROR_TITLE, DEFAULT_SYNC_ERROR_TEXT, { okBtn },
+                                                        static_cast<int>(IInteractive::Button::Ok),
+                                                        IInteractive::Option::WithIcon | IInteractive::Option::WithDontShowAgainCheckBox);
+
+            if (!result.showAgain()) {
+                cloudConfiguration()->setWarnOnSyncError(false);
+            }
+        }
         break;
+    }
     default:
         interactive()->infoSync(DEFAULT_CLOUD_ERROR_TITLE, DEFAULT_CLOUD_ERROR_TEXT);
         break;

--- a/src/project/internal/opensaveprojectscenario.cpp
+++ b/src/project/internal/opensaveprojectscenario.cpp
@@ -23,6 +23,7 @@
 #include "opensaveprojectscenario.h"
 
 #include "cloud/clouderrors.h"
+#include "interactive/iinteractive.h"
 #include "projecterrors.h"
 #include "translation.h"
 #include "types/uri.h"
@@ -96,6 +97,12 @@ const char* DEFAULT_CLOUD_ERROR_TEXT = "An error occurred while syncing with the
 
 const char* DOWNLOAD_CLOUD_AUDIO_ERROR_TITLE = "Error downloading audio from cloud";
 const char* DOWNLOAD_CLOUD_AUDIO_ERROR_TEXT = "Can't download audio from cloud.";
+
+const char* PROJECT_INCOMPLETE_TITLE = "Cloud project incomplete";
+const char* PROJECT_INCOMPLETE_TEXT
+    = "No version of this project has been fully uploaded to audio.com. It cannot be loaded.";
+const char* PROJECT_NOT_FULLY_SYNCED_TEXT
+    = "The latest version of this project was not fully uploaded to audio.com. You can load the last complete version instead.";
 }
 
 RetVal<SaveLocation> OpenSaveProjectScenario::askSaveLocation(IAudacityProjectPtr project, SaveMode mode,
@@ -620,7 +627,7 @@ Ret OpenSaveProjectScenario::showCloudOpenError(const Ret& error, const muse::io
             interactive()->buttonData(IInteractive::Button::Cancel),
             IInteractive::ButtonData(useLocalBtn, trc("project", OPEN_CONFLICT_LOCAL_BTN), false, false,
                                      IInteractive::ButtonRole::ApplyRole),
-            IInteractive::ButtonData(useRemoteBtn, trc("project", OPEN_CONFLICT_REMOTE_BTN), /*accent=*/ true, false,
+            IInteractive::ButtonData(useRemoteBtn, trc("project", OPEN_CONFLICT_REMOTE_BTN), true, false,
                                      IInteractive::ButtonRole::ApplyRole),
         };
         IInteractive::Result conflictResult = interactive()->infoSync(trc("project", OPEN_CONFLICT_TITLE),
@@ -636,6 +643,41 @@ Ret OpenSaveProjectScenario::showCloudOpenError(const Ret& error, const muse::io
     case Err::Cancelled:
     case Err::OpenProjectCancelled:
         break;
+    case Err::CloudProjectNotFullySynced: {
+        const int visitAudioComBtn = static_cast<int>(IInteractive::Button::CustomButton);
+        const int loadLatestBtn = static_cast<int>(IInteractive::Button::CustomButton) + 1;
+        IInteractive::ButtonDatas buttons {
+            IInteractive::ButtonData(IInteractive::Button::Cancel, muse::trc("global", "Cancel"), true),
+            IInteractive::ButtonData(visitAudioComBtn, trc("project", "Visit audio.com"), false, false,
+                                     IInteractive::ButtonRole::ApplyRole),
+            IInteractive::ButtonData(loadLatestBtn, trc("project", "Load latest"), false, false,
+                                     IInteractive::ButtonRole::ApplyRole),
+        };
+        IInteractive::Result result
+            = interactive()->infoSync(PROJECT_INCOMPLETE_TITLE, PROJECT_NOT_FULLY_SYNCED_TEXT, buttons,
+                                      static_cast<int>(IInteractive::Button::Cancel));
+        if (result.isButton(visitAudioComBtn)) {
+            return Ret(IOpenSaveProjectScenario::RET_CODE_OPEN_ON_AUDIOCOM);
+        } else if (result.isButton(loadLatestBtn)) {
+            return Ret(IOpenSaveProjectScenario::RET_CODE_LOAD_LATEST_SYNCED);
+        }
+        break;
+    }
+    case Err::CloudProjectNeverSynced: {
+        const int visitAudioComBtn = static_cast<int>(IInteractive::Button::CustomButton);
+        IInteractive::ButtonDatas buttons {
+            IInteractive::ButtonData(visitAudioComBtn, trc("project", "Visit audio.com"), false, false,
+                                     IInteractive::ButtonRole::RejectRole),
+            interactive()->buttonData(IInteractive::Button::Ok),
+        };
+        IInteractive::Result result
+            = interactive()->infoSync(PROJECT_INCOMPLETE_TITLE, PROJECT_INCOMPLETE_TEXT, buttons,
+                                      static_cast<int>(IInteractive::Button::Ok));
+        if (result.isButton(visitAudioComBtn)) {
+            return Ret(IOpenSaveProjectScenario::RET_CODE_OPEN_ON_AUDIOCOM);
+        }
+        break;
+    }
     default:
         interactive()->infoSync(trc("project", OPEN_DEFAULT_ERROR_TITLE), trc("project", OPEN_DEFAULT_ERROR_MESSAGE));
         break;

--- a/src/project/internal/opensaveprojectscenario.cpp
+++ b/src/project/internal/opensaveprojectscenario.cpp
@@ -561,59 +561,6 @@ Ret OpenSaveProjectScenario::warnCloudNotAvailableForSharingAudio() const
     return make_ret(Ret::Code::Cancel);
 }
 
-static std::string cloudStatusCodeErrorMessage(const Ret& ret, bool withHelp = false)
-{
-    std::string message;
-
-    switch (ret.code()) {
-    case int(cloud::Err::Status400_InvalidRequest):
-        //: %1 will be replaced with the error code that the cloud service returned; this might contain english text
-        //: that is deliberately not translated
-        message = muse::qtrc("project/cloud", "The cloud service returned an error code: %1.")
-                  .arg("400 Invalid request").toStdString();
-        break;
-    case int(cloud::Err::Status401_AuthorizationRequired):
-        //: %1 will be replaced with the error code that the cloud service returned; this might contain english text
-        //: that is deliberately not translated
-        message = muse::qtrc("project/cloud", "The cloud service returned an error code: %1.")
-                  .arg("401 Authorization required").toStdString();
-        break;
-    case int(cloud::Err::Status422_ValidationFailed):
-        //: %1 will be replaced with the error code that the cloud service returned; this might contain english text
-        //: that is deliberately not translated
-        message = muse::qtrc("project/cloud", "The cloud service returned an error code: %1.")
-                  .arg("422 Validation failed").toStdString();
-        break;
-    case int(cloud::Err::Status429_RateLimitExceeded):
-        //: %1 will be replaced with the error code that the cloud service returned; this might contain english text
-        //: that is deliberately not translated
-        message = muse::qtrc("project/cloud", "The cloud service returned an error code: %1.")
-                  .arg("429 Rate limit exceeded").toStdString();
-        break;
-    case int(cloud::Err::Status500_InternalServerError):
-        //: %1 will be replaced with the error code that the cloud service returned; this might contain english text
-        //: that is deliberately not translated
-        message = muse::qtrc("project/cloud", "The cloud service returned an error code: %1.")
-                  .arg("500 Internal server error").toStdString();
-        break;
-    case int(cloud::Err::UnknownStatusCode): {
-        if (const auto status = ret.data<int>("status", -1); status != -1) {
-            //: %1 will be replaced with the error code that the cloud service returned, which is a number.
-            message = muse::qtrc("project/cloud", "The cloud service returned an unknown error code: %1.")
-                      .arg(status).toStdString();
-        } else {
-            message = muse::trc("project/cloud", "The cloud service returned an unknown error code.");
-        }
-    } break;
-    }
-
-    if (withHelp) {
-        message += "\n\n" + muse::trc("project/cloud", "Please try again later, or get help for this problem on audacityteam.org.");
-    }
-
-    return message;
-}
-
 Ret OpenSaveProjectScenario::showCloudOpenError(const Ret& error, const muse::io::path_t& localPath) const
 {
     using Err = au::au3cloud::Err;

--- a/src/project/internal/opensaveprojectscenario.cpp
+++ b/src/project/internal/opensaveprojectscenario.cpp
@@ -802,6 +802,7 @@ Ret OpenSaveProjectScenario::showCloudAudioOpenError(const Ret& error) const
                                 trc("cloud", DOWNLOAD_CLOUD_AUDIO_ERROR_TEXT));
         break;
     case Err::DownloadAudioResultCancelled:
+    case Err::DownloadAudioResultBlocked:
         break;
     default:
         interactive()->infoSync(trc("cloud", "Open audio from cloud"), error.toString());

--- a/src/project/internal/opensaveprojectscenario.cpp
+++ b/src/project/internal/opensaveprojectscenario.cpp
@@ -26,11 +26,77 @@
 #include "projecterrors.h"
 #include "translation.h"
 #include "types/uri.h"
+#include "au3cloud/au3clouderrors.h"
 
 using namespace muse;
 using namespace au::project;
 
 static constexpr int RET_CODE_CHANGE_SAVE_LOCATION_TYPE = 1234;
+
+namespace {
+const char* OPEN_SYNC_ERROR_TITLE = "Cloud sync failed";
+const char* OPEN_SYNC_ERROR_MESSAGE = "Opened from local copy. Your project may not be up to date.";
+const char* OPEN_SYNC_ERROR_NO_LOCAL_FILE_MESSAGE = "No local copy is available. Could not open the project.";
+
+const char* OPEN_DEFAULT_ERROR_TITLE = "Cannot open cloud project";
+const char* OPEN_DEFAULT_ERROR_MESSAGE = "An error occurred while opening the cloud project.";
+
+const char* OPEN_CONFLICT_TITLE = "Project version conflict";
+const char* OPEN_CONFLICT_MESSAGE
+    = "There is a newer version of this project on audio.com. You can open your local version or discard it and download the latest.";
+const char* OPEN_CONFLICT_LOCAL_BTN = "Open local version";
+const char* OPEN_CONFLICT_REMOTE_BTN = "Discard and open latest";
+
+const char* OPEN_FORBIDDEN_TITLE = "Access denied";
+const char* OPEN_FORBIDDEN_MESSAGE
+    = "You don't have permission to sync this project. It may belong to a different account. Opened from local copy.";
+const char* OPEN_FORBIDDEN_NO_LOCAL_FILE_MESSAGE
+    = "You don't have access to this cloud project. It may belong to a different account.";
+
+const char* OPEN_NOT_FOUND_ERROR_TITLE = "Cloud project unavailable";
+const char* OPEN_NOT_FOUND_ERROR_MESSAGE
+    = "Your project is no longer linked to its previous cloud save. This may happen if the cloud version was deleted.\n\n"
+      "Save to audio.com to re-upload this project to the cloud.";
+const char* OPEN_NOT_FOUND_ERROR_NO_LOCAL_FILE_MESSAGE
+    =
+        "Your project is no longer linked to its previous cloud save and no local copy is available. This may happen if the cloud version was deleted.";
+
+const char* SAVE_CONFLICT_TITLE = "Project version conflict";
+const char* SAVE_CONFLICT_MESSAGE
+    =
+        "A newer version of this project exists on audio.com. You can overwrite it with your local version or discard your changes and open the latest version.";
+const char* SAVE_CONFLICT_LOCAL_BTN = "Overwrite cloud version";
+const char* SAVE_CONFLICT_REMOTE_BTN = "Discard and open latest";
+
+const char* SAVE_FORBIDDEN_TITLE = "Access denied";
+const char* SAVE_FORBIDDEN_MESSAGE
+    = "You don't have permission to save this project to the cloud. It may belong to a different account.";
+
+const char* PRJ_SIZE_EXCEEDED_TITLE = "Project size limit exceeded";
+const char* PRJ_SIZE_EXCEEDED_TEXT
+    = "Your project exceeds the maximum size of 10GB. Please consider reducing its size or save it to your computer.";
+
+const char* PRJ_LIMIT_REACHED_TITLE = "Your project limit has been reached";
+const char* PRJ_LIMIT_REACHED_TEXT
+    =
+        "You have used up all of your available projects. Visit the project page on audio.com to make room for new creations.\n\nYou can also save this project on your computer to avoid losing changes.";
+
+const char* CLOUD_SAVE_UNAVAILABLE_TITLE = "Cloud save unavailable";
+const char* CLOUD_SAVE_UNAVAILABLE_TEXT
+    =
+        "Your project is no longer linked to its previous cloud save. This may happen if the cloud version was deleted.\n\nSave to audio.com to re-upload this project to the cloud.";
+
+const char* DEFAULT_SYNC_ERROR_TITLE = "We encountered an issue syncing your file";
+const char* DEFAULT_SYNC_ERROR_TEXT
+    =
+        "Don't worry, your changes will be saved to a temporary location and will be synchronized to your cloud copy when your internet connection resumes.";
+
+const char* DEFAULT_CLOUD_ERROR_TITLE = "Cloud error";
+const char* DEFAULT_CLOUD_ERROR_TEXT = "An error occurred while syncing with the cloud. Please try again later.";
+
+const char* DOWNLOAD_CLOUD_AUDIO_ERROR_TITLE = "Error downloading audio from cloud";
+const char* DOWNLOAD_CLOUD_AUDIO_ERROR_TEXT = "Can't download audio from cloud.";
+}
 
 RetVal<SaveLocation> OpenSaveProjectScenario::askSaveLocation(IAudacityProjectPtr project, SaveMode mode,
                                                               SaveLocationType preselectedType) const
@@ -548,154 +614,200 @@ static std::string cloudStatusCodeErrorMessage(const Ret& ret, bool withHelp = f
     return message;
 }
 
-//! TODO AU4
-void OpenSaveProjectScenario::showCloudOpenError(const Ret& ret) const
+Ret OpenSaveProjectScenario::showCloudOpenError(const Ret& error, const muse::io::path_t& localPath) const
 {
-    // std::string title = muse::trc("project", "Your score could not be opened");
-    // std::string message;
+    using Err = au::au3cloud::Err;
+    const auto err = static_cast<Err>(error.code());
 
-    // switch (ret.code()) {
-    // case int(Err::InvalidCloudScoreId):
-    //     message = muse::trc("project", "This score is invalid.");
-    //     break;
-    // case int(Err::FileOpenError):
-    //     message = muse::trc("project/cloud", "The file could not be downloaded to your disk.");
-    //     break;
-    // case int(cloud::Err::Status403_AccountNotActivated):
-    //     message = muse::trc("project/cloud", "Your musescore.com account needs to be verified first. "
-    //                                          "Please activate your account via the link in the activation email.");
-    //     break;
-    // case int(cloud::Err::Status403_NotOwner):
-    //     message = muse::trc("project/cloud", "This score does not belong to this account. To access this score, make sure you are logged in "
-    //                                          "to the desktop app with the account to which this score belongs.");
-    //     break;
-    // case int(cloud::Err::Status404_NotFound):
-    //     message = muse::trc("project/cloud", "The score could not be found, or cannot be accessed by your account.");
-    //     break;
+    switch (err) {
+    case Err::SyncResultConnectionFailed:
+    case Err::SyncResultUnexpectedResponse:
+    case Err::SyncResultInternalClientError:
+    case Err::SyncResultInternalServerError:
+    case Err::SyncResultSyncImpossible:
+    case Err::SyncResultCancelled: {
+        if (fileSystem()->exists(localPath)) {
+            interactive()->infoSync(trc("project", OPEN_SYNC_ERROR_TITLE), trc("project", OPEN_SYNC_ERROR_MESSAGE));
+            return Ret(IOpenSaveProjectScenario::RET_CODE_OPEN_LOCAL);
+        }
+        interactive()->infoSync(trc("project", OPEN_SYNC_ERROR_TITLE), trc("project", OPEN_SYNC_ERROR_NO_LOCAL_FILE_MESSAGE));
+        break;
+    }
+    case Err::SyncResultNotFound: {
+        if (fileSystem()->exists(localPath)) {
+            const int saveLocallyBtn = static_cast<int>(IInteractive::Button::CustomButton);
+            const int saveToCloudBtn = static_cast<int>(IInteractive::Button::CustomButton) + 1;
+            IInteractive::ButtonDatas buttons {
+                interactive()->buttonData(IInteractive::Button::Cancel),
+                IInteractive::ButtonData(saveLocallyBtn, trc("project", "Save to computer"), false, false,
+                                         IInteractive::ButtonRole::ApplyRole),
+                IInteractive::ButtonData(saveToCloudBtn, trc("cloud", "Save to audio.com"), /*accent=*/ true, false,
+                                         IInteractive::ButtonRole::ApplyRole),
+            };
+            IInteractive::Result result = interactive()->infoSync(OPEN_NOT_FOUND_ERROR_TITLE, OPEN_NOT_FOUND_ERROR_MESSAGE,
+                                                                  buttons, saveToCloudBtn, {},
+                                                                  trc("cloud", "Save"));
+            if (result.isButton(saveLocallyBtn)) {
+                return Ret(IOpenSaveProjectScenario::RET_CODE_SAVE_LOCALLY_AND_REMOVE_CACHE);
+            } else if (result.isButton(saveToCloudBtn)) {
+                return Ret(IOpenSaveProjectScenario::RET_CODE_SAVE_TO_CLOUD);
+            }
+        } else {
+            interactive()->infoSync(trc("project", OPEN_NOT_FOUND_ERROR_TITLE),
+                                    trc("project", OPEN_NOT_FOUND_ERROR_NO_LOCAL_FILE_MESSAGE));
+        }
+        break;
+    }
+    case Err::SyncResultForbidden: {
+        if (fileSystem()->exists(localPath)) {
+            interactive()->infoSync(trc("project", OPEN_FORBIDDEN_TITLE), trc("project", OPEN_FORBIDDEN_MESSAGE));
+            return Ret(IOpenSaveProjectScenario::RET_CODE_OPEN_LOCAL);
+        }
+        interactive()->infoSync(trc("project", OPEN_FORBIDDEN_TITLE), trc("project", OPEN_FORBIDDEN_NO_LOCAL_FILE_MESSAGE));
+        break;
+    }
+    case Err::SyncResultConflict: {
+        const int useLocalBtn = static_cast<int>(IInteractive::Button::CustomButton);
+        const int useRemoteBtn = static_cast<int>(IInteractive::Button::CustomButton) + 1;
+        IInteractive::ButtonDatas buttons {
+            interactive()->buttonData(IInteractive::Button::Cancel),
+            IInteractive::ButtonData(useLocalBtn, trc("project", OPEN_CONFLICT_LOCAL_BTN), false, false,
+                                     IInteractive::ButtonRole::ApplyRole),
+            IInteractive::ButtonData(useRemoteBtn, trc("project", OPEN_CONFLICT_REMOTE_BTN), /*accent=*/ true, false,
+                                     IInteractive::ButtonRole::ApplyRole),
+        };
+        IInteractive::Result conflictResult = interactive()->infoSync(trc("project", OPEN_CONFLICT_TITLE),
+                                                                      trc("project", OPEN_CONFLICT_MESSAGE),
+                                                                      buttons, useRemoteBtn);
+        if (conflictResult.isButton(useLocalBtn)) {
+            return Ret(IOpenSaveProjectScenario::RET_CODE_OPEN_LOCAL);
+        } else if (conflictResult.isButton(useRemoteBtn)) {
+            return Ret(IOpenSaveProjectScenario::RET_CODE_OPEN_CLOUD_FORCE);
+        }
+        break;
+    }
+    case Err::Cancelled:
+    case Err::OpenProjectCancelled:
+        break;
+    default:
+        interactive()->infoSync(trc("project", OPEN_DEFAULT_ERROR_TITLE), trc("project", OPEN_DEFAULT_ERROR_MESSAGE));
+        break;
+    }
 
-    // case int(cloud::Err::Status400_InvalidRequest):
-    // case int(cloud::Err::Status401_AuthorizationRequired):
-    // case int(cloud::Err::Status422_ValidationFailed):
-    // case int(cloud::Err::Status429_RateLimitExceeded):
-    // case int(cloud::Err::Status500_InternalServerError):
-    // case int(cloud::Err::UnknownStatusCode):
-    //     message = cloudStatusCodeErrorMessage(ret);
-    //     break;
-
-    // case int(cloud::Err::NetworkError):
-    //     message = muse::trc("project/cloud", "Could not connect to <a href=\"https://musescore.com\">musescore.com</a>. "
-    //                                          "Please check your internet connection or try again later.");
-    //     break;
-    // default:
-    //     message = muse::trc("project/cloud", "Please try again later.");
-    //     break;
-    // }
-
-    // interactive()->warning(title, message);
+    return muse::make_ok();
 }
 
-//! TODO AU4
-Ret OpenSaveProjectScenario::showCloudSaveError(const Ret& ret, const CloudProjectInfo& info, bool isPublishShare,
-                                                bool alreadyAttempted) const
+Ret OpenSaveProjectScenario::showCloudSaveError(const Ret& error) const
 {
+    using Err = au::au3cloud::Err;
+    const auto err = static_cast<Err>(error.code());
+
+    switch (err) {
+    case Err::ProjectLimitReached:
+    case Err::ProjectStorageLimitReached: {
+        const int saveLocallyBtn = static_cast<int>(IInteractive::Button::Save);
+        IInteractive::ButtonDatas buttons {
+            interactive()->buttonData(IInteractive::Button::Cancel),
+            IInteractive::ButtonData(saveLocallyBtn, trc("project", "Save to computer"), /*accent=*/ true),
+        };
+        const char* title = err == Err::ProjectLimitReached ? PRJ_LIMIT_REACHED_TITLE : PRJ_SIZE_EXCEEDED_TITLE;
+        const char* text = err == Err::ProjectLimitReached ? PRJ_LIMIT_REACHED_TEXT : PRJ_SIZE_EXCEEDED_TEXT;
+        IInteractive::Result result = interactive()->infoSync(title, text, buttons, saveLocallyBtn, {},
+                                                              trc("cloud", "Save to audio.com"));
+        if (result.isButton(IInteractive::Button::Save)) {
+            return Ret(IOpenSaveProjectScenario::RET_CODE_SAVE_LOCALLY);
+        }
+        break;
+    }
+    case Err::ProjectNotFound: {
+        const int saveLocallyBtn = static_cast<int>(IInteractive::Button::CustomButton);
+        const int saveToCloudBtn = static_cast<int>(IInteractive::Button::CustomButton) + 1;
+        IInteractive::ButtonDatas buttons {
+            interactive()->buttonData(IInteractive::Button::Cancel),
+            IInteractive::ButtonData(saveLocallyBtn, trc("project", "Save to computer"), false, false,
+                                     IInteractive::ButtonRole::ApplyRole),
+            IInteractive::ButtonData(saveToCloudBtn, trc("cloud", "Save to audio.com"), /*accent=*/ true, false,
+                                     IInteractive::ButtonRole::ApplyRole),
+        };
+        IInteractive::Result result = interactive()->infoSync(CLOUD_SAVE_UNAVAILABLE_TITLE, CLOUD_SAVE_UNAVAILABLE_TEXT,
+                                                              buttons, saveToCloudBtn, {},
+                                                              trc("cloud", "Save"));
+        if (result.isButton(saveLocallyBtn)) {
+            return Ret(IOpenSaveProjectScenario::RET_CODE_SAVE_LOCALLY_AND_REMOVE_CACHE);
+        } else if (result.isButton(saveToCloudBtn)) {
+            return Ret(IOpenSaveProjectScenario::RET_CODE_SAVE_TO_CLOUD);
+        }
+        break;
+    }
+    case Err::ProjectVersionConflict: {
+        const int useLocalBtn = static_cast<int>(IInteractive::Button::CustomButton);
+        const int useRemoteBtn = static_cast<int>(IInteractive::Button::CustomButton) + 1;
+        IInteractive::ButtonDatas buttons {
+            IInteractive::ButtonData(useLocalBtn, trc("project", SAVE_CONFLICT_LOCAL_BTN), /*accent=*/ true, false,
+                                     IInteractive::ButtonRole::ApplyRole),
+            IInteractive::ButtonData(useRemoteBtn, trc("project", SAVE_CONFLICT_REMOTE_BTN), false, false,
+                                     IInteractive::ButtonRole::ApplyRole),
+        };
+        IInteractive::Result conflictResult = interactive()->infoSync(trc("project", SAVE_CONFLICT_TITLE),
+                                                                      trc("project", SAVE_CONFLICT_MESSAGE),
+                                                                      buttons, useLocalBtn);
+        if (conflictResult.isButton(useLocalBtn)) {
+            return Ret(IOpenSaveProjectScenario::RET_CODE_SAVE_TO_CLOUD_FORCE);
+        } else if (conflictResult.isButton(useRemoteBtn)) {
+            return Ret(IOpenSaveProjectScenario::RET_CODE_CLOSE_AND_OPEN_CLOUD_FORCE);
+        }
+        break;
+    }
+    case Err::ProjectForbidden:
+    case Err::SyncResultForbidden: {
+        const int saveLocallyBtn = static_cast<int>(IInteractive::Button::CustomButton);
+        IInteractive::ButtonDatas buttons {
+            interactive()->buttonData(IInteractive::Button::Cancel),
+            IInteractive::ButtonData(saveLocallyBtn, trc("project", "Save to computer"), /*accent=*/ true, false,
+                                     IInteractive::ButtonRole::ApplyRole),
+        };
+        IInteractive::Result result = interactive()->infoSync(trc("project", SAVE_FORBIDDEN_TITLE),
+                                                              trc("project", SAVE_FORBIDDEN_MESSAGE),
+                                                              buttons, saveLocallyBtn);
+        if (result.isButton(saveLocallyBtn)) {
+            return Ret(IOpenSaveProjectScenario::RET_CODE_SAVE_LOCALLY);
+        }
+        break;
+    }
+    case Err::NetworkError:
+    case Err::DataUploadFailed:
+    case Err::ServerError:
+    case Err::ClientFailure:
+    case Err::UploadFailed:
+    case Err::SyncCancelled:
+        interactive()->infoSync(DEFAULT_SYNC_ERROR_TITLE, DEFAULT_SYNC_ERROR_TEXT);
+        break;
+    default:
+        interactive()->infoSync(DEFAULT_CLOUD_ERROR_TITLE, DEFAULT_CLOUD_ERROR_TEXT);
+        break;
+    }
+
     return muse::make_ok();
+}
 
-    // std::string title;
-    // if (alreadyAttempted) {
-    //     title = isPublishShare
-    //             ? muse::trc("project/save", "Your score could not be published")
-    //             : muse::trc("project/save", "Your score could not be saved to the cloud");
-    // } else {
-    //     title = isPublishShare
-    //             ? muse::trc("project/save", "Your score cannot be published")
-    //             : muse::trc("project/save", "Your score cannot be saved to the cloud");
-    // }
+Ret OpenSaveProjectScenario::showCloudAudioOpenError(const Ret& error) const
+{
+    using Err = au::au3cloud::Err;
+    const auto err = static_cast<Err>(error.code());
 
-    // std::string msg;
+    switch (err) {
+    case Err::DownloadAudioResultFailed:
+        interactive()->infoSync(trc("cloud", DOWNLOAD_CLOUD_AUDIO_ERROR_TITLE),
+                                trc("cloud", DOWNLOAD_CLOUD_AUDIO_ERROR_TEXT));
+        break;
+    case Err::DownloadAudioResultCancelled:
+        break;
+    default:
+        interactive()->infoSync(trc("cloud", "Open audio from cloud"), error.toString());
+        break;
+    }
 
-    // static constexpr int helpBtnCode = int(IInteractive::Button::CustomButton) + 1;
-    // static constexpr int saveLocallyBtnCode = int(IInteractive::Button::CustomButton) + 2;
-    // static constexpr int saveAsBtnCode = int(IInteractive::Button::CustomButton) + 3;
-    // static constexpr int publishAsNewScoreBtnCode = int(IInteractive::Button::CustomButton) + 4;
-    // static constexpr int replaceBtnCode = int(IInteractive::Button::CustomButton) + 5;
-
-    // IInteractive::ButtonData okBtn = interactive()->buttonData(IInteractive::Button::Ok);
-    // IInteractive::ButtonData saveLocallyBtn { saveLocallyBtnCode, muse::trc("project/save", "Save to computer") };
-    // IInteractive::ButtonData helpBtn { helpBtnCode, muse::trc("project/save", "Get help") };
-
-    // IInteractive::ButtonDatas buttons = (alreadyAttempted || isPublishShare)
-    //                                     ? (IInteractive::ButtonDatas { helpBtn, okBtn })
-    //                                     : (IInteractive::ButtonDatas { helpBtn, saveLocallyBtn, okBtn });
-
-    // int defaultButtonCode = okBtn.btn;
-
-    // switch (ret.code()) {
-    // case int(cloud::Err::Status403_AccountNotActivated):
-    //     msg = muse::trc("project/cloud", "Your musescore.com account needs to be verified first. "
-    //                                      "Please activate your account via the link in the activation email.");
-    //     buttons = { okBtn };
-    //     break;
-    // case int(cloud::Err::Status409_Conflict):
-    //     title = muse::trc("project/save", "There are conflicting changes in the online score");
-    //     if (isPublishShare) {
-    //         msg = muse::qtrc("project/save", "You can replace the <a href=\"%1\">online score</a>, or publish this as a new score "
-    //                                          "to avoid losing changes in the current online version.")
-    //               .arg(info.sourceUrl.toString())
-    //               .toStdString();
-    //         buttons = {
-    //             interactive()->buttonData(IInteractive::Button::Cancel),
-    //             IInteractive::ButtonData { publishAsNewScoreBtnCode, muse::trc("project/save", "Publish as new score") },
-    //             IInteractive::ButtonData { replaceBtnCode, muse::trc("project/save", "Replace") }
-    //         };
-    //         defaultButtonCode = replaceBtnCode;
-    //     } else {
-    //         msg = muse::qtrc("project/save", "You can replace the <a href=\"%1\">online score</a>, or save this as a new file "
-    //                                          "to avoid losing changes in the current online version.")
-    //               .arg(info.sourceUrl.toString())
-    //               .toStdString();
-    //         buttons = {
-    //             interactive()->buttonData(IInteractive::Button::Cancel),
-    //             IInteractive::ButtonData { saveAsBtnCode, muse::trc("project/save", "Save as…") },
-    //             IInteractive::ButtonData { replaceBtnCode, muse::trc("project/save", "Replace") }
-    //         };
-    //         defaultButtonCode = replaceBtnCode;
-    //     }
-    //     break;
-
-    // case int(cloud::Err::Status400_InvalidRequest):
-    // case int(cloud::Err::Status401_AuthorizationRequired):
-    // case int(cloud::Err::Status422_ValidationFailed):
-    // case int(cloud::Err::Status429_RateLimitExceeded):
-    // case int(cloud::Err::Status500_InternalServerError):
-    // case int(cloud::Err::UnknownStatusCode):
-    //     msg = cloudStatusCodeErrorMessage(ret, /*withHelp=*/ true);
-    //     break;
-
-    // case int(cloud::Err::NetworkError):
-    //     msg = muse::trc("project/cloud", "Could not connect to <a href=\"https://musescore.com\">musescore.com</a>. "
-    //                                      "Please check your internet connection or try again later.");
-    //     break;
-    // default:
-    //     msg = muse::trc("project/cloud", "Please try again later, or get help for this problem on musescore.org.");
-    //     break;
-    // }
-
-    // IInteractive::Result result = interactive()->warning(title, msg, buttons, defaultButtonCode);
-    // switch (result.button()) {
-    // case helpBtnCode:
-    //     interactive()->openUrl(configuration()->supportForumUrl());
-    //     break;
-    // case saveLocallyBtnCode:
-    //     return Ret(RET_CODE_CHANGE_SAVE_LOCATION_TYPE);
-    // case saveAsBtnCode:
-    //     return Ret(RET_CODE_CONFLICT_RESPONSE_SAVE_AS);
-    // case publishAsNewScoreBtnCode:
-    //     return Ret(RET_CODE_CONFLICT_RESPONSE_PUBLISH_AS_NEW_SCORE);
-    // case replaceBtnCode:
-    //     return Ret(RET_CODE_CONFLICT_RESPONSE_REPLACE);
-    // }
-
-    // return make_ret(Ret::Code::Cancel);
+    return muse::make_ok();
 }
 
 Ret OpenSaveProjectScenario::showAudioCloudShareError(const Ret& ret) const

--- a/src/project/internal/opensaveprojectscenario.h
+++ b/src/project/internal/opensaveprojectscenario.h
@@ -35,6 +35,7 @@
 
 #include "project/iprojectconfiguration.h"
 #include "project/iprojectfilescontroller.h"
+#include "au3cloud/iau3cloudconfiguration.h"
 
 namespace au::project {
 class OpenSaveProjectScenario : public IOpenSaveProjectScenario, public muse::Contextable
@@ -43,6 +44,7 @@ class OpenSaveProjectScenario : public IOpenSaveProjectScenario, public muse::Co
     muse::GlobalInject<muse::io::IFileSystem> fileSystem;
     muse::GlobalInject<muse::cloud::IMuseScoreComService> museScoreComService;
     muse::GlobalInject<muse::cloud::IAudioComService> audioComService;
+    muse::GlobalInject<au::au3cloud::IAu3CloudConfiguration> cloudConfiguration;
 
     muse::ContextInject<IProjectFilesController> projectFilesController { this };
     muse::ContextInject<muse::IInteractive> interactive { this };

--- a/src/project/internal/opensaveprojectscenario.h
+++ b/src/project/internal/opensaveprojectscenario.h
@@ -63,9 +63,9 @@ public:
 
     bool warnBeforeSavingToExistingPubliclyVisibleCloudProject() const override;
 
-    void showCloudOpenError(const muse::Ret& ret) const override;
-    muse::Ret showCloudSaveError(const muse::Ret& ret, const CloudProjectInfo& info, bool isPublishShare,
-                                 bool alreadyAttempted) const override;
+    muse::Ret showCloudOpenError(const muse::Ret& ret, const muse::io::path_t& localPath) const override;
+    muse::Ret showCloudSaveError(const muse::Ret& ret) const override;
+    muse::Ret showCloudAudioOpenError(const muse::Ret& ret) const override;
     muse::Ret showAudioCloudShareError(const muse::Ret& ret) const override;
 
 private:

--- a/src/project/internal/projectactionscontroller.cpp
+++ b/src/project/internal/projectactionscontroller.cpp
@@ -39,6 +39,7 @@ static const QString OPEN_PROJECT_URL_HOSTNAME("open-project");
 static const muse::actions::ActionCode OPEN_CUSTOM_FFMPEG_OPTIONS("open-custom-ffmpeg-options");
 static const muse::actions::ActionCode OPEN_METADATA_DIALOG("open-metadata-dialog");
 static const muse::actions::ActionCode OPEN_CUSTOM_MAPPING("open-custom-mapping");
+static const muse::actions::ActionQuery OPEN_CLOUD_AUDIO_FILE_URI("audacity://cloud/open-audio-file");
 
 ProjectActionsController::ProjectActionsController(muse::modularity::ContextPtr ctx)
     : muse::Contextable(ctx)
@@ -62,6 +63,7 @@ void ProjectActionsController::init()
     dispatcher()->reg(this, "file-save-backup", [this]() { saveProject(SaveMode::SaveCopy); });
 
     dispatcher()->reg(this, "file-share-audio", this, &ProjectActionsController::shareAudio);
+    dispatcher()->reg(this, OPEN_CLOUD_AUDIO_FILE_URI, this, &ProjectActionsController::openCloudAudioFile);
 
     dispatcher()->reg(this, "export-audio", this, &ProjectActionsController::exportAudio);
     dispatcher()->reg(this, "export-labels", this, &ProjectActionsController::exportLabels);
@@ -115,6 +117,7 @@ bool ProjectActionsController::canReceiveAction(const muse::actions::ActionCode&
             "cloud-file-open",
             "continue-last-session",
             "clear-recent",
+            "audacity://cloud/open-audio-file",
         };
 
         return muse::contains(DONT_REQUIRE_OPEN_PROJECT, code);
@@ -1075,6 +1078,33 @@ void ProjectActionsController::shareAudio()
         {},
         showProgressInfo
         );
+}
+
+void ProjectActionsController::openCloudAudioFile(const muse::actions::ActionQuery& query)
+{
+    const auto audioId = query.param("audioId").toString();
+    auto progress = audioComService()->openAudioFile(audioId);
+
+    progress->finished().onReceive(this, [this, audioId](const ProgressResult& result) {
+        if (!result.ret) {
+            interactive()->error(muse::trc("cloud", "Open audio from cloud"), result.ret.toString());
+            return;
+        }
+
+        const auto project = globalContext()->currentProject();
+        if (project) {
+            QStringList args;
+            args << "--session-type" << "start-with-new" << result.val.toQString();
+            multiwindowsProvider()->openNewWindow(args);
+            return;
+        }
+
+        auto newproject = createProjectInCurrentWindow();
+        newproject->import(muse::io::path_t(result.val.toQString()));
+        openPageIfNeed(PROJECT_PAGE_URI);
+    });
+
+    interactive()->showProgress(muse::trc("cloud", "Downloading audio from cloud…"), *progress);
 }
 
 void ProjectActionsController::exportAudio()

--- a/src/project/internal/projectactionscontroller.cpp
+++ b/src/project/internal/projectactionscontroller.cpp
@@ -94,6 +94,7 @@ const muse::actions::ActionCodeList& ProjectActionsController::prohibitedActions
         "file-new",
         "file-open",
         "cloud-file-open",
+        "audacity://cloud/open-audio-file",
         "file-close",
         "project-import",
         "file-save",

--- a/src/project/internal/projectactionscontroller.cpp
+++ b/src/project/internal/projectactionscontroller.cpp
@@ -1085,7 +1085,7 @@ void ProjectActionsController::shareAudio()
                 }
             });
         } else {
-            //handleCloudError(result.ret);
+            handleCloudSaveError(result.ret);
         }
     });
 
@@ -1523,9 +1523,9 @@ void ProjectActionsController::handleCloudSaveError(const muse::Ret& error)
     case Err::DataUploadFailed:
     case Err::ServerError:
     case Err::ClientFailure:
-        interactive()->infoSync(DEFAULT_SYNC_ERROR_TITLE, DEFAULT_SYNC_ERROR_TEXT);
-        break;
+    case Err::UploadFailed:
     case Err::SyncCancelled:
+        interactive()->infoSync(DEFAULT_SYNC_ERROR_TITLE, DEFAULT_SYNC_ERROR_TEXT);
         break;
     default:
         interactive()->infoSync(DEFAULT_CLOUD_ERROR_TITLE, DEFAULT_CLOUD_ERROR_TEXT);

--- a/src/project/internal/projectactionscontroller.cpp
+++ b/src/project/internal/projectactionscontroller.cpp
@@ -1096,6 +1096,10 @@ void ProjectActionsController::shareAudio()
 void ProjectActionsController::openCloudAudioFile(const muse::actions::ActionQuery& query)
 {
     const auto audioId = query.param("audioId").toString();
+    if (audioId.empty()) {
+        return;
+    }
+
     auto progress = audioComService()->openAudioFile(audioId);
     if (!progress) {
         return;
@@ -1116,6 +1120,10 @@ void ProjectActionsController::openCloudAudioFile(const muse::actions::ActionQue
         }
 
         auto newproject = createProjectInCurrentWindow();
+        if (!newproject) {
+            return;
+        }
+
         newproject->import(muse::io::path_t(result.val.toQString()));
         openPageIfNeed(PROJECT_PAGE_URI);
     });

--- a/src/project/internal/projectactionscontroller.cpp
+++ b/src/project/internal/projectactionscontroller.cpp
@@ -2,6 +2,7 @@
 
 #include <QFileDialog>
 
+#include "au3cloud/internal/au3audiocomservice.h"
 #include "framework/global/async/async.h"
 #include "framework/global/defer.h"
 #include "framework/global/translation.h"
@@ -830,9 +831,10 @@ Ret ProjectActionsController::openCloudProject(const io::path_t& localPath, cons
         return make_ret(Ret::Code::UnknownError);
     }
 
-    progress->finished().onReceive(this, [this, localPath](const ProgressResult& result) {
+    const std::string cloudProjectIdStr = projectId.toStdString();
+    progress->finished().onReceive(this, [this, localPath, cloudProjectIdStr](const ProgressResult& result) {
         if (!result.ret) {
-            handleCloudOpenError(result.ret, localPath);
+            handleCloudOpenError(result.ret, localPath, cloudProjectIdStr);
             return;
         }
 
@@ -1219,7 +1221,8 @@ muse::Ret ProjectActionsController::ensureAuthorization()
     return authorization()->isAuthorized() ? make_ret(Ret::Code::Ok) : make_ret(Ret::Code::Cancel);
 }
 
-void ProjectActionsController::handleCloudOpenError(const muse::Ret& error, const io::path_t& localPath)
+void ProjectActionsController::handleCloudOpenError(const muse::Ret& error, const io::path_t& localPath,
+                                                    const std::string& cloudProjectId)
 {
     using Err = au::au3cloud::Err;
     const auto err = static_cast<Err>(error.code());
@@ -1257,6 +1260,14 @@ void ProjectActionsController::handleCloudOpenError(const muse::Ret& error, cons
     }
     case IOpenSaveProjectScenario::RET_CODE_OPEN_CLOUD_FORCE:
         openCloudProject(localPath, {}, true);
+        break;
+    case IOpenSaveProjectScenario::RET_CODE_LOAD_LATEST_SYNCED:
+        openCloudProject(localPath, muse::String::fromStdString(cloudProjectId), true);
+        break;
+    case IOpenSaveProjectScenario::RET_CODE_OPEN_ON_AUDIOCOM:
+        if (!cloudProjectId.empty()) {
+            platformInteractive()->openUrl(audioComService()->getCloudProjectPage(cloudProjectId));
+        }
         break;
     default:
         break;

--- a/src/project/internal/projectactionscontroller.cpp
+++ b/src/project/internal/projectactionscontroller.cpp
@@ -1370,6 +1370,9 @@ void ProjectActionsController::handleCloudOpenError(const muse::Ret& error, cons
         }
         break;
     }
+    case Err::Cancelled:
+    case Err::OpenProjectCancelled:
+        break;
     default: {
         interactive()->infoSync(trc("project", OPEN_DEFAULT_ERROR_TITLE), trc("project", OPEN_DEFAULT_ERROR_MESSAGE));
         break;

--- a/src/project/internal/projectactionscontroller.cpp
+++ b/src/project/internal/projectactionscontroller.cpp
@@ -1278,6 +1278,9 @@ const char* DEFAULT_SYNC_ERROR_TEXT
 
 const char* DEFAULT_CLOUD_ERROR_TITLE = "Cloud error";
 const char* DEFAULT_CLOUD_ERROR_TEXT = "An error occurred while syncing with the cloud. Please try again later.";
+
+const char* DOWNLOAD_CLOUD_AUDIO_ERROR_TITLE = "Error downloading audio from cloud";
+const char* DOWNLOAD_CLOUD_AUDIO_ERROR_TEXT = "Can't download audio from cloud.";
 }
 
 void ProjectActionsController::handleCloudOpenError(const muse::Ret& error, const io::path_t& localPath)
@@ -1539,10 +1542,14 @@ void ProjectActionsController::handleCloudAudioOpenError(const muse::Ret& error)
     const auto err = static_cast<Err>(error.code());
 
     switch (err) {
+    case Err::DownloadAudioResultFailed:
+        interactive()->infoSync(muse::trc("cloud", DOWNLOAD_CLOUD_AUDIO_ERROR_TITLE),
+                                muse::trc("cloud", DOWNLOAD_CLOUD_AUDIO_ERROR_TEXT));
+        break;
     case Err::DownloadAudioResultCancelled:
         break;
     default:
-        interactive()->error(muse::trc("cloud", "Open audio from cloud"), error.toString());
+        interactive()->infoSync(muse::trc("cloud", "Open audio from cloud"), error.toString());
         break;
     }
 }

--- a/src/project/internal/projectactionscontroller.cpp
+++ b/src/project/internal/projectactionscontroller.cpp
@@ -296,6 +296,8 @@ void ProjectActionsController::importFiles(const muse::actions::ActionData& args
 void ProjectActionsController::importStartupMedia(const muse::actions::ActionData& args)
 {
     const QStringList files = !args.empty() ? args.arg<QStringList>(0) : QStringList();
+    const bool removeAfterImport = args.count() >= 2 ? args.arg<bool>(1) : false;
+
     muse::io::paths_t filePaths;
     filePaths.reserve(files.size());
     for (const QString& file : files) {
@@ -303,6 +305,12 @@ void ProjectActionsController::importStartupMedia(const muse::actions::ActionDat
     }
 
     Ret ret = processMediaFiles(filePaths);
+    if (removeAfterImport) {
+        for (const auto& filePath : filePaths) {
+            fileSystem()->remove(filePath);
+        }
+    }
+
     if (!ret) {
         openPageIfNeed(HOME_PAGE_URI);
     }
@@ -1116,7 +1124,9 @@ void ProjectActionsController::openCloudAudioFile(const muse::actions::ActionQue
         const auto project = globalContext()->currentProject();
         if (project) {
             QStringList args;
-            args << "--session-type" << "start-with-new" << localPath;
+            args << "--session-type" << "start-with-new";
+            args << "--import-media-file" << localPath;
+            args << "--remove-media-after-import";
             multiwindowsProvider()->openNewWindow(args);
             return;
         }

--- a/src/project/internal/projectactionscontroller.cpp
+++ b/src/project/internal/projectactionscontroller.cpp
@@ -476,9 +476,14 @@ bool ProjectActionsController::saveProjectToCloud(const CloudProjectInfo& cloudI
         return false;
     }
 
-    auto progress = audioComService()->uploadProject(project, cloudInfo.name.toStdString(), [this, projectFilePath]() {
+    auto [uploadRet, progress] = audioComService()->uploadProject(project, cloudInfo.name.toStdString(), [this, projectFilePath]() {
         return saveProjectLocally(projectFilePath, SaveMode::Save);
     }, forceOverwrite);
+
+    if (!uploadRet) {
+        handleCloudSaveError(uploadRet);
+        return false;
+    }
 
     if (!progress) {
         LOGE() << "Failed to start cloud upload";
@@ -827,12 +832,17 @@ Ret ProjectActionsController::openCloudProject(const io::path_t& localPath, cons
         return make_ret(Ret::Code::Cancel);
     }
 
-    muse::ProgressPtr progress = audioComService()->openCloudProject(localPath, projectId.toStdString(), forceOverwrite);
+    const std::string cloudProjectIdStr = projectId.toStdString();
+    auto [openRet, progress] = audioComService()->openCloudProject(localPath, cloudProjectIdStr, forceOverwrite);
+    if (!openRet) {
+        handleCloudOpenError(openRet, localPath, cloudProjectIdStr);
+        return openRet;
+    }
+
     if (!progress) {
         return make_ret(Ret::Code::UnknownError);
     }
 
-    const std::string cloudProjectIdStr = projectId.toStdString();
     progress->finished().onReceive(this, [this, localPath, cloudProjectIdStr](const ProgressResult& result) {
         if (!result.ret) {
             handleCloudOpenError(result.ret, localPath, cloudProjectIdStr);
@@ -850,12 +860,12 @@ Ret ProjectActionsController::openCloudProject(const io::path_t& localPath, cons
             return;
         }
 
-        auto progress = audioComService()->resumeProjectSync(project);
-        if (!progress || progress->isCanceled()) {
+        auto [syncRet, syncProgress] = audioComService()->resumeProjectSync(project);
+        if (!syncRet || !syncProgress || syncProgress->isCanceled()) {
             return;
         }
 
-        progress->finished().onReceive(this, [this](const ProgressResult& result) {
+        syncProgress->finished().onReceive(this, [this](const ProgressResult& result) {
             if (!result.ret.success()) {
                 handleCloudSaveError(result.ret);
             }
@@ -866,7 +876,7 @@ Ret ProjectActionsController::openCloudProject(const io::path_t& localPath, cons
         toastService()->showWithProgress(
             trc("project", "Resuming sync to audio.com…"),
             {},
-            progress,
+            syncProgress,
             muse::ui::IconCode::Code::CLOUD,
             dismissible,
             {},
@@ -1066,8 +1076,8 @@ void ProjectActionsController::shareAudio()
         return;
     }
 
-    auto progress = audioComService()->shareAudio(title);
-    if (!progress) {
+    auto [shareRet, progress] = audioComService()->shareAudio(title);
+    if (!shareRet || !progress) {
         return;
     }
 
@@ -1112,7 +1122,12 @@ void ProjectActionsController::openCloudAudioFile(const muse::actions::ActionQue
         return;
     }
 
-    auto progress = audioComService()->downloadAudioFile(audioId);
+    auto [downloadRet, progress] = audioComService()->downloadAudioFile(audioId);
+    if (!downloadRet) {
+        handleCloudAudioOpenError(downloadRet);
+        return;
+    }
+
     if (!progress) {
         return;
     }

--- a/src/project/internal/projectactionscontroller.cpp
+++ b/src/project/internal/projectactionscontroller.cpp
@@ -486,29 +486,30 @@ bool ProjectActionsController::saveProjectToCloud(const CloudProjectInfo& cloudI
     }
 
     progress->finished().onReceive(this, [this, exists, projectFilePath](const ProgressResult& result) {
-        if (result.ret.success()) {
-            if (exists) {
-                return;
-            }
-
-            const bool dismissable = false;
-            toastService()->show(trc("global", "Success"),
-                                 trc("project",
-                                     "All saved changes will now update to the cloud.\nYou can manage this file from your updated projects page on audio.com"),
-                                 muse::ui::IconCode::Code::TICK,
-                                 dismissable,
-            {
-                { trc("project", "Dismiss"), au::toast::ToastActionCode::None },
-                { trc("cloud", "View on audio.com"), au::toast::ToastActionCode::Custom }
-            }
-                                 ).onResolve(this, [this, url = result.val.toQString()](au::toast::ToastActionCode actionCode) {
-                if (actionCode == au::toast::ToastActionCode::Custom) {
-                    platformInteractive()->openUrl(url);
-                }
-            });
-        } else {
+        if (!result.ret.success()) {
             handleCloudSaveError(result.ret);
+            return;
         }
+
+        if (exists) {
+            return;
+        }
+
+        const bool dismissable = false;
+        toastService()->show(trc("global", "Success"),
+                             trc("project",
+                                 "All saved changes will now update to the cloud.\nYou can manage this file from your updated projects page on audio.com"),
+                             muse::ui::IconCode::Code::TICK,
+                             dismissable,
+        {
+            { trc("project", "Dismiss"), au::toast::ToastActionCode::None },
+            { trc("cloud", "View on audio.com"), au::toast::ToastActionCode::Custom }
+        }
+                             ).onResolve(this, [this, url = result.val.toQString()](au::toast::ToastActionCode actionCode) {
+            if (actionCode == au::toast::ToastActionCode::Custom) {
+                platformInteractive()->openUrl(url);
+            }
+        });
     });
 
     const bool dismissible = false;

--- a/src/project/internal/projectactionscontroller.cpp
+++ b/src/project/internal/projectactionscontroller.cpp
@@ -1108,7 +1108,7 @@ void ProjectActionsController::openCloudAudioFile(const muse::actions::ActionQue
 
     progress->finished().onReceive(this, [this, audioId](const ProgressResult& result) {
         if (!result.ret) {
-            interactive()->error(muse::trc("cloud", "Open audio from cloud"), result.ret.toString());
+            handleCloudAudioOpenError(result.ret);
             return;
         }
 
@@ -1511,6 +1511,20 @@ void ProjectActionsController::handleCloudSaveError(const muse::Ret& error)
         break;
     default:
         interactive()->infoSync(DEFAULT_CLOUD_ERROR_TITLE, DEFAULT_CLOUD_ERROR_TEXT);
+        break;
+    }
+}
+
+void ProjectActionsController::handleCloudAudioOpenError(const muse::Ret& error)
+{
+    using Err = au::au3cloud::Err;
+    const auto err = static_cast<Err>(error.code());
+
+    switch (err) {
+    case Err::DownloadAudioResultCancel:
+        break;
+    default:
+        interactive()->error(muse::trc("cloud", "Open audio from cloud"), error.toString());
         break;
     }
 }

--- a/src/project/internal/projectactionscontroller.cpp
+++ b/src/project/internal/projectactionscontroller.cpp
@@ -1219,182 +1219,47 @@ muse::Ret ProjectActionsController::ensureAuthorization()
     return authorization()->isAuthorized() ? make_ret(Ret::Code::Ok) : make_ret(Ret::Code::Cancel);
 }
 
-namespace {
-const char* OPEN_SYNC_ERROR_TITLE = "Cloud sync failed";
-const char* OPEN_SYNC_ERROR_MESSAGE = "Opened from local copy. Your project may not be up to date.";
-const char* OPEN_SYNC_ERROR_NO_LOCAL_FILE_MESSAGE = "No local copy is available. Could not open the project.";
-
-const char* OPEN_DEFAULT_ERROR_TITLE = "Cannot open cloud project";
-const char* OPEN_DEFAULT_ERROR_MESSAGE = "An error occurred while opening the cloud project.";
-
-const char* OPEN_CONFLICT_TITLE = "Project version conflict";
-const char* OPEN_CONFLICT_MESSAGE
-    = "There is a newer version of this project on audio.com. You can open your local version or discard it and download the latest.";
-const char* OPEN_CONFLICT_LOCAL_BTN = "Open local version";
-const char* OPEN_CONFLICT_REMOTE_BTN = "Discard and open latest";
-
-const char* SAVE_CONFLICT_TITLE = "Project version conflict";
-const char* SAVE_CONFLICT_MESSAGE
-    =
-        "A newer version of this project exists on audio.com. You can overwrite it with your local version or discard your changes and open the latest version.";
-const char* SAVE_CONFLICT_LOCAL_BTN = "Overwrite cloud version";
-const char* SAVE_CONFLICT_REMOTE_BTN = "Discard and open latest";
-
-const char* OPEN_FORBIDDEN_TITLE = "Access denied";
-const char* OPEN_FORBIDDEN_MESSAGE
-    = "You don’t have permission to sync this project. It may belong to a different account. Opened from local copy.";
-const char* OPEN_FORBIDDEN_NO_LOCAL_FILE_MESSAGE
-    = "You don’t have access to this cloud project. It may belong to a different account.";
-
-const char* SAVE_FORBIDDEN_TITLE = "Access denied";
-const char* SAVE_FORBIDDEN_MESSAGE
-    = "You don’t have permission to save this project to the cloud. It may belong to a different account.";
-
-const char* OPEN_NOT_FOUND_ERROR_TITLE = "Cloud project unavailable";
-const char* OPEN_NOT_FOUND_ERROR_MESSAGE
-    = "Your project is no longer linked to its previous cloud save. This may happen if the cloud version was deleted.\n\n"
-      "Save to audio.com to re-upload this project to the cloud.";
-const char* OPEN_NOT_FOUND_ERROR_NO_LOCAL_FILE_MESSAGE
-    =
-        "Your project is no longer linked to its previous cloud save and no local copy is available. This may happen if the cloud version was deleted.";
-const char* PRJ_SIZE_EXCEEDED_TITLE = "Project size limit exceeded";
-const char* PRJ_SIZE_EXCEEDED_TEXT
-    = "Your project exceeds the maximum size of 10GB. Please consider reducing its size or save it to your computer.";
-
-const char* PRJ_LIMIT_REACHED_TITLE = "Your project limit has been reached";
-const char* PRJ_LIMIT_REACHED_TEXT
-    =
-        "You have used up all of your available projects. Visit the project page on audio.com to make room for new creations.\n\nYou can also save this project on your computer to avoid losing changes.";
-
-const char* CLOUD_SAVE_UNAVAILABLE_TITLE = "Cloud save unavailable";
-const char* CLOUD_SAVE_UNAVAILABLE_TEXT
-    =
-        "Your project is no longer linked to its previous cloud save. This may happen if the cloud version was deleted.\n\nSave to audio.com to re-upload this project to the cloud.";
-
-const char* DEFAULT_SYNC_ERROR_TITLE = "We encountered an issue syncing your file";
-const char* DEFAULT_SYNC_ERROR_TEXT
-    =
-        "Don’t worry, your changes will be saved to a temporary location and will be synchronized to your cloud copy when your internet connection resumes.";
-
-const char* DEFAULT_CLOUD_ERROR_TITLE = "Cloud error";
-const char* DEFAULT_CLOUD_ERROR_TEXT = "An error occurred while syncing with the cloud. Please try again later.";
-
-const char* DOWNLOAD_CLOUD_AUDIO_ERROR_TITLE = "Error downloading audio from cloud";
-const char* DOWNLOAD_CLOUD_AUDIO_ERROR_TEXT = "Can't download audio from cloud.";
-}
-
 void ProjectActionsController::handleCloudOpenError(const muse::Ret& error, const io::path_t& localPath)
 {
     using Err = au::au3cloud::Err;
     const auto err = static_cast<Err>(error.code());
 
-    switch (err) {
-    case Err::SyncResultConnectionFailed:
-    case Err::SyncResultUnexpectedResponse:
-    case Err::SyncResultInternalClientError:
-    case Err::SyncResultInternalServerError:
-    case Err::SyncResultSyncImpossible:
-    case Err::SyncResultCancelled: {
-        if (fileSystem()->exists(localPath)) {
-            doOpenProject(localPath);
-            toastService()->showError(
-                trc("project", OPEN_SYNC_ERROR_TITLE),
-                trc("project", OPEN_SYNC_ERROR_MESSAGE));
-        } else {
-            interactive()->infoSync(trc("project", OPEN_SYNC_ERROR_TITLE), trc("project", OPEN_SYNC_ERROR_NO_LOCAL_FILE_MESSAGE));
-        }
-        break;
+    if (err == Err::SyncResultNotFound && fileSystem()->exists(localPath)) {
+        doOpenProject(localPath);
     }
-    case Err::SyncResultNotFound: {
-        if (fileSystem()->exists(localPath)) {
-            doOpenProject(localPath);
-            const int saveLocallyBtn = static_cast<int>(muse::IInteractive::Button::CustomButton);
-            const int saveToCloudBtn = static_cast<int>(muse::IInteractive::Button::CustomButton) + 1;
-            muse::IInteractive::ButtonDatas buttons {
-                interactive()->buttonData(IInteractive::Button::Cancel),
-                muse::IInteractive::ButtonData(saveLocallyBtn, muse::trc("project",
-                                                                         "Save to computer"), false, false,
-                                               muse::IInteractive::ButtonRole::ApplyRole),
-                muse::IInteractive::ButtonData(saveToCloudBtn, muse::trc("cloud", "Save to audio.com"), /*accent=*/ true, false,
-                                               muse::IInteractive::ButtonRole::ApplyRole),
-            };
-            muse::IInteractive::Result result = interactive()->infoSync(OPEN_NOT_FOUND_ERROR_TITLE, OPEN_NOT_FOUND_ERROR_MESSAGE,
-                                                                        buttons, saveToCloudBtn, {},
-                                                                        muse::trc("cloud", "Save"));
-            if (result.isButton(saveLocallyBtn)) {
-                IAudacityProjectPtr project = currentProject();
-                if (!project) {
-                    break;
-                }
 
-                const auto ret = openSaveProjectScenario()->askLocalPath(project, SaveMode::Save);
-                if (!ret.ret) {
-                    break;
-                }
+    const auto ret = openSaveProjectScenario()->showCloudOpenError(error, localPath);
 
-                const auto newPath = ret.val;
-                if (newPath.empty()) {
-                    break;
-                }
-
-                saveProjectLocally(newPath, SaveMode::Save);
-                fileSystem()->remove(localPath);
-            } else if (result.isButton(saveToCloudBtn)) {
-                IAudacityProjectPtr project = currentProject();
-                if (!project) {
-                    break;
-                }
-
-                saveProjectToCloud(CloudProjectInfo { QUrl {}, {}, project->displayName() }, SaveMode::Save);
-            }
-        } else {
-            interactive()->infoSync(
-                trc("project", OPEN_NOT_FOUND_ERROR_TITLE),
-                trc("project", OPEN_NOT_FOUND_ERROR_NO_LOCAL_FILE_MESSAGE));
+    switch (ret.code()) {
+    case IOpenSaveProjectScenario::RET_CODE_OPEN_LOCAL:
+        doOpenProject(localPath);
+        break;
+    case IOpenSaveProjectScenario::RET_CODE_SAVE_LOCALLY_AND_REMOVE_CACHE: {
+        IAudacityProjectPtr project = currentProject();
+        if (!project) {
+            break;
         }
-        break;
-    }
-    case Err::SyncResultForbidden: {
-        if (fileSystem()->exists(localPath)) {
-            doOpenProject(localPath);
-            toastService()->showError(
-                trc("project", OPEN_FORBIDDEN_TITLE),
-                trc("project", OPEN_FORBIDDEN_MESSAGE));
-        } else {
-            interactive()->infoSync(trc("project", OPEN_FORBIDDEN_TITLE),
-                                    trc("project", OPEN_FORBIDDEN_NO_LOCAL_FILE_MESSAGE));
+        const auto askRet = openSaveProjectScenario()->askLocalPath(project, SaveMode::Save);
+        if (!askRet.ret || askRet.val.empty()) {
+            break;
         }
+        saveProjectLocally(askRet.val, SaveMode::Save);
+        fileSystem()->remove(localPath);
         break;
     }
-    case Err::SyncResultConflict: {
-        const int useLocalBtn = static_cast<int>(muse::IInteractive::Button::CustomButton);
-        const int useRemoteBtn = static_cast<int>(muse::IInteractive::Button::CustomButton) + 1;
-        muse::IInteractive::ButtonDatas buttons {
-            interactive()->buttonData(IInteractive::Button::Cancel),
-            muse::IInteractive::ButtonData(useLocalBtn, muse::trc("project", OPEN_CONFLICT_LOCAL_BTN), false, false,
-                                           muse::IInteractive::ButtonRole::ApplyRole),
-            muse::IInteractive::ButtonData(useRemoteBtn, muse::trc("project", OPEN_CONFLICT_REMOTE_BTN), /*accent=*/ true, false,
-                                           muse::IInteractive::ButtonRole::ApplyRole),
-        };
-        auto conflictResult = interactive()->infoSync(
-            trc("project", OPEN_CONFLICT_TITLE),
-            trc("project", OPEN_CONFLICT_MESSAGE),
-            buttons, useRemoteBtn);
-        if (conflictResult.isButton(useLocalBtn)) {
-            doOpenProject(localPath);
-        } else if (conflictResult.isButton(useRemoteBtn)) {
-            const bool forceOverwrite = true;
-            openCloudProject(localPath, {}, forceOverwrite);
+    case IOpenSaveProjectScenario::RET_CODE_SAVE_TO_CLOUD: {
+        IAudacityProjectPtr project = currentProject();
+        if (!project) {
+            break;
         }
+        saveProjectToCloud(CloudProjectInfo { QUrl {}, {}, project->displayName() }, SaveMode::Save);
         break;
     }
-    case Err::Cancelled:
-    case Err::OpenProjectCancelled:
+    case IOpenSaveProjectScenario::RET_CODE_OPEN_CLOUD_FORCE:
+        openCloudProject(localPath, {}, true);
         break;
-    default: {
-        interactive()->infoSync(trc("project", OPEN_DEFAULT_ERROR_TITLE), trc("project", OPEN_DEFAULT_ERROR_MESSAGE));
+    default:
         break;
-    }
     }
 }
 
@@ -1405,151 +1270,45 @@ void ProjectActionsController::handleCloudSaveError(const muse::Ret& error)
         return;
     }
 
-    using Err = au::au3cloud::Err;
-    const auto err = static_cast<Err>(error.code());
+    const auto ret = openSaveProjectScenario()->showCloudSaveError(error);
 
-    switch (err) {
-    case Err::ProjectLimitReached:
-    case Err::ProjectStorageLimitReached: {
-        const int saveLocallyBtn = int(muse::IInteractive::Button::Save);
-        muse::IInteractive::ButtonDatas buttons {
-            interactive()->buttonData(IInteractive::Button::Cancel),
-            muse::IInteractive::ButtonData(saveLocallyBtn, muse::trc("project", "Save to computer"), /*accent=*/ true),
-        };
-
-        const char* title = err == Err::ProjectLimitReached ? PRJ_LIMIT_REACHED_TITLE : PRJ_SIZE_EXCEEDED_TITLE;
-        const char* text = err == Err::ProjectLimitReached ? PRJ_LIMIT_REACHED_TEXT : PRJ_SIZE_EXCEEDED_TEXT;
-
-        muse::IInteractive::Result result = interactive()->infoSync(title, text, buttons, saveLocallyBtn, {},
-                                                                    muse::trc("cloud", "Save to audio.com"));
-        if (result.isButton(muse::IInteractive::Button::Save)) {
-            const auto ret = openSaveProjectScenario()->askLocalPath(project, SaveMode::Save);
-            if (!ret.ret) {
-                break;
-            }
-
-            const auto localPath = ret.val;
-            if (localPath.empty()) {
-                break;
-            }
-
-            saveProjectLocally(localPath, SaveMode::Save);
+    switch (ret.code()) {
+    case IOpenSaveProjectScenario::RET_CODE_SAVE_LOCALLY: {
+        const auto askRet = openSaveProjectScenario()->askLocalPath(project, SaveMode::Save);
+        if (!askRet.ret || askRet.val.empty()) {
+            break;
         }
-    }
-    break;
-    case Err::ProjectNotFound: {
-        const auto localPath = project->path();
-
-        const int saveLocallyBtn = static_cast<int>(muse::IInteractive::Button::CustomButton);
-        const int saveToCloudBtn = static_cast<int>(muse::IInteractive::Button::CustomButton) + 1;
-        muse::IInteractive::ButtonDatas buttons {
-            interactive()->buttonData(IInteractive::Button::Cancel),
-            muse::IInteractive::ButtonData(saveLocallyBtn, muse::trc("project",
-                                                                     "Save to computer"), false, false,
-                                           muse::IInteractive::ButtonRole::ApplyRole),
-            muse::IInteractive::ButtonData(saveToCloudBtn, muse::trc("cloud", "Save to audio.com"), /*accent=*/ true, false,
-                                           muse::IInteractive::ButtonRole::ApplyRole),
-        };
-        muse::IInteractive::Result result = interactive()->infoSync(CLOUD_SAVE_UNAVAILABLE_TITLE, CLOUD_SAVE_UNAVAILABLE_TEXT,
-                                                                    buttons, saveToCloudBtn, {},
-                                                                    muse::trc("cloud", "Save"));
-        if (result.isButton(saveLocallyBtn)) {
-            const auto ret = openSaveProjectScenario()->askLocalPath(project, SaveMode::Save);
-            if (!ret.ret) {
-                break;
-            }
-
-            const auto newPath = ret.val;
-            if (newPath.empty()) {
-                break;
-            }
-
-            saveProjectLocally(newPath, SaveMode::Save);
-            fileSystem()->remove(localPath);
-        } else if (result.isButton(saveToCloudBtn)) {
-            saveProjectToCloud(CloudProjectInfo { QUrl {}, {}, project->displayName() }, SaveMode::Save);
-        }
-    }
-    break;
-    case Err::ProjectVersionConflict: {
-        const int useLocalBtn = static_cast<int>(muse::IInteractive::Button::CustomButton);
-        const int useRemoteBtn = static_cast<int>(muse::IInteractive::Button::CustomButton) + 1;
-        muse::IInteractive::ButtonDatas buttons {
-            muse::IInteractive::ButtonData(useLocalBtn, muse::trc("project", SAVE_CONFLICT_LOCAL_BTN), /*accent=*/ true, false,
-                                           muse::IInteractive::ButtonRole::ApplyRole),
-            muse::IInteractive::ButtonData(useRemoteBtn, muse::trc("project", SAVE_CONFLICT_REMOTE_BTN), false, false,
-                                           muse::IInteractive::ButtonRole::ApplyRole),
-        };
-        auto conflictResult = interactive()->infoSync(
-            trc("project", SAVE_CONFLICT_TITLE),
-            trc("project", SAVE_CONFLICT_MESSAGE),
-            buttons, useLocalBtn);
-        if (conflictResult.isButton(useLocalBtn)) {
-            const bool forceOverwrite = true;
-            saveProjectToCloud(CloudProjectInfo { QUrl {}, {}, project->displayName() }, SaveMode::Save, forceOverwrite);
-        } else if (conflictResult.isButton(useRemoteBtn)) {
-            const io::path_t localPath = project->path();
-            closeOpenedProject(false);
-            const bool forceOverwrite = true;
-            openCloudProject(localPath, {}, forceOverwrite);
-        }
+        saveProjectLocally(askRet.val, SaveMode::Save);
         break;
     }
-    case Err::ProjectForbidden:
-    case Err::SyncResultForbidden: {
-        const int saveLocallyBtn = static_cast<int>(muse::IInteractive::Button::CustomButton);
-        muse::IInteractive::ButtonDatas buttons {
-            interactive()->buttonData(IInteractive::Button::Cancel),
-            muse::IInteractive::ButtonData(saveLocallyBtn, muse::trc("project", "Save to computer"), /*accent=*/ true, false,
-                                           muse::IInteractive::ButtonRole::ApplyRole),
-        };
-        muse::IInteractive::Result result = interactive()->infoSync(
-            trc("project", SAVE_FORBIDDEN_TITLE),
-            trc("project", SAVE_FORBIDDEN_MESSAGE),
-            buttons, saveLocallyBtn);
-        if (result.isButton(saveLocallyBtn)) {
-            const auto ret = openSaveProjectScenario()->askLocalPath(project, SaveMode::Save);
-            if (!ret.ret) {
-                break;
-            }
-
-            const auto newPath = ret.val;
-            if (newPath.empty()) {
-                break;
-            }
-
-            saveProjectLocally(newPath, SaveMode::Save);
+    case IOpenSaveProjectScenario::RET_CODE_SAVE_LOCALLY_AND_REMOVE_CACHE: {
+        const auto oldPath = project->path();
+        const auto askRet = openSaveProjectScenario()->askLocalPath(project, SaveMode::Save);
+        if (!askRet.ret || askRet.val.empty()) {
+            break;
         }
+        saveProjectLocally(askRet.val, SaveMode::Save);
+        fileSystem()->remove(oldPath);
         break;
     }
-    case Err::NetworkError:
-    case Err::DataUploadFailed:
-    case Err::ServerError:
-    case Err::ClientFailure:
-    case Err::UploadFailed:
-    case Err::SyncCancelled:
-        interactive()->infoSync(DEFAULT_SYNC_ERROR_TITLE, DEFAULT_SYNC_ERROR_TEXT);
+    case IOpenSaveProjectScenario::RET_CODE_SAVE_TO_CLOUD:
+        saveProjectToCloud(CloudProjectInfo { QUrl {}, {}, project->displayName() }, SaveMode::Save);
         break;
+    case IOpenSaveProjectScenario::RET_CODE_SAVE_TO_CLOUD_FORCE:
+        saveProjectToCloud(CloudProjectInfo { QUrl {}, {}, project->displayName() }, SaveMode::Save, true);
+        break;
+    case IOpenSaveProjectScenario::RET_CODE_CLOSE_AND_OPEN_CLOUD_FORCE: {
+        const io::path_t localPath = project->path();
+        closeOpenedProject(false);
+        openCloudProject(localPath, {}, true);
+        break;
+    }
     default:
-        interactive()->infoSync(DEFAULT_CLOUD_ERROR_TITLE, DEFAULT_CLOUD_ERROR_TEXT);
         break;
     }
 }
 
 void ProjectActionsController::handleCloudAudioOpenError(const muse::Ret& error)
 {
-    using Err = au::au3cloud::Err;
-    const auto err = static_cast<Err>(error.code());
-
-    switch (err) {
-    case Err::DownloadAudioResultFailed:
-        interactive()->infoSync(muse::trc("cloud", DOWNLOAD_CLOUD_AUDIO_ERROR_TITLE),
-                                muse::trc("cloud", DOWNLOAD_CLOUD_AUDIO_ERROR_TEXT));
-        break;
-    case Err::DownloadAudioResultCancelled:
-        break;
-    default:
-        interactive()->infoSync(muse::trc("cloud", "Open audio from cloud"), error.toString());
-        break;
-    }
+    openSaveProjectScenario()->showCloudAudioOpenError(error);
 }

--- a/src/project/internal/projectactionscontroller.cpp
+++ b/src/project/internal/projectactionscontroller.cpp
@@ -1109,7 +1109,7 @@ void ProjectActionsController::openCloudAudioFile(const muse::actions::ActionQue
         return;
     }
 
-    auto progress = audioComService()->openAudioFile(audioId);
+    auto progress = audioComService()->downloadAudioFile(audioId);
     if (!progress) {
         return;
     }

--- a/src/project/internal/projectactionscontroller.cpp
+++ b/src/project/internal/projectactionscontroller.cpp
@@ -470,6 +470,11 @@ bool ProjectActionsController::saveProjectToCloud(const CloudProjectInfo& cloudI
         return saveProjectLocally(projectFilePath, SaveMode::Save);
     }, forceOverwrite);
 
+    if (!progress) {
+        LOGE() << "Failed to start cloud upload";
+        return false;
+    }
+
     progress->finished().onReceive(this, [this, exists, projectFilePath](const ProgressResult& result) {
         if (result.ret.success()) {
             if (exists) {
@@ -812,6 +817,10 @@ Ret ProjectActionsController::openCloudProject(const io::path_t& localPath, cons
     }
 
     muse::ProgressPtr progress = audioComService()->openCloudProject(localPath, projectId.toStdString(), forceOverwrite);
+    if (!progress) {
+        return make_ret(Ret::Code::UnknownError);
+    }
+
     progress->finished().onReceive(this, [this, localPath](const ProgressResult& result) {
         if (!result.ret) {
             handleCloudOpenError(result.ret, localPath);
@@ -1046,6 +1055,10 @@ void ProjectActionsController::shareAudio()
     }
 
     auto progress = audioComService()->shareAudio(title);
+    if (!progress) {
+        return;
+    }
+
     progress->finished().onReceive(this, [this](const ProgressResult& result) {
         if (result.ret.success()) {
             const bool dismissable = false;
@@ -1084,6 +1097,9 @@ void ProjectActionsController::openCloudAudioFile(const muse::actions::ActionQue
 {
     const auto audioId = query.param("audioId").toString();
     auto progress = audioComService()->openAudioFile(audioId);
+    if (!progress) {
+        return;
+    }
 
     progress->finished().onReceive(this, [this, audioId](const ProgressResult& result) {
         if (!result.ret) {

--- a/src/project/internal/projectactionscontroller.cpp
+++ b/src/project/internal/projectactionscontroller.cpp
@@ -1125,7 +1125,9 @@ void ProjectActionsController::openCloudAudioFile(const muse::actions::ActionQue
             return;
         }
 
-        newproject->import(muse::io::path_t(result.val.toQString()));
+        const muse::io::path_t audioPath(result.val.toQString());
+        newproject->import(audioPath);
+        fileSystem()->remove(audioPath);
         openPageIfNeed(PROJECT_PAGE_URI);
     });
 

--- a/src/project/internal/projectactionscontroller.cpp
+++ b/src/project/internal/projectactionscontroller.cpp
@@ -468,7 +468,6 @@ bool ProjectActionsController::saveProjectToCloud(const CloudProjectInfo& cloudI
     }
 
     io::path_t projectFilePath = cloudProjectsPath.appendingComponent(cloudInfo.name).appendingSuffix(au::project::AUP4);
-    bool exists = io::FileInfo::exists(projectFilePath);
 
     IAudacityProjectPtr project = currentProject();
     if (!project) {
@@ -490,13 +489,9 @@ bool ProjectActionsController::saveProjectToCloud(const CloudProjectInfo& cloudI
         return false;
     }
 
-    progress->finished().onReceive(this, [this, exists, projectFilePath](const ProgressResult& result) {
+    progress->finished().onReceive(this, [this, projectFilePath](const ProgressResult& result) {
         if (!result.ret.success()) {
             handleCloudSaveError(result.ret);
-            return;
-        }
-
-        if (exists) {
             return;
         }
 

--- a/src/project/internal/projectactionscontroller.cpp
+++ b/src/project/internal/projectactionscontroller.cpp
@@ -1106,16 +1106,17 @@ void ProjectActionsController::openCloudAudioFile(const muse::actions::ActionQue
         return;
     }
 
-    progress->finished().onReceive(this, [this, audioId](const ProgressResult& result) {
+    progress->finished().onReceive(this, [this](const ProgressResult& result) {
         if (!result.ret) {
             handleCloudAudioOpenError(result.ret);
             return;
         }
 
+        const auto localPath = result.val.toQString();
         const auto project = globalContext()->currentProject();
         if (project) {
             QStringList args;
-            args << "--session-type" << "start-with-new" << result.val.toQString();
+            args << "--session-type" << "start-with-new" << localPath;
             multiwindowsProvider()->openNewWindow(args);
             return;
         }
@@ -1125,9 +1126,13 @@ void ProjectActionsController::openCloudAudioFile(const muse::actions::ActionQue
             return;
         }
 
-        const muse::io::path_t audioPath(result.val.toQString());
-        newproject->import(audioPath);
-        fileSystem()->remove(audioPath);
+        const auto importRet = newproject->import(muse::io::paths_t { localPath });
+        fileSystem()->remove(localPath);
+        if (!importRet) {
+            LOGE() << importRet.toString();
+            return;
+        }
+
         openPageIfNeed(PROJECT_PAGE_URI);
     });
 
@@ -1524,7 +1529,7 @@ void ProjectActionsController::handleCloudAudioOpenError(const muse::Ret& error)
     const auto err = static_cast<Err>(error.code());
 
     switch (err) {
-    case Err::DownloadAudioResultCancel:
+    case Err::DownloadAudioResultCancelled:
         break;
     default:
         interactive()->error(muse::trc("cloud", "Open audio from cloud"), error.toString());

--- a/src/project/internal/projectactionscontroller.h
+++ b/src/project/internal/projectactionscontroller.h
@@ -115,7 +115,7 @@ private:
 
     muse::Ret openPageIfNeed(muse::Uri pageUri);
 
-    void handleCloudOpenError(const muse::Ret& error, const muse::io::path_t& localPath);
+    void handleCloudOpenError(const muse::Ret& error, const muse::io::path_t& localPath, const std::string& cloudProjectId = {});
     void handleCloudAudioOpenError(const muse::Ret& error);
     void handleCloudSaveError(const muse::Ret& error);
 

--- a/src/project/internal/projectactionscontroller.h
+++ b/src/project/internal/projectactionscontroller.h
@@ -119,6 +119,7 @@ private:
     void handleCloudSaveError(const muse::Ret& error);
 
     void shareAudio();
+    void openCloudAudioFile(const muse::actions::ActionQuery& query);
 
     void openCustomFFmpegOptions();
     void openMetadataDialog();

--- a/src/project/internal/projectactionscontroller.h
+++ b/src/project/internal/projectactionscontroller.h
@@ -116,6 +116,7 @@ private:
     muse::Ret openPageIfNeed(muse::Uri pageUri);
 
     void handleCloudOpenError(const muse::Ret& error, const muse::io::path_t& localPath);
+    void handleCloudAudioOpenError(const muse::Ret& error);
     void handleCloudSaveError(const muse::Ret& error);
 
     void shareAudio();

--- a/src/project/internal/projectuiactions.cpp
+++ b/src/project/internal/projectuiactions.cpp
@@ -29,17 +29,11 @@ const UiActionList ProjectUiActions::m_actions = {
              TranslatableString("action", "&Open…"),
              TranslatableString("action", "Open…")
              ),
-    UiAction("cloud-file-open",
-             au::context::UiCtxAny,
-             au::context::CTX_ANY,
-             TranslatableString("action", "&Open cloud project…"),
-             TranslatableString("action", "Open cloud project…")
-             ),
-    UiAction("cloud-audio-open",
+    UiAction("audacity://cloud/open-audio-file",
              au::context::UiCtxAny,
              au::context::CTX_ANY,
              TranslatableString("action", "Open"),
-             TranslatableString("action", "Open cloud audio")
+             TranslatableString("action", "Open")
              ),
     UiAction("clear-recent",
              au::context::UiCtxAny,

--- a/src/project/projectmodule.cpp
+++ b/src/project/projectmodule.cpp
@@ -40,6 +40,7 @@
 #include "view/cloudaudiofilesmodel.h"
 #include "view/cloudaudiofilecontextmenumodel.h"
 #include "view/projectthumbnailloader.h"
+#include "view/thumbnailloader.h"
 #include "view/pixmapprojectthumbnailview.h"
 #include "view/newprojectmodel.h"
 #include "internal/opensaveprojectscenario.h"
@@ -109,6 +110,7 @@ void ProjectModule::registerUiTypes()
     qmlRegisterType<CloudAudioFileContextMenuModel>("Audacity.Project", 1, 0, "CloudAudioFileContextMenuModel");
     qmlRegisterType<NewProjectModel>("Audacity.Project", 1, 0, "NewProjectModel");
     qmlRegisterType<ProjectThumbnailLoader>("Audacity.Project", 1, 0, "ProjectThumbnailLoader");
+    qmlRegisterType<ThumbnailLoader>("Audacity.Project", 1, 0, "ThumbnailLoader");
     qmlRegisterType<PixmapProjectThumbnailView>("Audacity.Project", 1, 0, "PixmapProjectThumbnailView");
     qmlRegisterType<ProjectPropertiesModel>("Audacity.Project", 1, 0, "ProjectPropertiesModel");
 

--- a/src/project/qml/Audacity/Project/ProjectsGridView.qml
+++ b/src/project/qml/Audacity/Project/ProjectsGridView.qml
@@ -170,9 +170,7 @@ Item {
                         root.createNewProjectRequested()
                     } else if (!isNoResultsFound) {
                         if (item.isCloud) {
-                            var projectId = item.itemId ?? ""
-                            console.log("Open cloud project requested for project ID: " + projectId + ", path: " + item.path + ", name: " + item.name)
-                            root.openCloudProjectRequested(projectId, item.path, item.name)
+                            root.openCloudProjectRequested(item.itemId, item.path, item.name)
                         } else {
                             root.openProjectRequested(item.path, item.name)
                         }

--- a/src/project/qml/Audacity/Project/ProjectsGridView.qml
+++ b/src/project/qml/Audacity/Project/ProjectsGridView.qml
@@ -158,7 +158,7 @@ Item {
 
                 name: item.name
                 path: item.path ?? ""
-                suffix: item.suffix ?? ""
+                thumbnailUrl: item.thumbnailUrl ?? ""
                 isCreateNew: item.isCreateNew
                 isNoResultsFound: item.isNoResultsFound
                 isCloud: item.isCloud

--- a/src/project/qml/Audacity/Project/ProjectsGridView.qml
+++ b/src/project/qml/Audacity/Project/ProjectsGridView.qml
@@ -171,6 +171,7 @@ Item {
                     } else if (!isNoResultsFound) {
                         if (item.isCloud) {
                             var projectId = item.itemId ?? ""
+                            console.log("Open cloud project requested for project ID: " + projectId + ", path: " + item.path + ", name: " + item.name)
                             root.openCloudProjectRequested(projectId, item.path, item.name)
                         } else {
                             root.openProjectRequested(item.path, item.name)

--- a/src/project/qml/Audacity/Project/ProjectsListView.qml
+++ b/src/project/qml/Audacity/Project/ProjectsListView.qml
@@ -49,6 +49,7 @@ Item {
 
     signal createNewProjectRequested
     signal openProjectRequested(var projectPath, var displayName)
+    signal openCloudProjectRequested(var projectId, var projectPath, var displayName)
 
     component ColumnItem: QtObject {
         property string header
@@ -234,7 +235,11 @@ Item {
                         navigation.column: 0
 
                         onClicked: {
-                            root.openProjectRequested(item.path, item.name)
+                            if (item.isCloud) {
+                                root.openCloudProjectRequested(item.itemId, item.path, item.name)
+                            } else {
+                                root.openProjectRequested(item.path, item.name)
+                            }
                         }
                     }
                 }

--- a/src/project/qml/Audacity/Project/ProjectsListView.qml
+++ b/src/project/qml/Audacity/Project/ProjectsListView.qml
@@ -43,6 +43,8 @@ Item {
 
     property bool isCloudList: false
 
+    property bool thumbnailFull: false
+
     property alias view: view
 
     property alias navigation: navPanel
@@ -100,6 +102,8 @@ Item {
             visible: false
             itemInset: view.itemInset
             showBottomBorder: false
+
+            thumbnailFull: root.thumbnailFull
 
             navigation.panel: navPanel
             navigation.row: 0
@@ -227,6 +231,7 @@ Item {
                         columnSpacing: view.columnSpacing
 
                         isCloudItem: root.isCloudList
+                        thumbnailFull: root.thumbnailFull
 
                         placeholder: root.placeholder
 

--- a/src/project/qml/Audacity/Project/ProjectsPage.qml
+++ b/src/project/qml/Audacity/Project/ProjectsPage.qml
@@ -348,10 +348,9 @@ FocusScope {
                 })
                 item.navigationSection = navSec
                 item.navigationOrder = 6
-            }
-
-            onOpenCloudAudioFileRequested: function (cloudItemId) {
-                Qt.callLater(projectsPageModel.openCloudAudioFile, cloudItemId)
+                item.openCloudAudioFileRequested.connect(function (cloudItemId) {
+                    Qt.callLater(projectsPageModel.openCloudAudioFile, cloudItemId)
+                })
             }
 
             Connections {

--- a/src/project/qml/Audacity/Project/ProjectsPage.qml
+++ b/src/project/qml/Audacity/Project/ProjectsPage.qml
@@ -350,6 +350,10 @@ FocusScope {
                 item.navigationOrder = 6
             }
 
+            onOpenCloudAudioFileRequested: function (cloudItemId) {
+                Qt.callLater(projectsPageModel.openCloudAudioFile, cloudItemId)
+            }
+
             Connections {
                 target: refreshButton
                 function onClicked() {

--- a/src/project/qml/Audacity/Project/ProjectsView.qml
+++ b/src/project/qml/Audacity/Project/ProjectsView.qml
@@ -41,4 +41,5 @@ Loader {
     signal createNewProjectRequested
     signal openProjectRequested(var projectPath, var displayName)
     signal openCloudProjectRequested(var projectId, var projectPath, var displayName)
+    signal openCloudAudioFileRequested(var cloudItemId)
 }

--- a/src/project/qml/Audacity/Project/internal/ProjectsPage/CloudAudioFilesView.qml
+++ b/src/project/qml/Audacity/Project/internal/ProjectsPage/CloudAudioFilesView.qml
@@ -140,7 +140,7 @@ ProjectsView {
             navigation.name: "CloudAudioFilesGrid"
             navigation.accessible.name: qsTrc("project", "Cloud audio files grid")
 
-            onOpenCloudProjectRequested: function (id, _, _) {
+            onOpenCloudProjectRequested: function (id, _slug, _path) {
                 root.openCloudAudioFileRequested(id)
             }
         }
@@ -166,7 +166,7 @@ ProjectsView {
             navigation.order: root.navigationOrder
             navigation.name: "CloudAudioFilesList"
 
-            onOpenCloudProjectRequested: function (id, _, _) {
+            onOpenCloudProjectRequested: function (id, _slug, _path) {
                 root.openCloudAudioFileRequested(id)
             }
 

--- a/src/project/qml/Audacity/Project/internal/ProjectsPage/CloudAudioFilesView.qml
+++ b/src/project/qml/Audacity/Project/internal/ProjectsPage/CloudAudioFilesView.qml
@@ -160,7 +160,6 @@ ProjectsView {
             backgroundColor: root.backgroundColor
             sideMargin: root.sideMargin
 
-            isCloudList: true
             thumbnailFull: true
 
             navigation.section: root.navigationSection

--- a/src/project/qml/Audacity/Project/internal/ProjectsPage/CloudAudioFilesView.qml
+++ b/src/project/qml/Audacity/Project/internal/ProjectsPage/CloudAudioFilesView.qml
@@ -43,7 +43,7 @@ ProjectsView {
 
     QtObject {
         id: prv
-        property string gridPlaceholderFile: "qrc:/resources/AudioFilePlaceholder.svg"
+        property string gridPlaceholderFile: ":/resources/AudioFilePlaceholder.svg"
         property bool updateDesiredRowCountScheduled: false
 
         readonly property var activeView: root.item

--- a/src/project/qml/Audacity/Project/internal/ProjectsPage/CloudAudioFilesView.qml
+++ b/src/project/qml/Audacity/Project/internal/ProjectsPage/CloudAudioFilesView.qml
@@ -140,8 +140,9 @@ ProjectsView {
             navigation.name: "CloudAudioFilesGrid"
             navigation.accessible.name: qsTrc("project", "Cloud audio files grid")
 
-            //onCreateNewProjectRequested: {}
-            //onOpenProjectRequested: function(projectPath, displayName) {}
+            onOpenCloudProjectRequested: function (id, _, _) {
+                cloudAudioFilesModel.openAudioFile(id)
+            }
         }
     }
 

--- a/src/project/qml/Audacity/Project/internal/ProjectsPage/CloudAudioFilesView.qml
+++ b/src/project/qml/Audacity/Project/internal/ProjectsPage/CloudAudioFilesView.qml
@@ -161,6 +161,7 @@ ProjectsView {
             sideMargin: root.sideMargin
 
             isCloudList: true
+            thumbnailFull: true
 
             navigation.section: root.navigationSection
             navigation.order: root.navigationOrder

--- a/src/project/qml/Audacity/Project/internal/ProjectsPage/CloudAudioFilesView.qml
+++ b/src/project/qml/Audacity/Project/internal/ProjectsPage/CloudAudioFilesView.qml
@@ -166,6 +166,10 @@ ProjectsView {
             navigation.order: root.navigationOrder
             navigation.name: "CloudAudioFilesList"
 
+            onOpenCloudProjectRequested: function (id, _, _) {
+                root.openCloudAudioFileRequested(id)
+            }
+
             columns: [
                 ProjectsListView.ColumnItem {
                     id: modifiedColumn

--- a/src/project/qml/Audacity/Project/internal/ProjectsPage/CloudAudioFilesView.qml
+++ b/src/project/qml/Audacity/Project/internal/ProjectsPage/CloudAudioFilesView.qml
@@ -34,7 +34,7 @@ ProjectsView {
     }
 
     Connections {
-        target: root.item ? root.item.view : null
+        target: (root.item && root.item.view) ? root.item.view : null
 
         function onContentYChanged() {
             prv.updateDesiredRowCount()

--- a/src/project/qml/Audacity/Project/internal/ProjectsPage/CloudAudioFilesView.qml
+++ b/src/project/qml/Audacity/Project/internal/ProjectsPage/CloudAudioFilesView.qml
@@ -141,7 +141,7 @@ ProjectsView {
             navigation.accessible.name: qsTrc("project", "Cloud audio files grid")
 
             onOpenCloudProjectRequested: function (id, _, _) {
-                cloudAudioFilesModel.openAudioFile(id)
+                root.openCloudAudioFileRequested(id)
             }
         }
     }

--- a/src/project/qml/Audacity/Project/internal/ProjectsPage/CloudAudioFilesView.qml
+++ b/src/project/qml/Audacity/Project/internal/ProjectsPage/CloudAudioFilesView.qml
@@ -299,6 +299,8 @@ ProjectsView {
 
                             CloudAudioFileContextMenuModel {
                                 id: contextMenuModel
+
+                                audioId: item.itemId ?? ""
                                 slug: item.slug ?? ""
                             }
 

--- a/src/project/qml/Audacity/Project/internal/ProjectsPage/CloudAudioFilesView.qml
+++ b/src/project/qml/Audacity/Project/internal/ProjectsPage/CloudAudioFilesView.qml
@@ -299,7 +299,7 @@ ProjectsView {
 
                             CloudAudioFileContextMenuModel {
                                 id: contextMenuModel
-                                cloudItemId: item.itemId
+                                slug: item.slug ?? ""
                             }
 
                             Component.onCompleted: contextMenuModel.load()

--- a/src/project/qml/Audacity/Project/internal/ProjectsPage/CloudAudioFilesView.qml
+++ b/src/project/qml/Audacity/Project/internal/ProjectsPage/CloudAudioFilesView.qml
@@ -108,8 +108,9 @@ ProjectsView {
             return notSignedInComp
         case CloudAudioFilesModel.Error:
             return errorComp
-        case CloudAudioFilesModel.Fine:
         case CloudAudioFilesModel.Loading:
+            return loadingComp
+        case CloudAudioFilesModel.Fine:
             break
         }
 
@@ -379,6 +380,25 @@ ProjectsView {
 
                 title: qsTrc("project", "You are not signed in")
                 body: qsTrc("project", "Please sign in to view your online files")
+            }
+        }
+    }
+
+    Component {
+        id: loadingComp
+
+        Item {
+            anchors.fill: parent
+
+            Message {
+                anchors.top: parent.top
+                anchors.topMargin: Math.max(parent.height / 3 - height / 2, 0)
+                anchors.left: parent.left
+                anchors.leftMargin: root.sideMargin
+                anchors.right: parent.right
+                anchors.rightMargin: root.sideMargin
+
+                title: qsTrc("global", "Loading...")
             }
         }
     }

--- a/src/project/qml/Audacity/Project/internal/ProjectsPage/CloudAudioFilesView.qml
+++ b/src/project/qml/Audacity/Project/internal/ProjectsPage/CloudAudioFilesView.qml
@@ -390,15 +390,11 @@ ProjectsView {
         Item {
             anchors.fill: parent
 
-            Message {
-                anchors.top: parent.top
-                anchors.topMargin: Math.max(parent.height / 3 - height / 2, 0)
-                anchors.left: parent.left
-                anchors.leftMargin: root.sideMargin
-                anchors.right: parent.right
-                anchors.rightMargin: root.sideMargin
-
-                title: qsTrc("global", "Loading...")
+            StyledBusyIndicator {
+                anchors.centerIn: parent
+                width: 40
+                height: 40
+                running: true
             }
         }
     }

--- a/src/project/qml/Audacity/Project/internal/ProjectsPage/CloudProjectIndicatorButton.qml
+++ b/src/project/qml/Audacity/Project/internal/ProjectsPage/CloudProjectIndicatorButton.qml
@@ -51,7 +51,7 @@ Item {
         enabled: root.enabled && root.visible
 
         accessible.role: MUAccessible.Button
-        accessible.name: prv.toolTipText
+        //accessible.name: prv.toolTipText
         accessible.visualItem: root
         accessible.enabled: navCtrl.enabled
 

--- a/src/project/qml/Audacity/Project/internal/ProjectsPage/CloudProjectsView.qml
+++ b/src/project/qml/Audacity/Project/internal/ProjectsPage/CloudProjectsView.qml
@@ -318,15 +318,11 @@ ProjectsView {
         Item {
             anchors.fill: parent
 
-            Message {
-                anchors.top: parent.top
-                anchors.topMargin: Math.max(parent.height / 3 - height / 2, 0)
-                anchors.left: parent.left
-                anchors.leftMargin: root.sideMargin
-                anchors.right: parent.right
-                anchors.rightMargin: root.sideMargin
-
-                title: qsTrc("global", "Loading...")
+            StyledBusyIndicator {
+                anchors.centerIn: parent
+                width: 40
+                height: 40
+                running: true
             }
         }
     }

--- a/src/project/qml/Audacity/Project/internal/ProjectsPage/CloudProjectsView.qml
+++ b/src/project/qml/Audacity/Project/internal/ProjectsPage/CloudProjectsView.qml
@@ -32,7 +32,7 @@ ProjectsView {
     }
 
     Connections {
-        target: root.item ? root.item.view : null
+        target: (root.item && root.item.view) ? root.item.view : null
 
         function onContentYChanged() {
             prv.updateDesiredRowCount()

--- a/src/project/qml/Audacity/Project/internal/ProjectsPage/CloudProjectsView.qml
+++ b/src/project/qml/Audacity/Project/internal/ProjectsPage/CloudProjectsView.qml
@@ -105,8 +105,9 @@ ProjectsView {
             return notSignedInComp
         case CloudProjectsModel.Error:
             return errorComp
-        case CloudProjectsModel.Fine:
         case CloudProjectsModel.Loading:
+            return loadingComp
+        case CloudProjectsModel.Fine:
             break
         }
 
@@ -307,6 +308,25 @@ ProjectsView {
 
                 title: qsTrc("project", "You are not signed in")
                 body: qsTrc("project", "Please sign in to view your online projects")
+            }
+        }
+    }
+
+    Component {
+        id: loadingComp
+
+        Item {
+            anchors.fill: parent
+
+            Message {
+                anchors.top: parent.top
+                anchors.topMargin: Math.max(parent.height / 3 - height / 2, 0)
+                anchors.left: parent.left
+                anchors.leftMargin: root.sideMargin
+                anchors.right: parent.right
+                anchors.rightMargin: root.sideMargin
+
+                title: qsTrc("global", "Loading...")
             }
         }
     }

--- a/src/project/qml/Audacity/Project/internal/ProjectsPage/CloudProjectsView.qml
+++ b/src/project/qml/Audacity/Project/internal/ProjectsPage/CloudProjectsView.qml
@@ -163,8 +163,9 @@ ProjectsView {
             navigation.name: "CloudProjectsList"
             navigation.accessible.name: qsTrc("project", "Cloud projects list")
 
-            //onCreateNewProjectRequested: {}
-            //onOpenProjectRequested: function(projectPath, displayName) {}
+            onOpenCloudProjectRequested: function (cloudItemId, projectPath, displayName) {
+                root.openCloudProjectRequested(cloudItemId, projectPath, displayName)
+            }
 
             columns: [
                 ProjectsListView.ColumnItem {

--- a/src/project/qml/Audacity/Project/internal/ProjectsPage/CloudProjectsView.qml
+++ b/src/project/qml/Audacity/Project/internal/ProjectsPage/CloudProjectsView.qml
@@ -153,6 +153,8 @@ ProjectsView {
             model: cloudProjectsModel
             searchText: root.searchText
 
+            isCloudList: true
+
             backgroundColor: root.backgroundColor
             sideMargin: root.sideMargin
 

--- a/src/project/qml/Audacity/Project/internal/ProjectsPage/ProjectGridItem.qml
+++ b/src/project/qml/Audacity/Project/internal/ProjectsPage/ProjectGridItem.qml
@@ -303,7 +303,7 @@ FocusScope {
             placeholder: root.placeholder
 
             backgroundColor: ui.theme.backgroundSecondaryColor
-            lineColor: Qt.rgba(ui.theme.fontPrimaryColor.r, ui.theme.fontPrimaryColor.g, ui.theme.fontPrimaryColor.b, 0.8)
+            lineColor: Qt.alpha(ui.theme.fontPrimaryColor, 0.8)
             borderColor: ui.theme.strokeColor
         }
     }

--- a/src/project/qml/Audacity/Project/internal/ProjectsPage/ProjectGridItem.qml
+++ b/src/project/qml/Audacity/Project/internal/ProjectsPage/ProjectGridItem.qml
@@ -32,6 +32,7 @@ FocusScope {
 
     property string name: ""
     property string path: ""
+    property string thumbnailUrl: ""
     property alias timeSinceModified: timeSinceModified.text
     property string placeholder: ""
     property bool isCreateNew: false
@@ -298,8 +299,7 @@ FocusScope {
         id: projectItemComp
 
         ProjectThumbnail {
-            path: root.path
-            suffix: root.suffix
+            path: root.thumbnailUrl
             placeholder: root.placeholder
 
             backgroundColor: ui.theme.backgroundSecondaryColor

--- a/src/project/qml/Audacity/Project/internal/ProjectsPage/ProjectGridItem.qml
+++ b/src/project/qml/Audacity/Project/internal/ProjectsPage/ProjectGridItem.qml
@@ -32,7 +32,6 @@ FocusScope {
 
     property string name: ""
     property string path: ""
-    property string suffix: ""
     property alias timeSinceModified: timeSinceModified.text
     property string placeholder: ""
     property bool isCreateNew: false

--- a/src/project/qml/Audacity/Project/internal/ProjectsPage/ProjectGridItem.qml
+++ b/src/project/qml/Audacity/Project/internal/ProjectsPage/ProjectGridItem.qml
@@ -301,6 +301,10 @@ FocusScope {
             path: root.path
             suffix: root.suffix
             placeholder: root.placeholder
+
+            backgroundColor: ui.theme.backgroundSecondaryColor
+            lineColor: Qt.rgba(ui.theme.fontPrimaryColor.r, ui.theme.fontPrimaryColor.g, ui.theme.fontPrimaryColor.b, 0.8)
+            borderColor: ui.theme.strokeColor
         }
     }
 }

--- a/src/project/qml/Audacity/Project/internal/ProjectsPage/ProjectListItem.qml
+++ b/src/project/qml/Audacity/Project/internal/ProjectsPage/ProjectListItem.qml
@@ -59,7 +59,7 @@ ListItemBlank {
         id: prv
 
         property color backgroundColor: root.thumbnailFull ? "transparent" : ui.theme.backgroundSecondaryColor
-        property color lineColor: Qt.rgba(ui.theme.fontPrimaryColor.r, ui.theme.fontPrimaryColor.g, ui.theme.fontPrimaryColor.b, 0.8)
+        property color lineColor: Qt.alpha(ui.theme.fontPrimaryColor, 0.8)
         property color borderColor: root.thumbnailFull ? "transparent" : ui.theme.strokeColor
     }
 
@@ -70,9 +70,9 @@ ListItemBlank {
             path: root.item.thumbnailUrl ?? ""
             placeholder: root.placeholder
 
-            backgroundColor: ui.theme.backgroundSecondaryColor
-            lineColor: Qt.rgba(ui.theme.fontPrimaryColor.r, ui.theme.fontPrimaryColor.g, ui.theme.fontPrimaryColor.b, 0.8)
-            borderColor: ui.theme.strokeColor
+            backgroundColor: prv.backgroundColor
+            lineColor: prv.lineColor
+            borderColor: prv.borderColor
         }
     }
 
@@ -117,11 +117,10 @@ ListItemBlank {
             Loader {
                 active: root.isCloudItem ?? false
                 visible: active
+                Layout.alignment: Qt.AlignTrailing | Qt.AlignVCenter
 
                 sourceComponent: CloudProjectIndicatorButton {
                     id: cloudIndicator
-
-                    Layout.alignment: Qt.AlignTrailing | Qt.AlignVCenter
 
                     isProgress: false //cloudProjectStatusWatcher.isProgress
                     isDownloadedAndUpToDate: true //cloudProjectStatusWatcher.isDownloadedAndUpToDate

--- a/src/project/qml/Audacity/Project/internal/ProjectsPage/ProjectListItem.qml
+++ b/src/project/qml/Audacity/Project/internal/ProjectsPage/ProjectListItem.qml
@@ -78,80 +78,42 @@ ListItemBlank {
 
             spacing: 24
 
+            StyledTextLabel {
+                id: projectName
+
+                Layout.preferredWidth: 200
+
+                text: root.item.name ?? ""
+                font: ui.theme.largeBodyFont
+                horizontalAlignment: Text.AlignLeft
+            }
+
             Loader {
-                active: !(root.isCloudItem ?? false)
-                visible: active
-                Layout.fillWidth: active
+                sourceComponent: root.thumbnailComponent
+            }
 
-                sourceComponent: RowLayout {
-                    spacing: 24
-
-                    Loader {
-                        Layout.preferredWidth: 71
-                        Layout.preferredHeight: 40
-
-                        sourceComponent: root.thumbnailComponent
-
-                        layer.enabled: true
-                        layer.effect: RoundedCornersEffect {
-                            radius: 2
-                        }
-                    }
-
-                    StyledTextLabel {
-                        Layout.fillWidth: true
-
-                        text: root.item.name ?? ""
-                        font: ui.theme.largeBodyFont
-                        horizontalAlignment: Text.AlignLeft
-                    }
-                }
+            Item {
+                Layout.fillWidth: true
             }
 
             Loader {
                 active: root.isCloudItem ?? false
                 visible: active
-                Layout.fillWidth: active
 
-                sourceComponent: RowLayout {
-                    visible: root.item.isCloud
-                    spacing: 24
+                sourceComponent: CloudProjectIndicatorButton {
+                    id: cloudIndicator
 
-                    StyledTextLabel {
-                        id: cloudProjectName
+                    Layout.alignment: Qt.AlignTrailing | Qt.AlignVCenter
 
-                        Layout.preferredWidth: 200
+                    isProgress: false //cloudProjectStatusWatcher.isProgress
+                    isDownloadedAndUpToDate: true //cloudProjectStatusWatcher.isDownloadedAndUpToDate
 
-                        text: root.item.name ?? ""
-                        font: ui.theme.largeBodyFont
-                        horizontalAlignment: Text.AlignLeft
-                    }
-
-                    Image {
-                        id: previewImage
-
-                        Layout.fillWidth: true
-
-                        source: "qrc:/resources/Waveform.svg"
-                        horizontalAlignment: Image.AlignLeft
-                        verticalAlignment: Image.AlignVCenter
-                    }
-
-                    CloudProjectIndicatorButton {
-                        id: cloudIndicator
-
-                        Layout.alignment: Qt.AlignTrailing | Qt.AlignVCenter
-
-                        isProgress: false //cloudProjectStatusWatcher.isProgress
-                        isDownloadedAndUpToDate: true //cloudProjectStatusWatcher.isDownloadedAndUpToDate
-
-                        navigation.panel: root.navigation.panel
-                        navigation.row: root.navigation.row
-                        navigation.column: 3
-                        navigation.onActiveChanged: {
-                            if (navigation.active) {
-                                root.scrollIntoView()
-                            }
+                    navigation.panel: root.navigation.panel
+                    navigation.row: root.navigation.row
+                    navigation.column: 3
+                    navigation.onActiveChanged: {
+                        if (navigation.active) {
+                            root.scrollIntoView()
                         }
                     }
                 }

--- a/src/project/qml/Audacity/Project/internal/ProjectsPage/ProjectListItem.qml
+++ b/src/project/qml/Audacity/Project/internal/ProjectsPage/ProjectListItem.qml
@@ -42,6 +42,7 @@ ListItemBlank {
     property string placeholder: ""
 
     property bool isCloudItem: false
+    property bool thumbnailFull: false
 
     implicitHeight: 64
 
@@ -89,10 +90,16 @@ ListItemBlank {
             }
 
             Loader {
+                Layout.fillWidth: root.thumbnailFull
+                Layout.fillHeight: root.thumbnailFull
+                Layout.preferredWidth: root.thumbnailFull ? -1 : 71
+                Layout.preferredHeight: root.thumbnailFull ? -1 : 40
+
                 sourceComponent: root.thumbnailComponent
             }
 
             Item {
+                visible: !root.thumbnailFull
                 Layout.fillWidth: true
             }
 

--- a/src/project/qml/Audacity/Project/internal/ProjectsPage/ProjectListItem.qml
+++ b/src/project/qml/Audacity/Project/internal/ProjectsPage/ProjectListItem.qml
@@ -55,6 +55,14 @@ ListItemBlank {
 
     focusBorder.anchors.bottomMargin: bottomBorder.visible ? bottomBorder.height : 0
 
+    QtObject {
+        id: prv
+
+        property color backgroundColor: root.thumbnailFull ? "transparent" : ui.theme.backgroundSecondaryColor
+        property color lineColor: Qt.rgba(ui.theme.fontPrimaryColor.r, ui.theme.fontPrimaryColor.g, ui.theme.fontPrimaryColor.b, 0.8)
+        property color borderColor: root.thumbnailFull ? "transparent" : ui.theme.strokeColor
+    }
+
     Component {
         id: defaultThumbnailComponent
 

--- a/src/project/qml/Audacity/Project/internal/ProjectsPage/ProjectListItem.qml
+++ b/src/project/qml/Audacity/Project/internal/ProjectsPage/ProjectListItem.qml
@@ -67,9 +67,12 @@ ListItemBlank {
         id: defaultThumbnailComponent
 
         ProjectThumbnail {
-            path: root.item.path ?? ""
-            suffix: root.item.suffix ?? ""
+            path: root.item.thumbnailUrl ?? ""
             placeholder: root.placeholder
+
+            backgroundColor: ui.theme.backgroundSecondaryColor
+            lineColor: Qt.rgba(ui.theme.fontPrimaryColor.r, ui.theme.fontPrimaryColor.g, ui.theme.fontPrimaryColor.b, 0.8)
+            borderColor: ui.theme.strokeColor
         }
     }
 

--- a/src/project/qml/Audacity/Project/internal/ProjectsPage/ProjectThumbnail.qml
+++ b/src/project/qml/Audacity/Project/internal/ProjectsPage/ProjectThumbnail.qml
@@ -38,6 +38,7 @@ Item {
         id: thumbnailLoader
         path: root.thumbnailUrl
         thumbnailSize: Qt.size(root.width, root.height)
+        backgroundColor: ui.theme.backgroundTertiaryColor
     }
 
     Loader {

--- a/src/project/qml/Audacity/Project/internal/ProjectsPage/ProjectThumbnail.qml
+++ b/src/project/qml/Audacity/Project/internal/ProjectsPage/ProjectThumbnail.qml
@@ -28,11 +28,8 @@ import Audacity.Project 1.0
 Item {
     id: root
 
-    property string path: ""
-    property string suffix: ""
-    property string placeholder: ""
-
-    readonly property bool isJsonThumbnail: root.thumbnailUrl.endsWith(".json")
+    property alias path: thumbnailLoader.path
+    property alias placeholder: thumbnailLoader.placeholder
 
     property alias backgroundColor: thumbnailLoader.backgroundColor
     property alias lineColor: thumbnailLoader.lineColor
@@ -45,31 +42,11 @@ Item {
         height: root.height
     }
 
-    Loader {
+    PixmapProjectThumbnailView {
+        id: pixmapThumbnail
+
         anchors.fill: parent
-        active: visible
 
-        sourceComponent: Rectangle {
-            anchors.fill: parent
-            color: ui.theme.backgroundSecondaryColor
-
-            Image {
-                anchors.centerIn: parent
-
-                width: parent.width / 2
-
-                source: {
-                    switch (root.suffix) {
-                    default:
-                        return root.placeholder || "qrc:/resources/ProjectPlaceholder.svg"
-                    }
-                }
-
-                fillMode: Image.PreserveAspectFit
-
-                // Prevent image from looking pixelated on low-res screens
-                mipmap: true
-            }
-        }
+        thumbnail: thumbnailLoader.thumbnail
     }
 }

--- a/src/project/qml/Audacity/Project/internal/ProjectsPage/ProjectThumbnail.qml
+++ b/src/project/qml/Audacity/Project/internal/ProjectsPage/ProjectThumbnail.qml
@@ -32,57 +32,38 @@ Item {
     property string suffix: ""
     property string placeholder: ""
 
-    ProjectThumbnailLoader {
-        id: thumbnailLoader
+    readonly property bool isJsonThumbnail: root.thumbnailUrl.endsWith(".json")
 
-        projectPath: root.path
+    ThumbnailLoader {
+        id: thumbnailLoader
+        path: root.thumbnailUrl
+        thumbnailSize: Qt.size(root.width, root.height)
     }
 
     Loader {
         anchors.fill: parent
         active: visible
 
-        sourceComponent: {
-            if (thumbnailLoader.isThumbnailValid) {
-                return projectThumbnailComp
-            }
+        sourceComponent: Rectangle {
+            anchors.fill: parent
+            color: ui.theme.backgroundSecondaryColor
 
-            return genericThumbnailComp
-        }
+            Image {
+                anchors.centerIn: parent
 
-        Component {
-            id: projectThumbnailComp
+                width: parent.width / 2
 
-            PixmapProjectThumbnailView {
-                anchors.fill: parent
-                thumbnail: thumbnailLoader.thumbnail
-            }
-        }
-
-        Component {
-            id: genericThumbnailComp
-
-            Rectangle {
-                anchors.fill: parent
-                color: ui.theme.backgroundSecondaryColor
-
-                Image {
-                    anchors.centerIn: parent
-
-                    width: parent.width / 2
-
-                    source: {
-                        switch (root.suffix) {
-                        default:
-                            return root.placeholder || "qrc:/resources/ProjectPlaceholder.svg"
-                        }
+                source: {
+                    switch (root.suffix) {
+                    default:
+                        return root.placeholder || "qrc:/resources/ProjectPlaceholder.svg"
                     }
-
-                    fillMode: Image.PreserveAspectFit
-
-                    // Prevent image from looking pixelated on low-res screens
-                    mipmap: true
                 }
+
+                fillMode: Image.PreserveAspectFit
+
+                // Prevent image from looking pixelated on low-res screens
+                mipmap: true
             }
         }
     }

--- a/src/project/qml/Audacity/Project/internal/ProjectsPage/ProjectThumbnail.qml
+++ b/src/project/qml/Audacity/Project/internal/ProjectsPage/ProjectThumbnail.qml
@@ -36,8 +36,13 @@ Item {
 
     ThumbnailLoader {
         id: thumbnailLoader
-        path: root.thumbnailUrl
-        thumbnailSize: Qt.size(root.width, root.height)
+
+        width: root.width
+        height: root.height
+
+        path: root.path
+        placeholder: root.placeholder
+
         backgroundColor: ui.theme.backgroundTertiaryColor
     }
 

--- a/src/project/qml/Audacity/Project/internal/ProjectsPage/ProjectThumbnail.qml
+++ b/src/project/qml/Audacity/Project/internal/ProjectsPage/ProjectThumbnail.qml
@@ -43,9 +43,6 @@ Item {
 
         width: root.width
         height: root.height
-
-        path: root.path
-        placeholder: root.placeholder
     }
 
     Loader {

--- a/src/project/qml/Audacity/Project/internal/ProjectsPage/ProjectThumbnail.qml
+++ b/src/project/qml/Audacity/Project/internal/ProjectsPage/ProjectThumbnail.qml
@@ -34,6 +34,10 @@ Item {
 
     readonly property bool isJsonThumbnail: root.thumbnailUrl.endsWith(".json")
 
+    property alias backgroundColor: thumbnailLoader.backgroundColor
+    property alias lineColor: thumbnailLoader.lineColor
+    property alias borderColor: thumbnailLoader.borderColor
+
     ThumbnailLoader {
         id: thumbnailLoader
 
@@ -42,10 +46,6 @@ Item {
 
         path: root.path
         placeholder: root.placeholder
-
-        backgroundColor: ui.theme.backgroundSecondaryColor
-        lineColor: ui.theme.strokeColor
-        borderColor: ui.theme.strokeColor
     }
 
     Loader {

--- a/src/project/qml/Audacity/Project/internal/ProjectsPage/ProjectThumbnail.qml
+++ b/src/project/qml/Audacity/Project/internal/ProjectsPage/ProjectThumbnail.qml
@@ -43,7 +43,9 @@ Item {
         path: root.path
         placeholder: root.placeholder
 
-        backgroundColor: ui.theme.backgroundTertiaryColor
+        backgroundColor: ui.theme.backgroundSecondaryColor
+        lineColor: ui.theme.strokeColor
+        borderColor: ui.theme.strokeColor
     }
 
     Loader {

--- a/src/project/qml/Audacity/Project/internal/ProjectsPage/RecentProjectsView.qml
+++ b/src/project/qml/Audacity/Project/internal/ProjectsPage/RecentProjectsView.qml
@@ -99,6 +99,10 @@ ProjectsView {
                 root.openProjectRequested(projectPath, displayName)
             }
 
+            onOpenCloudProjectRequested: function (projectId, projectPath, displayName) {
+                root.openCloudProjectRequested(projectId, projectPath, displayName)
+            }
+
             columns: [
                 ProjectsListView.ColumnItem {
                     id: modifiedColumn

--- a/src/project/view/abstractitemmodel.cpp
+++ b/src/project/view/abstractitemmodel.cpp
@@ -28,7 +28,6 @@ using namespace au::project;
 const QString AbstractItemModel::NAME_KEY("name");
 const QString AbstractItemModel::SLUG_KEY("slug");
 const QString AbstractItemModel::PATH_KEY("path");
-const QString AbstractItemModel::SUFFIX_KEY("suffix");
 const QString AbstractItemModel::FILE_SIZE_KEY("fileSize");
 const QString AbstractItemModel::DURATION_KEY("duration");
 const QString AbstractItemModel::TIME_SINCE_MODIFIED_KEY("timeSinceModified");

--- a/src/project/view/abstractitemmodel.cpp
+++ b/src/project/view/abstractitemmodel.cpp
@@ -26,6 +26,7 @@
 using namespace au::project;
 
 const QString AbstractItemModel::NAME_KEY("name");
+const QString AbstractItemModel::SLUG_KEY("slug");
 const QString AbstractItemModel::PATH_KEY("path");
 const QString AbstractItemModel::SUFFIX_KEY("suffix");
 const QString AbstractItemModel::FILE_SIZE_KEY("fileSize");

--- a/src/project/view/abstractitemmodel.cpp
+++ b/src/project/view/abstractitemmodel.cpp
@@ -28,6 +28,7 @@ using namespace au::project;
 const QString AbstractItemModel::NAME_KEY("name");
 const QString AbstractItemModel::SLUG_KEY("slug");
 const QString AbstractItemModel::PATH_KEY("path");
+const QString AbstractItemModel::THUMBNAIL_URL_KEY("thumbnailUrl");
 const QString AbstractItemModel::FILE_SIZE_KEY("fileSize");
 const QString AbstractItemModel::DURATION_KEY("duration");
 const QString AbstractItemModel::TIME_SINCE_MODIFIED_KEY("timeSinceModified");

--- a/src/project/view/abstractitemmodel.h
+++ b/src/project/view/abstractitemmodel.h
@@ -55,7 +55,6 @@ protected:
     static const QString NAME_KEY;
     static const QString SLUG_KEY;
     static const QString PATH_KEY;
-    static const QString SUFFIX_KEY;
     static const QString FILE_SIZE_KEY;
     static const QString DURATION_KEY;
     static const QString TIME_SINCE_MODIFIED_KEY;

--- a/src/project/view/abstractitemmodel.h
+++ b/src/project/view/abstractitemmodel.h
@@ -53,6 +53,7 @@ protected:
     };
 
     static const QString NAME_KEY;
+    static const QString SLUG_KEY;
     static const QString PATH_KEY;
     static const QString SUFFIX_KEY;
     static const QString FILE_SIZE_KEY;

--- a/src/project/view/abstractitemmodel.h
+++ b/src/project/view/abstractitemmodel.h
@@ -55,6 +55,7 @@ protected:
     static const QString NAME_KEY;
     static const QString SLUG_KEY;
     static const QString PATH_KEY;
+    static const QString THUMBNAIL_URL_KEY;
     static const QString FILE_SIZE_KEY;
     static const QString DURATION_KEY;
     static const QString TIME_SINCE_MODIFIED_KEY;

--- a/src/project/view/cloudaudiofilecontextmenumodel.cpp
+++ b/src/project/view/cloudaudiofilecontextmenumodel.cpp
@@ -3,6 +3,8 @@
 */
 #include "cloudaudiofilecontextmenumodel.h"
 
+#include "framework/actions/actiontypes.h"
+
 using namespace au::project;
 
 void CloudAudioFileContextMenuModel::load()
@@ -12,26 +14,33 @@ void CloudAudioFileContextMenuModel::load()
     muse::uicomponents::MenuItem* openItem = makeMenuItem("cloud-audio-open");
     openItem->setState({ false, false });
 
-    muse::uicomponents::MenuItem* viewAudiocom = makeMenuItem("audio-view-on-audiocom");
-    viewAudiocom->setState({ false, false });
+    muse::uicomponents::MenuItem* viewAudiocom = makeMenuItem("cloud-open-audio-page");
 
     setItems({ openItem, viewAudiocom });
 }
 
-void CloudAudioFileContextMenuModel::handleMenuItem(const QString&)
+void CloudAudioFileContextMenuModel::handleMenuItem(const QString& itemId)
 {
-}
-
-QString CloudAudioFileContextMenuModel::cloudItemId() const
-{
-    return m_cloudItemId;
-}
-
-void CloudAudioFileContextMenuModel::setCloudItemId(const QString& cloudItemId)
-{
-    if (m_cloudItemId == cloudItemId) {
+    if (itemId == "cloud-open-audio-page") {
+        muse::actions::ActionQuery query("audacity://cloud/open-audio-page");
+        query.addParam("slug", muse::Val(m_slug.toStdString()));
+        dispatch(query);
         return;
     }
-    m_cloudItemId = cloudItemId;
-    emit cloudItemIdChanged();
+
+    AbstractMenuModel::handleMenuItem(itemId);
+}
+
+QString CloudAudioFileContextMenuModel::slug() const
+{
+    return m_slug;
+}
+
+void CloudAudioFileContextMenuModel::setSlug(const QString& slug)
+{
+    if (m_slug == slug) {
+        return;
+    }
+    m_slug = slug;
+    emit slugChanged();
 }

--- a/src/project/view/cloudaudiofilecontextmenumodel.cpp
+++ b/src/project/view/cloudaudiofilecontextmenumodel.cpp
@@ -7,27 +7,40 @@
 
 using namespace au::project;
 
+namespace {
+constexpr const char* OPEN_AUDIO_FILE_ACTION = "audacity://cloud/open-audio-file";
+constexpr const char* OPEN_AUDIO_PAGE_ACTION = "audacity://cloud/open-audio-page";
+}
+
 void CloudAudioFileContextMenuModel::load()
 {
     muse::uicomponents::AbstractMenuModel::load();
 
-    muse::uicomponents::MenuItem* openItem = makeMenuItem("audacity://cloud/open-audio-file");
-    muse::uicomponents::MenuItem* viewAudiocom = makeMenuItem("audacity://cloud/open-audio-page");
+    muse::uicomponents::MenuItem* openItem = makeMenuItem(OPEN_AUDIO_FILE_ACTION);
+    muse::uicomponents::MenuItem* viewAudiocom = makeMenuItem(OPEN_AUDIO_PAGE_ACTION);
 
     setItems({ openItem, viewAudiocom });
 }
 
 void CloudAudioFileContextMenuModel::handleMenuItem(const QString& itemId)
 {
-    if (itemId == "audacity://cloud/open-audio-page") {
-        muse::actions::ActionQuery query("audacity://cloud/open-audio-page");
+    if (itemId == OPEN_AUDIO_PAGE_ACTION) {
+        if (m_slug.isEmpty()) {
+            return;
+        }
+
+        muse::actions::ActionQuery query(OPEN_AUDIO_PAGE_ACTION);
         query.addParam("slug", muse::Val(m_slug.toStdString()));
         dispatch(query);
         return;
     }
 
-    if (itemId == "audacity://cloud/open-audio-file") {
-        muse::actions::ActionQuery query("audacity://cloud/open-audio-file");
+    if (itemId == OPEN_AUDIO_FILE_ACTION) {
+        if (m_audioId.isEmpty()) {
+            return;
+        }
+
+        muse::actions::ActionQuery query(OPEN_AUDIO_FILE_ACTION);
         query.addParam("audioId", muse::Val(m_audioId.toStdString()));
         dispatch(query);
         return;

--- a/src/project/view/cloudaudiofilecontextmenumodel.cpp
+++ b/src/project/view/cloudaudiofilecontextmenumodel.cpp
@@ -11,24 +11,43 @@ void CloudAudioFileContextMenuModel::load()
 {
     muse::uicomponents::AbstractMenuModel::load();
 
-    muse::uicomponents::MenuItem* openItem = makeMenuItem("cloud-audio-open");
-    openItem->setState({ false, false });
-
-    muse::uicomponents::MenuItem* viewAudiocom = makeMenuItem("cloud-open-audio-page");
+    muse::uicomponents::MenuItem* openItem = makeMenuItem("audacity://cloud/open-audio-file");
+    muse::uicomponents::MenuItem* viewAudiocom = makeMenuItem("audacity://cloud/open-audio-page");
 
     setItems({ openItem, viewAudiocom });
 }
 
 void CloudAudioFileContextMenuModel::handleMenuItem(const QString& itemId)
 {
-    if (itemId == "cloud-open-audio-page") {
+    if (itemId == "audacity://cloud/open-audio-page") {
         muse::actions::ActionQuery query("audacity://cloud/open-audio-page");
         query.addParam("slug", muse::Val(m_slug.toStdString()));
         dispatch(query);
         return;
     }
 
+    if (itemId == "audacity://cloud/open-audio-file") {
+        muse::actions::ActionQuery query("audacity://cloud/open-audio-file");
+        query.addParam("audioId", muse::Val(m_audioId.toStdString()));
+        dispatch(query);
+        return;
+    }
+
     AbstractMenuModel::handleMenuItem(itemId);
+}
+
+QString CloudAudioFileContextMenuModel::audioId() const
+{
+    return m_audioId;
+}
+
+void CloudAudioFileContextMenuModel::setAudioId(const QString& audioId)
+{
+    if (m_audioId == audioId) {
+        return;
+    }
+    m_audioId = audioId;
+    emit audioIdChanged();
 }
 
 QString CloudAudioFileContextMenuModel::slug() const

--- a/src/project/view/cloudaudiofilecontextmenumodel.h
+++ b/src/project/view/cloudaudiofilecontextmenumodel.h
@@ -10,7 +10,7 @@ class CloudAudioFileContextMenuModel : public muse::uicomponents::AbstractMenuMo
 {
     Q_OBJECT
 
-    Q_PROPERTY(QString cloudItemId READ cloudItemId WRITE setCloudItemId NOTIFY cloudItemIdChanged)
+    Q_PROPERTY(QString slug READ slug WRITE setSlug NOTIFY slugChanged)
 
 public:
     CloudAudioFileContextMenuModel() = default;
@@ -18,13 +18,13 @@ public:
     Q_INVOKABLE void load() override;
     void handleMenuItem(const QString& itemId) override;
 
-    QString cloudItemId() const;
-    void setCloudItemId(const QString& cloudItemId);
+    QString slug() const;
+    void setSlug(const QString& slug);
 
 signals:
-    void cloudItemIdChanged();
+    void slugChanged();
 
 private:
-    QString m_cloudItemId;
+    QString m_slug;
 };
 }

--- a/src/project/view/cloudaudiofilecontextmenumodel.h
+++ b/src/project/view/cloudaudiofilecontextmenumodel.h
@@ -10,6 +10,7 @@ class CloudAudioFileContextMenuModel : public muse::uicomponents::AbstractMenuMo
 {
     Q_OBJECT
 
+    Q_PROPERTY(QString audioId READ audioId WRITE setAudioId NOTIFY audioIdChanged)
     Q_PROPERTY(QString slug READ slug WRITE setSlug NOTIFY slugChanged)
 
 public:
@@ -18,13 +19,18 @@ public:
     Q_INVOKABLE void load() override;
     void handleMenuItem(const QString& itemId) override;
 
+    QString audioId() const;
+    void setAudioId(const QString& audioId);
+
     QString slug() const;
     void setSlug(const QString& slug);
 
 signals:
+    void audioIdChanged();
     void slugChanged();
 
 private:
+    QString m_audioId;
     QString m_slug;
 };
 }

--- a/src/project/view/cloudaudiofilesmodel.cpp
+++ b/src/project/view/cloudaudiofilesmodel.cpp
@@ -144,7 +144,7 @@ void CloudAudioFilesModel::loadItemsIfNecessary()
                     obj[NAME_KEY] = QString::fromStdString(item.title);
                     obj[SLUG_KEY] = QString::fromStdString(item.slug);
                     obj[PATH_KEY] = ""; //configuration()->cloudProjectPath(item.id).toQString();
-                    obj[THUMBNAIL_URL_KEY] = item.waveformPath.toQString();
+                    obj[THUMBNAIL_URL_KEY] = fileSystem()->exists(item.waveformPath) ? item.waveformPath.toQString() : QString();
                     obj[IS_CLOUD_KEY] = true;
                     obj[CLOUD_ITEM_ID_KEY] = QString::fromStdString(item.id);
                     obj[TIME_SINCE_MODIFIED_KEY]

--- a/src/project/view/cloudaudiofilesmodel.cpp
+++ b/src/project/view/cloudaudiofilesmodel.cpp
@@ -23,12 +23,8 @@ CloudAudioFilesModel::CloudAudioFilesModel(QObject* parent)
 
 void CloudAudioFilesModel::load()
 {
-    auto onUserAuthorizedChanged = [this](au::au3cloud::AuthState status) {
-        if (std::holds_alternative<au::au3cloud::Authorizing>(status)) {
-            return;
-        }
-
-        if (std::holds_alternative<au::au3cloud::Authorized>(status) || (authorization()->ensureAuthorization())) {
+    auto onUserAuthorizedChanged = [this](bool authorized) {
+        if (authorized) {
             setState(State::Loading);
             loadItemsIfNecessary();
         } else {
@@ -39,14 +35,16 @@ void CloudAudioFilesModel::load()
 
             setState(State::NotSignedIn);
         }
-
-        setState(State::NotSignedIn);
     };
 
-    onUserAuthorizedChanged(authorization()->authState().val);
+    auto isAuthorized = [](au::au3cloud::AuthState authState) {
+        return std::holds_alternative<au::au3cloud::Authorized>(authState);
+    };
 
-    authorization()->authState().ch.onReceive(this, [onUserAuthorizedChanged](au::au3cloud::AuthState authState) {
-        onUserAuthorizedChanged(std::move(authState));
+    onUserAuthorizedChanged(isAuthorized(authorization()->authState().val));
+
+    authorization()->authState().ch.onReceive(this, [isAuthorized, onUserAuthorizedChanged](au::au3cloud::AuthState authState) {
+        onUserAuthorizedChanged(isAuthorized(std::move(authState)));
     }, muse::async::Asyncable::Mode::SetReplace);
 
     connect(this, &CloudAudioFilesModel::desiredRowCountChanged, this, &CloudAudioFilesModel::loadItemsIfNecessary);
@@ -150,7 +148,7 @@ void CloudAudioFilesModel::loadItemsIfNecessary()
                     obj[NAME_KEY] = QString::fromStdString(item.title);
                     obj[SLUG_KEY] = QString::fromStdString(item.slug);
                     obj[PATH_KEY] = ""; //configuration()->cloudProjectPath(item.id).toQString();
-                    obj[THUMBNAIL_URL_KEY] = filesystem()->exists(item.waveformPath) ? item.waveformPath.toQString() : QString();
+                    obj[THUMBNAIL_URL_KEY] = item.waveformPath.toQString();
                     obj[IS_CLOUD_KEY] = true;
                     obj[CLOUD_ITEM_ID_KEY] = QString::fromStdString(item.id);
                     obj[TIME_SINCE_MODIFIED_KEY]

--- a/src/project/view/cloudaudiofilesmodel.cpp
+++ b/src/project/view/cloudaudiofilesmodel.cpp
@@ -150,7 +150,6 @@ void CloudAudioFilesModel::loadItemsIfNecessary()
                     obj[NAME_KEY] = QString::fromStdString(item.title);
                     obj[SLUG_KEY] = QString::fromStdString(item.slug);
                     obj[PATH_KEY] = ""; //configuration()->cloudProjectPath(item.id).toQString();
-                    obj[SUFFIX_KEY] = "";
                     obj[IS_CLOUD_KEY] = true;
                     obj[CLOUD_ITEM_ID_KEY] = QString::fromStdString(item.id);
                     obj[TIME_SINCE_MODIFIED_KEY]

--- a/src/project/view/cloudaudiofilesmodel.cpp
+++ b/src/project/view/cloudaudiofilesmodel.cpp
@@ -181,3 +181,14 @@ bool CloudAudioFilesModel::needsLoading()
 {
     return hasMore() && static_cast<int>(m_items.size()) < m_desiredRowCount;
 }
+
+void CloudAudioFilesModel::openAudioFile(const QString& audioId)
+{
+    if (audioId.isEmpty()) {
+        return;
+    }
+
+    muse::actions::ActionQuery query("audacity://cloud/open-audio-file");
+    query.addParam("audioId", muse::Val(audioId.toStdString()));
+    dispatcher()->dispatch(query);
+}

--- a/src/project/view/cloudaudiofilesmodel.cpp
+++ b/src/project/view/cloudaudiofilesmodel.cpp
@@ -181,14 +181,3 @@ bool CloudAudioFilesModel::needsLoading()
 {
     return hasMore() && static_cast<int>(m_items.size()) < m_desiredRowCount;
 }
-
-void CloudAudioFilesModel::openAudioFile(const QString& audioId)
-{
-    if (audioId.isEmpty()) {
-        return;
-    }
-
-    muse::actions::ActionQuery query("audacity://cloud/open-audio-file");
-    query.addParam("audioId", muse::Val(audioId.toStdString()));
-    dispatcher()->dispatch(query);
-}

--- a/src/project/view/cloudaudiofilesmodel.cpp
+++ b/src/project/view/cloudaudiofilesmodel.cpp
@@ -40,6 +40,8 @@ void CloudAudioFilesModel::load()
         if (std::holds_alternative<au::au3cloud::Authorized>(authState)) {
             setState(State::Loading);
             loadItemsIfNecessary();
+        } else {
+            setState(State::NotSignedIn);
         }
     }, muse::async::Asyncable::Mode::SetReplace);
 

--- a/src/project/view/cloudaudiofilesmodel.cpp
+++ b/src/project/view/cloudaudiofilesmodel.cpp
@@ -150,6 +150,7 @@ void CloudAudioFilesModel::loadItemsIfNecessary()
                     obj[NAME_KEY] = QString::fromStdString(item.title);
                     obj[SLUG_KEY] = QString::fromStdString(item.slug);
                     obj[PATH_KEY] = ""; //configuration()->cloudProjectPath(item.id).toQString();
+                    obj[THUMBNAIL_URL_KEY] = filesystem()->exists(item.waveformPath) ? item.waveformPath.toQString() : QString();
                     obj[IS_CLOUD_KEY] = true;
                     obj[CLOUD_ITEM_ID_KEY] = QString::fromStdString(item.id);
                     obj[TIME_SINCE_MODIFIED_KEY]

--- a/src/project/view/cloudaudiofilesmodel.cpp
+++ b/src/project/view/cloudaudiofilesmodel.cpp
@@ -23,28 +23,24 @@ CloudAudioFilesModel::CloudAudioFilesModel(QObject* parent)
 
 void CloudAudioFilesModel::load()
 {
-    auto onUserAuthorizedChanged = [this](bool authorized) {
-        if (authorized) {
+    const auto authState = authorization()->authState().val;
+    if (std::holds_alternative<au::au3cloud::Authorized>(authState)) {
+        setState(State::Loading);
+        loadItemsIfNecessary();
+    } else if (std::holds_alternative<au::au3cloud::NotAuthorized>(authState)) {
+        muse::actions::ActionQuery query("audacity://cloud/open-signin-dialog");
+        query.addParam("sync", muse::Val(false));
+        query.addParam("showTourPage", muse::Val(false));
+        dispatcher()->dispatch(query);
+
+        setState(State::NotSignedIn);
+    }
+
+    authorization()->authState().ch.onReceive(this, [this](au::au3cloud::AuthState authState) {
+        if (std::holds_alternative<au::au3cloud::Authorized>(authState)) {
             setState(State::Loading);
             loadItemsIfNecessary();
-        } else {
-            muse::actions::ActionQuery query("audacity://cloud/open-signin-dialog");
-            query.addParam("sync", muse::Val(false));
-            query.addParam("showTourPage", muse::Val(false));
-            dispatcher()->dispatch(query);
-
-            setState(State::NotSignedIn);
         }
-    };
-
-    auto isAuthorized = [](au::au3cloud::AuthState authState) {
-        return std::holds_alternative<au::au3cloud::Authorized>(authState);
-    };
-
-    onUserAuthorizedChanged(isAuthorized(authorization()->authState().val));
-
-    authorization()->authState().ch.onReceive(this, [isAuthorized, onUserAuthorizedChanged](au::au3cloud::AuthState authState) {
-        onUserAuthorizedChanged(isAuthorized(std::move(authState)));
     }, muse::async::Asyncable::Mode::SetReplace);
 
     connect(this, &CloudAudioFilesModel::desiredRowCountChanged, this, &CloudAudioFilesModel::loadItemsIfNecessary);

--- a/src/project/view/cloudaudiofilesmodel.cpp
+++ b/src/project/view/cloudaudiofilesmodel.cpp
@@ -135,6 +135,7 @@ void CloudAudioFilesModel::loadItemsIfNecessary()
                     QVariantMap obj;
 
                     obj[NAME_KEY] = QString::fromStdString(item.title);
+                    obj[SLUG_KEY] = QString::fromStdString(item.slug);
                     obj[PATH_KEY] = ""; //configuration()->cloudProjectPath(item.id).toQString();
                     obj[SUFFIX_KEY] = "";
                     obj[IS_CLOUD_KEY] = true;

--- a/src/project/view/cloudaudiofilesmodel.cpp
+++ b/src/project/view/cloudaudiofilesmodel.cpp
@@ -3,6 +3,7 @@
 */
 #include "cloudaudiofilesmodel.h"
 
+#include "framework/global/async/asyncable.h"
 #include "framework/global/dataformatter.h"
 #include "framework/global/types/datetime.h"
 
@@ -22,8 +23,12 @@ CloudAudioFilesModel::CloudAudioFilesModel(QObject* parent)
 
 void CloudAudioFilesModel::load()
 {
-    auto onUserAuthorizedChanged = [this](bool authorized) {
-        if (authorized) {
+    auto onUserAuthorizedChanged = [this](au::au3cloud::AuthState status) {
+        if (std::holds_alternative<au::au3cloud::Authorizing>(status)) {
+            return;
+        }
+
+        if (std::holds_alternative<au::au3cloud::Authorized>(status) || (authorization()->ensureAuthorization())) {
             setState(State::Loading);
             loadItemsIfNecessary();
         } else {
@@ -34,17 +39,15 @@ void CloudAudioFilesModel::load()
 
             setState(State::NotSignedIn);
         }
+
+        setState(State::NotSignedIn);
     };
 
-    auto isAuthorized = [](au::au3cloud::AuthState authState) {
-        return std::holds_alternative<au::au3cloud::Authorized>(authState);
-    };
+    onUserAuthorizedChanged(authorization()->authState().val);
 
-    onUserAuthorizedChanged(isAuthorized(authorization()->authState().val));
-
-    authorization()->authState().ch.onReceive(this, [isAuthorized, onUserAuthorizedChanged](au::au3cloud::AuthState authState) {
-        onUserAuthorizedChanged(isAuthorized(std::move(authState)));
-    });
+    authorization()->authState().ch.onReceive(this, [onUserAuthorizedChanged](au::au3cloud::AuthState authState) {
+        onUserAuthorizedChanged(std::move(authState));
+    }, muse::async::Asyncable::Mode::SetReplace);
 
     connect(this, &CloudAudioFilesModel::desiredRowCountChanged, this, &CloudAudioFilesModel::loadItemsIfNecessary);
 }

--- a/src/project/view/cloudaudiofilesmodel.cpp
+++ b/src/project/view/cloudaudiofilesmodel.cpp
@@ -37,11 +37,14 @@ void CloudAudioFilesModel::load()
     }
 
     authorization()->authState().ch.onReceive(this, [this](au::au3cloud::AuthState authState) {
-        if (std::holds_alternative<au::au3cloud::Authorized>(authState)) {
-            setState(State::Loading);
-            loadItemsIfNecessary();
-        } else {
+        if (std::holds_alternative < au::au3cloud::NotAuthorized>(authState)) {
             setState(State::NotSignedIn);
+            return;
+        }
+
+        setState(State::Loading);
+        if (std::holds_alternative<au::au3cloud::Authorized>(authState)) {
+            loadItemsIfNecessary();
         }
     }, muse::async::Asyncable::Mode::SetReplace);
 

--- a/src/project/view/cloudaudiofilesmodel.cpp
+++ b/src/project/view/cloudaudiofilesmodel.cpp
@@ -50,6 +50,16 @@ void CloudAudioFilesModel::load()
     }, muse::async::Asyncable::Mode::SetReplace);
 
     connect(this, &CloudAudioFilesModel::desiredRowCountChanged, this, &CloudAudioFilesModel::loadItemsIfNecessary);
+
+    audioComService()->audioThumbnailFileUpdated().onReceive(this, [this](const std::string& audioId, const muse::io::path_t& path) {
+        for (int i = 0; i < static_cast<int>(m_items.size()); ++i) {
+            if (m_items[i][CLOUD_ITEM_ID_KEY].toString() == QString::fromStdString(audioId)) {
+                m_items[i][THUMBNAIL_URL_KEY] = path.toQString();
+                emit dataChanged(index(i), index(i));
+                break;
+            }
+        }
+    });
 }
 
 void CloudAudioFilesModel::reload()

--- a/src/project/view/cloudaudiofilesmodel.h
+++ b/src/project/view/cloudaudiofilesmodel.h
@@ -52,6 +52,8 @@ public:
     int desiredRowCount() const;
     void setDesiredRowCount(int count);
 
+    Q_INVOKABLE void openAudioFile(const QString& audioId);
+
 signals:
     void stateChanged();
     void hasMoreChanged();

--- a/src/project/view/cloudaudiofilesmodel.h
+++ b/src/project/view/cloudaudiofilesmodel.h
@@ -10,6 +10,7 @@
 #include "modularity/ioc.h"
 #include "iprojectconfiguration.h"
 #include "au3cloud/iau3audiocomservice.h"
+#include "framework/global/io/ifilesystem.h"
 #include "au3cloud/iauthorization.h"
 #include "framework/interactive/iinteractive.h"
 #include "framework/actions/iactionsdispatcher.h"
@@ -21,6 +22,7 @@ class CloudAudioFilesModel : public AbstractItemModel, public muse::async::Async
 
     muse::GlobalInject<au::project::IProjectConfiguration> configuration;
     muse::GlobalInject<au::au3cloud::IAuthorization> authorization;
+    muse::GlobalInject<muse::io::IFileSystem> fileSystem;
 
     muse::ContextInject<au::au3cloud::IAu3AudioComService> audioComService { this };
     muse::ContextInject<muse::IInteractive> interactive { this };

--- a/src/project/view/cloudaudiofilesmodel.h
+++ b/src/project/view/cloudaudiofilesmodel.h
@@ -9,6 +9,7 @@
 
 #include "modularity/ioc.h"
 #include "iprojectconfiguration.h"
+#include "framework/global/io/ifilesystem.h"
 #include "au3cloud/iau3audiocomservice.h"
 #include "au3cloud/iauthorization.h"
 #include "framework/interactive/iinteractive.h"

--- a/src/project/view/cloudaudiofilesmodel.h
+++ b/src/project/view/cloudaudiofilesmodel.h
@@ -9,10 +9,10 @@
 
 #include "modularity/ioc.h"
 #include "iprojectconfiguration.h"
-#include "framework/global/io/ifilesystem.h"
 #include "au3cloud/iau3audiocomservice.h"
 #include "au3cloud/iauthorization.h"
 #include "framework/interactive/iinteractive.h"
+#include "framework/actions/iactionsdispatcher.h"
 
 namespace au::project {
 class CloudAudioFilesModel : public AbstractItemModel, public muse::async::Asyncable, public muse::Contextable
@@ -24,6 +24,7 @@ class CloudAudioFilesModel : public AbstractItemModel, public muse::async::Async
 
     muse::ContextInject<au::au3cloud::IAu3AudioComService> audioComService { this };
     muse::ContextInject<muse::IInteractive> interactive { this };
+    muse::ContextInject<muse::actions::IActionsDispatcher> dispatcher { this };
 
     Q_PROPERTY(State state READ state NOTIFY stateChanged)
     Q_PROPERTY(bool hasMore READ hasMore NOTIFY hasMoreChanged)

--- a/src/project/view/cloudaudiofilesmodel.h
+++ b/src/project/view/cloudaudiofilesmodel.h
@@ -12,7 +12,6 @@
 #include "au3cloud/iau3audiocomservice.h"
 #include "au3cloud/iauthorization.h"
 #include "framework/interactive/iinteractive.h"
-#include "framework/actions/iactionsdispatcher.h"
 
 namespace au::project {
 class CloudAudioFilesModel : public AbstractItemModel, public muse::async::Asyncable, public muse::Contextable
@@ -24,7 +23,6 @@ class CloudAudioFilesModel : public AbstractItemModel, public muse::async::Async
 
     muse::ContextInject<au::au3cloud::IAu3AudioComService> audioComService { this };
     muse::ContextInject<muse::IInteractive> interactive { this };
-    muse::ContextInject<muse::actions::IActionsDispatcher> dispatcher { this };
 
     Q_PROPERTY(State state READ state NOTIFY stateChanged)
     Q_PROPERTY(bool hasMore READ hasMore NOTIFY hasMoreChanged)
@@ -51,8 +49,6 @@ public:
     // Used by the view to request more items
     int desiredRowCount() const;
     void setDesiredRowCount(int count);
-
-    Q_INVOKABLE void openAudioFile(const QString& audioId);
 
 signals:
     void stateChanged();

--- a/src/project/view/cloudprojectsmodel.cpp
+++ b/src/project/view/cloudprojectsmodel.cpp
@@ -38,11 +38,14 @@ void CloudProjectsModel::load()
     }
 
     authorization()->authState().ch.onReceive(this, [this](au::au3cloud::AuthState authState) {
-        if (std::holds_alternative<au::au3cloud::Authorized>(authState)) {
-            setState(State::Loading);
-            loadItemsIfNecessary();
-        } else {
+        if (std::holds_alternative < au::au3cloud::NotAuthorized>(authState)) {
             setState(State::NotSignedIn);
+            return;
+        }
+
+        setState(State::Loading);
+        if (std::holds_alternative<au::au3cloud::Authorized>(authState)) {
+            loadItemsIfNecessary();
         }
     }, muse::async::Asyncable::Mode::SetReplace);
 

--- a/src/project/view/cloudprojectsmodel.cpp
+++ b/src/project/view/cloudprojectsmodel.cpp
@@ -3,6 +3,7 @@
 */
 #include "cloudprojectsmodel.h"
 
+#include "framework/global/async/asyncable.h"
 #include "framework/global/dataformatter.h"
 #include "framework/global/types/datetime.h"
 
@@ -23,8 +24,12 @@ CloudProjectsModel::CloudProjectsModel(QObject* parent)
 
 void CloudProjectsModel::load()
 {
-    auto onUserAuthorizedChanged = [this](bool authorized) {
-        if (authorized) {
+    auto onUserAuthorizedChanged = [this](au::au3cloud::AuthState status) {
+        if (std::holds_alternative<au::au3cloud::Authorizing>(status)) {
+            return;
+        }
+
+        if (std::holds_alternative<au::au3cloud::Authorized>(status) || (authorization()->ensureAuthorization())) {
             setState(State::Loading);
             loadItemsIfNecessary();
         } else {
@@ -35,17 +40,15 @@ void CloudProjectsModel::load()
 
             setState(State::NotSignedIn);
         }
+
+        setState(State::NotSignedIn);
     };
 
-    auto isAuthorized = [](au::au3cloud::AuthState authState) {
-        return std::holds_alternative<au::au3cloud::Authorized>(authState);
-    };
+    onUserAuthorizedChanged(authorization()->authState().val);
 
-    onUserAuthorizedChanged(isAuthorized(authorization()->authState().val));
-
-    authorization()->authState().ch.onReceive(this, [isAuthorized, onUserAuthorizedChanged](au::au3cloud::AuthState authState) {
-        onUserAuthorizedChanged(isAuthorized(std::move(authState)));
-    });
+    authorization()->authState().ch.onReceive(this, [onUserAuthorizedChanged](au::au3cloud::AuthState authState) {
+        onUserAuthorizedChanged(std::move(authState));
+    }, muse::async::Asyncable::Mode::SetReplace);
 
     connect(this, &CloudProjectsModel::desiredRowCountChanged, this, &CloudProjectsModel::loadItemsIfNecessary);
 }

--- a/src/project/view/cloudprojectsmodel.cpp
+++ b/src/project/view/cloudprojectsmodel.cpp
@@ -143,6 +143,7 @@ void CloudProjectsModel::loadItemsIfNecessary()
                                     .appendingComponent(item.name)
                                     .appendingSuffix(au::project::AUP4)
                                     .toQString();
+                    obj[THUMBNAIL_URL_KEY] = obj[PATH_KEY];
                     obj[IS_CLOUD_KEY] = true;
                     obj[CLOUD_ITEM_ID_KEY] = QString::fromStdString(item.id);
                     obj[TIME_SINCE_MODIFIED_KEY]

--- a/src/project/view/cloudprojectsmodel.cpp
+++ b/src/project/view/cloudprojectsmodel.cpp
@@ -41,6 +41,8 @@ void CloudProjectsModel::load()
         if (std::holds_alternative<au::au3cloud::Authorized>(authState)) {
             setState(State::Loading);
             loadItemsIfNecessary();
+        } else {
+            setState(State::NotSignedIn);
         }
     }, muse::async::Asyncable::Mode::SetReplace);
 

--- a/src/project/view/cloudprojectsmodel.cpp
+++ b/src/project/view/cloudprojectsmodel.cpp
@@ -143,7 +143,6 @@ void CloudProjectsModel::loadItemsIfNecessary()
                                     .appendingComponent(item.name)
                                     .appendingSuffix(au::project::AUP4)
                                     .toQString();
-                    obj[SUFFIX_KEY] = QString::fromStdString(au::project::AUP4);
                     obj[IS_CLOUD_KEY] = true;
                     obj[CLOUD_ITEM_ID_KEY] = QString::fromStdString(item.id);
                     obj[TIME_SINCE_MODIFIED_KEY]

--- a/src/project/view/cloudprojectsmodel.cpp
+++ b/src/project/view/cloudprojectsmodel.cpp
@@ -24,12 +24,8 @@ CloudProjectsModel::CloudProjectsModel(QObject* parent)
 
 void CloudProjectsModel::load()
 {
-    auto onUserAuthorizedChanged = [this](au::au3cloud::AuthState status) {
-        if (std::holds_alternative<au::au3cloud::Authorizing>(status)) {
-            return;
-        }
-
-        if (std::holds_alternative<au::au3cloud::Authorized>(status) || (authorization()->ensureAuthorization())) {
+    auto onUserAuthorizedChanged = [this](bool authorized) {
+        if (authorized) {
             setState(State::Loading);
             loadItemsIfNecessary();
         } else {
@@ -40,14 +36,16 @@ void CloudProjectsModel::load()
 
             setState(State::NotSignedIn);
         }
-
-        setState(State::NotSignedIn);
     };
 
-    onUserAuthorizedChanged(authorization()->authState().val);
+    auto isAuthorized = [](au::au3cloud::AuthState authState) {
+        return std::holds_alternative<au::au3cloud::Authorized>(authState);
+    };
 
-    authorization()->authState().ch.onReceive(this, [onUserAuthorizedChanged](au::au3cloud::AuthState authState) {
-        onUserAuthorizedChanged(std::move(authState));
+    onUserAuthorizedChanged(isAuthorized(authorization()->authState().val));
+
+    authorization()->authState().ch.onReceive(this, [isAuthorized, onUserAuthorizedChanged](au::au3cloud::AuthState authState) {
+        onUserAuthorizedChanged(isAuthorized(std::move(authState)));
     }, muse::async::Asyncable::Mode::SetReplace);
 
     connect(this, &CloudProjectsModel::desiredRowCountChanged, this, &CloudProjectsModel::loadItemsIfNecessary);

--- a/src/project/view/cloudprojectsmodel.cpp
+++ b/src/project/view/cloudprojectsmodel.cpp
@@ -24,28 +24,24 @@ CloudProjectsModel::CloudProjectsModel(QObject* parent)
 
 void CloudProjectsModel::load()
 {
-    auto onUserAuthorizedChanged = [this](bool authorized) {
-        if (authorized) {
+    const auto authState = authorization()->authState().val;
+    if (std::holds_alternative<au::au3cloud::Authorized>(authState)) {
+        setState(State::Loading);
+        loadItemsIfNecessary();
+    } else if (std::holds_alternative<au::au3cloud::NotAuthorized>(authState)) {
+        muse::actions::ActionQuery query("audacity://cloud/open-signin-dialog");
+        query.addParam("sync", muse::Val(false));
+        query.addParam("showTourPage", muse::Val(false));
+        dispatcher()->dispatch(query);
+
+        setState(State::NotSignedIn);
+    }
+
+    authorization()->authState().ch.onReceive(this, [this](au::au3cloud::AuthState authState) {
+        if (std::holds_alternative<au::au3cloud::Authorized>(authState)) {
             setState(State::Loading);
             loadItemsIfNecessary();
-        } else {
-            muse::actions::ActionQuery query("audacity://cloud/open-signin-dialog");
-            query.addParam("sync", muse::Val(false));
-            query.addParam("showTourPage", muse::Val(false));
-            dispatcher()->dispatch(query);
-
-            setState(State::NotSignedIn);
         }
-    };
-
-    auto isAuthorized = [](au::au3cloud::AuthState authState) {
-        return std::holds_alternative<au::au3cloud::Authorized>(authState);
-    };
-
-    onUserAuthorizedChanged(isAuthorized(authorization()->authState().val));
-
-    authorization()->authState().ch.onReceive(this, [isAuthorized, onUserAuthorizedChanged](au::au3cloud::AuthState authState) {
-        onUserAuthorizedChanged(isAuthorized(std::move(authState)));
     }, muse::async::Asyncable::Mode::SetReplace);
 
     connect(this, &CloudProjectsModel::desiredRowCountChanged, this, &CloudProjectsModel::loadItemsIfNecessary);

--- a/src/project/view/projectspagemodel.cpp
+++ b/src/project/view/projectspagemodel.cpp
@@ -63,6 +63,17 @@ void ProjectsPageModel::openCloudProject(const QString& cloudProjectId, const QS
                                                                              localPath), displayNameOverride));
 }
 
+void ProjectsPageModel::openCloudAudioFile(const QString& cloudItemId)
+{
+    if (cloudItemId.isEmpty()) {
+        return;
+    }
+
+    muse::actions::ActionQuery query("audacity://cloud/open-audio-file");
+    query.addParam("audioId", muse::Val(cloudItemId.toStdString()));
+    dispatcher()->dispatch(query);
+}
+
 void ProjectsPageModel::openProjectManager()
 {
     platformInteractive()->openUrl(audioComService()->projectManagerUrl());

--- a/src/project/view/projectspagemodel.h
+++ b/src/project/view/projectspagemodel.h
@@ -73,6 +73,7 @@ public:
     Q_INVOKABLE void openOther();
     Q_INVOKABLE void openProject(const QString& scorePath, const QString& displayNameOverride);
     Q_INVOKABLE void openCloudProject(const QString& cloudProjectId, const QString& localPath, const QString& displayNameOverride);
+    Q_INVOKABLE void openCloudAudioFile(const QString& cloudItemId);
     Q_INVOKABLE void openProjectManager();
 
 signals:

--- a/src/project/view/recentprojectsmodel.cpp
+++ b/src/project/view/recentprojectsmodel.cpp
@@ -79,7 +79,6 @@ void RecentProjectsModel::updateRecentProjects()
 
         obj[NAME_KEY] = file.displayName(false);
         obj[PATH_KEY] = file.path.toQString();
-        obj[SUFFIX_KEY] = QString::fromStdString(suffix);
         obj[FILE_SIZE_KEY] = fileSizeString;
         obj[IS_CLOUD_KEY] = configuration()->isCloudProject(file.path);
         // obj[CLOUD_PROJECT_ID_KEY] = configuration()->cloudProjectIdFromPath(file.path);

--- a/src/project/view/recentprojectsmodel.cpp
+++ b/src/project/view/recentprojectsmodel.cpp
@@ -79,6 +79,7 @@ void RecentProjectsModel::updateRecentProjects()
 
         obj[NAME_KEY] = file.displayName(false);
         obj[PATH_KEY] = file.path.toQString();
+        obj[THUMBNAIL_URL_KEY] = obj[PATH_KEY];
         obj[FILE_SIZE_KEY] = fileSizeString;
         obj[IS_CLOUD_KEY] = configuration()->isCloudProject(file.path);
         // obj[CLOUD_PROJECT_ID_KEY] = configuration()->cloudProjectIdFromPath(file.path);

--- a/src/project/view/thumbnailloader.cpp
+++ b/src/project/view/thumbnailloader.cpp
@@ -49,15 +49,13 @@ QPixmap ThumbnailLoader::renderWaveformToPixmap()
     }
 
     QPixmap pixmap(QSize(m_width, m_height));
-    pixmap.fill(Qt::transparent);
+    pixmap.fill(m_backgroundColor);
 
     QPainter painter(&pixmap);
     if (!painter.isActive()) {
         return QPixmap();
     }
     painter.setRenderHint(QPainter::Antialiasing, true);
-
-    painter.fillRect(QRectF(0, 0, m_width, m_height), m_backgroundColor);
 
     painter.setPen(Qt::NoPen);
     painter.setBrush(m_lineColor);
@@ -266,6 +264,10 @@ void ThumbnailLoader::loadThumbnail()
 
 void ThumbnailLoader::setThumbnail(const QPixmap& thumbnail)
 {
+    if (m_thumbnail.cacheKey() == thumbnail.cacheKey()) {
+        return;
+    }
+
     m_thumbnail = thumbnail;
     emit thumbnailChanged();
 }

--- a/src/project/view/thumbnailloader.cpp
+++ b/src/project/view/thumbnailloader.cpp
@@ -3,15 +3,47 @@
 */
 #include "thumbnailloader.h"
 
-#include <QFileInfo>
-#include <QUrl>
+#include <QPixmap>
+
+#include "framework/global/io/path.h"
+#include "modularity/ioc.h"
 
 using namespace au::project;
 
 namespace {
-QPixmap renderWaveformToPixmap(const QVector<float>& points, const QSize& size, const QColor& backgroundColor)
+constexpr auto DEFAULT_PLACEHOLDER = ":/resources/ProjectPlaceholder.svg";
+}
+
+ThumbnailLoader::ThumbnailLoader(QObject* parent)
+    : QObject(parent), muse::Contextable(muse::iocCtxForQmlObject(this)), m_placeholder(DEFAULT_PLACEHOLDER)
 {
-    if (points.isEmpty() || size.isEmpty()) {
+}
+
+QPixmap ThumbnailLoader::renderWaveformToPixmap(const muse::io::path_t& path, const QSize& size, const QColor& backgroundColor)
+{
+    if (size.isEmpty()) {
+        return QPixmap();
+    }
+
+    muse::RetVal<muse::ByteArray> result = filesystem()->readFile(path);
+    if (!result.ret) {
+        return QPixmap();
+    }
+
+    const QJsonDocument doc = QJsonDocument::fromJson(result.val.toQByteArray());
+    if (!doc.isArray()) {
+        return QPixmap();
+    }
+
+    const QJsonArray arr = doc.array();
+
+    std::vector<float> points;
+    points.reserve(arr.size());
+
+    for (const auto& v : arr) {
+        points.push_back(static_cast<float>(qBound(0.0, v.toDouble(), 1.0)));
+    }
+    if (points.empty() || size.isEmpty()) {
         return QPixmap();
     }
 
@@ -19,6 +51,9 @@ QPixmap renderWaveformToPixmap(const QVector<float>& points, const QSize& size, 
     pixmap.fill(Qt::transparent);
 
     QPainter painter(&pixmap);
+    if (!painter.isActive()) {
+        return QPixmap();
+    }
     painter.setRenderHint(QPainter::Antialiasing, true);
 
     painter.fillRect(QRectF(0, 0, size.width(), size.height()), backgroundColor);
@@ -29,7 +64,7 @@ QPixmap renderWaveformToPixmap(const QVector<float>& points, const QSize& size, 
     const double midY = size.height() / 2.0;
     const double barWidth = size.width() / static_cast<double>(points.size());
 
-    for (int i = 0; i < points.size(); ++i) {
+    for (unsigned i = 0; i < points.size(); ++i) {
         const double barHeight = qMax(2.0, static_cast<double>(points[i]) * size.height() * 0.9);
         painter.drawRect(QRectF(
                              i * barWidth,
@@ -41,11 +76,39 @@ QPixmap renderWaveformToPixmap(const QVector<float>& points, const QSize& size, 
 
     return pixmap;
 }
-}
 
-ThumbnailLoader::ThumbnailLoader(QObject* parent)
-    : QObject(parent)
+QPixmap ThumbnailLoader::renderFromImage(const muse::io::path_t& path, const QSize& size, const QColor& backgroundColor)
 {
+    if (size.isEmpty()) {
+        return QPixmap();
+    }
+
+    const bool isPlaceholder = !filesystem()->exists(path);
+
+    const QString pixmapPath = isPlaceholder ? QString(DEFAULT_PLACEHOLDER) : path.toQString();
+    QPixmap pixmap(pixmapPath);
+    if (pixmap.isNull()) {
+        return QPixmap();
+    }
+
+    const QSize targetSize = isPlaceholder ? size / 2 : size;
+    QPixmap scaledPixmap = pixmap.scaled(targetSize, Qt::KeepAspectRatio, Qt::SmoothTransformation);
+
+    QPixmap finalPixmap(size);
+    finalPixmap.fill(Qt::transparent);
+
+    QPainter painter(&finalPixmap);
+    if (!painter.isActive()) {
+        return QPixmap();
+    }
+    painter.setRenderHint(QPainter::Antialiasing, true);
+
+    painter.fillRect(QRectF(0, 0, size.width(), size.height()), backgroundColor);
+
+    const QPointF center((size.width() - scaledPixmap.width()) / 2.0, (size.height() - scaledPixmap.height()) / 2.0);
+    painter.drawPixmap(center, scaledPixmap);
+
+    return finalPixmap;
 }
 
 QString ThumbnailLoader::path() const
@@ -65,19 +128,52 @@ void ThumbnailLoader::setPath(const QString& path)
     loadThumbnail();
 }
 
-QSize ThumbnailLoader::thumbnailSize() const
+QString ThumbnailLoader::placeholder() const
 {
-    return m_thumbnailSize;
+    return m_placeholder;
 }
 
-void ThumbnailLoader::setThumbnailSize(const QSize& size)
+void ThumbnailLoader::setPlaceholder(const QString& placeholder)
 {
-    if (m_thumbnailSize == size) {
+    if (m_placeholder == placeholder) {
         return;
     }
 
-    m_thumbnailSize = size;
-    emit thumbnailSizeChanged();
+    m_placeholder = placeholder.isEmpty() ? DEFAULT_PLACEHOLDER : placeholder;
+
+    if (m_path.isEmpty()) {
+        loadThumbnail();
+    }
+}
+
+int ThumbnailLoader::width() const
+{
+    return m_width;
+}
+
+void ThumbnailLoader::setWidth(int width)
+{
+    if (m_width == width) {
+        return;
+    }
+
+    m_width = width;
+
+    loadThumbnail();
+}
+
+int ThumbnailLoader::height() const
+{
+    return m_height;
+}
+
+void ThumbnailLoader::setHeight(int height)
+{
+    if (m_height == height) {
+        return;
+    }
+
+    m_height = height;
 
     loadThumbnail();
 }
@@ -99,11 +195,6 @@ void ThumbnailLoader::setBackgroundColor(const QColor& color)
     loadThumbnail();
 }
 
-bool ThumbnailLoader::isThumbnailValid() const
-{
-    return !m_thumbnail.isNull();
-}
-
 QPixmap ThumbnailLoader::thumbnail() const
 {
     return m_thumbnail;
@@ -116,27 +207,13 @@ void ThumbnailLoader::loadThumbnail()
         return;
     }
 
-    const QString localPath = QUrl(path()).toLocalFile();
-    QFile file(localPath.isEmpty() ? path() : localPath);
-    if (!file.open(QIODevice::ReadOnly)) {
-        setThumbnail(QPixmap());
-        return;
-    }
+    const muse::io::path_t filePath(m_path);
+    const QSize size(m_width, m_height);
+    const QPixmap thumbnail = filePath.hasSuffix("json")
+                              ? renderWaveformToPixmap(filePath, size, m_backgroundColor)
+                              : renderFromImage(filePath, size, m_backgroundColor);
 
-    const QJsonDocument doc = QJsonDocument::fromJson(file.readAll());
-    if (!doc.isArray()) {
-        setThumbnail(QPixmap());
-        return;
-    }
-
-    const QJsonArray arr = doc.array();
-    QVector<float> points;
-    points.reserve(arr.size());
-    for (const QJsonValue& v : arr) {
-        points.append(static_cast<float>(qBound(0.0, v.toDouble(), 1.0)));
-    }
-
-    setThumbnail(renderWaveformToPixmap(points, m_thumbnailSize, m_backgroundColor));
+    setThumbnail(thumbnail);
 }
 
 void ThumbnailLoader::setThumbnail(const QPixmap& thumbnail)

--- a/src/project/view/thumbnailloader.cpp
+++ b/src/project/view/thumbnailloader.cpp
@@ -8,6 +8,7 @@
 #include <QPainter>
 #include <QPen>
 #include <QPixmap>
+#include <qpixmap.h>
 
 using namespace au::project;
 
@@ -81,6 +82,27 @@ void ThumbnailLoader::drawWaveform(QPainter& painter, const std::vector<float>& 
                              barHeight
                              ));
     }
+}
+
+QPixmap ThumbnailLoader::renderFromProject(const muse::io::path_t& source)
+{
+    if (m_width <= 0 || m_height <= 0) {
+        return QPixmap();
+    }
+
+    const auto pngData = au3ProjectReader()->readProjectThumbnail(source);
+
+    if (!pngData.has_value()) {
+        return QPixmap();
+    }
+
+    QPixmap pixmap;
+    if (!pixmap.loadFromData(pngData->data(), static_cast<uint>(pngData->size()), "PNG")) {
+        LOGE() << "Failed to decode thumbnail for: " << source.toQString();
+        return QPixmap();
+    }
+
+    return pixmap;
 }
 
 QPixmap ThumbnailLoader::renderWaveformToPixmap(const muse::io::path_t& source)
@@ -276,9 +298,15 @@ void ThumbnailLoader::loadThumbnail()
     }
 
     const muse::io::path_t source = selectSource();
-    const QPixmap thumbnail = source.hasSuffix("json")
-                              ? renderWaveformToPixmap(source)
-                              : renderFromImage(source);
+
+    QPixmap thumbnail {};
+    if (source.hasSuffix("aup4")) {
+        thumbnail = renderFromProject(source);
+    } else if (source.hasSuffix("json")) {
+        thumbnail = renderWaveformToPixmap(source);
+    } else {
+        thumbnail = renderFromImage(source);
+    }
 
     setThumbnail(thumbnail);
 }

--- a/src/project/view/thumbnailloader.cpp
+++ b/src/project/view/thumbnailloader.cpp
@@ -4,6 +4,7 @@
 #include "thumbnailloader.h"
 
 #include <QPixmap>
+#include <qnamespace.h>
 
 #include "framework/global/io/path.h"
 #include "modularity/ioc.h"
@@ -19,13 +20,13 @@ ThumbnailLoader::ThumbnailLoader(QObject* parent)
 {
 }
 
-QPixmap ThumbnailLoader::renderWaveformToPixmap(const muse::io::path_t& path, const QSize& size, const QColor& backgroundColor)
+QPixmap ThumbnailLoader::renderWaveformToPixmap()
 {
-    if (size.isEmpty()) {
+    if (m_width <= 0 || m_height <= 0) {
         return QPixmap();
     }
 
-    muse::RetVal<muse::ByteArray> result = filesystem()->readFile(path);
+    muse::RetVal<muse::ByteArray> result = filesystem()->readFile(m_path);
     if (!result.ret) {
         return QPixmap();
     }
@@ -43,11 +44,11 @@ QPixmap ThumbnailLoader::renderWaveformToPixmap(const muse::io::path_t& path, co
     for (const auto& v : arr) {
         points.push_back(static_cast<float>(qBound(0.0, v.toDouble(), 1.0)));
     }
-    if (points.empty() || size.isEmpty()) {
+    if (points.empty() || m_width <= 0 || m_height <= 0) {
         return QPixmap();
     }
 
-    QPixmap pixmap(size);
+    QPixmap pixmap(QSize(m_width, m_height));
     pixmap.fill(Qt::transparent);
 
     QPainter painter(&pixmap);
@@ -56,16 +57,16 @@ QPixmap ThumbnailLoader::renderWaveformToPixmap(const muse::io::path_t& path, co
     }
     painter.setRenderHint(QPainter::Antialiasing, true);
 
-    painter.fillRect(QRectF(0, 0, size.width(), size.height()), backgroundColor);
+    painter.fillRect(QRectF(0, 0, m_width, m_height), m_backgroundColor);
 
     painter.setPen(Qt::NoPen);
-    painter.setBrush(QColor(0xE4, 0xE4, 0xE4));
+    painter.setBrush(m_lineColor);
 
-    const double midY = size.height() / 2.0;
-    const double barWidth = size.width() / static_cast<double>(points.size());
+    const double midY = m_height / 2.0;
+    const double barWidth = m_width / static_cast<double>(points.size());
 
     for (unsigned i = 0; i < points.size(); ++i) {
-        const double barHeight = qMax(2.0, static_cast<double>(points[i]) * size.height() * 0.9);
+        const double barHeight = qMax(2.0, static_cast<double>(points[i]) * m_height * 0.9);
         painter.drawRect(QRectF(
                              i * barWidth,
                              midY - barHeight / 2.0,
@@ -74,27 +75,33 @@ QPixmap ThumbnailLoader::renderWaveformToPixmap(const muse::io::path_t& path, co
                              ));
     }
 
+    if (m_borderColor.isValid() && m_borderColor.alpha() > 0) {
+        painter.setPen(QPen(m_borderColor, 1));
+        painter.setBrush(Qt::NoBrush);
+        painter.drawRect(QRectF(0, 0, m_width, m_height).adjusted(0.5, 0.5, -0.5, -0.5));
+    }
+
     return pixmap;
 }
 
-QPixmap ThumbnailLoader::renderFromImage(const muse::io::path_t& path, const QSize& size, const QColor& backgroundColor)
+QPixmap ThumbnailLoader::renderFromImage()
 {
-    if (size.isEmpty()) {
+    if (m_width <= 0 || m_height <= 0) {
         return QPixmap();
     }
 
-    const bool isPlaceholder = !filesystem()->exists(path);
+    const bool isPlaceholder = !filesystem()->exists(m_path);
 
-    const QString pixmapPath = isPlaceholder ? QString(DEFAULT_PLACEHOLDER) : path.toQString();
+    const QString pixmapPath = isPlaceholder ? QString(DEFAULT_PLACEHOLDER) : m_path;
     QPixmap pixmap(pixmapPath);
     if (pixmap.isNull()) {
         return QPixmap();
     }
 
-    const QSize targetSize = isPlaceholder ? size / 2 : size;
-    QPixmap scaledPixmap = pixmap.scaled(targetSize, Qt::KeepAspectRatio, Qt::SmoothTransformation);
+    const QSize targetSize = isPlaceholder ? QSize(m_width / 2, m_height / 2) : QSize(m_width, m_height);
+    QPixmap scaledPixmap = pixmap.scaled(targetSize, Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
 
-    QPixmap finalPixmap(size);
+    QPixmap finalPixmap(QSize(m_width, m_height));
     finalPixmap.fill(Qt::transparent);
 
     QPainter painter(&finalPixmap);
@@ -103,10 +110,16 @@ QPixmap ThumbnailLoader::renderFromImage(const muse::io::path_t& path, const QSi
     }
     painter.setRenderHint(QPainter::Antialiasing, true);
 
-    painter.fillRect(QRectF(0, 0, size.width(), size.height()), backgroundColor);
+    painter.fillRect(QRectF(0, 0, m_width, m_height), m_backgroundColor);
 
-    const QPointF center((size.width() - scaledPixmap.width()) / 2.0, (size.height() - scaledPixmap.height()) / 2.0);
+    const QPointF center((m_width - scaledPixmap.width()) / 2.0, (m_height - scaledPixmap.height()) / 2.0);
     painter.drawPixmap(center, scaledPixmap);
+
+    if (m_borderColor.isValid() && m_borderColor.alpha() > 0) {
+        painter.setPen(QPen(m_borderColor, 1));
+        painter.setBrush(Qt::NoBrush);
+        painter.drawRect(QRectF(0, 0, m_width, m_height).adjusted(0.5, 0.5, -0.5, -0.5));
+    }
 
     return finalPixmap;
 }
@@ -159,7 +172,9 @@ void ThumbnailLoader::setWidth(int width)
 
     m_width = width;
 
-    loadThumbnail();
+    if (m_width > 0 && m_height > 0) {
+        loadThumbnail();
+    }
 }
 
 int ThumbnailLoader::height() const
@@ -175,7 +190,9 @@ void ThumbnailLoader::setHeight(int height)
 
     m_height = height;
 
-    loadThumbnail();
+    if (m_width > 0 && m_height > 0) {
+        loadThumbnail();
+    }
 }
 
 QColor ThumbnailLoader::backgroundColor() const
@@ -190,7 +207,38 @@ void ThumbnailLoader::setBackgroundColor(const QColor& color)
     }
 
     m_backgroundColor = color;
-    emit backgroundColorChanged();
+
+    loadThumbnail();
+}
+
+QColor ThumbnailLoader::lineColor() const
+{
+    return m_lineColor;
+}
+
+void ThumbnailLoader::setLineColor(const QColor& color)
+{
+    if (m_lineColor == color) {
+        return;
+    }
+
+    m_lineColor = color;
+
+    loadThumbnail();
+}
+
+QColor ThumbnailLoader::borderColor() const
+{
+    return m_borderColor;
+}
+
+void ThumbnailLoader::setBorderColor(const QColor& color)
+{
+    if (m_borderColor == color) {
+        return;
+    }
+
+    m_borderColor = color;
 
     loadThumbnail();
 }
@@ -210,8 +258,8 @@ void ThumbnailLoader::loadThumbnail()
     const muse::io::path_t filePath(m_path);
     const QSize size(m_width, m_height);
     const QPixmap thumbnail = filePath.hasSuffix("json")
-                              ? renderWaveformToPixmap(filePath, size, m_backgroundColor)
-                              : renderFromImage(filePath, size, m_backgroundColor);
+                              ? renderWaveformToPixmap()
+                              : renderFromImage();
 
     setThumbnail(thumbnail);
 }

--- a/src/project/view/thumbnailloader.cpp
+++ b/src/project/view/thumbnailloader.cpp
@@ -9,7 +9,7 @@
 using namespace au::project;
 
 namespace {
-QPixmap renderWaveformToPixmap(const QVector<float>& points, const QSize& size)
+QPixmap renderWaveformToPixmap(const QVector<float>& points, const QSize& size, const QColor& backgroundColor)
 {
     if (points.isEmpty() || size.isEmpty()) {
         return QPixmap();
@@ -21,7 +21,7 @@ QPixmap renderWaveformToPixmap(const QVector<float>& points, const QSize& size)
     QPainter painter(&pixmap);
     painter.setRenderHint(QPainter::Antialiasing, true);
 
-    painter.fillRect(QRectF(0, 0, size.width(), size.height()), QColor(0x38, 0x38, 0x38));
+    painter.fillRect(QRectF(0, 0, size.width(), size.height()), backgroundColor);
 
     painter.setPen(Qt::NoPen);
     painter.setBrush(QColor(0xE4, 0xE4, 0xE4));
@@ -82,6 +82,23 @@ void ThumbnailLoader::setThumbnailSize(const QSize& size)
     loadThumbnail();
 }
 
+QColor ThumbnailLoader::backgroundColor() const
+{
+    return m_backgroundColor;
+}
+
+void ThumbnailLoader::setBackgroundColor(const QColor& color)
+{
+    if (m_backgroundColor == color) {
+        return;
+    }
+
+    m_backgroundColor = color;
+    emit backgroundColorChanged();
+
+    loadThumbnail();
+}
+
 bool ThumbnailLoader::isThumbnailValid() const
 {
     return !m_thumbnail.isNull();
@@ -119,7 +136,7 @@ void ThumbnailLoader::loadThumbnail()
         points.append(static_cast<float>(qBound(0.0, v.toDouble(), 1.0)));
     }
 
-    setThumbnail(renderWaveformToPixmap(points, m_thumbnailSize));
+    setThumbnail(renderWaveformToPixmap(points, m_thumbnailSize, m_backgroundColor));
 }
 
 void ThumbnailLoader::setThumbnail(const QPixmap& thumbnail)

--- a/src/project/view/thumbnailloader.cpp
+++ b/src/project/view/thumbnailloader.cpp
@@ -3,16 +3,16 @@
 */
 #include "thumbnailloader.h"
 
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QPainter>
+#include <QPen>
 #include <QPixmap>
-#include <qnamespace.h>
-
-#include "framework/global/io/path.h"
-#include "modularity/ioc.h"
 
 using namespace au::project;
 
 namespace {
-constexpr auto DEFAULT_PLACEHOLDER = ":/resources/ProjectPlaceholder.svg";
+const muse::io::path_t DEFAULT_PLACEHOLDER(":/resources/ProjectPlaceholder.svg");
 }
 
 ThumbnailLoader::ThumbnailLoader(QObject* parent)
@@ -20,43 +20,52 @@ ThumbnailLoader::ThumbnailLoader(QObject* parent)
 {
 }
 
-QPixmap ThumbnailLoader::renderWaveformToPixmap()
+muse::io::path_t ThumbnailLoader::selectSource() const
 {
-    if (m_width <= 0 || m_height <= 0) {
-        return QPixmap();
+    if (!m_path.empty() && filesystem()->exists(m_path)) {
+        return m_path;
     }
 
-    muse::RetVal<muse::ByteArray> result = filesystem()->readFile(m_path);
+    if (!m_placeholder.empty() && filesystem()->exists(m_placeholder)) {
+        return m_placeholder;
+    }
+
+    return DEFAULT_PLACEHOLDER;
+}
+
+void ThumbnailLoader::drawBorder(QPainter& painter) const
+{
+    if (!m_borderColor.isValid() || m_borderColor.alpha() == 0) {
+        return;
+    }
+    painter.setPen(QPen(m_borderColor, 1));
+    painter.setBrush(Qt::NoBrush);
+    painter.drawRect(QRectF(0, 0, m_width, m_height).adjusted(0.5, 0.5, -0.5, -0.5));
+}
+
+std::vector<float> ThumbnailLoader::parseWaveformData(const muse::io::path_t& source) const
+{
+    muse::RetVal<muse::ByteArray> result = filesystem()->readFile(source);
     if (!result.ret) {
-        return QPixmap();
+        return {};
     }
 
     const QJsonDocument doc = QJsonDocument::fromJson(result.val.toQByteArray());
     if (!doc.isArray()) {
-        return QPixmap();
+        return {};
     }
 
     const QJsonArray arr = doc.array();
-
     std::vector<float> points;
     points.reserve(arr.size());
-
     for (const auto& v : arr) {
         points.push_back(static_cast<float>(qBound(0.0, v.toDouble(), 1.0)));
     }
-    if (points.empty() || m_width <= 0 || m_height <= 0) {
-        return QPixmap();
-    }
+    return points;
+}
 
-    QPixmap pixmap(QSize(m_width, m_height));
-    pixmap.fill(m_backgroundColor);
-
-    QPainter painter(&pixmap);
-    if (!painter.isActive()) {
-        return QPixmap();
-    }
-    painter.setRenderHint(QPainter::Antialiasing, true);
-
+void ThumbnailLoader::drawWaveform(QPainter& painter, const std::vector<float>& points) const
+{
     painter.setPen(Qt::NoPen);
     painter.setBrush(m_lineColor);
 
@@ -72,32 +81,49 @@ QPixmap ThumbnailLoader::renderWaveformToPixmap()
                              barHeight
                              ));
     }
-
-    if (m_borderColor.isValid() && m_borderColor.alpha() > 0) {
-        painter.setPen(QPen(m_borderColor, 1));
-        painter.setBrush(Qt::NoBrush);
-        painter.drawRect(QRectF(0, 0, m_width, m_height).adjusted(0.5, 0.5, -0.5, -0.5));
-    }
-
-    return pixmap;
 }
 
-QPixmap ThumbnailLoader::renderFromImage()
+QPixmap ThumbnailLoader::renderWaveformToPixmap(const muse::io::path_t& source)
 {
     if (m_width <= 0 || m_height <= 0) {
         return QPixmap();
     }
 
-    const bool isPlaceholder = !filesystem()->exists(m_path);
+    const std::vector<float> points = parseWaveformData(source);
+    if (points.empty()) {
+        return QPixmap();
+    }
 
-    const QString pixmapPath = isPlaceholder ? QString(DEFAULT_PLACEHOLDER) : m_path;
-    QPixmap pixmap(pixmapPath);
+    QPixmap pixmap(QSize(m_width, m_height));
+    pixmap.fill(m_backgroundColor);
+
+    QPainter painter(&pixmap);
+    if (!painter.isActive()) {
+        return QPixmap();
+    }
+    painter.setRenderHint(QPainter::Antialiasing, true);
+
+    drawWaveform(painter, points);
+    drawBorder(painter);
+
+    return pixmap;
+}
+
+QPixmap ThumbnailLoader::renderFromImage(const muse::io::path_t& source)
+{
+    if (m_width <= 0 || m_height <= 0) {
+        return QPixmap();
+    }
+
+    QPixmap pixmap(source.toQString());
     if (pixmap.isNull()) {
         return QPixmap();
     }
 
-    const QSize targetSize = isPlaceholder ? QSize(m_width / 2, m_height / 2) : QSize(m_width, m_height);
-    QPixmap scaledPixmap = pixmap.scaled(targetSize, Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
+    const bool isDefault = (source == m_placeholder) || (source == DEFAULT_PLACEHOLDER);
+    const auto aspectRatio = isDefault ? Qt::KeepAspectRatio : Qt::IgnoreAspectRatio;
+    const QSize targetSize = isDefault ? QSize(m_width / 2, m_height / 2) : QSize(m_width, m_height);
+    const QPixmap scaledPixmap = pixmap.scaled(targetSize, aspectRatio, Qt::SmoothTransformation);
 
     QPixmap finalPixmap(QSize(m_width, m_height));
     finalPixmap.fill(Qt::transparent);
@@ -107,33 +133,29 @@ QPixmap ThumbnailLoader::renderFromImage()
         return QPixmap();
     }
     painter.setRenderHint(QPainter::Antialiasing, true);
-
     painter.fillRect(QRectF(0, 0, m_width, m_height), m_backgroundColor);
 
     const QPointF center((m_width - scaledPixmap.width()) / 2.0, (m_height - scaledPixmap.height()) / 2.0);
     painter.drawPixmap(center, scaledPixmap);
 
-    if (m_borderColor.isValid() && m_borderColor.alpha() > 0) {
-        painter.setPen(QPen(m_borderColor, 1));
-        painter.setBrush(Qt::NoBrush);
-        painter.drawRect(QRectF(0, 0, m_width, m_height).adjusted(0.5, 0.5, -0.5, -0.5));
-    }
+    drawBorder(painter);
 
     return finalPixmap;
 }
 
 QString ThumbnailLoader::path() const
 {
-    return m_path;
+    return m_path.toQString();
 }
 
 void ThumbnailLoader::setPath(const QString& path)
 {
-    if (m_path == path) {
+    const muse::io::path_t newPath(path);
+    if (m_path == newPath) {
         return;
     }
 
-    m_path = path;
+    m_path = newPath;
     emit pathChanged();
 
     loadThumbnail();
@@ -141,18 +163,19 @@ void ThumbnailLoader::setPath(const QString& path)
 
 QString ThumbnailLoader::placeholder() const
 {
-    return m_placeholder;
+    return m_placeholder.toQString();
 }
 
 void ThumbnailLoader::setPlaceholder(const QString& placeholder)
 {
-    if (m_placeholder == placeholder) {
+    const muse::io::path_t newPlaceholder = placeholder.isEmpty() ? DEFAULT_PLACEHOLDER : muse::io::path_t(placeholder);
+    if (m_placeholder == newPlaceholder) {
         return;
     }
 
-    m_placeholder = placeholder.isEmpty() ? DEFAULT_PLACEHOLDER : placeholder;
+    m_placeholder = newPlaceholder;
 
-    if (m_path.isEmpty()) {
+    if (m_path.empty()) {
         loadThumbnail();
     }
 }
@@ -248,16 +271,14 @@ QPixmap ThumbnailLoader::thumbnail() const
 
 void ThumbnailLoader::loadThumbnail()
 {
-    if (m_path.isEmpty()) {
-        setThumbnail(QPixmap());
+    if (m_width <= 0 || m_height <= 0) {
         return;
     }
 
-    const muse::io::path_t filePath(m_path);
-    const QSize size(m_width, m_height);
-    const QPixmap thumbnail = filePath.hasSuffix("json")
-                              ? renderWaveformToPixmap()
-                              : renderFromImage();
+    const muse::io::path_t source = selectSource();
+    const QPixmap thumbnail = source.hasSuffix("json")
+                              ? renderWaveformToPixmap(source)
+                              : renderFromImage(source);
 
     setThumbnail(thumbnail);
 }

--- a/src/project/view/thumbnailloader.cpp
+++ b/src/project/view/thumbnailloader.cpp
@@ -1,0 +1,129 @@
+/*
+* Audacity: A Digital Audio Editor
+*/
+#include "thumbnailloader.h"
+
+#include <QFileInfo>
+#include <QUrl>
+
+using namespace au::project;
+
+namespace {
+QPixmap renderWaveformToPixmap(const QVector<float>& points, const QSize& size)
+{
+    if (points.isEmpty() || size.isEmpty()) {
+        return QPixmap();
+    }
+
+    QPixmap pixmap(size);
+    pixmap.fill(Qt::transparent);
+
+    QPainter painter(&pixmap);
+    painter.setRenderHint(QPainter::Antialiasing, true);
+
+    painter.fillRect(QRectF(0, 0, size.width(), size.height()), QColor(0x38, 0x38, 0x38));
+
+    painter.setPen(Qt::NoPen);
+    painter.setBrush(QColor(0xE4, 0xE4, 0xE4));
+
+    const double midY = size.height() / 2.0;
+    const double barWidth = size.width() / static_cast<double>(points.size());
+
+    for (int i = 0; i < points.size(); ++i) {
+        const double barHeight = qMax(2.0, static_cast<double>(points[i]) * size.height() * 0.9);
+        painter.drawRect(QRectF(
+                             i * barWidth,
+                             midY - barHeight / 2.0,
+                             qMax(1.0, barWidth - 0.5),
+                             barHeight
+                             ));
+    }
+
+    return pixmap;
+}
+}
+
+ThumbnailLoader::ThumbnailLoader(QObject* parent)
+    : QObject(parent)
+{
+}
+
+QString ThumbnailLoader::path() const
+{
+    return m_path;
+}
+
+void ThumbnailLoader::setPath(const QString& path)
+{
+    if (m_path == path) {
+        return;
+    }
+
+    m_path = path;
+    emit pathChanged();
+
+    loadThumbnail();
+}
+
+QSize ThumbnailLoader::thumbnailSize() const
+{
+    return m_thumbnailSize;
+}
+
+void ThumbnailLoader::setThumbnailSize(const QSize& size)
+{
+    if (m_thumbnailSize == size) {
+        return;
+    }
+
+    m_thumbnailSize = size;
+    emit thumbnailSizeChanged();
+
+    loadThumbnail();
+}
+
+bool ThumbnailLoader::isThumbnailValid() const
+{
+    return !m_thumbnail.isNull();
+}
+
+QPixmap ThumbnailLoader::thumbnail() const
+{
+    return m_thumbnail;
+}
+
+void ThumbnailLoader::loadThumbnail()
+{
+    if (m_path.isEmpty()) {
+        setThumbnail(QPixmap());
+        return;
+    }
+
+    const QString localPath = QUrl(path()).toLocalFile();
+    QFile file(localPath.isEmpty() ? path() : localPath);
+    if (!file.open(QIODevice::ReadOnly)) {
+        setThumbnail(QPixmap());
+        return;
+    }
+
+    const QJsonDocument doc = QJsonDocument::fromJson(file.readAll());
+    if (!doc.isArray()) {
+        setThumbnail(QPixmap());
+        return;
+    }
+
+    const QJsonArray arr = doc.array();
+    QVector<float> points;
+    points.reserve(arr.size());
+    for (const QJsonValue& v : arr) {
+        points.append(static_cast<float>(qBound(0.0, v.toDouble(), 1.0)));
+    }
+
+    setThumbnail(renderWaveformToPixmap(points, m_thumbnailSize));
+}
+
+void ThumbnailLoader::setThumbnail(const QPixmap& thumbnail)
+{
+    m_thumbnail = thumbnail;
+    emit thumbnailChanged();
+}

--- a/src/project/view/thumbnailloader.h
+++ b/src/project/view/thumbnailloader.h
@@ -9,30 +9,42 @@
 #include <QPixmap>
 #include <QSize>
 
+#include "framework/global/modularity/ioc.h"
+#include "framework/global/io/ifilesystem.h"
+
 namespace au::project {
-class ThumbnailLoader : public QObject
+class ThumbnailLoader : public QObject, public muse::Contextable
 {
     Q_OBJECT
 
-    Q_PROPERTY(QString path READ path WRITE setPath NOTIFY pathChanged)
+    muse::GlobalInject<muse::io::IFileSystem> filesystem;
 
-    Q_PROPERTY(bool isThumbnailValid READ isThumbnailValid NOTIFY thumbnailChanged)
+    Q_PROPERTY(QString path READ path WRITE setPath NOTIFY pathChanged)
+    Q_PROPERTY(QString placeholder READ placeholder WRITE setPlaceholder)
+
     Q_PROPERTY(QPixmap thumbnail READ thumbnail NOTIFY thumbnailChanged)
 
-    Q_PROPERTY(QSize thumbnailSize READ thumbnailSize WRITE setThumbnailSize NOTIFY thumbnailSizeChanged)
+    Q_PROPERTY(int width READ width WRITE setWidth)
+    Q_PROPERTY(int height READ height WRITE setHeight)
+
     Q_PROPERTY(QColor backgroundColor READ backgroundColor WRITE setBackgroundColor NOTIFY backgroundColorChanged)
 
 public:
     ThumbnailLoader(QObject* parent = nullptr);
 
-    bool isThumbnailValid() const;
-    QPixmap thumbnail() const;
-
     QString path() const;
     void setPath(const QString& path);
 
-    QSize thumbnailSize() const;
-    void setThumbnailSize(const QSize& size);
+    QString placeholder() const;
+    void setPlaceholder(const QString& placeholder);
+
+    QPixmap thumbnail() const;
+
+    int width() const;
+    void setWidth(int width);
+
+    int height() const;
+    void setHeight(int height);
 
     QColor backgroundColor() const;
     void setBackgroundColor(const QColor& color);
@@ -40,16 +52,23 @@ public:
 signals:
     void pathChanged();
     void thumbnailChanged();
-    void thumbnailSizeChanged();
     void backgroundColorChanged();
 
 private:
     void loadThumbnail();
     void setThumbnail(const QPixmap& thumbnail);
 
-    QPixmap m_thumbnail;
+    QPixmap renderWaveformToPixmap(const muse::io::path_t& path, const QSize& size, const QColor& backgroundColor);
+    QPixmap renderFromImage(const muse::io::path_t& path, const QSize& size, const QColor& backgroundColor);
+
     QString m_path;
-    QSize m_thumbnailSize;
+    QString m_placeholder;
+
+    int m_width = 0;
+    int m_height = 0;
+
+    QPixmap m_thumbnail;
+
     QColor m_backgroundColor;
 };
 }

--- a/src/project/view/thumbnailloader.h
+++ b/src/project/view/thumbnailloader.h
@@ -1,0 +1,49 @@
+/*
+* Audacity: A Digital Audio Editor
+*/
+
+#pragma once
+
+#include <QFileSystemWatcher>
+#include <QObject>
+#include <QPixmap>
+#include <QSize>
+
+namespace au::project {
+class ThumbnailLoader : public QObject
+{
+    Q_OBJECT;
+
+    Q_PROPERTY(QString path READ path WRITE setPath NOTIFY pathChanged)
+
+    Q_PROPERTY(bool isThumbnailValid READ isThumbnailValid NOTIFY thumbnailChanged)
+    Q_PROPERTY(QPixmap thumbnail READ thumbnail NOTIFY thumbnailChanged)
+
+    Q_PROPERTY(QSize thumbnailSize READ thumbnailSize WRITE setThumbnailSize NOTIFY thumbnailSizeChanged)
+
+public:
+    ThumbnailLoader(QObject* parent = nullptr);
+
+    bool isThumbnailValid() const;
+    QPixmap thumbnail() const;
+
+    QString path() const;
+    void setPath(const QString& path);
+
+    QSize thumbnailSize() const;
+    void setThumbnailSize(const QSize& size);
+
+signals:
+    void pathChanged();
+    void thumbnailChanged();
+    void thumbnailSizeChanged();
+
+private:
+    void loadThumbnail();
+    void setThumbnail(const QPixmap& thumbnail);
+
+    QPixmap m_thumbnail;
+    QString m_path;
+    QSize m_thumbnailSize;
+};
+}

--- a/src/project/view/thumbnailloader.h
+++ b/src/project/view/thumbnailloader.h
@@ -8,8 +8,13 @@
 #include <QPixmap>
 #include <QSize>
 
+#include <vector>
+
+#include "framework/global/io/path.h"
 #include "framework/global/modularity/ioc.h"
 #include "framework/global/io/ifilesystem.h"
+
+class QPainter;
 
 namespace au::project {
 class ThumbnailLoader : public QObject, public muse::Contextable
@@ -61,14 +66,20 @@ signals:
     void thumbnailChanged();
 
 private:
+    muse::io::path_t selectSource() const;
+
     void loadThumbnail();
     void setThumbnail(const QPixmap& thumbnail);
 
-    QPixmap renderWaveformToPixmap();
-    QPixmap renderFromImage();
+    std::vector<float> parseWaveformData(const muse::io::path_t& source) const;
+    void drawWaveform(QPainter& painter, const std::vector<float>& points) const;
 
-    QString m_path;
-    QString m_placeholder;
+    QPixmap renderWaveformToPixmap(const muse::io::path_t& source);
+    QPixmap renderFromImage(const muse::io::path_t& source);
+    void drawBorder(QPainter& painter) const;
+
+    muse::io::path_t m_path;
+    muse::io::path_t m_placeholder;
 
     int m_width = 0;
     int m_height = 0;

--- a/src/project/view/thumbnailloader.h
+++ b/src/project/view/thumbnailloader.h
@@ -4,15 +4,17 @@
 
 #pragma once
 
+#include <vector>
+
 #include <QObject>
 #include <QPixmap>
 #include <QSize>
 
-#include <vector>
-
 #include "framework/global/io/path.h"
+
 #include "framework/global/modularity/ioc.h"
 #include "framework/global/io/ifilesystem.h"
+#include "au3wrap/iau3project.h"
 
 class QPainter;
 
@@ -22,6 +24,7 @@ class ThumbnailLoader : public QObject, public muse::Contextable
     Q_OBJECT
 
     muse::GlobalInject<muse::io::IFileSystem> filesystem;
+    muse::GlobalInject<au::au3::IAu3ProjectReader> au3ProjectReader;
 
     Q_PROPERTY(QString path READ path WRITE setPath NOTIFY pathChanged)
     Q_PROPERTY(QString placeholder READ placeholder WRITE setPlaceholder)
@@ -74,6 +77,7 @@ private:
     std::vector<float> parseWaveformData(const muse::io::path_t& source) const;
     void drawWaveform(QPainter& painter, const std::vector<float>& points) const;
 
+    QPixmap renderFromProject(const muse::io::path_t& source);
     QPixmap renderWaveformToPixmap(const muse::io::path_t& source);
     QPixmap renderFromImage(const muse::io::path_t& source);
     void drawBorder(QPainter& painter) const;

--- a/src/project/view/thumbnailloader.h
+++ b/src/project/view/thumbnailloader.h
@@ -27,7 +27,9 @@ class ThumbnailLoader : public QObject, public muse::Contextable
     Q_PROPERTY(int width READ width WRITE setWidth)
     Q_PROPERTY(int height READ height WRITE setHeight)
 
-    Q_PROPERTY(QColor backgroundColor READ backgroundColor WRITE setBackgroundColor NOTIFY backgroundColorChanged)
+    Q_PROPERTY(QColor backgroundColor READ backgroundColor WRITE setBackgroundColor)
+    Q_PROPERTY(QColor lineColor READ lineColor WRITE setLineColor)
+    Q_PROPERTY(QColor borderColor READ borderColor WRITE setBorderColor)
 
 public:
     ThumbnailLoader(QObject* parent = nullptr);
@@ -49,17 +51,22 @@ public:
     QColor backgroundColor() const;
     void setBackgroundColor(const QColor& color);
 
+    QColor lineColor() const;
+    void setLineColor(const QColor& color);
+
+    QColor borderColor() const;
+    void setBorderColor(const QColor& color);
+
 signals:
     void pathChanged();
     void thumbnailChanged();
-    void backgroundColorChanged();
 
 private:
     void loadThumbnail();
     void setThumbnail(const QPixmap& thumbnail);
 
-    QPixmap renderWaveformToPixmap(const muse::io::path_t& path, const QSize& size, const QColor& backgroundColor);
-    QPixmap renderFromImage(const muse::io::path_t& path, const QSize& size, const QColor& backgroundColor);
+    QPixmap renderWaveformToPixmap();
+    QPixmap renderFromImage();
 
     QString m_path;
     QString m_placeholder;
@@ -70,5 +77,7 @@ private:
     QPixmap m_thumbnail;
 
     QColor m_backgroundColor;
+    QColor m_lineColor;
+    QColor m_borderColor;
 };
 }

--- a/src/project/view/thumbnailloader.h
+++ b/src/project/view/thumbnailloader.h
@@ -4,7 +4,6 @@
 
 #pragma once
 
-#include <QFileSystemWatcher>
 #include <QObject>
 #include <QPixmap>
 #include <QSize>

--- a/src/project/view/thumbnailloader.h
+++ b/src/project/view/thumbnailloader.h
@@ -12,7 +12,7 @@
 namespace au::project {
 class ThumbnailLoader : public QObject
 {
-    Q_OBJECT;
+    Q_OBJECT
 
     Q_PROPERTY(QString path READ path WRITE setPath NOTIFY pathChanged)
 
@@ -20,6 +20,7 @@ class ThumbnailLoader : public QObject
     Q_PROPERTY(QPixmap thumbnail READ thumbnail NOTIFY thumbnailChanged)
 
     Q_PROPERTY(QSize thumbnailSize READ thumbnailSize WRITE setThumbnailSize NOTIFY thumbnailSizeChanged)
+    Q_PROPERTY(QColor backgroundColor READ backgroundColor WRITE setBackgroundColor NOTIFY backgroundColorChanged)
 
 public:
     ThumbnailLoader(QObject* parent = nullptr);
@@ -33,10 +34,14 @@ public:
     QSize thumbnailSize() const;
     void setThumbnailSize(const QSize& size);
 
+    QColor backgroundColor() const;
+    void setBackgroundColor(const QColor& color);
+
 signals:
     void pathChanged();
     void thumbnailChanged();
     void thumbnailSizeChanged();
+    void backgroundColorChanged();
 
 private:
     void loadThumbnail();
@@ -45,5 +50,6 @@ private:
     QPixmap m_thumbnail;
     QString m_path;
     QSize m_thumbnailSize;
+    QColor m_backgroundColor;
 };
 }

--- a/src/stubs/au3cloud/au3audiocomservicestub.cpp
+++ b/src/stubs/au3cloud/au3audiocomservicestub.cpp
@@ -58,6 +58,21 @@ muse::RetVal<muse::ProgressPtr> Au3AudioComServiceStub::resumeProjectSync(au::pr
     return muse::RetVal<muse::ProgressPtr>::make_ret(muse::Ret::Code::NotSupported);
 }
 
+muse::async::Channel<std::string, muse::io::path_t> Au3AudioComServiceStub::audioThumbnailFileUpdated() const
+{
+    return {};
+}
+
+std::string Au3AudioComServiceStub::getCloudAudioPage(const std::string& /*unused*/) const
+{
+    return {};
+}
+
+std::string Au3AudioComServiceStub::getCloudProjectPage(const std::string& /*unused*/) const
+{
+    return {};
+}
+
 void Au3AudioComServiceStub::deinit()
 {
 }

--- a/src/stubs/au3cloud/au3audiocomservicestub.cpp
+++ b/src/stubs/au3cloud/au3audiocomservicestub.cpp
@@ -32,25 +32,30 @@ void Au3AudioComServiceStub::clearAudioListCache()
 {
 }
 
-muse::ProgressPtr Au3AudioComServiceStub::uploadProject(au::project::IAudacityProjectPtr, const std::string&,
-                                                        std::function<bool()>, bool)
+muse::RetVal<muse::ProgressPtr> Au3AudioComServiceStub::uploadProject(au::project::IAudacityProjectPtr, const std::string&,
+                                                                      std::function<bool()>, bool)
 {
-    return nullptr;
+    return muse::RetVal<muse::ProgressPtr>::make_ret(muse::Ret::Code::NotSupported);
 }
 
-muse::ProgressPtr Au3AudioComServiceStub::shareAudio(const std::string&)
+muse::RetVal<muse::ProgressPtr> Au3AudioComServiceStub::shareAudio(const std::string&)
 {
-    return nullptr;
+    return muse::RetVal<muse::ProgressPtr>::make_ret(muse::Ret::Code::NotSupported);
 }
 
-muse::ProgressPtr Au3AudioComServiceStub::openCloudProject(const muse::io::path_t&, const std::string&, bool)
+muse::RetVal<muse::ProgressPtr> Au3AudioComServiceStub::downloadAudioFile(const std::string&)
 {
-    return nullptr;
+    return muse::RetVal<muse::ProgressPtr>::make_ret(muse::Ret::Code::NotSupported);
 }
 
-muse::ProgressPtr Au3AudioComServiceStub::resumeProjectSync(au::project::IAudacityProjectPtr)
+muse::RetVal<muse::ProgressPtr> Au3AudioComServiceStub::openCloudProject(const muse::io::path_t&, const std::string&, bool)
 {
-    return nullptr;
+    return muse::RetVal<muse::ProgressPtr>::make_ret(muse::Ret::Code::NotSupported);
+}
+
+muse::RetVal<muse::ProgressPtr> Au3AudioComServiceStub::resumeProjectSync(au::project::IAudacityProjectPtr)
+{
+    return muse::RetVal<muse::ProgressPtr>::make_ret(muse::Ret::Code::NotSupported);
 }
 
 void Au3AudioComServiceStub::deinit()

--- a/src/stubs/au3cloud/au3audiocomservicestub.h
+++ b/src/stubs/au3cloud/au3audiocomservicestub.h
@@ -22,13 +22,14 @@ public:
     muse::async::Promise<AudioList> downloadAudioList(size_t audiosPerBatch, size_t batchNumber, const FetchOptions& options) override;
     void clearAudioListCache() override;
 
-    muse::ProgressPtr uploadProject(au::project::IAudacityProjectPtr project, const std::string& name,
-                                    std::function<bool()> projectSaveCallback = nullptr, bool forceOverwrite = false) override;
-    muse::ProgressPtr shareAudio(const std::string& title) override;
+    muse::RetVal<muse::ProgressPtr> uploadProject(au::project::IAudacityProjectPtr project, const std::string& name,
+                                                  std::function<bool()> projectSaveCallback = nullptr, bool forceOverwrite = false) override;
+    muse::RetVal<muse::ProgressPtr> shareAudio(const std::string& title) override;
+    muse::RetVal<muse::ProgressPtr> downloadAudioFile(const std::string& audioId) override;
 
-    muse::ProgressPtr openCloudProject(const muse::io::path_t& localPath, const std::string& projectId = {},
-                                       bool forceOverwrite = false) override;
-    muse::ProgressPtr resumeProjectSync(au::project::IAudacityProjectPtr project) override;
+    muse::RetVal<muse::ProgressPtr> openCloudProject(const muse::io::path_t& localPath, const std::string& projectId = {},
+                                                     bool forceOverwrite = false) override;
+    muse::RetVal<muse::ProgressPtr> resumeProjectSync(au::project::IAudacityProjectPtr project) override;
     void deinit() override;
 };
 }

--- a/src/stubs/au3cloud/au3audiocomservicestub.h
+++ b/src/stubs/au3cloud/au3audiocomservicestub.h
@@ -21,6 +21,7 @@ public:
 
     muse::async::Promise<AudioList> downloadAudioList(size_t audiosPerBatch, size_t batchNumber, const FetchOptions& options) override;
     void clearAudioListCache() override;
+    muse::async::Channel<std::string, muse::io::path_t> audioThumbnailFileUpdated() const override;
 
     muse::RetVal<muse::ProgressPtr> uploadProject(au::project::IAudacityProjectPtr project, const std::string& name,
                                                   std::function<bool()> projectSaveCallback = nullptr, bool forceOverwrite = false) override;
@@ -30,6 +31,10 @@ public:
     muse::RetVal<muse::ProgressPtr> openCloudProject(const muse::io::path_t& localPath, const std::string& projectId = {},
                                                      bool forceOverwrite = false) override;
     muse::RetVal<muse::ProgressPtr> resumeProjectSync(au::project::IAudacityProjectPtr project) override;
+
+    std::string getCloudProjectPage(const std::string& slug) const override;
+    std::string getCloudAudioPage(const std::string& audioId) const override;
+
     void deinit() override;
 };
 }

--- a/src/stubs/au3cloud/au3cloudconfigurationstub.cpp
+++ b/src/stubs/au3cloud/au3cloudconfigurationstub.cpp
@@ -23,3 +23,12 @@ std::string Au3CloudConfigurationStub::exportConfig(const std::string&) const
 {
     return {};
 }
+
+bool Au3CloudConfigurationStub::shouldWarnOnSyncError() const
+{
+    return false;
+}
+
+void Au3CloudConfigurationStub::setWarnOnSyncError(bool /*warn*/)
+{
+}

--- a/src/stubs/au3cloud/au3cloudconfigurationstub.h
+++ b/src/stubs/au3cloud/au3cloudconfigurationstub.h
@@ -14,5 +14,8 @@ public:
 
     std::vector<std::string> preferredAudioFormats() const override;
     std::string exportConfig(const std::string& mimeType) const override;
+
+    bool shouldWarnOnSyncError() const override;
+    void setWarnOnSyncError(bool warn) override;
 };
 }


### PR DESCRIPTION
Resolves: #10195, https://github.com/audacity/audacity/issues/10217

We can now download an audio file from audio.com and open it on a separate project.

I'll ignore the rabbit :rabbit: now because it has already reviewed the code and the changes were just fixes for its comments. 

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Autobot test cases have been run
- [x] Check the new change for the thumbnails(preview) for audio and cloud projects
- [x] Test thumbnails on list and grid view
- [x] Click on the list should open the project/audio?
- [x] Context menu for audio
- [x] Open an audio when there is already a project opened should open in a new window
- [ ] Test corner cases to check #10217

@coderabbitai ignore
