### PR TITLE
10261 warn time track on import project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,6 +154,9 @@ option(AU_USE_SOUNDTOUCH "Build with SoundTouch support for pitch/tempo effects"
 # Networking
 option(AU_USE_LIBCURL "Use libcurl for HTTP requests" OFF)
 
+# Time track
+option(AU_LOAD_TIMETRACK "Load time track from Audacity 3 projects" OFF)
+
 # === Setup ===
 
 # === Pack ===

--- a/au3/libraries/au3-time-track/TimeTrack.cpp
+++ b/au3/libraries/au3-time-track/TimeTrack.cpp
@@ -25,9 +25,32 @@
 #define TIMETRACK_MIN 0.01
 #define TIMETRACK_MAX 10.0
 
-static ProjectFileIORegistry::ObjectReaderEntry readerEntry{
+static const AudacityProject::AttachedObjects::RegisteredFactory sTimeTrackDetectorKey {
+    [](AudacityProject&) {
+        return std::make_shared<TimeTrackDetector>();
+    }
+};
+
+TimeTrackDetector& TimeTrackDetector::Get(AudacityProject& project)
+{
+    return project.AttachedObjects::Get<TimeTrackDetector>(sTimeTrackDetectorKey);
+}
+
+const TimeTrackDetector& TimeTrackDetector::Get(const AudacityProject& project)
+{
+    return Get(const_cast<AudacityProject&>(project));
+}
+
+static ProjectFileIORegistry::ObjectReaderEntry readerEntry {
     "timetrack",
-    TimeTrack::New
+    [](AudacityProject& project) -> XMLTagHandler* {
+        TimeTrackDetector::Get(project).found = true;
+#ifdef AU_LOAD_TIMETRACK
+        return TimeTrack::New(project);
+#else
+        return nullptr;
+#endif
+    }
 };
 
 wxString TimeTrack::GetDefaultName()

--- a/au3/libraries/au3-time-track/TimeTrack.h
+++ b/au3/libraries/au3-time-track/TimeTrack.h
@@ -124,4 +124,13 @@ private:
 
 ENUMERATE_TRACK_TYPE(TimeTrack);
 
+class TIME_TRACK_API TimeTrackDetector final : public ClientData::Base
+{
+public:
+    static TimeTrackDetector& Get(AudacityProject& project);
+    static const TimeTrackDetector& Get(const AudacityProject& project);
+
+    bool found { false };
+};
+
 #endif // __AUDACITY_TIMETRACK__

--- a/src/au3wrap/internal/domconverter.cpp
+++ b/src/au3wrap/internal/domconverter.cpp
@@ -1,6 +1,7 @@
 #include "domconverter.h"
 
 #include "au3-label-track/LabelTrack.h"
+#include "au3-time-track/TimeTrack.h"
 #include "au3-track/Track.h"
 #include "au3-wave-track/WaveClip.h"
 #include "au3-wave-track/WaveTrack.h"
@@ -18,6 +19,10 @@ au::trackedit::TrackType trackType(const Au3Track* track)
 {
     if (dynamic_cast<const LabelTrack*>(track)) {
         return au::trackedit::TrackType::Label;
+    }
+
+    if (dynamic_cast<const TimeTrack*>(track)) {
+        return au::trackedit::TrackType::Undefined;
     }
 
     switch (track->NChannels()) {

--- a/src/project/internal/projectactionscontroller.cpp
+++ b/src/project/internal/projectactionscontroller.cpp
@@ -872,7 +872,7 @@ Ret ProjectActionsController::doOpenProject(const io::path_t& filePath)
     if (trackeditProject && trackeditProject->timeTrackFound()) {
         interactive()->infoSync(muse::trc("project/open", "Time Track not supported"),
                                 muse::trc("project/open",
-                                          "The project contained a time track, which is not yet supported in Audacity 4, and was removed. This does not affect your original Audacity 3 project."),
+                                          "The project contains a time track, which is not yet supported in Audacity 4, and will need to be removed. This does not affect your original Audacity 3 project."),
         {
             muse::IInteractive::ButtonData(
                 muse::IInteractive::Button::Ok, muse::trc("project/open", "Ok"), false)

--- a/src/project/internal/projectactionscontroller.cpp
+++ b/src/project/internal/projectactionscontroller.cpp
@@ -868,7 +868,8 @@ Ret ProjectActionsController::doOpenProject(const io::path_t& filePath)
     globalContext()->setCurrentProject(project);
 
 #ifndef AU_LOAD_TIMETRACK
-    if (project->trackeditProject()->timeTrackFound()) {
+    const auto trackeditProject = project->trackeditProject();
+    if (trackeditProject && trackeditProject->timeTrackFound()) {
         interactive()->infoSync(muse::trc("project/open", "Time Track not supported"),
                                 muse::trc("project/open",
                                           "The project contained a time track, which is not yet supported in Audacity 4, and was removed. This does not affect your original Audacity 3 project."),

--- a/src/project/internal/projectactionscontroller.cpp
+++ b/src/project/internal/projectactionscontroller.cpp
@@ -867,6 +867,7 @@ Ret ProjectActionsController::doOpenProject(const io::path_t& filePath)
 
     globalContext()->setCurrentProject(project);
 
+#ifndef AU_LOAD_TIMETRACK
     if (project->trackeditProject()->timeTrackFound()) {
         interactive()->infoSync(muse::trc("project/open", "Time Track not supported"),
                                 muse::trc("project/open",
@@ -880,6 +881,7 @@ Ret ProjectActionsController::doOpenProject(const io::path_t& filePath)
         // We need to save the project immediately to remove the time track from the project file and avoid showing this message repeatedly
         saveProject(SaveMode::Save);
     }
+#endif
 
     projectHistory()->init();
 

--- a/src/project/internal/projectactionscontroller.cpp
+++ b/src/project/internal/projectactionscontroller.cpp
@@ -867,6 +867,16 @@ Ret ProjectActionsController::doOpenProject(const io::path_t& filePath)
 
     globalContext()->setCurrentProject(project);
 
+    if (project->trackeditProject()->timeTrackFound()) {
+        interactive()->infoSync(muse::trc("project/open", "Time Track not supported"),
+                                muse::trc("project/open",
+                                          "This project contains a time track, which is not yet supported in Audacity 4, and will need to be removed. This does not affect your original Audacity 3 project."),
+        {
+            muse::IInteractive::ButtonData(
+                muse::IInteractive::Button::Ok, muse::trc("project/open", "Ok"), false)
+        });
+    }
+
     projectHistory()->init();
 
     return openPageIfNeed(PROJECT_PAGE_URI);

--- a/src/project/internal/projectactionscontroller.cpp
+++ b/src/project/internal/projectactionscontroller.cpp
@@ -875,6 +875,10 @@ Ret ProjectActionsController::doOpenProject(const io::path_t& filePath)
             muse::IInteractive::ButtonData(
                 muse::IInteractive::Button::Ok, muse::trc("project/open", "Ok"), false)
         });
+
+        // When saving we do a full project rewrite
+        // We need to save the project immediately to remove the time track from the project file and avoid showing this message repeatedly
+        saveProject(SaveMode::Save);
     }
 
     projectHistory()->init();

--- a/src/project/internal/projectactionscontroller.cpp
+++ b/src/project/internal/projectactionscontroller.cpp
@@ -870,7 +870,7 @@ Ret ProjectActionsController::doOpenProject(const io::path_t& filePath)
     if (project->trackeditProject()->timeTrackFound()) {
         interactive()->infoSync(muse::trc("project/open", "Time Track not supported"),
                                 muse::trc("project/open",
-                                          "This project contains a time track, which is not yet supported in Audacity 4, and will need to be removed. This does not affect your original Audacity 3 project."),
+                                          "The project contained a time track, which is not yet supported in Audacity 4, and was removed. This does not affect your original Audacity 3 project."),
         {
             muse::IInteractive::ButtonData(
                 muse::IInteractive::Button::Ok, muse::trc("project/open", "Ok"), false)

--- a/src/trackedit/internal/au3/au3trackeditproject.cpp
+++ b/src/trackedit/internal/au3/au3trackeditproject.cpp
@@ -1,6 +1,7 @@
 #include "au3trackeditproject.h"
 
 #include "au3-track/Track.h"
+#include "au3-time-track/TimeTrack.h"
 #include "au3-numeric-formats/ProjectTimeSignature.h"
 #include "au3-stretching-sequence/TempoChange.h"
 #include "au3-project-history/UndoManager.h"
@@ -49,6 +50,11 @@ Au3TrackeditProject::Au3TrackeditProject(const muse::modularity::ContextPtr& ctx
 Au3TrackeditProject::~Au3TrackeditProject()
 {
     m_impl->tracksSubc.Reset();
+}
+
+bool Au3TrackeditProject::timeTrackFound() const
+{
+    return TimeTrackDetector::Get(*m_impl->prj).found;
 }
 
 std::vector<int64_t> Au3TrackeditProject::groupsIdsList() const

--- a/src/trackedit/internal/au3/au3trackeditproject.h
+++ b/src/trackedit/internal/au3/au3trackeditproject.h
@@ -25,6 +25,7 @@ public:
 
     TrackIdList trackIdList() const override;
     std::vector<Track> trackList() const override;
+    bool timeTrackFound() const override;
     std::optional<Track> track(TrackId trackId) const override;
     Clip clip(const ClipKey& key) const override;
     Label label(const LabelKey& key) const override;

--- a/src/trackedit/itrackeditproject.h
+++ b/src/trackedit/itrackeditproject.h
@@ -34,6 +34,7 @@ public:
 
     virtual std::vector<TrackId> trackIdList() const = 0;
     virtual std::vector<Track> trackList() const = 0;
+    virtual bool timeTrackFound() const = 0;
     virtual std::optional<Track> track(TrackId trackId) const = 0;
     virtual Clip clip(const ClipKey& key) const = 0;
     virtual Label label(const LabelKey& key) const = 0;

--- a/src/trackedit/tests/mocks/trackeditprojectmock.h
+++ b/src/trackedit/tests/mocks/trackeditprojectmock.h
@@ -13,6 +13,7 @@ class TrackeditProjectMock : public ITrackeditProject
 public:
     MOCK_METHOD(std::vector<TrackId>, trackIdList, (), (const, override));
     MOCK_METHOD(std::vector<Track>, trackList, (), (const, override));
+    MOCK_METHOD(bool, timeTrackFound, (), (const, override));
     MOCK_METHOD(std::optional<Track>, track, (TrackId trackId), (const, override));
 
     MOCK_METHOD(Clip, clip, (const ClipKey& key), (const, override));


### PR DESCRIPTION
Resolves: #10261

Warn the user that the time track data will be removed on the aup3 to aup4 conversion.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Autobot test cases have been run

@coderabbitai ignore
