### PR TITLE
Cursor shifts right when stopping lead-in recording before actual recording starts

### DIFF
--- a/src/record/internal/au3/au3record.cpp
+++ b/src/record/internal/au3/au3record.cpp
@@ -588,6 +588,10 @@ muse::Ret Au3Record::leadInRecording()
     Ret ret = doRecord(project, transportTracks, t1, DBL_MAX, false, rateOfSelected, leadInTime, pCrossfadeData);
 
     if (ret) {
+        // Initialize recording position to punch point so that cancelling
+        // during lead-in returns to the correct position
+        m_recordPosition.set(t1);
+
         // Set playhead to lead-in time start and trigger position tracking.
         // With isDefaultPlayTrackPolicy=false, the stream time starts from
         // t1-leadInTime so this will align with the actual audio position.


### PR DESCRIPTION
Resolves: #10666 

the behaviour was caused by the updated record position that wasn't happening until the recording started so jumping to the previous position from previous succeeded recording, nice catch @dozzzzer 


<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Autobot test cases have been run
