### PR TITLE
10444: put resize area on top of separator

### DIFF
--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TrackItemsContainer.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TrackItemsContainer.qml
@@ -102,17 +102,24 @@ Item {
         visible: root.isLeadInRecordingTrack
         z: 2
 
-        onVisibleChanged: if (visible) updatePosition()
+        onVisibleChanged: if (visible)
+            updatePosition()
 
         Connections {
             target: root.context
-            function onFrameStartTimeChanged() { leadInRecordingLine.updatePosition() }
-            function onFrameEndTimeChanged() { leadInRecordingLine.updatePosition() }
+            function onFrameStartTimeChanged() {
+                leadInRecordingLine.updatePosition()
+            }
+            function onFrameEndTimeChanged() {
+                leadInRecordingLine.updatePosition()
+            }
         }
 
         Connections {
             target: root
-            function onLeadInRecordingStartTimeChanged() { leadInRecordingLine.updatePosition() }
+            function onLeadInRecordingStartTimeChanged() {
+                leadInRecordingLine.updatePosition()
+            }
         }
     }
 
@@ -163,6 +170,7 @@ Item {
         anchors.right: parent.right
         anchors.bottom: parent.bottom
         height: 4
+        z: sep.z + 1
 
         cursorShape: Qt.SizeVerCursor
 


### PR DESCRIPTION
Resolves: #10444 

Resize area should be on top of separator

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Autobot test cases have been run
