### PR TITLE
Add a shortcut to start/stop recording

### DIFF
--- a/src/app/configs/data/shortcuts.xml
+++ b/src/app/configs/data/shortcuts.xml
@@ -858,7 +858,7 @@
         <seq>P</seq>
     </SC>
     <SC>
-        <key>record1st-choice</key>
+        <key>action://record/start</key>
         <seq>R</seq>
     </SC>
     <SC>

--- a/src/record/internal/recorduiactions.cpp
+++ b/src/record/internal/recorduiactions.cpp
@@ -24,7 +24,7 @@ static const ActionQuery RECORD_TOGGLE_INPUT_MONITORING("action://record/toggle-
 const UiActionList RecordUiActions::m_mainActions = {
     UiAction(RECORD_START_QUERY.toString(),
              au::context::UiCtxProjectOpened,
-             au::context::CTX_PROJECT_FOCUSED,
+             au::context::CTX_PROJECT_OPENED,
              TranslatableString("action", "Record"),
              TranslatableString("action", "Record"),
              IconCode::Code::RECORD_FILL


### PR DESCRIPTION
Resolves: *https://github.com/audacity/audacity/issues/8954*

- <kbd>R</kbd> was bound to `action://record/start.`
- Action's shortcut context was changed to `CTX_PROJECT_OPENED`, matching how the playback Play/Stop shortcuts work, i.e. active whenever a project is open

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [ ] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Autobot test cases have been run
