### PR TITLE
6996 store thumbnail on xml data

### DIFF
--- a/au3/libraries/au3-project-file-io/ProjectFileIO.cpp
+++ b/au3/libraries/au3-project-file-io/ProjectFileIO.cpp
@@ -1355,14 +1355,17 @@ public:
 
 std::optional<std::vector<uint8_t> > ProjectFileIO::ReadThumbnail(const FilePath& fileName)
 {
+    // We won´t change the database. This will avoid shm and wal files to be created, and we won´t have to worry about them.
+    const wxString uri = wxString::Format("file:%s?immutable=1", fileName.ToUTF8());
+
     sqlite3* db = nullptr;
-    if (sqlite3_open_v2(
-            fileName.ToUTF8().data(), &db, SQLITE_OPEN_READONLY, nullptr)
-        != SQLITE_OK) {
+    const int openRc = sqlite3_open_v2(
+        uri.ToUTF8().data(), &db, SQLITE_OPEN_READONLY, nullptr);
+    auto closeDb = finally([db] { sqlite3_close(db); });
+
+    if (openRc != SQLITE_OK) {
         return std::nullopt;
     }
-
-    auto closeDb = finally([db] { sqlite3_close(db); });
 
     int64_t rowId = 0;
     sqlite3_stmt* stmt = nullptr;
@@ -1382,7 +1385,10 @@ std::optional<std::vector<uint8_t> > ProjectFileIO::ReadThumbnail(const FilePath
 
     BufferedProjectBlobStream stream(db, "main", "project", rowId);
     ThumbnailOnlyHandler handler;
-    ProjectSerializer::Decode(stream, &handler);
+    bool success = ProjectSerializer::Decode(stream, &handler);
+    if (!success) {
+        return std::nullopt;
+    }
 
     return handler.result.empty() ? std::nullopt : std::optional<std::vector<uint8_t> >(std::move(handler.result));
 }

--- a/au3/libraries/au3-project-file-io/ProjectFileIO.cpp
+++ b/au3/libraries/au3-project-file-io/ProjectFileIO.cpp
@@ -1327,6 +1327,66 @@ bool ProjectFileIO::RemoveProject(const FilePath& filename)
     return success;
 }
 
+namespace {
+class ThumbnailOnlyHandler final : public XMLTagHandler
+{
+public:
+    bool HandleXMLTag(const std::string_view& tag, const AttributesList&) override
+    {
+        return tag == "project" || tag == "thumbnail";
+    }
+
+    XMLTagHandler* HandleXMLChild(const std::string_view& tag) override
+    {
+        return (tag == "thumbnail") ? this : nullptr;
+    }
+
+    void HandleXMLBlob(const std::string_view& name, const void* data, size_t len) override
+    {
+        if (name == "data") {
+            const auto* bytes = static_cast<const uint8_t*>(data);
+            result.assign(bytes, bytes + len);
+        }
+    }
+
+    std::vector<uint8_t> result;
+};
+}
+
+std::optional<std::vector<uint8_t> > ProjectFileIO::ReadThumbnail(const FilePath& fileName)
+{
+    sqlite3* db = nullptr;
+    if (sqlite3_open_v2(
+            fileName.ToUTF8().data(), &db, SQLITE_OPEN_READONLY, nullptr)
+        != SQLITE_OK) {
+        return std::nullopt;
+    }
+
+    auto closeDb = finally([db] { sqlite3_close(db); });
+
+    int64_t rowId = 0;
+    sqlite3_stmt* stmt = nullptr;
+    if (sqlite3_prepare_v2(
+            db, "SELECT ROWID FROM main.project WHERE id = 1;",
+            -1, &stmt, nullptr)
+        != SQLITE_OK) {
+        return std::nullopt;
+    }
+
+    auto finalizeStmt = finally([stmt] { sqlite3_finalize(stmt); });
+
+    if (sqlite3_step(stmt) != SQLITE_ROW) {
+        return std::nullopt;
+    }
+    rowId = sqlite3_column_int64(stmt, 0);
+
+    BufferedProjectBlobStream stream(db, "main", "project", rowId);
+    ThumbnailOnlyHandler handler;
+    ProjectSerializer::Decode(stream, &handler);
+
+    return handler.result.empty() ? std::nullopt : std::optional<std::vector<uint8_t> >(std::move(handler.result));
+}
+
 ProjectFileIO::BackupProject::BackupProject(
     ProjectFileIO& projectFileIO, const FilePath& path)
 {

--- a/au3/libraries/au3-project-file-io/ProjectFileIO.h
+++ b/au3/libraries/au3-project-file-io/ProjectFileIO.h
@@ -16,7 +16,6 @@ Paul Licameli split from AudacityProject.h
 #include <optional>
 #include <unordered_set>
 #include <vector>
-#include <optional>
 
 #include <wx/event.h>
 

--- a/au3/libraries/au3-project-file-io/ProjectFileIO.h
+++ b/au3/libraries/au3-project-file-io/ProjectFileIO.h
@@ -11,9 +11,12 @@ Paul Licameli split from AudacityProject.h
 #ifndef __AUDACITY_PROJECT_FILE_IO__
 #define __AUDACITY_PROJECT_FILE_IO__
 
+#include <cstdint>
 #include <memory>
 #include <optional>
 #include <unordered_set>
+#include <vector>
+#include <optional>
 
 #include <wx/event.h>
 
@@ -180,6 +183,10 @@ private:
 public:
     //! Remove any files associated with a project at given path; return true if successful
     static bool RemoveProject(const FilePath& filename);
+
+    // Read only the thumbnail blob from a project file without opening it fully.
+    // Returns none if the file has no thumbnail or cannot be read.
+    static std::optional<std::vector<uint8_t> > ReadThumbnail(const FilePath& fileName);
 
     // Object manages the temporary backing-up of project paths while
     // trying to overwrite with new contents, and restoration in case of failure

--- a/au3/libraries/au3-project-file-io/ProjectSerializer.cpp
+++ b/au3/libraries/au3-project-file-io/ProjectSerializer.cpp
@@ -75,7 +75,8 @@ enum FieldTypes
     FT_Raw,          // type, string length, string
     FT_Push,         // type only
     FT_Pop,          // type only
-    FT_Name          // type, ID, name length, name
+    FT_Name,         // type, ID, name length, name
+    FT_Blob          // type, ID, length, raw bytes
 };
 
 // Static so that the dict can be reused each time.
@@ -262,6 +263,17 @@ public:
         // The only data that is serialized by FT_Raw
         // is the boilerplate code like <?xml > and <!DOCTYPE>
         // which are ignored
+    }
+
+    void WriteBlob(const std::string_view& name, const void* data, size_t len)
+    {
+        if (mInTag) {
+            EmitStartTag();
+        }
+
+        if (XMLTagHandler* const handler = mHandlers.back()) {
+            handler->HandleXMLBlob(name, data, len);
+        }
     }
 
     bool Finalize()
