### PR TITLE
fix crash on first launch setup

### DIFF
--- a/src/appshell/qml/Audacity/AppShell/FirstLaunchSetup/firstlaunchsetupmodel.cpp
+++ b/src/appshell/qml/Audacity/AppShell/FirstLaunchSetup/firstlaunchsetupmodel.cpp
@@ -43,16 +43,21 @@ FirstLaunchSetupModel::FirstLaunchSetupModel(QObject* parent)
         Page { CLIP_VISUALIZATION_PAGE, "audacity://project" },
         Page { WORKSPACE_LAYOUT_PAGE, "audacity://project" },
     };
+}
+
+void FirstLaunchSetupModel::load()
+{
+    if (m_loaded) {
+        return;
+    }
 
     if (au3CloudService()->enabled()) {
         m_pages.append(Page { SIGNIN_AUDIO_COM_PAGE, "audacity://project" });
         m_pages.append(Page { APP_UPDATES_AND_USAGE_INFO_PAGE, "audacity://project" });
     }
-}
 
-void FirstLaunchSetupModel::load()
-{
     setCurrentPageIndex(0);
+    m_loaded = true;
 }
 
 int FirstLaunchSetupModel::numberOfPages() const

--- a/src/appshell/qml/Audacity/AppShell/FirstLaunchSetup/firstlaunchsetupmodel.h
+++ b/src/appshell/qml/Audacity/AppShell/FirstLaunchSetup/firstlaunchsetupmodel.h
@@ -91,6 +91,7 @@ private:
 
     QList<Page> m_pages;
     int m_currentPageIndex = -1;
+    bool m_loaded = false;
 };
 }
 


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/10646
<!-- Use "x" to fill the checkboxes below like [x] -->

fixes a crash on first launch setup by moving inject access to a later stage, since injects are not initialized at constructor time for qml objects.

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [ ] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Autobot test cases have been run
