### PR TITLE
Set zoom level on initialization

### DIFF
--- a/src/projectscene/view/tracksitemsview/waveview.cpp
+++ b/src/projectscene/view/tracksitemsview/waveview.cpp
@@ -213,6 +213,8 @@ void WaveView::setTimelineContext(TimelineContext* newContext)
         connect(m_context, &TimelineContext::selectionStartTimeChanged, this, &WaveView::updateView);
         connect(m_context, &TimelineContext::selectionEndTimeChanged, this, &WaveView::updateView);
         connect(m_context, &TimelineContext::zoomChanged, this, &WaveView::onWaveZoomChanged);
+
+        onWaveZoomChanged();
     }
 
     emit timelineContextChanged();


### PR DESCRIPTION
Resolves: #10658

Fixes the crash during rapid zooming

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [ ] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Autobot test cases have been run