@@ -462,6 +474,15 @@ void ProjectSerializer::WriteData(const wxString& value)
     Length len = value.length() * sizeof(wxStringCharType);
     WriteLength(mBuffer, len);
     mBuffer.AppendData(value.wx_str(), len);
+}
+
+void ProjectSerializer::WriteBlob(const wxString& name, const void* data, size_t size)
+{
+    mBuffer.AppendByte(FT_Blob);
+    WriteName(name);
+
+    WriteLength(mBuffer, (Length)size);
+    mBuffer.AppendData(data, size);
 }
 
 void ProjectSerializer::Write(const wxString& value)
@@ -711,6 +732,16 @@ bool ProjectSerializer::Decode(BufferedStreamReader& in, XMLTagHandler* handler)
             {
                 int len = ReadLength(in);
                 adapter.WriteRaw(ReadString(len));
+            }
+            break;
+
+            case FT_Blob:
+            {
+                id = ReadUShort(in);
+                const int len = ReadLength(in);
+                bytes.resize(len);
+                in.Read(bytes.data(), len);
+                adapter.WriteBlob(Lookup(id), bytes.data(), len);
             }
             break;
 

--- a/au3/libraries/au3-project-file-io/ProjectSerializer.cpp
+++ b/au3/libraries/au3-project-file-io/ProjectSerializer.cpp
@@ -478,10 +478,12 @@ void ProjectSerializer::WriteData(const wxString& value)
 
 void ProjectSerializer::WriteBlob(const wxString& name, const void* data, size_t size)
 {
+    assert(size <= static_cast<size_t>(std::numeric_limits<Length>::max()));
+
     mBuffer.AppendByte(FT_Blob);
     WriteName(name);
 
-    WriteLength(mBuffer, (Length)size);
+    WriteLength(mBuffer, static_cast<Length>(size));
     mBuffer.AppendData(data, size);
 }
 

--- a/au3/libraries/au3-project-file-io/ProjectSerializer.h
+++ b/au3/libraries/au3-project-file-io/ProjectSerializer.h
@@ -58,6 +58,7 @@ public:
 
     void WriteData(const wxString& value) override;
     void Write(const wxString& data) override;
+    void WriteBlob(const wxString& name, const void* data, size_t size);
 
     const MemoryStream& GetDict() const;
     const MemoryStream& GetData() const;

--- a/au3/libraries/au3-xml/XMLTagHandler.h
+++ b/au3/libraries/au3-xml/XMLTagHandler.h
@@ -63,6 +63,11 @@ public:
     // It is optional to override this method.
     virtual void HandleXMLContent(const std::string_view& WXUNUSED(content)) {}
 
+    // This method will be called when a binary blob attribute has been
+    // encountered (written via ProjectSerializer::WriteBlob).
+    // It is optional to override this method.
+    virtual void HandleXMLBlob(const std::string_view& WXUNUSED(name), const void* WXUNUSED(data), size_t WXUNUSED(len)) {}
+
     // If the XML document has children of your tag, this method
     // should be called.  Typically you should construct a NEW
     // object for the child, insert it into your own local data

--- a/src/au3wrap/CMakeLists.txt
+++ b/src/au3wrap/CMakeLists.txt
@@ -48,6 +48,8 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/internal/au3basicui.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/projectsnap.cpp
     ${CMAKE_CURRENT_LIST_DIR}/internal/projectsnap.h
+    ${CMAKE_CURRENT_LIST_DIR}/internal/projectthumbnail.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/internal/projectthumbnail.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/trackcolor.cpp
     ${CMAKE_CURRENT_LIST_DIR}/internal/trackcolor.h
     )

--- a/src/au3wrap/au3wrapmodule.cpp
+++ b/src/au3wrap/au3wrapmodule.cpp
@@ -43,6 +43,7 @@ std::string Au3WrapModule::moduleName() const
 void Au3WrapModule::registerExports()
 {
     globalIoc()->registerExport<IAu3ProjectCreator>(moduleName(), new Au3ProjectCreator());
+    globalIoc()->registerExport<IAu3ProjectReader>(moduleName(), new Au3ProjectReader());
 }
 
 void Au3WrapModule::onPreInit(const muse::IApplication::RunMode&)

--- a/src/au3wrap/iau3project.h
+++ b/src/au3wrap/iau3project.h
@@ -6,6 +6,9 @@
 #include <string>
 #include <memory>
 
+#include <vector>
+#include <cstdint>
+
 #include "global/io/path.h"
 #include "global/types/ret.h"
 #include "global/async/notification.h"
@@ -25,6 +28,7 @@ public:
     [[nodiscard]] virtual muse::Ret open() = 0;
     [[nodiscard]] virtual muse::Ret load(const muse::io::path_t& filePath, bool ignoreAutosave = false) = 0;
     virtual bool save(const muse::io::path_t& fileName) = 0;
+    virtual void saveThumbnail(std::vector<uint8_t> pngData) = 0;
     virtual void close() = 0;
 
     virtual std::string title() const = 0;

--- a/src/au3wrap/iau3project.h
+++ b/src/au3wrap/iau3project.h
@@ -5,9 +5,9 @@
 
 #include <string>
 #include <memory>
-
 #include <vector>
 #include <cstdint>
+#include <optional>
 
 #include "global/io/path.h"
 #include "global/types/ret.h"
