### PR TITLE
9913 Add indicator in the windows title for unsaved projects

### DIFF
--- a/src/appshell/qml/Audacity/AppShell/mainwindowtitleprovider.cpp
+++ b/src/appshell/qml/Audacity/AppShell/mainwindowtitleprovider.cpp
@@ -105,10 +105,11 @@ void MainWindowTitleProvider::update()
     }
 
     const QString projectTitle = project->title().toQString();
+    const bool projectModified = project->hasUnsavedChanges();
     setTitle(projectTitle.isEmpty()
              ? muse::qtrc("appshell", "Audacity 4")
-             : muse::qtrc("appshell", "%1 - Audacity 4").arg(projectTitle));
+             : muse::qtrc("appshell", "%1 %2- Audacity 4").arg(projectTitle, projectModified ? QString("* ") : QString()));
 
     setFilePath(project->path().toQString());
-    setFileModified(project->hasUnsavedChanges());
+    setFileModified(projectModified);
 }


### PR DESCRIPTION
Resolves: #9913 

Add indicator on windows title for unsaved projects.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Autobot test cases have been run
