### PR TITLE
improve track ui loading speed

### DIFF
--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/VerticalRulersPanel.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/VerticalRulersPanel.qml
@@ -183,29 +183,45 @@ Rectangle {
                         anchors.right: parent.right
                         anchors.bottomMargin: 1
 
-                        WaveformRuler {
+                        Loader {
+                            id: waveformRulerLoader
+
                             Layout.fillWidth: true
                             Layout.fillHeight: true
 
+                            active: false
                             visible: model.isWaveformViewVisible
 
-                            isCollapsed: trackViewState.isTrackCollapsed
-                            channelHeightRatio: trackViewState.channelHeightRatio
+                            // Defer ruler creation, to speed up track loading
+                            Component.onCompleted: Qt.callLater(function() { waveformRulerLoader.active = Qt.binding(function() { return model.isWaveformViewVisible }) })
+
+                            sourceComponent: WaveformRuler {
+                                isCollapsed: trackViewState.isTrackCollapsed
+                                channelHeightRatio: trackViewState.channelHeightRatio
+                            }
                         }
 
                         SeparatorLine {
                             color: ui.theme.extra["waveform_ruler_tick_extension_color"]
                         }
 
-                        SpectrogramTrackRulers {
+                        Loader {
+                            id: spectrogramRulerLoader
+
                             Layout.fillWidth: true
                             Layout.fillHeight: true
 
+                            active: false
                             visible: model.isSpectrogramViewVisible
 
-                            trackId: model.trackId
-                            isStereo: model.isStereo
-                            channelHeightRatio: trackViewState.channelHeightRatio
+                            // Defer ruler creation, to speed up track loading
+                            Component.onCompleted: Qt.callLater(function() { spectrogramRulerLoader.active = Qt.binding(function() { return model.isSpectrogramViewVisible }) })
+
+                            sourceComponent: SpectrogramTrackRulers {
+                                trackId: model.trackId
+                                isStereo: model.isStereo
+                                channelHeightRatio: trackViewState.channelHeightRatio
+                            }
                         }
                     }
                 }

--- a/src/projectscene/view/trackruler/trackrulermodel.cpp
+++ b/src/projectscene/view/trackruler/trackrulermodel.cpp
@@ -63,6 +63,9 @@ void TrackRulerModel::init()
         emit fullStepsChanged();
         emit smallStepsChanged();
     }, muse::async::Asyncable::Mode::SetReplace);
+
+    emit fullStepsChanged();
+    emit smallStepsChanged();
 }
 
 std::vector<QVariantMap> TrackRulerModel::fullSteps() const


### PR DESCRIPTION
Track rulers take quite a while to fully load and draw, which adds to sluggishness during rapid track creation.
Also fixes the issue when a newly created mono track was created with an empty ruler:

<img width="1165" height="371" alt="image" src="https://github.com/user-attachments/assets/f72cfbdf-5f23-4158-a0a9-5e2845c12ee4" />


<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Autobot test cases have been run