@@ -59,5 +59,14 @@ public:
     virtual std::shared_ptr<IAu3Project> create(const muse::modularity::ContextPtr& ctx) const = 0;
 
     [[nodiscard]] virtual muse::Ret removeUnsavedData(const muse::io::path_t& projectPath) const = 0;
+};
+
+class IAu3ProjectReader : MODULE_GLOBAL_INTERFACE
+{
+    INTERFACE_ID(IAu3ProjectReader)
+public:
+    virtual ~IAu3ProjectReader() = default;
+
+    virtual std::optional<std::vector<uint8_t> > readProjectThumbnail(const muse::io::path_t& projectPath) const = 0;
 };
 }

--- a/src/au3wrap/internal/au3project.cpp
+++ b/src/au3wrap/internal/au3project.cpp
@@ -110,14 +110,14 @@ Au3ProjectAccessor::Au3ProjectAccessor(const muse::modularity::ContextPtr& ctx)
     // Subscribe to undo manager changes for save status notifications
     mUndoSubscription = UndoManager::Get(m_data->projectRef()).Subscribe([this](const UndoRedoMessage& message) {
         switch (message.type) {
-        case UndoRedoMessage::Pushed:
-        case UndoRedoMessage::Modified:
-        case UndoRedoMessage::UndoOrRedo:
-        case UndoRedoMessage::Reset:
-            m_projectChanged.notify();
-            break;
-        default:
-            break;
+            case UndoRedoMessage::Pushed:
+            case UndoRedoMessage::Modified:
+            case UndoRedoMessage::UndoOrRedo:
+            case UndoRedoMessage::Reset:
+                m_projectChanged.notify();
+                break;
+            default:
+                break;
         }
     });
 }

--- a/src/au3wrap/internal/au3project.cpp
+++ b/src/au3wrap/internal/au3project.cpp
@@ -54,6 +54,17 @@ std::shared_ptr<IAu3Project> Au3ProjectCreator::create(const muse::modularity::C
     return std::make_shared<Au3ProjectAccessor>(ctx);
 }
 
+std::optional<std::vector<uint8_t> > Au3ProjectReader::readProjectThumbnail(const muse::io::path_t& projectPath) const
+{
+    const std::string sstr = projectPath.toStdString();
+    const FilePath fileName = wxString::FromUTF8(sstr.c_str(), sstr.size());
+    if (fileName.empty()) {
+        return std::nullopt;
+    }
+
+    return ProjectFileIO::ReadThumbnail(fileName);
+}
+
 muse::Ret Au3ProjectCreator::removeUnsavedData(const muse::io::path_t& projectPath) const
 {
     // Helper method to remove autosave data from a project file without keeping it open

--- a/src/au3wrap/internal/au3project.cpp
+++ b/src/au3wrap/internal/au3project.cpp
@@ -20,6 +20,7 @@
 #include "au3-wave-track/WaveTrack.h"
 #include "au3-wave-track/WaveTrackUtilities.h"
 #include "au3-stretching-sequence/TempoChange.h"
+#include "projectthumbnail.h"
 
 //! HACK
 //! Static variable is not initialized
@@ -98,14 +99,14 @@ Au3ProjectAccessor::Au3ProjectAccessor(const muse::modularity::ContextPtr& ctx)
     // Subscribe to undo manager changes for save status notifications
     mUndoSubscription = UndoManager::Get(m_data->projectRef()).Subscribe([this](const UndoRedoMessage& message) {
         switch (message.type) {
-            case UndoRedoMessage::Pushed:
-            case UndoRedoMessage::Modified:
-            case UndoRedoMessage::UndoOrRedo:
-            case UndoRedoMessage::Reset:
-                m_projectChanged.notify();
-                break;
-            default:
-                break;
+        case UndoRedoMessage::Pushed:
+        case UndoRedoMessage::Modified:
+        case UndoRedoMessage::UndoOrRedo:
+        case UndoRedoMessage::Reset:
+            m_projectChanged.notify();
+            break;
+        default:
+            break;
         }
     });
 }
@@ -163,6 +164,11 @@ muse::Ret Au3ProjectAccessor::load(const muse::io::path_t& filePath, bool ignore
     updateSavedState();
 
     return ret;
+}
+
+void Au3ProjectAccessor::saveThumbnail(std::vector<uint8_t> pngData)
+{
+    ProjectThumbnail::Get(m_data->projectRef()).SetData(std::move(pngData));
 }
 
 bool Au3ProjectAccessor::save(const muse::io::path_t& filePath)

--- a/src/au3wrap/internal/au3project.h
+++ b/src/au3wrap/internal/au3project.h
@@ -28,6 +28,7 @@ public:
     [[nodiscard]] muse::Ret open() override;
     [[nodiscard]] muse::Ret load(const muse::io::path_t& filePath, bool ignoreAutosave) override;
     bool save(const muse::io::path_t& fileName) override;
+    void saveThumbnail(std::vector<uint8_t> pngData) override;
     void close() override;
 
     std::string title() const override;

--- a/src/au3wrap/internal/au3project.h
+++ b/src/au3wrap/internal/au3project.h
@@ -69,4 +69,10 @@ public:
     std::shared_ptr<IAu3Project> create(const muse::modularity::ContextPtr& ctx) const override;
     [[nodiscard]] muse::Ret removeUnsavedData(const muse::io::path_t& projectPath) const override;
 };
+
+class Au3ProjectReader : public IAu3ProjectReader
+{
+public:
+    std::optional<std::vector<uint8_t> > readProjectThumbnail(const muse::io::path_t& projectPath) const override;
+};
 }

