### PR TITLE
Add shortcuts for import and export

### DIFF
--- a/src/app/configs/data/shortcuts.xml
+++ b/src/app/configs/data/shortcuts.xml
@@ -395,9 +395,6 @@
         <seq>Ctrl+W</seq>
     </SC>
     <SC>
-        <key>export</key>
-    </SC>
-    <SC>
         <key>export-labels</key>
     </SC>
     <SC>

--- a/src/app/configs/data/shortcuts.xml
+++ b/src/app/configs/data/shortcuts.xml
@@ -402,7 +402,11 @@
         <key>export-labels</key>
     </SC>
     <SC>
-        <key>import-audio</key>
+        <key>export-audio</key>
+        <seq>Ctrl+Shift+E</seq>
+    </SC>
+    <SC>
+        <key>project-import</key>
         <seq>Ctrl+Shift+I</seq>
     </SC>
     <SC>

--- a/src/app/configs/data/shortcuts.xml
+++ b/src/app/configs/data/shortcuts.xml
@@ -396,7 +396,6 @@
     </SC>
     <SC>
         <key>export</key>
-        <seq>Ctrl+Shift+E</seq>
     </SC>
     <SC>
         <key>export-labels</key>

--- a/src/project/internal/projectuiactions.cpp
+++ b/src/project/internal/projectuiactions.cpp
@@ -50,8 +50,8 @@ const UiActionList ProjectUiActions::m_actions = {
     UiAction("project-import",
              au::context::UiCtxAny,
              au::context::CTX_ANY,
-             TranslatableString("action", "Import"),
-             TranslatableString("action", "Import")
+             TranslatableString("action", "Import..."),
+             TranslatableString("action", "Import...")
              ),
     UiAction("file-save",
              au::context::UiCtxAny,
@@ -74,8 +74,8 @@ const UiActionList ProjectUiActions::m_actions = {
     UiAction("export-audio",
              au::context::UiCtxAny,
              au::context::CTX_ANY,
-             TranslatableString("action", "&Export audio"),
-             TranslatableString("action", "Export audio")
+             TranslatableString("action", "&Export audio..."),
+             TranslatableString("action", "Export audio...")
              ),
     UiAction("export-labels",
              au::context::UiCtxAny,

--- a/src/project/internal/projectuiactions.cpp
+++ b/src/project/internal/projectuiactions.cpp
@@ -50,8 +50,8 @@ const UiActionList ProjectUiActions::m_actions = {
     UiAction("project-import",
              au::context::UiCtxAny,
              au::context::CTX_ANY,
-             TranslatableString("action", "Import..."),
-             TranslatableString("action", "Import...")
+             TranslatableString("action", "Import…"),
+             TranslatableString("action", "Import…")
              ),
     UiAction("file-save",
              au::context::UiCtxAny,
@@ -74,8 +74,8 @@ const UiActionList ProjectUiActions::m_actions = {
     UiAction("export-audio",
              au::context::UiCtxAny,
              au::context::CTX_ANY,
-             TranslatableString("action", "&Export audio..."),
-             TranslatableString("action", "Export audio...")
+             TranslatableString("action", "&Export audio…"),
+             TranslatableString("action", "Export audio…")
              ),
     UiAction("export-labels",
              au::context::UiCtxAny,


### PR DESCRIPTION
Resolves: 
https://github.com/audacity/audacity/issues/10695
https://github.com/audacity/audacity/issues/9058

- Shortcuts added: Ctrl+Shift+E (maps to Cmd+Shift+E on macOS) and Ctrl+Shift+I (maps to Cmd+Shift+I on macOS);
- Also, I decided to rename two of the File menu entries: "Import" → "Import..." and "Export audio" → "Export audio..."

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [ ] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Autobot test cases have been run
