### PR TITLE
Fix VAMP plugin effects that process selected tracks that are not selected.

### DIFF
--- a/src/effects/vamp/VampEffect.cpp
+++ b/src/effects/vamp/VampEffect.cpp
@@ -297,11 +297,14 @@ bool VampEffect::Init()
    // Use the first selected wave track, not the first wave track in the project.
    // Otherwise a Vamp effect may inherit rate/context from an unselected track.
    auto selected = inputTracks()->Selected<const WaveTrack>();
-   if (selected.empty()) {
+   if (selected.empty()) 
+   {
       mRate = mProjectRate;
-   } else {
+   } 
+   else 
+   {
       mRate = (*selected.begin())->GetRate();
-    }
+   }
 
    // The plugin must be reloaded to allow changing parameters
 
@@ -360,8 +363,9 @@ bool VampEffect::Process(EffectInstance &, EffectSettings &)
       GetBounds(*pTrack, &start, &len);
 
       // Selection may not intersect this selected track.
-      if (len == 0) {
-          continue;
+      if (len == 0) 
+      {
+         continue;
       }
       
       // TODO: more-than-two-channels

--- a/src/effects/vamp/VampEffect.cpp
+++ b/src/effects/vamp/VampEffect.cpp
@@ -294,13 +294,14 @@ bool VampEffect::Init()
 {
    mRate = 0.0;
 
-   // PRL: There is no check that all tracks have one rate, and only the first
-   // is remembered in mRate.  Is that correct?
-
-   if (inputTracks()->empty())
+   // Use the first selected wave track, not the first wave track in the project.
+   // Otherwise a Vamp effect may inherit rate/context from an unselected track.
+   auto selected = inputTracks()->Selected<const WaveTrack>();
+   if (selected.empty()) {
       mRate = mProjectRate;
-   else
-      mRate = (*inputTracks()->Any<const WaveTrack>().begin())->GetRate();
+   } else {
+      mRate = (*selected.begin())->GetRate();
+    }
 
    // The plugin must be reloaded to allow changing parameters
 
@@ -338,8 +339,10 @@ bool VampEffect::Process(EffectInstance &, EffectSettings &)
    }
 
    std::vector<std::shared_ptr<AddedAnalysisTrack>> addedTracks;
-
-   for (auto pTrack : inputTracks()->Any<const WaveTrack>())
+   
+   // Process only selected wave tracks.
+   //Using Any<> causes Vamp effects to ignore vertical track selection and process every wave track in project.
+   for (auto pTrack : inputTracks()->Selected<const WaveTrack>())
    {
       auto channelGroup = pTrack->Channels();
       auto left = *channelGroup.first++;
@@ -356,6 +359,11 @@ bool VampEffect::Process(EffectInstance &, EffectSettings &)
       sampleCount len = 0;
       GetBounds(*pTrack, &start, &len);
 
+      // Selection may not intersect this selected track.
+      if (len == 0) {
+          continue;
+      }
+      
       // TODO: more-than-two-channels
 
       size_t step = mPlugin->getPreferredStepSize();


### PR DESCRIPTION
This fixes an issue where VAMP effects process audio from all wave tracks in the project, ignoring the track or track segment selected by the user.

Currently, VampEffect::Process iterates over all wave tracks using `inputTracks()->Any<const WaveTrack>()`. As a result, when a user selects a single track and runs a VAMP effect, the plugin still receives audio from other unselected tracks.

This also causes incorrect behavior when only a portion of a track is selected, leading to extra plugin invocations and timestamp misalignment across tracks.

The fix updates the processing loop to use `inputTracks()->Selected<const WaveTrack>()` ensuring that only the selected tracks are processed. Additionally, tracks that do not intersect the current time selection are skipped.

**Bug reproduction:**
- Import two mono wave tracks
- Select only one track, or select only a segment of one track
- Run a VAMP effect

**Before this fix:**
The plugin processes audio from unselected tracks as well, and may also process regions outside the selected time range.

**After this fix:**
The plugin processes only the selected track, or only the selected segment of the selected track.

Resolves: #10656

**Motivation:**
This change makes VAMP effect behavior consistent with user expectations and with the behavior of other Audacity analysis effects. It also fixes incorrect plugin invocation patterns that can cause output misalignment when working with multiple track and time selections.

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Autobot test cases have been run