--- a/src/au3wrap/internal/projectthumbnail.cpp
+++ b/src/au3wrap/internal/projectthumbnail.cpp
@@ -1,0 +1,85 @@
+#include "projectthumbnail.h"
+
+#include "au3-project-file-io/ProjectFileIO.h"
+#include "au3-project-file-io/ProjectSerializer.h"
+#include "au3-project/Project.h"
+
+using namespace au::au3;
+
+static const AudacityProject::AttachedObjects::RegisteredFactory key {
+    [](AudacityProject&) {
+        return std::make_shared<ProjectThumbnail>();
+    }
+};
+
+static ProjectFileIORegistry::ObjectWriterEntry writerEntry {
+    [](const AudacityProject& project, XMLWriter& xmlFile) {
+        ProjectThumbnail::Get(const_cast<AudacityProject&>(project)).WriteXML(xmlFile);
+    }
+};
+
+static ProjectFileIORegistry::ObjectReaderEntry readerEntry {
+    "thumbnail",
+    [](AudacityProject& project) -> XMLTagHandler* {
+        return &ProjectThumbnail::Get(project);
+    }
+};
+
+ProjectThumbnail& ProjectThumbnail::Get(AudacityProject& project)
+{
+    return project.AttachedObjects::Get<ProjectThumbnail>(key);
+}
+
+const ProjectThumbnail& ProjectThumbnail::Get(const AudacityProject& project)
+{
+    return Get(const_cast<AudacityProject&>(project));
+}
+
+void ProjectThumbnail::SetData(std::vector<uint8_t> data)
+{
+    m_data = std::move(data);
+}
+
+const std::vector<uint8_t>& ProjectThumbnail::GetData() const
+{
+    return m_data;
+}
+
+bool ProjectThumbnail::HasData() const
+{
+    return !m_data.empty();
+}
+
+void ProjectThumbnail::WriteXML(XMLWriter& xmlFile) const
+{
+    if (!HasData()) {
+        return;
+    }
+
+    auto* serializer = dynamic_cast<ProjectSerializer*>(&xmlFile);
+    if (serializer == nullptr) {
+        return;
+    }
+
+    xmlFile.StartTag(wxT("thumbnail"));
+    serializer->WriteBlob(wxT("data"), m_data.data(), m_data.size());
+    xmlFile.EndTag(wxT("thumbnail"));
+}
+
+bool ProjectThumbnail::HandleXMLTag(const std::string_view& tag, const AttributesList&)
+{
+    return tag == "thumbnail";
+}
+
+XMLTagHandler* ProjectThumbnail::HandleXMLChild(const std::string_view&)
+{
+    return nullptr;
+}
+
+void ProjectThumbnail::HandleXMLBlob(const std::string_view& name, const void* data, size_t len)
+{
+    if (name == "data") {
+        const auto* bytes = static_cast<const uint8_t*>(data);
+        m_data.assign(bytes, bytes + len);
+    }
+}

--- a/src/au3wrap/internal/projectthumbnail.h
+++ b/src/au3wrap/internal/projectthumbnail.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <vector>
+#include <cstdint>
+
+#include "au3-project/Project.h"
+#include "au3-xml/XMLTagHandler.h"
+
+namespace au::au3 {
+class ProjectThumbnail final : public ClientData::Base, public XMLTagHandler
+{
+public:
+    static ProjectThumbnail& Get(AudacityProject& project);
+    static const ProjectThumbnail& Get(const AudacityProject& project);
+
+    void SetData(std::vector<uint8_t> data);
+    const std::vector<uint8_t>& GetData() const;
+    bool HasData() const;
+
+    void WriteXML(XMLWriter& xmlFile) const;
+
+    bool HandleXMLTag(const std::string_view& tag, const AttributesList& attrs) override;
+    XMLTagHandler* HandleXMLChild(const std::string_view& tag) override;
+    void HandleXMLBlob(const std::string_view& name, const void* data, size_t len) override;
+
+private:
+    std::vector<uint8_t> m_data;
+};
+}

--- a/src/au3wrap/tests/mocks/au3projectmock.h
+++ b/src/au3wrap/tests/mocks/au3projectmock.h
@@ -17,6 +17,7 @@ public:
     MOCK_METHOD(muse::Ret, open, (), (override));
     MOCK_METHOD(muse::Ret, load, (const muse::io::path_t& filePath, bool ignoreAutosave), (override));
     MOCK_METHOD(bool, save, (const muse::io::path_t& fileName), (override));
+    MOCK_METHOD(void, saveThumbnail, (std::vector<uint8_t> pngData), (override));
     MOCK_METHOD(void, close, (), (override));
 
     MOCK_METHOD(std::string, title, (), (const, override));

--- a/src/project/internal/audacityproject.cpp
+++ b/src/project/internal/audacityproject.cpp
@@ -390,7 +390,7 @@ Ret Audacity4Project::doSave(const muse::io::path_t& savePath, bool generateBack
         if (!pngData.has_value()) {
             LOGE() << "Failed to create thumbnail for: " << savePath;
         } else {
-            m_au3Project->saveThumbnail(std::move(pngData.value()));
+            m_au3Project->saveThumbnail(std::move(pngData).value());
         }
     }
 

--- a/src/project/internal/audacityproject.cpp
+++ b/src/project/internal/audacityproject.cpp
@@ -385,17 +385,18 @@ Ret Audacity4Project::doSave(const muse::io::path_t& savePath, bool generateBack
         return make_ret(io::Err::FSNotExist);
     }
 
+    if (createThumbnail) {
+        std::optional<std::vector<uint8_t> > pngData = thumbnailCreator()->createThumbnail();
+        if (!pngData.has_value()) {
+            LOGE() << "Failed to create thumbnail for: " << savePath;
+        } else {
+            m_au3Project->saveThumbnail(std::move(pngData.value()));
+        }
+    }
+
     auto ret = m_au3Project->save(savePath);
     if (!ret) {
         return make_ret(Ret::Code::UnknownError);
-    }
-
-    if (createThumbnail) {
-        Ret ret = thumbnailCreator()->createThumbnail(savePath);
-        if (!ret) {
-            LOGE() << "Failed create thumbnail: " << ret.toString();
-            return ret;
-        }
     }
 
     return muse::make_ok();

--- a/src/project/internal/recentfilescontroller.cpp
+++ b/src/project/internal/recentfilescontroller.cpp
@@ -21,12 +21,10 @@
  */
 #include "recentfilescontroller.h"
 
-#include "global/concurrency/concurrent.h"
-#include "global/async/async.h"
-#include "global/defer.h"
-#include "global/serialization/json.h"
-
-#include "multiwindows/resourcelockguard.h"
+#include "framework/global/async/async.h"
+#include "framework/global/defer.h"
+#include "framework/global/serialization/json.h"
+#include "framework/multiwindows/resourcelockguard.h"
 
 using namespace au::project;
 using namespace muse;
@@ -206,8 +204,6 @@ void RecentFilesController::setRecentFilesList(const RecentFilesList& list, cons
 
     m_recentFilesList = list;
 
-    cleanUpThumbnailCache(list);
-
     if (saveAndNotify) {
         saveRecentFilesList();
 
@@ -244,52 +240,4 @@ void RecentFilesController::saveRecentFilesList() const
     if (!ret) {
         LOGE() << "Failed to save recent files list: " << ret.toString();
     }
-}
-
-Promise<QPixmap> RecentFilesController::thumbnail(const muse::io::path_t& filePath) const
-{
-    // TODO: doublecheck if this code is used anywhere
-    return Promise<QPixmap>([this, filePath](const auto& resolve, const auto& reject) {
-        if (filePath.empty()) {
-            return reject(static_cast<int>(Ret::Code::UnknownError), "Invalid file specified");
-        }
-
-        Concurrent::run([this, filePath, resolve, reject]() {
-            std::lock_guard lock(m_thumbnailCacheMutex);
-
-            DateTime lastModified = fileSystem()->lastModified(filePath);
-
-            auto it = m_thumbnailCache.find(filePath);
-            if (it != m_thumbnailCache.cend()) {
-                if (lastModified == it->second.lastModified) {
-                    (void)resolve(it->second.thumbnail);
-                    return;
-                }
-            }
-        });
-
-        return Promise<QPixmap>::Result::unchecked();
-    }, PromiseType::AsyncByBody);
-}
-
-void RecentFilesController::cleanUpThumbnailCache(const RecentFilesList& files) const
-{
-    Concurrent::run([this, files] {
-        std::lock_guard lock(m_thumbnailCacheMutex);
-
-        if (files.empty()) {
-            m_thumbnailCache.clear();
-        } else {
-            std::map<muse::io::path_t, CachedThumbnail> cleanedCache;
-
-            for (const RecentFile& file : files) {
-                auto it = m_thumbnailCache.find(file.path);
-                if (it != m_thumbnailCache.cend()) {
-                    cleanedCache[file.path] = it->second;
-                }
-            }
-
-            m_thumbnailCache = cleanedCache;
-        }
-    });
 }

--- a/src/project/internal/recentfilescontroller.h
+++ b/src/project/internal/recentfilescontroller.h
@@ -19,21 +19,19 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-#ifndef MU_PROJECT_RECENTFILESCONTROLLER_H
-#define MU_PROJECT_RECENTFILESCONTROLLER_H
+#pragma once
 
 #include "irecentfilescontroller.h"
 
 #include <mutex>
 #include <map>
 
-#include "async/asyncable.h"
-#include "async/promise.h"
+#include "framework/global/async/asyncable.h"
 
-#include "modularity/ioc.h"
-#include "iprojectconfiguration.h"
-#include "io/ifilesystem.h"
-#include "multiwindows/imultiwindowsprovider.h"
+#include "framework/global/modularity/ioc.h"
+#include "project/iprojectconfiguration.h"
+#include "framework/global/io/ifilesystem.h"
+#include "framework/multiwindows/imultiwindowsprovider.h"
 
 namespace au::project {
 class RecentFilesController : public IRecentFilesController, public muse::async::Asyncable
@@ -52,8 +50,6 @@ public:
     void moveRecentFile(const muse::io::path_t& before, const RecentFile& after) override;
     void clearRecentFiles() override;
 
-    muse::async::Promise<QPixmap> thumbnail(const muse::io::path_t& file) const override;
-
 protected:
     virtual void prependPlatformRecentFile(const muse::io::path_t& path);
     virtual void clearPlatformRecentFiles();
@@ -63,8 +59,6 @@ private:
     void removeNonexistentFiles();
     void setRecentFilesList(const RecentFilesList& list, bool saveAndNotify);
     void saveRecentFilesList() const;
-
-    void cleanUpThumbnailCache(const RecentFilesList& files) const;
 
     mutable bool m_dirty = true;
     mutable RecentFilesList m_recentFilesList;
@@ -80,5 +74,3 @@ private:
     mutable std::map<muse::io::path_t, CachedThumbnail> m_thumbnailCache;
 };
 }
-
-#endif // MU_PROJECT_RECENTFILESCONTROLLER_H

--- a/src/project/internal/thumbnailcreator.cpp
+++ b/src/project/internal/thumbnailcreator.cpp
@@ -2,44 +2,30 @@
 
 #include <QEventLoop>
 
-#include "global/io/fileinfo.h"
-
 using namespace au::project;
 
-constexpr auto FILE_SUFFIX = ".png";
-
-void ThumbnailCreator::onThumbnailCreated(const bool success)
+void ThumbnailCreator::onThumbnailCreated(std::vector<uint8_t> pngData)
 {
-    m_thumbnailCreated.send(success);
+    m_thumbnailCreated.send(pngData);
 }
 
-muse::async::Channel<muse::io::path_t> ThumbnailCreator::captureThumbnailRequested() const
+muse::async::Notification ThumbnailCreator::captureThumbnailRequested() const
 {
     return m_createThumbnailRequested;
 }
 
-muse::Ret ThumbnailCreator::createThumbnail(const muse::io::path_t& path)
+std::optional<std::vector<uint8_t> > ThumbnailCreator::createThumbnail()
 {
-    muse::Ret ret;
+    std::optional<std::vector<uint8_t> > result;
     QEventLoop loop;
-    m_thumbnailCreated.onReceive(this, [&loop, &ret](const bool ok) {
-        ret = ok ? muse::make_ok() : muse::make_ret(muse::Ret::Code::UnknownError);
+    m_thumbnailCreated.onReceive(this, [&loop, &result](std::vector<uint8_t> data) {
+        result = std::move(data);
         loop.quit();
     });
 
-    m_createThumbnailRequested.send(thumbnailPath(path));
+    m_createThumbnailRequested.notify();
     loop.exec();
     m_thumbnailCreated.disconnect(this);
 
-    return ret;
-}
-
-muse::io::path_t ThumbnailCreator::thumbnailPath(const muse::io::path_t& path)
-{
-    const muse::io::FileInfo fileInfo(path);
-    muse::io::path_t completePath = fileInfo.dirPath()
-                                    .appendingComponent(fileInfo.baseName())
-                                    .appendingSuffix(FILE_SUFFIX);
-
-    return completePath;
+    return result;
 }

--- a/src/project/internal/thumbnailcreator.h
+++ b/src/project/internal/thumbnailcreator.h
@@ -1,23 +1,27 @@
 #pragma once
 
-#include "ithumbnailcreator.h"
+#include <vector>
+#include <optional>
+#include <cstdint>
 
-#include "global/async/asyncable.h"
-#include "global/async/channel.h"
+#include "framework/global/async/asyncable.h"
+#include "framework/global/async/channel.h"
+#include "framework/global/async/notification.h"
+
+#include "ithumbnailcreator.h"
 
 namespace au::project {
 class ThumbnailCreator final : public IThumbnailCreator, public muse::async::Asyncable
 {
 public:
     ThumbnailCreator() = default;
-    void onThumbnailCreated(bool success) override;
-    muse::Ret createThumbnail(const muse::io::path_t& path) override;
-    muse::async::Channel<muse::io::path_t> captureThumbnailRequested() const override;
+
+    void onThumbnailCreated(std::vector<uint8_t> pngData) override;
+    std::optional<std::vector<uint8_t> > createThumbnail() override;
+    muse::async::Notification captureThumbnailRequested() const override;
 
 private:
-    static muse::io::path_t thumbnailPath(const muse::io::path_t& path);
-
-    muse::async::Channel<muse::io::path_t> m_createThumbnailRequested;
-    muse::async::Channel<bool> m_thumbnailCreated;
+    muse::async::Notification m_createThumbnailRequested;
+    muse::async::Channel<std::vector<uint8_t> > m_thumbnailCreated;
 };
 }

--- a/src/project/irecentfilescontroller.h
+++ b/src/project/irecentfilescontroller.h
@@ -19,13 +19,11 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-#ifndef AU_PROJECT_IRECENTFILESCONTROLLER_H
-#define AU_PROJECT_IRECENTFILESCONTROLLER_H
+#pragma once
 
-#include "modularity/imoduleinterface.h"
+#include "framework/global/modularity/imoduleinterface.h"
 
-#include "async/notification.h"
-#include "async/promise.h"
+#include "framework/global/async/notification.h"
 
 #include "types/projecttypes.h"
 
@@ -45,9 +43,5 @@ public:
     virtual void prependRecentFile(const RecentFile& file) = 0;
     virtual void moveRecentFile(const muse::io::path_t& before, const RecentFile& after) = 0;
     virtual void clearRecentFiles() = 0;
-
-    virtual muse::async::Promise<QPixmap> thumbnail(const muse::io::path_t& filePath) const = 0;
 };
 }
-
-#endif // AU_PROJECT_IRECENTFILESCONTROLLER_H

--- a/src/project/ithumbnailcreator.h
+++ b/src/project/ithumbnailcreator.h
@@ -1,9 +1,11 @@
 #pragma once
 
-#include "modularity/imoduleinterface.h"
-#include "global/async/channel.h"
-#include "global/types/ret.h"
-#include "global/io/path.h"
+#include <vector>
+#include <optional>
+#include <cstdint>
+
+#include "framework/global/modularity/imoduleinterface.h"
+#include "framework/global/async/notification.h"
 
 namespace au::project {
 class IThumbnailCreator : MODULE_EXPORT_INTERFACE
@@ -12,10 +14,10 @@ class IThumbnailCreator : MODULE_EXPORT_INTERFACE
 
 public:
     virtual ~IThumbnailCreator() = default;
-    virtual muse::Ret createThumbnail(const muse::io::path_t& path) = 0;
 
-    //for internal use
-    virtual muse::async::Channel<muse::io::path_t> captureThumbnailRequested() const = 0;
-    virtual void onThumbnailCreated(bool success) = 0;
+    virtual std::optional<std::vector<uint8_t> > createThumbnail() = 0;
+
+    virtual muse::async::Notification captureThumbnailRequested() const = 0;
+    virtual void onThumbnailCreated(std::vector<uint8_t> pngData) = 0;
 };
 }

--- a/src/project/qml/Audacity/Project/ProjectsGridView.qml
+++ b/src/project/qml/Audacity/Project/ProjectsGridView.qml
@@ -159,7 +159,6 @@ Item {
                 name: item.name
                 path: item.path ?? ""
                 suffix: item.suffix ?? ""
-                thumbnailUrl: item.thumbnailUrl ? Qt.resolvedUrl("file:" + item.thumbnailUrl) : ""
                 isCreateNew: item.isCreateNew
                 isNoResultsFound: item.isNoResultsFound
                 isCloud: item.isCloud

--- a/src/project/qml/Audacity/Project/internal/ProjectsPage/ProjectGridItem.qml
+++ b/src/project/qml/Audacity/Project/internal/ProjectsPage/ProjectGridItem.qml
@@ -34,7 +34,6 @@ FocusScope {
     property string path: ""
     property string suffix: ""
     property alias timeSinceModified: timeSinceModified.text
-    property string thumbnailUrl: ""
     property string placeholder: ""
     property bool isCreateNew: false
     property bool isNoResultsFound: false
@@ -302,7 +301,6 @@ FocusScope {
         ProjectThumbnail {
             path: root.path
             suffix: root.suffix
-            thumbnailUrl: root.thumbnailUrl
             placeholder: root.placeholder
         }
     }

--- a/src/project/qml/Audacity/Project/internal/ProjectsPage/ProjectListItem.qml
+++ b/src/project/qml/Audacity/Project/internal/ProjectsPage/ProjectListItem.qml
@@ -60,7 +60,6 @@ ListItemBlank {
         ProjectThumbnail {
             path: root.item.path ?? ""
             suffix: root.item.suffix ?? ""
-            thumbnailUrl: root.item.thumbnailUrl ? Qt.resolvedUrl("file:" + root.item.thumbnailUrl) : ""
             placeholder: root.placeholder
         }
     }

--- a/src/project/qml/Audacity/Project/internal/ProjectsPage/ProjectThumbnail.qml
+++ b/src/project/qml/Audacity/Project/internal/ProjectsPage/ProjectThumbnail.qml
@@ -30,7 +30,6 @@ Item {
 
     property string path: ""
     property string suffix: ""
-    property string thumbnailUrl: ""
     property string placeholder: ""
 
     ProjectThumbnailLoader {
@@ -39,16 +38,8 @@ Item {
         projectPath: root.path
     }
 
-    Image {
-        id: image
-        anchors.fill: parent
-        visible: status == Image.Ready
-        source: root.thumbnailUrl
-    }
-
     Loader {
         anchors.fill: parent
-        visible: !image.visible
         active: visible
 
         sourceComponent: {

--- a/src/project/view/abstractitemmodel.cpp
+++ b/src/project/view/abstractitemmodel.cpp
@@ -30,7 +30,6 @@ const QString AbstractItemModel::PATH_KEY("path");
 const QString AbstractItemModel::SUFFIX_KEY("suffix");
 const QString AbstractItemModel::FILE_SIZE_KEY("fileSize");
 const QString AbstractItemModel::DURATION_KEY("duration");
-const QString AbstractItemModel::THUMBNAIL_URL_KEY("thumbnailUrl");
 const QString AbstractItemModel::TIME_SINCE_MODIFIED_KEY("timeSinceModified");
 const QString AbstractItemModel::IS_CREATE_NEW_KEY("isCreateNew");
 const QString AbstractItemModel::IS_NO_RESULTS_FOUND_KEY("isNoResultsFound");

--- a/src/project/view/abstractitemmodel.h
+++ b/src/project/view/abstractitemmodel.h
@@ -57,7 +57,6 @@ protected:
     static const QString SUFFIX_KEY;
     static const QString FILE_SIZE_KEY;
     static const QString DURATION_KEY;
-    static const QString THUMBNAIL_URL_KEY;
     static const QString TIME_SINCE_MODIFIED_KEY;
     static const QString IS_CREATE_NEW_KEY;
     static const QString IS_NO_RESULTS_FOUND_KEY;

--- a/src/project/view/cloudaudiofilesmodel.cpp
+++ b/src/project/view/cloudaudiofilesmodel.cpp
@@ -141,7 +141,6 @@ void CloudAudioFilesModel::loadItemsIfNecessary()
                     obj[FILE_SIZE_KEY] = (item.fileSize > 0) ? DataFormatter::formatFileSize(item.fileSize).toQString() : QString();
                     obj[DURATION_KEY] = (item.duration > 0) ? QTime(0, 0).addMSecs(static_cast<int>(item.duration)).toString(
                         "hh:mm:ss") : QString();
-                    obj[THUMBNAIL_URL_KEY] = "";
                     obj[IS_CREATE_NEW_KEY] = false;
                     obj[IS_NO_RESULTS_FOUND_KEY] = false;
 

--- a/src/project/view/cloudprojectsmodel.cpp
+++ b/src/project/view/cloudprojectsmodel.cpp
@@ -142,7 +142,6 @@ void CloudProjectsModel::loadItemsIfNecessary()
                     obj[TIME_SINCE_MODIFIED_KEY]
                         = DataFormatter::formatTimeSince(Date::fromQDate(QDateTime::fromSecsSinceEpoch(
                                                                              static_cast<qint64>(item.updated)).date())).toQString();
-                    obj[THUMBNAIL_URL_KEY] = "";
                     obj[FILE_SIZE_KEY] = (item.fileSize > 0) ? DataFormatter::formatFileSize(item.fileSize).toQString() : QString();
                     obj[IS_CREATE_NEW_KEY] = false;
                     obj[IS_NO_RESULTS_FOUND_KEY] = false;

--- a/src/project/view/projectpropertiesmodel.cpp
+++ b/src/project/view/projectpropertiesmodel.cpp
@@ -21,6 +21,10 @@
  */
 #include "projectpropertiesmodel.h"
 
+#include <QByteArray>
+#include <QBuffer>
+#include <QImage>
+
 #include "modularity/ioc.h"
 #include "translation.h"
 #include "log.h"
@@ -40,8 +44,8 @@ void ProjectPropertiesModel::init()
         init();
     }, muse::async::Asyncable::Mode::SetReplace);
 
-    thumbnailCreator()->captureThumbnailRequested().onReceive(this, [this](const muse::io::path_t& response) {
-        captureThumbnail(response.toQString());
+    thumbnailCreator()->captureThumbnailRequested().onNotify(this, [this]() {
+        emit captureThumbnail();
     }, muse::async::Asyncable::Mode::SetReplace);
 
     m_project = globalContext()->currentProject();
@@ -49,9 +53,22 @@ void ProjectPropertiesModel::init()
     load();
 }
 
-void ProjectPropertiesModel::onThumbnailCreated(bool success)
+void ProjectPropertiesModel::onThumbnailCreated(const QVariant& image)
 {
-    thumbnailCreator()->onThumbnailCreated(success);
+    const auto qimage = qvariant_cast<QImage>(image);
+    if (qimage.isNull()) {
+        LOGE() << "onThumbnailCreated: received null image";
+        thumbnailCreator()->onThumbnailCreated({});
+        return;
+    }
+
+    QByteArray bytes;
+    QBuffer buffer(&bytes);
+    buffer.open(QIODevice::WriteOnly);
+    qimage.save(&buffer, "PNG");
+    buffer.close();
+
+    thumbnailCreator()->onThumbnailCreated(std::vector<uint8_t>(bytes.begin(), bytes.end()));
 }
 
 void ProjectPropertiesModel::load()

--- a/src/project/view/projectpropertiesmodel.h
+++ b/src/project/view/projectpropertiesmodel.h
@@ -23,6 +23,7 @@
 #pragma once
 
 #include <QAbstractListModel>
+#include <QVariant>
 
 #include "framework/global/modularity/ioc.h"
 #include "framework/interactive/iplatforminteractive.h"
@@ -49,7 +50,7 @@ public:
     explicit ProjectPropertiesModel(QObject* parent = nullptr);
 
     Q_INVOKABLE void init();
-    Q_INVOKABLE void onThumbnailCreated(bool success);
+    Q_INVOKABLE void onThumbnailCreated(const QVariant& image);
 
     QVariant data(const QModelIndex& index, int role) const override;
     bool setData(const QModelIndex& index, const QVariant& value, int role) override;
@@ -69,7 +70,7 @@ public:
 
 signals:
     void propertyAdded(int index);
-    void captureThumbnail(QString path);
+    void captureThumbnail();
 
 private:
     enum Roles {

--- a/src/project/view/projectthumbnailloader.cpp
+++ b/src/project/view/projectthumbnailloader.cpp
@@ -21,6 +21,10 @@
  */
 #include "projectthumbnailloader.h"
 
+#include <QPixmap>
+
+#include "log.h"
+
 using namespace au::project;
 
 ProjectThumbnailLoader::ProjectThumbnailLoader(QObject* parent)
@@ -62,13 +66,22 @@ void ProjectThumbnailLoader::loadThumbnail()
         return;
     }
 
-    // recentFilesController()->thumbnail(m_scorePath)
-    // .onResolve(this, [this](const QPixmap& thumbnail) {
-    //     setThumbnail(thumbnail);
-    // }).onReject(this, [this](int code, const std::string& error) {
-    //     LOGE() << "Could not load thumbnail for " << m_scorePath << ": [" << code << "] " << error;
-    //     setThumbnail(QPixmap());
-    // });
+    const std::optional<std::vector<uint8_t> > pngData
+        = au3ProjectReader()->readProjectThumbnail(m_projectPath);
+
+    if (!pngData.has_value()) {
+        setThumbnail(QPixmap());
+        return;
+    }
+
+    QPixmap pixmap;
+    if (!pixmap.loadFromData(pngData->data(), static_cast<uint>(pngData->size()), "PNG")) {
+        LOGE() << "Failed to decode thumbnail for: " << m_projectPath;
+        setThumbnail(QPixmap());
+        return;
+    }
+
+    setThumbnail(pixmap);
 }
 
 void ProjectThumbnailLoader::setThumbnail(const QPixmap& thumbnail)

--- a/src/project/view/projectthumbnailloader.h
+++ b/src/project/view/projectthumbnailloader.h
@@ -24,16 +24,17 @@
 
 #include <QObject>
 
-#include "async/asyncable.h"
+#include "framework/global/async/asyncable.h"
 
-#include "irecentfilescontroller.h"
+#include "framework/global/modularity/ioc.h"
+#include "au3wrap/iau3project.h"
 
 namespace au::project {
 class ProjectThumbnailLoader : public QObject, public muse::async::Asyncable
 {
     Q_OBJECT;
 
-    // INJECT(IRecentFilesController, recentFilesController)
+    muse::GlobalInject<au::au3::IAu3ProjectReader> au3ProjectReader;
 
     Q_PROPERTY(QString projectPath READ projectPath WRITE setProjectPath NOTIFY projectPathChanged)
 

--- a/src/project/view/projectthumbnailloader.h
+++ b/src/project/view/projectthumbnailloader.h
@@ -1,26 +1,4 @@
-/*
- * SPDX-License-Identifier: GPL-3.0-only
- * Audacity-CLA-applies
- *
- * Audacity
- * Music Composition & Notation
- *
- * Copyright (C) 2024 Audacity BVBA and others
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License version 3 as
- * published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
- */
-#ifndef AU_PROJECT_PROJECTTHUMBNAILLOADER_H
-#define AU_PROJECT_PROJECTTHUMBNAILLOADER_H
+#pragma once
 
 #include <QObject>
 
@@ -63,5 +41,3 @@ private:
     QString m_projectPath;
 };
 }
-
-#endif // AU_PROJECT_PROJECTTHUMBNAILLOADER_H

--- a/src/project/view/recentprojectsmodel.cpp
+++ b/src/project/view/recentprojectsmodel.cpp
@@ -81,7 +81,6 @@ void RecentProjectsModel::updateRecentProjects()
         obj[PATH_KEY] = file.path.toQString();
         obj[SUFFIX_KEY] = QString::fromStdString(suffix);
         obj[FILE_SIZE_KEY] = fileSizeString;
-        obj[THUMBNAIL_URL_KEY] = file.path.toQString().replace(QString::fromStdString(suffix), "png");
         obj[IS_CLOUD_KEY] = configuration()->isCloudProject(file.path);
         // obj[CLOUD_PROJECT_ID_KEY] = configuration()->cloudProjectIdFromPath(file.path);
         obj[TIME_SINCE_MODIFIED_KEY] = DataFormatter::formatTimeSince(io::FileInfo(file.path).lastModified().date()).toQString();

--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TracksItemsView.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TracksItemsView.qml
@@ -108,13 +108,12 @@ Rectangle {
     ProjectPropertiesModel {
         id: project
 
-        onCaptureThumbnail: function captureThumbnail(thumbnailUrl) {
+        onCaptureThumbnail: function captureThumbnail() {
             // hide playCursor for the time grabbing image
             playCursor.visible = false
             content.grabToImage(function (result) {
                 playCursor.visible = true
-                var success = result.saveToFile(thumbnailUrl)
-                project.onThumbnailCreated(success)
+                project.onThumbnailCreated(result.image)
             })
         }
     }
@@ -385,7 +384,7 @@ Rectangle {
                     hoverEnabled: true
                     cursorShape: pressed || timelineMouseArea.pressed ? Qt.ClosedHandCursor : Qt.OpenHandCursor
 
-                    onPressed: function(e) {
+                    onPressed: function (e) {
                         head.dragActive = true
                         head.dragPositionX = mapToItem(timeline, e.x, e.y).x
                         timeline.displayedPlayCursorX = head.dragPositionX


### PR DESCRIPTION
Resolves: #6996 

Store project preview on xml project data

I'll ignore the rabbit 🐰 now because it has already reviewed the code and the changes were just fixes for its comments.
@coderabbitai ignore

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [x] The thumbnail should be saved on the aup4 file. So no more png file for a newly created project.
- [ ] Autobot test cases have been run

