### PR TITLE
Clip navigation improvements

### DIFF
--- a/src/app/configs/data/shortcuts.xml
+++ b/src/app/configs/data/shortcuts.xml
@@ -151,12 +151,12 @@
     </SC>
 
     <SC>
-        <key>track-view-next-track</key>
-        <seq>Down</seq>
+        <key>track-view-above-item</key>
+        <seq>Up</seq>
     </SC>
     <SC>
-        <key>track-view-prev-track</key>
-        <seq>Up</seq>
+        <key>track-view-below-item</key>
+        <seq>Down</seq>
     </SC>
     <SC>
         <key>track-view-first-track</key>

--- a/src/appshell/internal/applicationactioncontroller.cpp
+++ b/src/appshell/internal/applicationactioncontroller.cpp
@@ -431,9 +431,9 @@ void ApplicationActionController::doGlobalCancel()
 {
     if (isProjectOpenedAndFocused()) {
         dispatcher()->dispatch("action://trackedit/cancel");
-    } else {
-        dispatcher()->dispatch("nav-escape");
     }
+
+    dispatcher()->dispatch("nav-escape");
 }
 
 void ApplicationActionController::doGlobalTrigger()

--- a/src/context/internal/uicontextresolver.cpp
+++ b/src/context/internal/uicontextresolver.cpp
@@ -118,7 +118,7 @@ muse::ui::UiContext UiContextResolver::resolveUiContext() const
 
         INavigationSection* activeSection = navigationController()->activeSection();
         if (activeSection) {
-            if (activeSection->name() == DEFAULT_NAVIGATION_SECTION && trackNavigationController()->isNavigationEnabled()) {
+            if (activeSection->name() == DEFAULT_NAVIGATION_SECTION) {
                 return context::UiCtxProjectFocused;
             }
         }

--- a/src/effects/effects_base/internal/effectexecutionscenario.cpp
+++ b/src/effects/effects_base/internal/effectexecutionscenario.cpp
@@ -133,7 +133,7 @@ muse::Ret EffectExecutionScenario::doPerformEffect(au3::Au3Project& project, con
                 }
                 t0 = selectionController()->dataSelectedStartTime();
                 t1 = selectionController()->dataSelectedEndTime();
-                isTimeSelection = selectionController()->timeSelectionIsNotEmpty();
+                isTimeSelection = !selectionController()->timeSelectionIsEmpty();
             } else if (!isTrackSelection) {
                 // Select all tracks without modifying time selection
                 const auto prj = globalContext()->currentTrackeditProject();

--- a/src/importexport/export/internal/au3/au3exporter.cpp
+++ b/src/importexport/export/internal/au3/au3exporter.cpp
@@ -204,10 +204,10 @@ muse::Ret Au3Exporter::exportData(const muse::io::path_t& path, const Options& o
     // TODO: implement other ExportProcessType's selections
     if (processType == ExportProcessType::SELECTED_AUDIO) {
         m_t0
-            = selectionController()->timeSelectionIsNotEmpty() ? selectionController()->dataSelectedStartTime()
+            = !selectionController()->timeSelectionIsEmpty() ? selectionController()->dataSelectedStartTime()
               : selectionController()->leftMostSelectedClipStartTime().value_or(0.0);
         m_t1
-            = selectionController()->timeSelectionIsNotEmpty() ? selectionController()->dataSelectedEndTime()
+            = !selectionController()->timeSelectionIsEmpty() ? selectionController()->dataSelectedEndTime()
               : selectionController()->rightMostSelectedClipEndTime().value_or(0.0);
         m_selectedOnly = true;
     } else if (processType == ExportProcessType::AUDIO_IN_LOOP_REGION) {

--- a/src/importexport/export/view/exportpreferencesmodel.cpp
+++ b/src/importexport/export/view/exportpreferencesmodel.cpp
@@ -87,7 +87,7 @@ void ExportPreferencesModel::init()
     if ((exportConfiguration()->processType() == ExportProcessType::AUDIO_IN_LOOP_REGION
          && !playbackController()->loopRegion().isValid())
         || (exportConfiguration()->processType() == ExportProcessType::SELECTED_AUDIO
-            && !selectionController()->timeSelectionIsNotEmpty())) {
+            && selectionController()->timeSelectionIsEmpty())) {
         setCurrentProcess(QString::fromStdString(EXPORT_PROCESS_MAPPING[ExportProcessType::FULL_PROJECT_AUDIO]));
     }
 
@@ -174,7 +174,7 @@ void ExportPreferencesModel::setCurrentProcess(const QString& newProcess)
         return;
     }
 
-    const bool timeEmpty = !selectionController()->timeSelectionIsNotEmpty();
+    const bool timeEmpty = selectionController()->timeSelectionIsEmpty();
     const bool noClips = !selectionController()->hasSelectedClips();
     const bool moreThanOneClip = selectionController()->selectedClips().size() > 1;
     if (type == ExportProcessType::SELECTED_AUDIO

--- a/src/playback/internal/au3/au3player.cpp
+++ b/src/playback/internal/au3/au3player.cpp
@@ -453,7 +453,7 @@ void Au3Player::setLoopRegionActive(const bool active)
         double start = 0;
         double end = 0;
 
-        if (selectionController()->timeSelectionIsNotEmpty()) {
+        if (!selectionController()->timeSelectionIsEmpty()) {
             start = selectionController()->dataSelectedStartTime();
             end = selectionController()->dataSelectedEndTime();
         } else if (selectionController()->leftMostSelectedItemStartTime().has_value()) {

--- a/src/playback/internal/playbackcontroller.cpp
+++ b/src/playback/internal/playbackcontroller.cpp
@@ -176,7 +176,7 @@ PlaybackRegion PlaybackController::selectionPlaybackRegion() const
         return { itemStart.value(), itemEnd.value() };
     }
 
-    if (selectionController()->timeSelectionIsNotEmpty()) {
+    if (!selectionController()->timeSelectionIsEmpty()) {
         return { selectionController()->dataSelectedStartTime(),
                  selectionController()->dataSelectedEndTime() };
     }
@@ -593,7 +593,7 @@ void PlaybackController::setLoopRegionToSelection()
     double start = 0;
     double end = 0;
 
-    if (selectionController()->timeSelectionIsNotEmpty()) {
+    if (!selectionController()->timeSelectionIsEmpty()) {
         start = selectionController()->dataSelectedStartTime();
         end = selectionController()->dataSelectedEndTime();
     } else {

--- a/src/playback/tests/playbackcontroller_tests.cpp
+++ b/src/playback/tests/playbackcontroller_tests.cpp
@@ -163,8 +163,8 @@ TEST_F(PlaybackControllerTests, TogglePlay_WhenStopped)
     .WillOnce(Return(std::nullopt));
 
     //! [GIVEN] No time selection
-    EXPECT_CALL(*m_selectionController, timeSelectionIsNotEmpty())
-    .WillOnce(Return(false));
+    EXPECT_CALL(*m_selectionController, timeSelectionIsEmpty())
+    .WillOnce(Return(true));
 
     //! [GIVEN] No loop region active
     EXPECT_CALL(*m_player, isLoopRegionActive())
@@ -226,8 +226,8 @@ TEST_F(PlaybackControllerTests, TogglePlay_WithSelection)
 
     //! [GIVEN] There is selection from 10 to 20 secs
     PlaybackRegion selectionRegion = { secs_t(10.0), secs_t(20.0) };
-    EXPECT_CALL(*m_selectionController, timeSelectionIsNotEmpty())
-    .WillOnce(Return(true));
+    EXPECT_CALL(*m_selectionController, timeSelectionIsEmpty())
+    .WillOnce(Return(false));
     EXPECT_CALL(*m_selectionController, dataSelectedStartTime())
     .WillOnce(Return(selectionRegion.start));
     EXPECT_CALL(*m_selectionController, dataSelectedEndTime())
@@ -299,7 +299,7 @@ TEST_F(PlaybackControllerTests, TogglePlay_WithIgnoreSelection)
     .WillByDefault(Return(Qt::ShiftModifier));
 
     //! [THEN] No checking selection
-    EXPECT_CALL(*m_selectionController, timeSelectionIsNotEmpty())
+    EXPECT_CALL(*m_selectionController, timeSelectionIsEmpty())
     .Times(0);
 
     //! [THEN] Expect that playback region will be reseted and playback will be seek to previous seek position
@@ -437,7 +437,7 @@ TEST_F(PlaybackControllerTests, TogglePlay_WhenPaused_WithIgnoreSelection)
     .WillRepeatedly(Return());
 
     //! [THEN] No checking selection
-    EXPECT_CALL(*m_selectionController, timeSelectionIsNotEmpty())
+    EXPECT_CALL(*m_selectionController, timeSelectionIsEmpty())
     .Times(0);
 
     //! [THEN] Player should start playing
@@ -476,8 +476,8 @@ TEST_F(PlaybackControllerTests, TogglePlay_WhenPaused_WithChangingSelection)
 
     //! [THEN] Expect that playbeck should run from selection start position
     PlaybackRegion selectionRegion = { secs_t(10.0), secs_t(20.0) };
-    EXPECT_CALL(*m_selectionController, timeSelectionIsNotEmpty())
-    .WillOnce(Return(true));
+    EXPECT_CALL(*m_selectionController, timeSelectionIsEmpty())
+    .WillOnce(Return(false));
     EXPECT_CALL(*m_selectionController, dataSelectedStartTime())
     .WillOnce(Return(selectionRegion.start));
     EXPECT_CALL(*m_selectionController, dataSelectedEndTime())
@@ -515,8 +515,8 @@ TEST_F(PlaybackControllerTests, TogglePlay_WithSelection_StartTimeIsMoreThanTota
 
     //! [GIVEN] There is selection from 10 to 20 secs
     PlaybackRegion selectionRegion = { secs_t(1000.0), secs_t(2000.0) };
-    EXPECT_CALL(*m_selectionController, timeSelectionIsNotEmpty())
-    .WillOnce(Return(true));
+    EXPECT_CALL(*m_selectionController, timeSelectionIsEmpty())
+    .WillOnce(Return(false));
     EXPECT_CALL(*m_selectionController, dataSelectedStartTime())
     .WillOnce(Return(selectionRegion.start));
     EXPECT_CALL(*m_selectionController, dataSelectedEndTime())

--- a/src/projectscene/internal/projectsceneuiactions.cpp
+++ b/src/projectscene/internal/projectsceneuiactions.cpp
@@ -195,6 +195,30 @@ static UiActionList STATIC_ACTIONS = {
              TranslatableString("action", "Move play cursor right"),
              TranslatableString("action", "Move play cursor right")
              ),
+    UiAction("sel-ext-left",
+             au::context::UiCtxProjectOpened,
+             muse::shortcuts::CTX_PROJECT_OPENED,
+             TranslatableString("action", "Extend selection left"),
+             TranslatableString("action", "Extend selection left")
+             ),
+    UiAction("sel-ext-right",
+             au::context::UiCtxProjectOpened,
+             muse::shortcuts::CTX_PROJECT_OPENED,
+             TranslatableString("action", "Extend selection right"),
+             TranslatableString("action", "Extend selection right")
+             ),
+    UiAction("sel-cntr-left",
+             au::context::UiCtxProjectOpened,
+             muse::shortcuts::CTX_PROJECT_OPENED,
+             TranslatableString("action", "Contract selection from left"),
+             TranslatableString("action", "Contract selection from left")
+             ),
+    UiAction("sel-cntr-right",
+             au::context::UiCtxProjectOpened,
+             muse::shortcuts::CTX_PROJECT_OPENED,
+             TranslatableString("action", "Contract selection from right"),
+             TranslatableString("action", "Contract selection from right")
+             ),
     UiAction("clip-pitch-speed",
              au::context::UiCtxAny,
              au::context::CTX_ANY,

--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TrackClipsContainer.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TrackClipsContainer.qml
@@ -258,12 +258,14 @@ TrackItemsContainer {
                         asynchronous: false
 
                         sourceComponent: {
-                            if ((itemData.x + itemData.width) < (0 - clipsModel.cacheBufferPx)) {
-                                return null
-                            }
+                            if (!itemData.focused) {
+                                if ((itemData.x + itemData.width) < (0 - clipsModel.cacheBufferPx)) {
+                                    return null
+                                }
 
-                            if (itemData.x > (clipsContainer.width + clipsModel.cacheBufferPx)) {
-                                return null
+                                if (itemData.x > (clipsContainer.width + clipsModel.cacheBufferPx)) {
+                                    return null
+                                }
                             }
 
                             //! NOTE This optimization is disabled, it is probably not needed,

--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TrackClipsContainer.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TrackClipsContainer.qml
@@ -354,7 +354,7 @@ TrackItemsContainer {
                                 navigation.accessible.name: Boolean(itemData) ? itemData.title : ""
                                 navigation.onActiveChanged: {
                                     if (navigation.active) {
-                                        root.context.insureVisible(root.context.positionToTime(itemData.x))
+                                        root.context.animatedInsureVisible(itemData.time.startTime)
                                         root.insureVerticallyVisible()
                                     }
                                 }

--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TrackLabelsContainer.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TrackLabelsContainer.qml
@@ -188,7 +188,7 @@ TrackItemsContainer {
                                 navigation.accessible.name: Boolean(itemData) ? itemData.title : ""
                                 navigation.onActiveChanged: {
                                     if (navigation.active) {
-                                        root.context.insureVisible(root.context.positionToTime(itemData.x))
+                                        root.context.animatedInsureVisible(itemData.time.startTime)
                                         root.insureVerticallyVisible()
                                     }
                                 }

--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TrackLabelsContainer.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TrackLabelsContainer.qml
@@ -146,12 +146,14 @@ TrackItemsContainer {
                         visible: y < root.height
 
                         sourceComponent: {
-                            if ((itemData.x + itemData.width) < (0 - labelsModel.cacheBufferPx)) {
-                                return null
-                            }
+                            if (!itemData.focused) {
+                                if ((itemData.x + itemData.width) < (0 - labelsModel.cacheBufferPx)) {
+                                    return null
+                                }
 
-                            if (itemData.x > (labelsContainer.width + labelsModel.cacheBufferPx)) {
-                                return null
+                                if (itemData.x > (labelsContainer.width + labelsModel.cacheBufferPx)) {
+                                    return null
+                                }
                             }
 
                             return labelComp

--- a/src/projectscene/types/projectscenetypes.h
+++ b/src/projectscene/types/projectscenetypes.h
@@ -55,6 +55,8 @@ class TrackItemTime
 {
     Q_GADGET
 
+    Q_PROPERTY(double startTime MEMBER startTime CONSTANT)
+
 public:
 
     double startTime = 0.0;

--- a/src/projectscene/view/playcursor/playcursorcontroller.cpp
+++ b/src/projectscene/view/playcursor/playcursorcontroller.cpp
@@ -134,7 +134,7 @@ void PlayCursorController::updatePositionX(muse::secs_t secs)
                 }
             } else {
                 double predictedSecs = secs + ANIMATION_DURATION_SEC;
-                if (predictedSecs < m_context->frameStartTime() || secs > m_context->frameEndTime()) {
+                if (predictedSecs < m_context->frameStartTime() || predictedSecs > m_context->frameEndTime()) {
                     if (zoomTooClose) {
                         m_context->insureVisible(secs);
                     } else {

--- a/src/projectscene/view/playcursor/playcursorcontroller.cpp
+++ b/src/projectscene/view/playcursor/playcursorcontroller.cpp
@@ -31,6 +31,7 @@ static const ActionQuery PLAYBACK_SEEK_QUERY("action://playback/seek");
 static const ActionQuery PLAYBACK_CHANGE_PLAY_REGION_QUERY("action://playback/play-region-change");
 
 static constexpr int SCROLL_SUPPRESSION_TIMEOUT_MS = 3000;
+static constexpr double ANIMATION_DURATION_SEC = TimelineContext::ANIMATION_DURATION_MS / 1000.0;
 
 PlayCursorController::PlayCursorController(QObject* parent)
     : QObject(parent), muse::Contextable(muse::iocCtxForQmlObject(this))
@@ -116,11 +117,30 @@ void PlayCursorController::updatePositionX(muse::secs_t secs)
         const bool updateDisplayWhilePlaying = m_context->updateDisplayWhilePlayingEnabled();
         const bool pinnedPlayHead = m_context->pinnedPlayHeadEnabled();
 
-        if (updateDisplayWhilePlaying && !m_viewUpdatesSuppressed) {
+        if (updateDisplayWhilePlaying && !m_viewUpdatesSuppressed && !m_context->isAnimating()) {
+            const double halfFrameDuration = (m_context->frameEndTime() - m_context->frameStartTime()) * 0.5;
+            const bool zoomTooClose = halfFrameDuration < ANIMATION_DURATION_SEC;
+
             if (pinnedPlayHead) {
-                ensureCursorAtCenter(secs);
+                if (secs < m_context->frameStartTime() || secs > m_context->frameEndTime()) {
+                    if (zoomTooClose) {
+                        ensureCursorAtCenter(secs);
+                    } else {
+                        double predictedSecs = secs + ANIMATION_DURATION_SEC;
+                        m_context->animatedCenterOnTime(predictedSecs);
+                    }
+                } else {
+                    ensureCursorAtCenter(secs);
+                }
             } else {
-                m_context->insureVisible(secs);
+                double predictedSecs = secs + ANIMATION_DURATION_SEC;
+                if (predictedSecs < m_context->frameStartTime() || secs > m_context->frameEndTime()) {
+                    if (zoomTooClose) {
+                        m_context->insureVisible(secs);
+                    } else {
+                        m_context->animatedInsureVisible(predictedSecs);
+                    }
+                }
             }
         }
     }

--- a/src/projectscene/view/playcursor/playpositionactioncontroller.cpp
+++ b/src/projectscene/view/playcursor/playpositionactioncontroller.cpp
@@ -111,7 +111,12 @@ void PlayPositionActionController::applySingleStep(Direction direction)
 
 muse::secs_t PlayPositionActionController::stepFromTime(muse::secs_t from, Direction direction) const
 {
-    IProjectViewStatePtr viewState = globalContext()->currentProject()->viewState();
+    auto currentProject = globalContext()->currentProject();
+    if (!currentProject) {
+        return from;
+    }
+
+    IProjectViewStatePtr viewState = currentProject->viewState();
     const bool snapEnabled = viewState->isSnapEnabled();
 
     if (snapEnabled) {

--- a/src/projectscene/view/playcursor/playpositionactioncontroller.cpp
+++ b/src/projectscene/view/playcursor/playpositionactioncontroller.cpp
@@ -130,7 +130,7 @@ muse::secs_t PlayPositionActionController::stepFromTime(muse::secs_t from, Direc
 
 void PlayPositionActionController::selectionExtendLeft()
 {
-    if (!selectionController()->timeSelectionIsNotEmpty()) {
+    if (selectionController()->timeSelectionIsEmpty()) {
         selectionController()->initSelectionAtPlayhead();
     }
     const muse::secs_t from = selectionController()->dataSelectedStartTime();
@@ -142,7 +142,7 @@ void PlayPositionActionController::selectionExtendLeft()
 
 void PlayPositionActionController::selectionExtendRight()
 {
-    if (!selectionController()->timeSelectionIsNotEmpty()) {
+    if (selectionController()->timeSelectionIsEmpty()) {
         selectionController()->initSelectionAtPlayhead();
     }
     const muse::secs_t from = selectionController()->dataSelectedEndTime();
@@ -151,7 +151,7 @@ void PlayPositionActionController::selectionExtendRight()
 
 void PlayPositionActionController::selectionContractLeft()
 {
-    if (!selectionController()->timeSelectionIsNotEmpty()) {
+    if (selectionController()->timeSelectionIsEmpty()) {
         return;
     }
     const muse::secs_t end = selectionController()->dataSelectedEndTime();
@@ -164,7 +164,7 @@ void PlayPositionActionController::selectionContractLeft()
 
 void PlayPositionActionController::selectionContractRight()
 {
-    if (!selectionController()->timeSelectionIsNotEmpty()) {
+    if (selectionController()->timeSelectionIsEmpty()) {
         return;
     }
     const muse::secs_t start = selectionController()->dataSelectedStartTime();

--- a/src/projectscene/view/playcursor/playpositionactioncontroller.cpp
+++ b/src/projectscene/view/playcursor/playpositionactioncontroller.cpp
@@ -113,6 +113,8 @@ void PlayPositionActionController::applySingleStep(Direction direction)
         q.addParam("seekTime", muse::Val(secs));
         q.addParam("triggerPlay", muse::Val(false));
         dispatcher()->dispatch(q);
+
+        m_context->animatedInsureVisible(secs);
     }
 }
 

--- a/src/projectscene/view/playcursor/playpositionactioncontroller.cpp
+++ b/src/projectscene/view/playcursor/playpositionactioncontroller.cpp
@@ -130,18 +130,23 @@ muse::secs_t PlayPositionActionController::stepFromTime(muse::secs_t from, Direc
 
 void PlayPositionActionController::selectionExtendLeft()
 {
-    const muse::secs_t from = selectionController()->timeSelectionIsNotEmpty()
-                              ? selectionController()->dataSelectedStartTime()
-                              : playbackState()->playbackPosition();
-    selectionController()->extendSelectionStart(stepFromTime(from, Direction::Left));
+    if (!selectionController()->timeSelectionIsNotEmpty()) {
+        selectionController()->initSelectionAtPlayhead();
+    }
+    const muse::secs_t from = selectionController()->dataSelectedStartTime();
+    const muse::secs_t newStart = stepFromTime(from, Direction::Left);
+    if (muse::RealIsEqualOrMore(newStart, 0.0)) {
+        selectionController()->setDataSelectedStartTime(newStart, true);
+    }
 }
 
 void PlayPositionActionController::selectionExtendRight()
 {
-    const muse::secs_t from = selectionController()->timeSelectionIsNotEmpty()
-                              ? selectionController()->dataSelectedEndTime()
-                              : playbackState()->playbackPosition();
-    selectionController()->extendSelectionEnd(stepFromTime(from, Direction::Right));
+    if (!selectionController()->timeSelectionIsNotEmpty()) {
+        selectionController()->initSelectionAtPlayhead();
+    }
+    const muse::secs_t from = selectionController()->dataSelectedEndTime();
+    selectionController()->setDataSelectedEndTime(stepFromTime(from, Direction::Right), true);
 }
 
 void PlayPositionActionController::selectionContractLeft()
@@ -149,8 +154,12 @@ void PlayPositionActionController::selectionContractLeft()
     if (!selectionController()->timeSelectionIsNotEmpty()) {
         return;
     }
-    const muse::secs_t from = selectionController()->dataSelectedStartTime();
-    selectionController()->contractSelectionStart(stepFromTime(from, Direction::Right));
+    const muse::secs_t end = selectionController()->dataSelectedEndTime();
+    muse::secs_t newStart = stepFromTime(selectionController()->dataSelectedStartTime(), Direction::Right);
+    if (muse::RealIsEqualOrMore(newStart, end)) {
+        newStart = end;
+    }
+    selectionController()->setDataSelectedStartTime(newStart, true);
 }
 
 void PlayPositionActionController::selectionContractRight()
@@ -158,8 +167,12 @@ void PlayPositionActionController::selectionContractRight()
     if (!selectionController()->timeSelectionIsNotEmpty()) {
         return;
     }
-    const muse::secs_t from = selectionController()->dataSelectedEndTime();
-    selectionController()->contractSelectionEnd(stepFromTime(from, Direction::Left));
+    const muse::secs_t start = selectionController()->dataSelectedStartTime();
+    muse::secs_t newEnd = stepFromTime(selectionController()->dataSelectedEndTime(), Direction::Left);
+    if (muse::RealIsEqualOrLess(newEnd, start)) {
+        newEnd = start;
+    }
+    selectionController()->setDataSelectedEndTime(newEnd, true);
 }
 
 void PlayPositionActionController::onProjectChanged()

--- a/src/projectscene/view/playcursor/playpositionactioncontroller.cpp
+++ b/src/projectscene/view/playcursor/playpositionactioncontroller.cpp
@@ -29,6 +29,10 @@ using namespace muse::actions;
 
 static const ActionCode PLAY_POSITION_DECREASE("play-position-decrease");
 static const ActionCode PLAY_POSITION_INCREASE("play-position-increase");
+static const ActionCode SEL_EXT_LEFT("sel-ext-left");
+static const ActionCode SEL_EXT_RIGHT("sel-ext-right");
+static const ActionCode SEL_CNTR_LEFT("sel-cntr-left");
+static const ActionCode SEL_CNTR_RIGHT("sel-cntr-right");
 static const ActionQuery PLAYBACK_SEEK_QUERY("action://playback/seek");
 
 au::projectscene::PlayPositionActionController::PlayPositionActionController(QObject* parent)
@@ -40,6 +44,10 @@ void PlayPositionActionController::init()
 {
     dispatcher()->reg(this, PLAY_POSITION_DECREASE, this, &PlayPositionActionController::playPositionDecrease);
     dispatcher()->reg(this, PLAY_POSITION_INCREASE, this, &PlayPositionActionController::playPositionIncrease);
+    dispatcher()->reg(this, SEL_EXT_LEFT, this, &PlayPositionActionController::selectionExtendLeft);
+    dispatcher()->reg(this, SEL_EXT_RIGHT, this, &PlayPositionActionController::selectionExtendRight);
+    dispatcher()->reg(this, SEL_CNTR_LEFT, this, &PlayPositionActionController::selectionContractLeft);
+    dispatcher()->reg(this, SEL_CNTR_RIGHT, this, &PlayPositionActionController::selectionContractRight);
 
     globalContext()->currentProjectChanged().onNotify(this, [this](){
         onProjectChanged();
@@ -88,25 +96,8 @@ void PlayPositionActionController::snapCurrentPosition()
 
 void PlayPositionActionController::applySingleStep(Direction direction)
 {
-    IProjectViewStatePtr viewState = globalContext()->currentProject()->viewState();
-    bool snapEnabled = viewState->isSnapEnabled();
-
     const muse::secs_t currentPlaybackPosition = playbackState()->playbackPosition();
-    muse::secs_t secs = 0;
-
-    if (snapEnabled) {
-        const double currentXPosition = m_context->timeToPosition(currentPlaybackPosition);
-        secs = m_context->singleStepToTime(currentXPosition, direction, viewState->snap().val);
-    } else {
-        double newXPosition = 0.0;
-        if (direction == Direction::Left) {
-            newXPosition = m_context->timeToPosition(currentPlaybackPosition) - 1;
-        } else {
-            newXPosition = m_context->timeToPosition(currentPlaybackPosition) + 1;
-        }
-
-        secs = m_context->positionToTime(newXPosition);
-    }
+    const muse::secs_t secs = stepFromTime(currentPlaybackPosition, direction);
 
     if (muse::RealIsEqualOrMore(secs, 0.0)) {
         muse::actions::ActionQuery q(PLAYBACK_SEEK_QUERY);
@@ -116,6 +107,54 @@ void PlayPositionActionController::applySingleStep(Direction direction)
 
         m_context->animatedInsureVisible(secs);
     }
+}
+
+muse::secs_t PlayPositionActionController::stepFromTime(muse::secs_t from, Direction direction) const
+{
+    IProjectViewStatePtr viewState = globalContext()->currentProject()->viewState();
+    const bool snapEnabled = viewState->isSnapEnabled();
+
+    if (snapEnabled) {
+        const double currentXPosition = m_context->timeToPosition(from);
+        return m_context->singleStepToTime(currentXPosition, direction, viewState->snap().val);
+    }
+
+    const double newXPosition = m_context->timeToPosition(from) + (direction == Direction::Left ? -1 : 1);
+    return m_context->positionToTime(newXPosition);
+}
+
+void PlayPositionActionController::selectionExtendLeft()
+{
+    const muse::secs_t from = selectionController()->timeSelectionIsNotEmpty()
+                              ? selectionController()->dataSelectedStartTime()
+                              : playbackState()->playbackPosition();
+    selectionController()->extendSelectionStart(stepFromTime(from, Direction::Left));
+}
+
+void PlayPositionActionController::selectionExtendRight()
+{
+    const muse::secs_t from = selectionController()->timeSelectionIsNotEmpty()
+                              ? selectionController()->dataSelectedEndTime()
+                              : playbackState()->playbackPosition();
+    selectionController()->extendSelectionEnd(stepFromTime(from, Direction::Right));
+}
+
+void PlayPositionActionController::selectionContractLeft()
+{
+    if (!selectionController()->timeSelectionIsNotEmpty()) {
+        return;
+    }
+    const muse::secs_t from = selectionController()->dataSelectedStartTime();
+    selectionController()->contractSelectionStart(stepFromTime(from, Direction::Right));
+}
+
+void PlayPositionActionController::selectionContractRight()
+{
+    if (!selectionController()->timeSelectionIsNotEmpty()) {
+        return;
+    }
+    const muse::secs_t from = selectionController()->dataSelectedEndTime();
+    selectionController()->contractSelectionEnd(stepFromTime(from, Direction::Left));
 }
 
 void PlayPositionActionController::onProjectChanged()

--- a/src/projectscene/view/playcursor/playpositionactioncontroller.h
+++ b/src/projectscene/view/playcursor/playpositionactioncontroller.h
@@ -27,6 +27,7 @@
 #include "modularity/ioc.h"
 #include "context/iglobalcontext.h"
 #include "actions/iactionsdispatcher.h"
+#include "trackedit/iselectioncontroller.h"
 
 #include "../timeline/timelinecontext.h"
 
@@ -40,6 +41,7 @@ class PlayPositionActionController : public QObject, public muse::actions::Actio
 
     muse::ContextInject<context::IGlobalContext> globalContext{ this };
     muse::ContextInject<muse::actions::IActionsDispatcher> dispatcher{ this };
+    muse::ContextInject<trackedit::ISelectionController> selectionController{ this };
 
 public:
     PlayPositionActionController(QObject* parent = nullptr);
@@ -52,6 +54,11 @@ public:
     void playPositionDecrease();
     void playPositionIncrease();
 
+    void selectionExtendLeft();
+    void selectionExtendRight();
+    void selectionContractLeft();
+    void selectionContractRight();
+
 signals:
     void timelineContextChanged();
 
@@ -60,6 +67,8 @@ private:
 
     void snapCurrentPosition();
     void applySingleStep(Direction direction);
+
+    muse::secs_t stepFromTime(muse::secs_t from, Direction direction) const;
 
     context::IPlaybackStatePtr playbackState() const;
 

--- a/src/projectscene/view/timeline/timelinecontext.cpp
+++ b/src/projectscene/view/timeline/timelinecontext.cpp
@@ -67,12 +67,14 @@ void TimelineContext::init(double frameWidth)
         double eased = 1.0 - (inv * inv * inv);
 
         double current = m_animationStartValue + (m_animationTargetValue - m_animationStartValue) * eased;
+        double frameStart = (t >= 1.0) ? m_animationTargetValue : current;
+
+        //! NOTE Bypass moveToFrameTime() so we don't cancel our own animation.
+        setFrameStartTime(std::max(frameStart, 0.0));
+        updateFrameTime();
 
         if (t >= 1.0) {
             m_animationTimer.stop();
-            moveToFrameTime(m_animationTargetValue);
-        } else {
-            moveToFrameTime(current);
         }
     });
 
@@ -443,16 +445,25 @@ void TimelineContext::onResizeFrameContentHeight(double frameHeight)
 
 void TimelineContext::moveToFrameTime(double startTime)
 {
+    stopAnimation();
     setFrameStartTime(std::max(startTime, 0.0));
     updateFrameTime();
 }
 
 void TimelineContext::animateToFrameTime(double targetStartTime)
 {
+    stopAnimation();
     m_animationStartValue = m_frameStartTime;
     m_animationTargetValue = std::max(targetStartTime, 0.0);
     m_animationElapsed.start();
     m_animationTimer.start();
+}
+
+void TimelineContext::stopAnimation()
+{
+    if (m_animationTimer.isActive()) {
+        m_animationTimer.stop();
+    }
 }
 
 void TimelineContext::shiftFrameTime(double shift)
@@ -460,6 +471,8 @@ void TimelineContext::shiftFrameTime(double shift)
     if (muse::is_zero(shift)) {
         return;
     }
+
+    stopAnimation();
 
     double timeShift = shift;
     double endTimeShift = shift;

--- a/src/projectscene/view/timeline/timelinecontext.cpp
+++ b/src/projectscene/view/timeline/timelinecontext.cpp
@@ -57,6 +57,25 @@ void TimelineContext::init(double frameWidth)
     m_scrollTimer.setInterval(16); // scroll at ~60 FPS
     connect(&m_scrollTimer, &QTimer::timeout, [this](){ autoScrollView(m_autoScrollStep); });
 
+    m_animationTimer.setInterval(ANIMATION_FRAME_MS);
+    connect(&m_animationTimer, &QTimer::timeout, [this]() {
+        double elapsed = m_animationElapsed.elapsed();
+        double t = std::min(elapsed / static_cast<double>(ANIMATION_DURATION_MS), 1.0);
+
+        // Cubic ease-out: f(t) = 1 - (1-t)^3
+        double inv = 1.0 - t;
+        double eased = 1.0 - (inv * inv * inv);
+
+        double current = m_animationStartValue + (m_animationTargetValue - m_animationStartValue) * eased;
+
+        if (t >= 1.0) {
+            m_animationTimer.stop();
+            moveToFrameTime(m_animationTargetValue);
+        } else {
+            moveToFrameTime(current);
+        }
+    });
+
     initToViewState(frameWidth);
 
     if (const auto vs = viewState()) {
@@ -314,6 +333,23 @@ void TimelineContext::insureVisible(double posSec)
     moveToFrameTime(newFrameTime);
 }
 
+void TimelineContext::animatedInsureVisible(double posSec)
+{
+    if (posSec >= m_frameStartTime && posSec <= m_frameEndTime) {
+        return;
+    }
+
+    const double frameTime = m_frameEndTime - m_frameStartTime;
+
+    if (posSec > m_frameEndTime) {
+        // Scrolling right: place clip start at ~75% of view width
+        animateToFrameTime(posSec - frameTime * 0.75);
+    } else {
+        // Scrolling left: place clip start at ~25% of view width
+        animateToFrameTime(posSec - frameTime * 0.25);
+    }
+}
+
 void TimelineContext::autoScrollView(double scrollStep)
 {
     if (!muse::RealIsEqualOrMore(scrollStep, 0.0)) {
@@ -397,6 +433,14 @@ void TimelineContext::moveToFrameTime(double startTime)
 {
     setFrameStartTime(std::max(startTime, 0.0));
     updateFrameTime();
+}
+
+void TimelineContext::animateToFrameTime(double targetStartTime)
+{
+    m_animationStartValue = m_frameStartTime;
+    m_animationTargetValue = std::max(targetStartTime, 0.0);
+    m_animationElapsed.start();
+    m_animationTimer.start();
 }
 
 void TimelineContext::shiftFrameTime(double shift)

--- a/src/projectscene/view/timeline/timelinecontext.cpp
+++ b/src/projectscene/view/timeline/timelinecontext.cpp
@@ -57,25 +57,12 @@ void TimelineContext::init(double frameWidth)
     m_scrollTimer.setInterval(16); // scroll at ~60 FPS
     connect(&m_scrollTimer, &QTimer::timeout, [this](){ autoScrollView(m_autoScrollStep); });
 
-    m_animationTimer.setInterval(ANIMATION_FRAME_MS);
-    connect(&m_animationTimer, &QTimer::timeout, [this]() {
-        double elapsed = m_animationElapsed.elapsed();
-        double t = std::min(elapsed / static_cast<double>(ANIMATION_DURATION_MS), 1.0);
-
-        // Cubic ease-out: f(t) = 1 - (1-t)^3
-        double inv = 1.0 - t;
-        double eased = 1.0 - (inv * inv * inv);
-
-        double current = m_animationStartValue + (m_animationTargetValue - m_animationStartValue) * eased;
-        double frameStart = (t >= 1.0) ? m_animationTargetValue : current;
-
+    m_frameStartAnimation.setDuration(ANIMATION_DURATION_MS);
+    m_frameStartAnimation.setEasingCurve(QEasingCurve::OutCubic);
+    connect(&m_frameStartAnimation, &QVariantAnimation::valueChanged, this, [this](const QVariant& value) {
         //! NOTE Bypass moveToFrameTime() so we don't cancel our own animation.
-        setFrameStartTime(std::max(frameStart, 0.0));
+        setFrameStartTime(std::max(value.toDouble(), 0.0));
         updateFrameTime();
-
-        if (t >= 1.0) {
-            m_animationTimer.stop();
-        }
     });
 
     initToViewState(frameWidth);
@@ -361,7 +348,7 @@ void TimelineContext::animatedCenterOnTime(double secs)
 
 bool TimelineContext::isAnimating() const
 {
-    return m_animationTimer.isActive();
+    return m_frameStartAnimation.state() == QAbstractAnimation::Running;
 }
 
 void TimelineContext::autoScrollView(double scrollStep)
@@ -453,16 +440,15 @@ void TimelineContext::moveToFrameTime(double startTime)
 void TimelineContext::animateToFrameTime(double targetStartTime)
 {
     stopAnimation();
-    m_animationStartValue = m_frameStartTime;
-    m_animationTargetValue = std::max(targetStartTime, 0.0);
-    m_animationElapsed.start();
-    m_animationTimer.start();
+    m_frameStartAnimation.setStartValue(m_frameStartTime);
+    m_frameStartAnimation.setEndValue(std::max(targetStartTime, 0.0));
+    m_frameStartAnimation.start();
 }
 
 void TimelineContext::stopAnimation()
 {
-    if (m_animationTimer.isActive()) {
-        m_animationTimer.stop();
+    if (m_frameStartAnimation.state() == QAbstractAnimation::Running) {
+        m_frameStartAnimation.stop();
     }
 }
 

--- a/src/projectscene/view/timeline/timelinecontext.cpp
+++ b/src/projectscene/view/timeline/timelinecontext.cpp
@@ -350,6 +350,18 @@ void TimelineContext::animatedInsureVisible(double posSec)
     }
 }
 
+void TimelineContext::animatedCenterOnTime(double secs)
+{
+    const double frameTime = m_frameEndTime - m_frameStartTime;
+    const double targetStartTime = secs - frameTime * 0.5;
+    animateToFrameTime(targetStartTime);
+}
+
+bool TimelineContext::isAnimating() const
+{
+    return m_animationTimer.isActive();
+}
+
 void TimelineContext::autoScrollView(double scrollStep)
 {
     if (!muse::RealIsEqualOrMore(scrollStep, 0.0)) {

--- a/src/projectscene/view/timeline/timelinecontext.h
+++ b/src/projectscene/view/timeline/timelinecontext.h
@@ -140,6 +140,7 @@ public:
 
     void animatedCenterOnTime(double secs);
     bool isAnimating() const;
+    void stopAnimation();
 
     qreal startHorizontalScrollPosition() const;
     qreal horizontalScrollbarSize() const;

--- a/src/projectscene/view/timeline/timelinecontext.h
+++ b/src/projectscene/view/timeline/timelinecontext.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <QElapsedTimer>
 #include <QObject>
 #include <QTimer>
+#include <QVariantAnimation>
 
 #include "modularity/ioc.h"
 #include "context/iglobalcontext.h"
@@ -277,10 +277,6 @@ private:
     QTimer m_scrollTimer;
     double m_autoScrollStep = 0.0;
 
-    static constexpr int ANIMATION_FRAME_MS = 16;
-    QTimer m_animationTimer;
-    QElapsedTimer m_animationElapsed;
-    double m_animationStartValue = 0.0;
-    double m_animationTargetValue = 0.0;
+    QVariantAnimation m_frameStartAnimation;
 };
 }

--- a/src/projectscene/view/timeline/timelinecontext.h
+++ b/src/projectscene/view/timeline/timelinecontext.h
@@ -72,6 +72,8 @@ class TimelineContext : public QObject, public muse::async::Asyncable, public mu
 
 public:
 
+    static constexpr int ANIMATION_DURATION_MS = 500;
+
     TimelineContext(QObject* parent = nullptr);
 
     double frameStartTime() const;
@@ -135,6 +137,9 @@ public:
 
     void moveToFrameTime(double startTime);
     void shiftFrameTime(double secs);
+
+    void animatedCenterOnTime(double secs);
+    bool isAnimating() const;
 
     qreal startHorizontalScrollPosition() const;
     qreal horizontalScrollbarSize() const;
@@ -271,7 +276,6 @@ private:
     QTimer m_scrollTimer;
     double m_autoScrollStep = 0.0;
 
-    static constexpr int ANIMATION_DURATION_MS = 500;
     static constexpr int ANIMATION_FRAME_MS = 16;
     QTimer m_animationTimer;
     QElapsedTimer m_animationElapsed;

--- a/src/projectscene/view/timeline/timelinecontext.h
+++ b/src/projectscene/view/timeline/timelinecontext.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <QElapsedTimer>
 #include <QObject>
 #include <QTimer>
 
@@ -117,6 +118,7 @@ public:
     void centerViewOnPlayhead(const muse::actions::ActionData& args);
     void centerOnTime(double secs);
     Q_INVOKABLE void insureVisible(double posSec);
+    Q_INVOKABLE void animatedInsureVisible(double posSec);
     Q_INVOKABLE void startAutoScroll(double posSec);
     Q_INVOKABLE void stopAutoScroll();
 
@@ -213,6 +215,7 @@ private:
     void shiftFrameTimeOnStep(int direction);
     void updateFrameTime();
     void autoScrollView(double scrollStep);
+    void animateToFrameTime(double targetStartTime);
 
     void setSelectionStartTime(double time);
     void setSelectionEndTime(double time);
@@ -267,5 +270,12 @@ private:
 
     QTimer m_scrollTimer;
     double m_autoScrollStep = 0.0;
+
+    static constexpr int ANIMATION_DURATION_MS = 500;
+    static constexpr int ANIMATION_FRAME_MS = 16;
+    QTimer m_animationTimer;
+    QElapsedTimer m_animationElapsed;
+    double m_animationStartValue = 0.0;
+    double m_animationTargetValue = 0.0;
 };
 }

--- a/src/projectscene/view/tracksitemsview/trackclipslistmodel.cpp
+++ b/src/projectscene/view/tracksitemsview/trackclipslistmodel.cpp
@@ -390,7 +390,7 @@ bool TrackClipsListModel::moveSelectedClips(const ClipKey& key, bool completed)
     }, completed);
 
     if (vs->moveInitiated()) {
-        if (selectionController()->timeSelectionIsNotEmpty()) {
+        if (!selectionController()->timeSelectionIsEmpty()) {
             trackeditInteraction()->moveRangeSelection(moveOffset.timeOffset, completed);
         } else {
             ClipKeyList selectedClips = selectionController()->selectedClipsInTrackOrder();

--- a/src/projectscene/view/tracksitemsview/tracklabelslistmodel.cpp
+++ b/src/projectscene/view/tracksitemsview/tracklabelslistmodel.cpp
@@ -245,7 +245,7 @@ void TrackLabelsListModel::selectLabel(const LabelKey& key)
         }
     } else {
         if (!muse::contains(selectionController()->selectedLabels(), key.key)) {
-            if (selectionController()->timeSelectionIsNotEmpty()
+            if (!selectionController()->timeSelectionIsEmpty()
                 && muse::contains(selectionController()->labelsIntersectingRangeSelection(), key.key)) {
                 selectionController()->addSelectedLabel(key.key);
             } else {
@@ -319,7 +319,7 @@ bool TrackLabelsListModel::moveSelectedLabels(const LabelKey& key, bool complete
     // Labels can only be moved to label tracks
     TrackItemsListModel::MoveOffset moveOffset = calculateMoveOffset(item, key, { trackedit::TrackType::Label }, completed);
     if (vs->moveInitiated()) {
-        if (selectionController()->timeSelectionIsNotEmpty()) {
+        if (!selectionController()->timeSelectionIsEmpty()) {
             ok = trackeditInteraction()->moveRangeSelection(moveOffset.timeOffset, completed);
         } else {
             auto selectedLabels = selectionController()->selectedLabels();
@@ -327,7 +327,7 @@ bool TrackLabelsListModel::moveSelectedLabels(const LabelKey& key, bool complete
         }
     }
 
-    if (ok && !selectionController()->timeSelectionIsNotEmpty() && isTrackDataSelected()) {
+    if (ok && selectionController()->timeSelectionIsEmpty() && isTrackDataSelected()) {
         doSelectTracksData(key);
     }
 
@@ -450,7 +450,7 @@ void TrackLabelsListModel::doSelectTracksData(const LabelKey& key)
 
 bool TrackLabelsListModel::isTrackDataSelected() const
 {
-    return !selectionController()->selectedTracks().empty() && selectionController()->timeSelectionIsNotEmpty();
+    return !selectionController()->selectedTracks().empty() && !selectionController()->timeSelectionIsEmpty();
 }
 
 void TrackLabelsListModel::resetSelectedTracksData()

--- a/src/projectscene/view/tracksitemsview/viewtrackslistmodel.cpp
+++ b/src/projectscene/view/tracksitemsview/viewtrackslistmodel.cpp
@@ -286,7 +286,7 @@ QVariant ViewTracksListModel::data(const QModelIndex& index, int role) const
         return static_cast<int>(track.rate);
     }
     case IsDataSelectedRole: {
-        return muse::contains(selectionController()->selectedTracks(), track.id) && selectionController()->timeSelectionIsNotEmpty();
+        return muse::contains(selectionController()->selectedTracks(), track.id) && !selectionController()->timeSelectionIsEmpty();
     }
     case IsTrackSelectedRole: {
         return muse::contains(selectionController()->selectedTracks(), track.id);

--- a/src/trackedit/internal/au3/au3selectioncontroller.cpp
+++ b/src/trackedit/internal/au3/au3selectioncontroller.cpp
@@ -871,52 +871,11 @@ void Au3SelectionController::setDataSelectedEndTime(au::trackedit::secs_t time, 
     }
 }
 
-void Au3SelectionController::extendSelectionStart(secs_t newStart)
+void Au3SelectionController::initSelectionAtPlayhead()
 {
-    if (!timeSelectionIsNotEmpty()) {
-        const secs_t playhead = globalContext()->playbackState()->playbackPosition();
-        setDataSelectedStartTime(playhead, true);
-        setDataSelectedEndTime(playhead, true);
-    }
-
-    if (muse::RealIsEqualOrMore(newStart, 0.0)) {
-        setDataSelectedStartTime(newStart, true);
-    }
-}
-
-void Au3SelectionController::extendSelectionEnd(secs_t newEnd)
-{
-    if (!timeSelectionIsNotEmpty()) {
-        const secs_t playhead = globalContext()->playbackState()->playbackPosition();
-        setDataSelectedStartTime(playhead, true);
-        setDataSelectedEndTime(playhead, true);
-    }
-
-    setDataSelectedEndTime(newEnd, true);
-}
-
-void Au3SelectionController::contractSelectionStart(secs_t newStart)
-{
-    if (!timeSelectionIsNotEmpty()) {
-        return;
-    }
-
-    if (muse::RealIsEqualOrMore(newStart, m_selectedEndTime.val)) {
-        newStart = m_selectedEndTime.val;
-    }
-    setDataSelectedStartTime(newStart, true);
-}
-
-void Au3SelectionController::contractSelectionEnd(secs_t newEnd)
-{
-    if (!timeSelectionIsNotEmpty()) {
-        return;
-    }
-
-    if (muse::RealIsEqualOrLess(newEnd, m_selectedStartTime.val)) {
-        newEnd = m_selectedStartTime.val;
-    }
-    setDataSelectedEndTime(newEnd, true);
+    const secs_t playhead = globalContext()->playbackState()->playbackPosition();
+    setDataSelectedStartTime(playhead, true);
+    setDataSelectedEndTime(playhead, true);
 }
 
 bool Au3SelectionController::selectionContainsGroup() const

--- a/src/trackedit/internal/au3/au3selectioncontroller.cpp
+++ b/src/trackedit/internal/au3/au3selectioncontroller.cpp
@@ -871,6 +871,54 @@ void Au3SelectionController::setDataSelectedEndTime(au::trackedit::secs_t time, 
     }
 }
 
+void Au3SelectionController::extendSelectionStart(secs_t newStart)
+{
+    if (!timeSelectionIsNotEmpty()) {
+        const secs_t playhead = globalContext()->playbackState()->playbackPosition();
+        setDataSelectedStartTime(playhead, true);
+        setDataSelectedEndTime(playhead, true);
+    }
+
+    if (muse::RealIsEqualOrMore(newStart, 0.0)) {
+        setDataSelectedStartTime(newStart, true);
+    }
+}
+
+void Au3SelectionController::extendSelectionEnd(secs_t newEnd)
+{
+    if (!timeSelectionIsNotEmpty()) {
+        const secs_t playhead = globalContext()->playbackState()->playbackPosition();
+        setDataSelectedStartTime(playhead, true);
+        setDataSelectedEndTime(playhead, true);
+    }
+
+    setDataSelectedEndTime(newEnd, true);
+}
+
+void Au3SelectionController::contractSelectionStart(secs_t newStart)
+{
+    if (!timeSelectionIsNotEmpty()) {
+        return;
+    }
+
+    if (muse::RealIsEqualOrMore(newStart, m_selectedEndTime.val)) {
+        newStart = m_selectedEndTime.val;
+    }
+    setDataSelectedStartTime(newStart, true);
+}
+
+void Au3SelectionController::contractSelectionEnd(secs_t newEnd)
+{
+    if (!timeSelectionIsNotEmpty()) {
+        return;
+    }
+
+    if (muse::RealIsEqualOrLess(newEnd, m_selectedStartTime.val)) {
+        newEnd = m_selectedStartTime.val;
+    }
+    setDataSelectedEndTime(newEnd, true);
+}
+
 bool Au3SelectionController::selectionContainsGroup() const
 {
     const auto clipKeyList = selectedClips();

--- a/src/trackedit/internal/au3/au3selectioncontroller.cpp
+++ b/src/trackedit/internal/au3/au3selectioncontroller.cpp
@@ -118,7 +118,7 @@ void Au3SelectionController::onHistoryEvent(const trackedit::HistoryEvent& event
 
 ClipKeyList Au3SelectionController::findClipsIntersectingRangeSelection() const
 {
-    if (!timeSelectionIsNotEmpty() || selectedTracks().empty()) {
+    if (timeSelectionIsEmpty() || selectedTracks().empty()) {
         return {};
     }
 
@@ -699,15 +699,15 @@ void Au3SelectionController::resetDataSelection()
     setLabelsIntersectingRangeSelection({});
 }
 
-bool Au3SelectionController::timeSelectionIsNotEmpty() const
+bool Au3SelectionController::timeSelectionIsEmpty() const
 {
-    return muse::RealIsEqualOrMore(m_selectedEndTime.val, 0.0) && !muse::RealIsEqualOrLess(
+    return !muse::RealIsEqualOrMore(m_selectedEndTime.val, 0.0) || muse::RealIsEqualOrLess(
         m_selectedEndTime.val, m_selectedStartTime.val);
 }
 
 bool au::trackedit::Au3SelectionController::timeSelectionHasAudioData() const
 {
-    if (!timeSelectionIsNotEmpty() || m_selectedTracks.val.empty()) {
+    if (timeSelectionIsEmpty() || m_selectedTracks.val.empty()) {
         return false;
     }
 
@@ -727,7 +727,7 @@ bool au::trackedit::Au3SelectionController::timeSelectionHasAudioData() const
 
 bool Au3SelectionController::isDataSelectedOnTrack(TrackId trackId) const
 {
-    return muse::contains(m_selectedTracks.val, trackId) && timeSelectionIsNotEmpty();
+    return muse::contains(m_selectedTracks.val, trackId) && !timeSelectionIsEmpty();
 }
 
 void Au3SelectionController::setSelectedAllAudioData(const std::optional<secs_t>& fromTime, const std::optional<secs_t>& toTime)
@@ -778,7 +778,7 @@ void Au3SelectionController::setLabelsIntersectingRangeSelection(const LabelKeyL
 
 LabelKeyList Au3SelectionController::findLabelsIntersectingRangeSelection() const
 {
-    if (!timeSelectionIsNotEmpty() || selectedTracks().empty()) {
+    if (timeSelectionIsEmpty() || selectedTracks().empty()) {
         return {};
     }
 

--- a/src/trackedit/internal/au3/au3selectioncontroller.h
+++ b/src/trackedit/internal/au3/au3selectioncontroller.h
@@ -97,6 +97,11 @@ public:
     trackedit::secs_t selectionStartTime() const override;
     void setSelectionStartTime(trackedit::secs_t time) override;
 
+    void extendSelectionStart(secs_t newStart) override;
+    void extendSelectionEnd(secs_t newEnd) override;
+    void contractSelectionStart(secs_t newStart) override;
+    void contractSelectionEnd(secs_t newEnd) override;
+
     // grouping
     bool selectionContainsGroup() const override;
     bool isSelectionGrouped() const override;

--- a/src/trackedit/internal/au3/au3selectioncontroller.h
+++ b/src/trackedit/internal/au3/au3selectioncontroller.h
@@ -73,7 +73,7 @@ public:
     // data selection
     void setSelectedTrackAudioData(trackedit::TrackId trackId) override;
     void resetDataSelection() override;
-    bool timeSelectionIsNotEmpty() const override;
+    bool timeSelectionIsEmpty() const override;
     bool timeSelectionHasAudioData() const override;
     bool isDataSelectedOnTrack(TrackId trackId) const override;
     void setSelectedAllAudioData(const std::optional<secs_t>& fromTime = std::nullopt,

--- a/src/trackedit/internal/au3/au3selectioncontroller.h
+++ b/src/trackedit/internal/au3/au3selectioncontroller.h
@@ -97,10 +97,7 @@ public:
     trackedit::secs_t selectionStartTime() const override;
     void setSelectionStartTime(trackedit::secs_t time) override;
 
-    void extendSelectionStart(secs_t newStart) override;
-    void extendSelectionEnd(secs_t newEnd) override;
-    void contractSelectionStart(secs_t newStart) override;
-    void contractSelectionEnd(secs_t newEnd) override;
+    void initSelectionAtPlayhead() override;
 
     // grouping
     bool selectionContainsGroup() const override;

--- a/src/trackedit/internal/trackeditactionscontroller.cpp
+++ b/src/trackedit/internal/trackeditactionscontroller.cpp
@@ -642,6 +642,7 @@ void TrackeditActionsController::doGlobalDelete()
 void TrackeditActionsController::doGlobalCancel()
 {
     trackeditInteraction()->notifyAboutCancelDragEdit();
+    trackNavigationController()->setIsNavigationActive(false);
 }
 
 void TrackeditActionsController::doGlobalDeletePerClipRipple()

--- a/src/trackedit/internal/trackeditactionscontroller.cpp
+++ b/src/trackedit/internal/trackeditactionscontroller.cpp
@@ -407,7 +407,7 @@ LabelKeyList TrackeditActionsController::labelsForInteraction() const
 
 void TrackeditActionsController::doGlobalCopy()
 {
-    if (selectionController()->timeSelectionIsNotEmpty()) {
+    if (!selectionController()->timeSelectionIsEmpty()) {
         dispatcher()->dispatch(RANGE_SELECTION_COPY_CODE);
         return;
     }
@@ -425,7 +425,7 @@ void TrackeditActionsController::doGlobalCopy()
 
 void TrackeditActionsController::doGlobalCut()
 {
-    const bool isTrackSelected = !selectionController()->timeSelectionIsNotEmpty() && !selectionController()->selectedTracks().empty()
+    const bool isTrackSelected = selectionController()->timeSelectionIsEmpty() && !selectionController()->selectedTracks().empty()
                                  && !selectionController()->hasSelectedClips() && !selectionController()->hasSelectedLabels();
 
     const bool wasSet = configuration()->deleteBehavior() != DeleteBehavior::NotSet;
@@ -465,7 +465,7 @@ void TrackeditActionsController::doGlobalCut()
         }
     }
 
-    if (selectionController()->timeSelectionIsNotEmpty()) {
+    if (!selectionController()->timeSelectionIsEmpty()) {
         auto selectedTracks = selectionController()->selectedTracks();
         secs_t selectedStartTime = selectionController()->dataSelectedStartTime();
         secs_t selectedEndTime = selectionController()->dataSelectedEndTime();
@@ -491,7 +491,7 @@ void TrackeditActionsController::doGlobalCut()
 void TrackeditActionsController::doGlobalCutPerClipRipple()
 {
     auto moveClips = ActionData::make_arg1(false);
-    if (selectionController()->timeSelectionIsNotEmpty()) {
+    if (!selectionController()->timeSelectionIsEmpty()) {
         dispatcher()->dispatch(RANGE_SELECTION_CUT_CODE, moveClips);
         return;
     }
@@ -510,7 +510,7 @@ void TrackeditActionsController::doGlobalCutPerClipRipple()
 void TrackeditActionsController::doGlobalCutPerTrackRipple()
 {
     auto moveClips = ActionData::make_arg1(true);
-    if (selectionController()->timeSelectionIsNotEmpty()) {
+    if (!selectionController()->timeSelectionIsEmpty()) {
         dispatcher()->dispatch(RANGE_SELECTION_CUT_CODE, moveClips);
         return;
     }
@@ -533,7 +533,7 @@ void TrackeditActionsController::doGlobalCutAllTracksRipple()
     project::IAudacityProjectPtr project = globalContext()->currentProject();
     auto tracks = project->trackeditProject()->trackIdList();
 
-    if (selectionController()->timeSelectionIsNotEmpty()) {
+    if (!selectionController()->timeSelectionIsEmpty()) {
         secs_t selectedStartTime = selectionController()->dataSelectedStartTime();
         secs_t selectedEndTime = selectionController()->dataSelectedEndTime();
 
@@ -558,7 +558,7 @@ void TrackeditActionsController::doGlobalCutAllTracksRipple()
 
 void TrackeditActionsController::doGlobalDelete()
 {
-    const bool isTrackSelected = !selectionController()->timeSelectionIsNotEmpty() && !selectionController()->selectedTracks().empty()
+    const bool isTrackSelected = selectionController()->timeSelectionIsEmpty() && !selectionController()->selectedTracks().empty()
                                  && !selectionController()->hasSelectedClips() && !selectionController()->hasSelectedLabels();
 
     const bool wasSet = configuration()->deleteBehavior() != DeleteBehavior::NotSet;
@@ -607,7 +607,7 @@ void TrackeditActionsController::doGlobalDelete()
         }
     }
 
-    if (selectionController()->timeSelectionIsNotEmpty()) {
+    if (!selectionController()->timeSelectionIsEmpty()) {
         auto selectedTracks = selectionController()->selectedTracks();
         secs_t selectedStartTime = selectionController()->dataSelectedStartTime();
         secs_t selectedEndTime = selectionController()->dataSelectedEndTime();
@@ -649,7 +649,7 @@ void TrackeditActionsController::doGlobalDeletePerClipRipple()
 {
     auto moveClips = ActionData::make_arg1(false);
 
-    if (selectionController()->timeSelectionIsNotEmpty()) {
+    if (!selectionController()->timeSelectionIsEmpty()) {
         dispatcher()->dispatch(RANGE_SELECTION_DELETE_CODE, moveClips);
         return;
     }
@@ -672,7 +672,7 @@ void TrackeditActionsController::doGlobalDeletePerTrackRipple()
 {
     auto moveClips = ActionData::make_arg1(true);
 
-    if (selectionController()->timeSelectionIsNotEmpty()) {
+    if (!selectionController()->timeSelectionIsEmpty()) {
         dispatcher()->dispatch(RANGE_SELECTION_DELETE_CODE, moveClips);
         return;
     }
@@ -698,7 +698,7 @@ void TrackeditActionsController::doGlobalDeleteAllTracksRipple()
     project::IAudacityProjectPtr project = globalContext()->currentProject();
     auto tracks = project->trackeditProject()->trackIdList();
 
-    if (selectionController()->timeSelectionIsNotEmpty()) {
+    if (!selectionController()->timeSelectionIsEmpty()) {
         secs_t selectedStartTime = selectionController()->dataSelectedStartTime();
         secs_t selectedEndTime = selectionController()->dataSelectedEndTime();
 
@@ -731,7 +731,7 @@ void TrackeditActionsController::doGlobalSplit()
     }
 
     std::vector<secs_t> pivots;
-    if (selectionController()->timeSelectionIsNotEmpty()) {
+    if (!selectionController()->timeSelectionIsEmpty()) {
         pivots.push_back(selectionController()->dataSelectedStartTime());
         pivots.push_back(selectionController()->dataSelectedEndTime());
     } else {
@@ -743,7 +743,7 @@ void TrackeditActionsController::doGlobalSplit()
 
 void TrackeditActionsController::doGlobalSplitIntoNewTrack()
 {
-    if (selectionController()->timeSelectionIsNotEmpty()) {
+    if (!selectionController()->timeSelectionIsEmpty()) {
         TrackIdList selectedTracks = selectionController()->selectedTracks();
         secs_t selectedStartTime = selectionController()->dataSelectedStartTime();
         secs_t selectedEndTime = selectionController()->dataSelectedEndTime();
@@ -772,7 +772,7 @@ void TrackeditActionsController::doGlobalJoin()
 
 void TrackeditActionsController::doGlobalDisjoin()
 {
-    if (selectionController()->timeSelectionIsNotEmpty()) {
+    if (!selectionController()->timeSelectionIsEmpty()) {
         TrackIdList selectedTracks = selectionController()->selectedTracks();
         secs_t selectedStartTime = selectionController()->dataSelectedStartTime();
         secs_t selectedEndTime = selectionController()->dataSelectedEndTime();

--- a/src/trackedit/internal/trackeditactionscontroller.cpp
+++ b/src/trackedit/internal/trackeditactionscontroller.cpp
@@ -2078,6 +2078,11 @@ void TrackeditActionsController::moveFocusedItemDown()
 
 void TrackeditActionsController::extendFocusedItemBoundaryLeft()
 {
+    if (!navigationController()->isHighlight()) {
+        dispatcher()->dispatch("sel-ext-left");
+        return;
+    }
+
     TrackItemKey focusedItemKey = trackNavigationController()->focusedItem();
     if (!focusedItemKey.isValid()) {
         return;
@@ -2096,6 +2101,11 @@ void TrackeditActionsController::extendFocusedItemBoundaryLeft()
 
 void TrackeditActionsController::extendFocusedItemBoundaryRight()
 {
+    if (!navigationController()->isHighlight()) {
+        dispatcher()->dispatch("sel-ext-right");
+        return;
+    }
+
     TrackItemKey focusedItemKey = trackNavigationController()->focusedItem();
     if (!focusedItemKey.isValid()) {
         return;
@@ -2114,6 +2124,11 @@ void TrackeditActionsController::extendFocusedItemBoundaryRight()
 
 void TrackeditActionsController::reduceFocusedItemBoundaryLeft()
 {
+    if (!navigationController()->isHighlight()) {
+        dispatcher()->dispatch("sel-cntr-right");
+        return;
+    }
+
     TrackItemKey focusedItemKey = trackNavigationController()->focusedItem();
     if (!focusedItemKey.isValid()) {
         return;
@@ -2132,6 +2147,11 @@ void TrackeditActionsController::reduceFocusedItemBoundaryLeft()
 
 void TrackeditActionsController::reduceFocusedItemBoundaryRight()
 {
+    if (!navigationController()->isHighlight()) {
+        dispatcher()->dispatch("sel-cntr-left");
+        return;
+    }
+
     TrackItemKey focusedItemKey = trackNavigationController()->focusedItem();
     if (!focusedItemKey.isValid()) {
         return;

--- a/src/trackedit/internal/trackeditactionscontroller.h
+++ b/src/trackedit/internal/trackeditactionscontroller.h
@@ -9,6 +9,7 @@
 #include "framework/global/modularity/ioc.h"
 #include "framework/interactive/iinteractive.h"
 #include "framework/actions/iactionsdispatcher.h"
+#include "framework/ui/inavigationcontroller.h"
 
 #include "audio/iaudiodevicesprovider.h"
 #include "context/iglobalcontext.h"
@@ -41,6 +42,7 @@ class TrackeditActionsController : public ITrackeditActionsController, public mu
     muse::ContextInject<trackedit::ISelectionController> selectionController { this };
     muse::ContextInject<trackedit::ITrackeditInteraction> trackeditInteraction { this };
     muse::ContextInject<trackedit::ITrackNavigationController> trackNavigationController { this };
+    muse::ContextInject<muse::ui::INavigationController> navigationController { this };
     muse::ContextInject<spectrogram::IFrequencySelectionController> frequencySelectionController { this };
 
 public:

--- a/src/trackedit/internal/trackedituiactions.cpp
+++ b/src/trackedit/internal/trackedituiactions.cpp
@@ -460,18 +460,6 @@ UiActionList STATIC_ACTIONS = {
              TranslatableString("action", "Below item")
              ),
 
-    UiAction("track-view-next-track",
-             au::context::UiCtxProjectFocused,
-             au::context::CTX_PROJECT_FOCUSED,
-             TranslatableString("action", "Next track"),
-             TranslatableString("action", "Next track")
-             ),
-    UiAction("track-view-prev-track",
-             au::context::UiCtxProjectFocused,
-             au::context::CTX_PROJECT_FOCUSED,
-             TranslatableString("action", "Previous track"),
-             TranslatableString("action", "Previous track")
-             ),
     UiAction("track-view-first-track",
              au::context::UiCtxProjectFocused,
              au::context::CTX_PROJECT_FOCUSED,

--- a/src/trackedit/internal/trackedituiactions.cpp
+++ b/src/trackedit/internal/trackedituiactions.cpp
@@ -447,6 +447,19 @@ UiActionList STATIC_ACTIONS = {
              TranslatableString("action", "Previous item")
              ),
 
+    UiAction("track-view-above-item",
+             au::context::UiCtxProjectFocused,
+             au::context::CTX_PROJECT_FOCUSED,
+             TranslatableString("action", "Above item"),
+             TranslatableString("action", "Above item")
+             ),
+    UiAction("track-view-below-item",
+             au::context::UiCtxProjectFocused,
+             au::context::CTX_PROJECT_FOCUSED,
+             TranslatableString("action", "Below item"),
+             TranslatableString("action", "Below item")
+             ),
+
     UiAction("track-view-next-track",
              au::context::UiCtxProjectFocused,
              au::context::CTX_PROJECT_FOCUSED,

--- a/src/trackedit/internal/tracknavigationcontroller.cpp
+++ b/src/trackedit/internal/tracknavigationcontroller.cpp
@@ -28,6 +28,8 @@ static const muse::actions::ActionCode TRACK_VIEW_TRACK_SELECTION_NEXT_CODE("tra
 
 static const muse::actions::ActionCode TRACK_VIEW_NEXT_ITEM_CODE("track-view-next-item");
 static const muse::actions::ActionCode TRACK_VIEW_PREV_ITEM_CODE("track-view-prev-item");
+static const muse::actions::ActionCode TRACK_VIEW_ABOVE_ITEM_CODE("track-view-above-item");
+static const muse::actions::ActionCode TRACK_VIEW_BELOW_ITEM_CODE("track-view-below-item");
 
 static const muse::actions::ActionCode TRACK_VIEW_ITEM_CONTEXT_MENU_CODE("track-view-item-context-menu");
 
@@ -45,6 +47,8 @@ void TrackNavigationController::init()
 
     dispatcher()->reg(this, TRACK_VIEW_NEXT_ITEM_CODE, this, &TrackNavigationController::navigateToNextItem);
     dispatcher()->reg(this, TRACK_VIEW_PREV_ITEM_CODE, this, &TrackNavigationController::navigateToPrevItem);
+    dispatcher()->reg(this, TRACK_VIEW_ABOVE_ITEM_CODE, this, &TrackNavigationController::navigateToAboveItem);
+    dispatcher()->reg(this, TRACK_VIEW_BELOW_ITEM_CODE, this, &TrackNavigationController::navigateToBelowItem);
 
     dispatcher()->reg(this, TRACK_VIEW_TOGGLE_SELECTION_CODE, this, &TrackNavigationController::toggleSelection);
     dispatcher()->reg(this, TRACK_RANGE_SELECTION_CODE, this, &TrackNavigationController::trackRangeSelection);
@@ -390,6 +394,8 @@ void TrackNavigationController::navigateToNextItem()
             break;
         }
     }
+
+    m_savedItemStartTime = std::nullopt;
 }
 
 void TrackNavigationController::navigateToPrevItem()
@@ -409,6 +415,145 @@ void TrackNavigationController::navigateToPrevItem()
                 setFocusedItem(itemsKeys.at(i - 1), true /*highlight*/);
             }
             break;
+        }
+    }
+
+    m_savedItemStartTime = std::nullopt;
+}
+
+double TrackNavigationController::itemStartTime(const TrackItemKey& key) const
+{
+    const ITrackeditProjectPtr prj = globalContext()->currentTrackeditProject();
+    if (!prj) {
+        return 0.0;
+    }
+
+    std::optional<Track> track = prj->track(key.trackId);
+    if (!track.has_value()) {
+        return 0.0;
+    }
+
+    if (track->type == TrackType::Label) {
+        Label l = prj->label(key);
+        return l.startTime;
+    }
+
+    Clip c = prj->clip(key);
+    return c.startTime;
+}
+
+TrackItemKey TrackNavigationController::findClosestItemOnTrack(const TrackId& trackId, double referenceStartTime) const
+{
+    TrackItemKeyList itemsKeys = sortedItemsKeys(trackId);
+    if (itemsKeys.empty()) {
+        return TrackItemKey { trackId, INVALID_TRACK_ITEM };
+    }
+
+    const ITrackeditProjectPtr prj = globalContext()->currentTrackeditProject();
+    if (!prj) {
+        return itemsKeys.front();
+    }
+
+    TrackItemKey closest = itemsKeys.front();
+    double closestDiff = std::numeric_limits<double>::max();
+
+    std::optional<Track> track = prj->track(trackId);
+    if (!track.has_value()) {
+        return closest;
+    }
+
+    for (const auto& itemKey : itemsKeys) {
+        double st = 0.0;
+        if (track->type == TrackType::Label) {
+            Label l = prj->label(itemKey);
+            st = l.startTime;
+        } else {
+            Clip c = prj->clip(itemKey);
+            st = c.startTime;
+        }
+
+        double diff = std::abs(st - referenceStartTime);
+        if (diff < closestDiff) {
+            closestDiff = diff;
+            closest = itemKey;
+        }
+    }
+
+    return closest;
+}
+
+void TrackNavigationController::navigateToAboveItem()
+{
+    if (m_focusedItemKey.itemId == INVALID_TRACK_ITEM) {
+        navigateToPrevTrack();
+        return;
+    }
+
+    const ITrackeditProjectPtr prj = globalContext()->currentTrackeditProject();
+    if (!prj) {
+        return;
+    }
+
+    std::vector<Track> trackList = prj->trackList();
+    if (trackList.empty()) {
+        return;
+    }
+
+    if (!m_savedItemStartTime.has_value()) {
+        m_savedItemStartTime = itemStartTime(m_focusedItemKey);
+    }
+
+    const TrackId currentTrackId = m_focusedItemKey.trackId;
+
+    for (size_t i = 0; i < trackList.size(); ++i) {
+        if (trackList[i].id == currentTrackId) {
+            for (size_t j = i; j > 0; --j) {
+                TrackId candidateId = trackList[j - 1].id;
+                if (!isTrackItemsEmpty(candidateId)) {
+                    TrackItemKey closest = findClosestItemOnTrack(candidateId, *m_savedItemStartTime);
+                    setFocusedItem(closest, true /*highlight*/);
+                    return;
+                }
+            }
+            return;
+        }
+    }
+}
+
+void TrackNavigationController::navigateToBelowItem()
+{
+    if (m_focusedItemKey.itemId == INVALID_TRACK_ITEM) {
+        navigateToNextTrack();
+        return;
+    }
+
+    const ITrackeditProjectPtr prj = globalContext()->currentTrackeditProject();
+    if (!prj) {
+        return;
+    }
+
+    std::vector<Track> trackList = prj->trackList();
+    if (trackList.empty()) {
+        return;
+    }
+
+    if (!m_savedItemStartTime.has_value()) {
+        m_savedItemStartTime = itemStartTime(m_focusedItemKey);
+    }
+
+    const TrackId currentTrackId = m_focusedItemKey.trackId;
+
+    for (size_t i = 0; i < trackList.size(); ++i) {
+        if (trackList[i].id == currentTrackId) {
+            for (size_t j = i + 1; j < trackList.size(); ++j) {
+                TrackId candidateId = trackList[j].id;
+                if (!isTrackItemsEmpty(candidateId)) {
+                    TrackItemKey closest = findClosestItemOnTrack(candidateId, *m_savedItemStartTime);
+                    setFocusedItem(closest, true /*highlight*/);
+                    return;
+                }
+            }
+            return;
         }
     }
 }

--- a/src/trackedit/internal/tracknavigationcontroller.cpp
+++ b/src/trackedit/internal/tracknavigationcontroller.cpp
@@ -16,8 +16,6 @@ using namespace au::trackedit;
 static const muse::actions::ActionCode TRACK_VIEW_NEXT_PANEL_CODE("track-view-next-panel");
 static const muse::actions::ActionCode TRACK_VIEW_PREV_PANEL_CODE("track-view-prev-panel");
 
-static const muse::actions::ActionCode TRACK_VIEW_NEXT_TRACK_CODE("track-view-next-track");
-static const muse::actions::ActionCode TRACK_VIEW_PREV_TRACK_CODE("track-view-prev-track");
 static const muse::actions::ActionCode TRACK_VIEW_FIRST_TRACK_CODE("track-view-first-track");
 static const muse::actions::ActionCode TRACK_VIEW_LAST_TRACK_CODE("track-view-last-track");
 
@@ -40,8 +38,6 @@ void TrackNavigationController::init()
     dispatcher()->reg(this, TRACK_VIEW_NEXT_PANEL_CODE, this, &TrackNavigationController::navigateToNextPanel);
     dispatcher()->reg(this, TRACK_VIEW_PREV_PANEL_CODE, this, &TrackNavigationController::navigateToPrevPanel);
 
-    dispatcher()->reg(this, TRACK_VIEW_NEXT_TRACK_CODE, this, &TrackNavigationController::navigateToNextTrack);
-    dispatcher()->reg(this, TRACK_VIEW_PREV_TRACK_CODE, this, &TrackNavigationController::navigateToPrevTrack);
     dispatcher()->reg(this, TRACK_VIEW_FIRST_TRACK_CODE, this, &TrackNavigationController::navigateToFirstTrack);
     dispatcher()->reg(this, TRACK_VIEW_LAST_TRACK_CODE, this, &TrackNavigationController::navigateToLastTrack);
 
@@ -444,7 +440,7 @@ double TrackNavigationController::itemStartTime(const TrackItemKey& key) const
     }
 
     std::optional<Track> track = prj->track(key.trackId);
-    if (!track.has_value()) {
+    if (!track.has_value() || track->type == TrackType::Undefined) {
         return 0.0;
     }
 

--- a/src/trackedit/internal/tracknavigationcontroller.cpp
+++ b/src/trackedit/internal/tracknavigationcontroller.cpp
@@ -63,6 +63,7 @@ void TrackNavigationController::init()
     });
 
     dispatcher()->reg(this, "nav-escape", [this] {
+        m_savedItemStartTime = std::nullopt;
         navigationController()->setIsHighlight(false);
     });
 

--- a/src/trackedit/internal/tracknavigationcontroller.cpp
+++ b/src/trackedit/internal/tracknavigationcontroller.cpp
@@ -62,6 +62,10 @@ void TrackNavigationController::init()
         m_selectionStart = std::nullopt;
     });
 
+    dispatcher()->reg(this, "nav-escape", [this] {
+        navigationController()->setIsHighlight(false);
+    });
+
     selectionController()->tracksSelected().onReceive(this, [this](const trackedit::TrackIdList& trackIds) {
         if (trackIds.size() == 1) {
             // The idea here is that range selection also supports the base track to be selected using the mouse.
@@ -377,6 +381,11 @@ void TrackNavigationController::navigateToLastTrack()
 
 void TrackNavigationController::navigateToNextItem()
 {
+    if (!navigationController()->isHighlight()) {
+        dispatcher()->dispatch("play-position-increase");
+        return;
+    }
+
     TrackItemKeyList itemsKeys = sortedItemsKeys(m_focusedItemKey.trackId);
 
     if (m_focusedItemKey.itemId == INVALID_TRACK_ITEM) {
@@ -400,6 +409,11 @@ void TrackNavigationController::navigateToNextItem()
 
 void TrackNavigationController::navigateToPrevItem()
 {
+    if (!navigationController()->isHighlight()) {
+        dispatcher()->dispatch("play-position-decrease");
+        return;
+    }
+
     TrackItemKeyList itemsKeys = sortedItemsKeys(m_focusedItemKey.trackId);
 
     if (m_focusedItemKey.itemId == INVALID_TRACK_ITEM) {
@@ -449,30 +463,11 @@ TrackItemKey TrackNavigationController::findClosestItemOnTrack(const TrackId& tr
         return TrackItemKey { trackId, INVALID_TRACK_ITEM };
     }
 
-    const ITrackeditProjectPtr prj = globalContext()->currentTrackeditProject();
-    if (!prj) {
-        return itemsKeys.front();
-    }
-
     TrackItemKey closest = itemsKeys.front();
     double closestDiff = std::numeric_limits<double>::max();
 
-    std::optional<Track> track = prj->track(trackId);
-    if (!track.has_value()) {
-        return closest;
-    }
-
     for (const auto& itemKey : itemsKeys) {
-        double st = 0.0;
-        if (track->type == TrackType::Label) {
-            Label l = prj->label(itemKey);
-            st = l.startTime;
-        } else {
-            Clip c = prj->clip(itemKey);
-            st = c.startTime;
-        }
-
-        double diff = std::abs(st - referenceStartTime);
+        double diff = std::abs(itemStartTime(itemKey) - referenceStartTime);
         if (diff < closestDiff) {
             closestDiff = diff;
             closest = itemKey;

--- a/src/trackedit/internal/tracknavigationcontroller.h
+++ b/src/trackedit/internal/tracknavigationcontroller.h
@@ -12,7 +12,7 @@
 #include "framework/ui/inavigationcontroller.h"
 #include "trackedit/iselectioncontroller.h"
 #include "context/iglobalcontext.h"
-#include "itrackeditinteraction.h"
+#include "trackedit/itrackeditinteraction.h"
 
 #include "trackedit/internal/itracknavigationcontroller.h"
 
@@ -52,6 +52,8 @@ public:
     muse::async::Channel<TrackItemKey> openContextMenuRequested() const override;
 
 private:
+    friend class TrackNavigationControllerTests;
+
     TrackItemKey focusedItemKey() const;
     bool isFocusedItemValid() const;
     bool isFocusedItemLabel() const;

--- a/src/trackedit/internal/tracknavigationcontroller.h
+++ b/src/trackedit/internal/tracknavigationcontroller.h
@@ -72,8 +72,13 @@ private:
 
     void navigateToNextItem();
     void navigateToPrevItem();
+    void navigateToAboveItem();
+    void navigateToBelowItem();
     void navigateToFirstItem();
     void navigateToLastItem();
+
+    TrackItemKey findClosestItemOnTrack(const TrackId& trackId, double referenceStartTime) const;
+    double itemStartTime(const TrackItemKey& key) const;
 
     void toggleSelection();
     void trackRangeSelection();
@@ -93,6 +98,8 @@ private:
 
     std::optional<TrackId> m_selectionStart;
     std::optional<TrackId> m_lastSelectedTrack;
+
+    std::optional<double> m_savedItemStartTime;
 
     TrackItemKey m_focusedItemKey;
     muse::async::Channel<TrackItemKey, bool /*highlight*/> m_focusedItemChanged;

--- a/src/trackedit/iselectioncontroller.h
+++ b/src/trackedit/iselectioncontroller.h
@@ -100,10 +100,7 @@ public:
     virtual trackedit::secs_t selectionStartTime() const = 0;
     virtual void setSelectionStartTime(trackedit::secs_t time) = 0;
 
-    virtual void extendSelectionStart(secs_t newStart) = 0;
-    virtual void extendSelectionEnd(secs_t newEnd) = 0;
-    virtual void contractSelectionStart(secs_t newStart) = 0;
-    virtual void contractSelectionEnd(secs_t newEnd) = 0;
+    virtual void initSelectionAtPlayhead() = 0;
 
     // grouping
     virtual bool selectionContainsGroup() const = 0;

--- a/src/trackedit/iselectioncontroller.h
+++ b/src/trackedit/iselectioncontroller.h
@@ -76,7 +76,7 @@ public:
     // data selection
     virtual void setSelectedTrackAudioData(trackedit::TrackId trackId) = 0;
     virtual void resetDataSelection() = 0;
-    virtual bool timeSelectionIsNotEmpty() const = 0;
+    virtual bool timeSelectionIsEmpty() const = 0;
     virtual bool timeSelectionHasAudioData() const = 0;
     virtual bool isDataSelectedOnTrack(TrackId trackId) const = 0;
     virtual void setSelectedAllAudioData(const std::optional<secs_t>& fromTime = std::nullopt,

--- a/src/trackedit/iselectioncontroller.h
+++ b/src/trackedit/iselectioncontroller.h
@@ -100,6 +100,11 @@ public:
     virtual trackedit::secs_t selectionStartTime() const = 0;
     virtual void setSelectionStartTime(trackedit::secs_t time) = 0;
 
+    virtual void extendSelectionStart(secs_t newStart) = 0;
+    virtual void extendSelectionEnd(secs_t newEnd) = 0;
+    virtual void contractSelectionStart(secs_t newStart) = 0;
+    virtual void contractSelectionEnd(secs_t newEnd) = 0;
+
     // grouping
     virtual bool selectionContainsGroup() const = 0;
     virtual bool isSelectionGrouped() const = 0;

--- a/src/trackedit/tests/CMakeLists.txt
+++ b/src/trackedit/tests/CMakeLists.txt
@@ -14,7 +14,9 @@ set(MODULE_TEST_SRC
     ${CMAKE_CURRENT_LIST_DIR}/mocks/trackeditprojectmock.h
     ${CMAKE_CURRENT_LIST_DIR}/mocks/projecthistorymock.h
     ${CMAKE_CURRENT_LIST_DIR}/mocks/tracknavigationcontrollermock.h
+    ${CMAKE_CURRENT_LIST_DIR}/mocks/navigationcontrollermock.h
 
+    ${CMAKE_CURRENT_LIST_DIR}/tracknavigationcontroller_tests.cpp
     ${CMAKE_CURRENT_LIST_DIR}/au3tracksinteraction_tests.cpp
     ${CMAKE_CURRENT_LIST_DIR}/au3clipsinteraction_tests.cpp
     ${CMAKE_CURRENT_LIST_DIR}/au3labelsinteractions_tests.cpp

--- a/src/trackedit/tests/mocks/navigationcontrollermock.h
+++ b/src/trackedit/tests/mocks/navigationcontrollermock.h
@@ -1,0 +1,43 @@
+/*
+* Audacity: A Digital Audio Editor
+*/
+#pragma once
+
+#include <gmock/gmock.h>
+
+#include "ui/inavigationcontroller.h"
+
+namespace muse::ui {
+class NavigationControllerMock : public INavigationController
+{
+public:
+    MOCK_METHOD(void, reg, (INavigationSection*), (override));
+    MOCK_METHOD(void, unreg, (INavigationSection*), (override));
+
+    MOCK_METHOD(bool, requestActivateByName, (const std::string&, const std::string&, const std::string&), (override));
+    MOCK_METHOD(bool, requestActivateByIndex, (const std::string&, const std::string&, const INavigation::Index&), (override));
+
+    MOCK_METHOD(void, resetNavigation, (), (override));
+
+    MOCK_METHOD(INavigationSection*, activeSection, (), (const, override));
+    MOCK_METHOD(INavigationPanel*, activePanel, (), (const, override));
+    MOCK_METHOD(INavigationControl*, activeControl, (), (const, override));
+
+    MOCK_METHOD((const std::set<INavigationSection*>&), sections, (), (const, override));
+    MOCK_METHOD(const INavigationSection*, findSection, (const std::string&), (const, override));
+    MOCK_METHOD(const INavigationPanel*, findPanel, (const std::string&, const std::string&), (const, override));
+    MOCK_METHOD(const INavigationControl*, findControl, (const std::string&, const std::string&, const std::string&), (const, override));
+
+    MOCK_METHOD(void, setDefaultNavigationControl, (INavigationControl*), (override));
+
+    MOCK_METHOD(async::Notification, navigationChanged, (), (const, override));
+
+    MOCK_METHOD(bool, isHighlight, (), (const, override));
+    MOCK_METHOD(void, setIsHighlight, (bool), (override));
+    MOCK_METHOD(async::Notification, highlightChanged, (), (const, override));
+
+    MOCK_METHOD(void, setIsResetOnMousePress, (bool), (override));
+
+    MOCK_METHOD(void, dump, (), (const, override));
+};
+}

--- a/src/trackedit/tests/mocks/selectioncontrollermock.h
+++ b/src/trackedit/tests/mocks/selectioncontrollermock.h
@@ -76,6 +76,11 @@ public:
     MOCK_METHOD(trackedit::secs_t, selectionStartTime, (), (const override));
     MOCK_METHOD(void, setSelectionStartTime, (trackedit::secs_t), (override));
 
+    MOCK_METHOD(void, extendSelectionStart, (secs_t), (override));
+    MOCK_METHOD(void, extendSelectionEnd, (secs_t), (override));
+    MOCK_METHOD(void, contractSelectionStart, (secs_t), (override));
+    MOCK_METHOD(void, contractSelectionEnd, (secs_t), (override));
+
     MOCK_METHOD(bool, selectionContainsGroup, (), (const, override));
     MOCK_METHOD(bool, isSelectionGrouped, (), (const, override));
 

--- a/src/trackedit/tests/mocks/selectioncontrollermock.h
+++ b/src/trackedit/tests/mocks/selectioncontrollermock.h
@@ -76,10 +76,7 @@ public:
     MOCK_METHOD(trackedit::secs_t, selectionStartTime, (), (const override));
     MOCK_METHOD(void, setSelectionStartTime, (trackedit::secs_t), (override));
 
-    MOCK_METHOD(void, extendSelectionStart, (secs_t), (override));
-    MOCK_METHOD(void, extendSelectionEnd, (secs_t), (override));
-    MOCK_METHOD(void, contractSelectionStart, (secs_t), (override));
-    MOCK_METHOD(void, contractSelectionEnd, (secs_t), (override));
+    MOCK_METHOD(void, initSelectionAtPlayhead, (), (override));
 
     MOCK_METHOD(bool, selectionContainsGroup, (), (const, override));
     MOCK_METHOD(bool, isSelectionGrouped, (), (const, override));

--- a/src/trackedit/tests/mocks/selectioncontrollermock.h
+++ b/src/trackedit/tests/mocks/selectioncontrollermock.h
@@ -53,7 +53,7 @@ public:
 
     MOCK_METHOD(void, setSelectedTrackAudioData, (TrackId), (override));
     MOCK_METHOD(void, resetDataSelection, (), (override));
-    MOCK_METHOD(bool, timeSelectionIsNotEmpty, (), (const, override));
+    MOCK_METHOD(bool, timeSelectionIsEmpty, (), (const, override));
     MOCK_METHOD(bool, timeSelectionHasAudioData, (), (const, override));
     MOCK_METHOD(bool, isDataSelectedOnTrack, (TrackId), (const, override));
     MOCK_METHOD(void, setSelectedAllAudioData, (const std::optional<secs_t>&, const std::optional<secs_t>&), (override));

--- a/src/trackedit/tests/tracknavigationcontroller_tests.cpp
+++ b/src/trackedit/tests/tracknavigationcontroller_tests.cpp
@@ -1,0 +1,239 @@
+/*
+* Audacity: A Digital Audio Editor
+*/
+#include <gtest/gtest.h>
+
+#include "../internal/tracknavigationcontroller.h"
+
+#include "actions/tests/mocks/actionsdispatchermock.h"
+#include "context/tests/mocks/globalcontextmock.h"
+#include "mocks/navigationcontrollermock.h"
+#include "mocks/selectioncontrollermock.h"
+#include "mocks/trackeditinteractionmock.h"
+#include "mocks/trackeditprojectmock.h"
+
+using ::testing::NiceMock;
+using ::testing::Return;
+using ::testing::_;
+
+using IActionsDispatcher = muse::actions::IActionsDispatcher;
+
+namespace au::trackedit {
+/*******************************************************************************
+ * TRACK NAVIGATION CONTROLLER TESTS
+ *
+ * Verifies arrow key behavior based on navigation highlight state:
+ * - When highlight is off (default): arrows move the playhead
+ * - When highlight is on (after Tab): arrows navigate clips
+ * - Escape dismisses highlight, returning arrows to playhead movement
+ ******************************************************************************/
+
+class TrackNavigationControllerTests : public ::testing::Test
+{
+public:
+    void SetUp() override
+    {
+        m_dispatcher = std::make_shared<NiceMock<muse::actions::ActionsDispatcherMock> >();
+        m_navigationController = std::make_shared<NiceMock<muse::ui::NavigationControllerMock> >();
+        m_globalContext = std::make_shared<NiceMock<context::GlobalContextMock> >();
+        m_selectionController = std::make_shared<NiceMock<SelectionControllerMock> >();
+        m_trackeditInteraction = std::make_shared<NiceMock<TrackeditInteractionMock> >();
+        m_trackeditProject = std::make_shared<NiceMock<TrackeditProjectMock> >();
+
+        m_testCtx = std::make_shared<muse::modularity::Context>(999);
+        m_controller = std::make_shared<TrackNavigationController>(m_testCtx);
+
+        //! NOTE Inject mock dependencies directly via friend access
+        m_controller->dispatcher.set(m_dispatcher);
+        m_controller->navigationController.set(m_navigationController);
+        m_controller->globalContext.set(m_globalContext);
+        m_controller->selectionController.set(m_selectionController);
+        m_controller->trackeditInteraction.set(m_trackeditInteraction);
+
+        ON_CALL(*m_globalContext, currentTrackeditProject())
+        .WillByDefault(Return(m_trackeditProject));
+
+        ON_CALL(*m_globalContext, currentTrackeditProjectChanged())
+        .WillByDefault(Return(muse::async::Notification()));
+
+        ON_CALL(*m_selectionController, tracksSelected())
+        .WillByDefault(Return(muse::async::Channel<TrackIdList>()));
+
+        //! NOTE Capture registered action callbacks so we can invoke them in tests
+        ON_CALL(*m_dispatcher,
+                reg(::testing::Matcher<muse::actions::Actionable*>(_),
+                    ::testing::Matcher<const muse::actions::ActionCode&>(_),
+                    ::testing::Matcher<const IActionsDispatcher::ActionCallBackWithNameAndData&>(_)))
+        .WillByDefault([this](muse::actions::Actionable*, const muse::actions::ActionCode& code,
+                              const IActionsDispatcher::ActionCallBackWithNameAndData& cb) {
+            m_actionCallbacks[code] = cb;
+        });
+    }
+
+    void TearDown() override
+    {
+        m_controller.reset();
+        muse::modularity::removeIoC(m_testCtx);
+    }
+
+    void initController()
+    {
+        m_controller->init();
+    }
+
+    void invokeAction(const muse::actions::ActionCode& code)
+    {
+        auto it = m_actionCallbacks.find(code);
+        ASSERT_NE(it, m_actionCallbacks.end()) << "Action not registered: " << code;
+        it->second(code, muse::actions::ActionData());
+    }
+
+    std::shared_ptr<muse::modularity::Context> m_testCtx;
+    std::shared_ptr<TrackNavigationController> m_controller;
+    std::shared_ptr<muse::actions::ActionsDispatcherMock> m_dispatcher;
+    std::shared_ptr<muse::ui::NavigationControllerMock> m_navigationController;
+    std::shared_ptr<context::GlobalContextMock> m_globalContext;
+    std::shared_ptr<SelectionControllerMock> m_selectionController;
+    std::shared_ptr<TrackeditInteractionMock> m_trackeditInteraction;
+    std::shared_ptr<TrackeditProjectMock> m_trackeditProject;
+
+    std::map<muse::actions::ActionCode, IActionsDispatcher::ActionCallBackWithNameAndData> m_actionCallbacks;
+};
+
+/**
+ * Test 1: When project just opened (no highlight), right arrow should move playhead
+ */
+TEST_F(TrackNavigationControllerTests, RightArrowMovesPlayheadWhenNoHighlight)
+{
+    //! [GIVEN] Navigation highlight is off (default after opening project)
+    ON_CALL(*m_navigationController, isHighlight())
+    .WillByDefault(Return(false));
+
+    //! [GIVEN] Controller is initialized
+    initController();
+
+    //! [EXPECT] Playhead move action is dispatched
+    EXPECT_CALL(*m_dispatcher, dispatch(muse::actions::ActionCode("play-position-increase"))).Times(1);
+
+    //! [WHEN] Right arrow is pressed (track-view-next-item is dispatched by shortcut system)
+    invokeAction("track-view-next-item");
+}
+
+/**
+ * Test 2: When project just opened (no highlight), left arrow should move playhead
+ */
+TEST_F(TrackNavigationControllerTests, LeftArrowMovesPlayheadWhenNoHighlight)
+{
+    //! [GIVEN] Navigation highlight is off
+    ON_CALL(*m_navigationController, isHighlight())
+    .WillByDefault(Return(false));
+
+    //! [GIVEN] Controller is initialized
+    initController();
+
+    //! [EXPECT] Playhead move action is dispatched
+    EXPECT_CALL(*m_dispatcher, dispatch(muse::actions::ActionCode("play-position-decrease"))).Times(1);
+
+    //! [WHEN] Left arrow is pressed
+    invokeAction("track-view-prev-item");
+}
+
+/**
+ * Test 3: When navigation is highlighted, right arrow should navigate to next clip (not move playhead)
+ */
+TEST_F(TrackNavigationControllerTests, RightArrowNavigatesClipsWhenHighlighted)
+{
+    //! [GIVEN] Navigation highlight is on (user pressed Tab)
+    ON_CALL(*m_navigationController, isHighlight())
+    .WillByDefault(Return(true));
+
+    //! [GIVEN] There is a track with two clips, focus is on the first clip
+    Track track;
+    track.id = 1;
+    track.type = TrackType::Mono;
+
+    Clip clip1;
+    clip1.key = { 1, 100 };
+    clip1.startTime = 0.0;
+    Clip clip2;
+    clip2.key = { 1, 200 };
+    clip2.startTime = 2.0;
+
+    ON_CALL(*m_trackeditProject, track(1))
+    .WillByDefault(Return(track));
+    ON_CALL(*m_trackeditProject, clipList(1))
+    .WillByDefault([clip1, clip2](const TrackId&) {
+        muse::async::NotifyList<Clip> list;
+        list.push_back(clip1);
+        list.push_back(clip2);
+        return list;
+    });
+
+    //! [GIVEN] Controller is initialized with focus on the first clip
+    initController();
+    m_controller->setFocusedItem(clip1.key);
+
+    //! [EXPECT] Playhead move is NOT dispatched
+    EXPECT_CALL(*m_dispatcher, dispatch(muse::actions::ActionCode("play-position-increase"))).Times(0);
+
+    //! [WHEN] Right arrow is pressed
+    invokeAction("track-view-next-item");
+}
+
+/**
+ * Test 4: When project just opened, Tab should trigger panel navigation
+ */
+TEST_F(TrackNavigationControllerTests, TabNavigatesToNextPanelWhenNoItems)
+{
+    //! [GIVEN] There is one track with no clips
+    Track track;
+    track.id = 1;
+    track.type = TrackType::Mono;
+
+    ON_CALL(*m_trackeditProject, trackList())
+    .WillByDefault(Return(std::vector<Track>({ track })));
+    ON_CALL(*m_trackeditProject, track(1))
+    .WillByDefault(Return(track));
+    ON_CALL(*m_trackeditProject, clipList(1))
+    .WillByDefault(Return(muse::async::NotifyList<Clip> {}));
+
+    //! [GIVEN] Controller is initialized with focus on the track (no item)
+    initController();
+    m_controller->setFocusedTrack(1);
+
+    //! [EXPECT] Framework panel navigation is dispatched
+    EXPECT_CALL(*m_dispatcher, dispatch(muse::actions::ActionCode("nav-next-panel"))).Times(1);
+
+    //! [WHEN] Tab is pressed (track-view-next-panel is dispatched by shortcut system)
+    invokeAction("track-view-next-panel");
+}
+
+/**
+ * Test 5: Pressing Escape dismisses highlight, then arrow moves playhead
+ */
+TEST_F(TrackNavigationControllerTests, EscapeDismissesHighlightThenArrowMovesPlayhead)
+{
+    //! [GIVEN] Navigation highlight is initially on
+    bool isHighlighted = true;
+    ON_CALL(*m_navigationController, isHighlight())
+    .WillByDefault([&isHighlighted]() { return isHighlighted; });
+
+    //! [GIVEN] Controller is initialized
+    initController();
+
+    //! [EXPECT] Escape sets highlight to false
+    EXPECT_CALL(*m_navigationController, setIsHighlight(false)).Times(1);
+
+    //! [WHEN] Escape is pressed (nav-escape is dispatched)
+    invokeAction("nav-escape");
+
+    //! [THEN] Simulate highlight being turned off
+    isHighlighted = false;
+
+    //! [EXPECT] Now arrow dispatches playhead move
+    EXPECT_CALL(*m_dispatcher, dispatch(muse::actions::ActionCode("play-position-increase"))).Times(1);
+
+    //! [WHEN] Right arrow is pressed after Escape
+    invokeAction("track-view-next-item");
+}
+}

--- a/src/trackedit/view/tracknavigationmodel.cpp
+++ b/src/trackedit/view/tracknavigationmodel.cpp
@@ -161,13 +161,14 @@ void TrackNavigationModel::addPanels(const TrackId& trackId, int pos)
 
     connect(trackPanel, &muse::ui::NavigationPanel::navigationEvent, this,
             [this, trackId](muse::ui::NavigationEvent* event) {
-        if (event->type() != muse::ui::NavigationEvent::AboutActive) {
+        if (event->type() == muse::ui::NavigationEvent::AboutActive) {
+            if (tracksNavigationController()->focusedTrack() != trackId) {
+                tracksNavigationController()->setFocusedTrack(trackId);
+            }
             return;
         }
 
-        if (tracksNavigationController()->focusedTrack() != trackId) {
-            tracksNavigationController()->setFocusedTrack(trackId);
-        }
+        handleArrowKeyFallback(event);
     });
 
     muse::ui::NavigationPanel* itemsPanel = new muse::ui::NavigationPanel(this);
@@ -176,6 +177,11 @@ void TrackNavigationModel::addPanels(const TrackId& trackId, int pos)
     itemsPanel->setOrder(2 * pos + 1);
     itemsPanel->setSection(m_section);
     itemsPanel->componentComplete();
+
+    connect(itemsPanel, &muse::ui::NavigationPanel::navigationEvent, this,
+            [this](muse::ui::NavigationEvent* event) {
+        handleArrowKeyFallback(event);
+    });
 
     m_trackItemPanels.append(trackPanel);
     m_viewItemPanels.append(itemsPanel);
@@ -196,6 +202,19 @@ void TrackNavigationModel::resetPanelOrder()
 
     emit trackItemPanelsChanged();
     emit viewItemPanelsChanged();
+}
+
+void TrackNavigationModel::handleArrowKeyFallback(muse::ui::NavigationEvent* event)
+{
+    if (!tracksNavigationController()->isNavigationEnabled()) {
+        if (event->type() == muse::ui::NavigationEvent::Right) {
+            event->setAccepted(true);
+            dispatcher()->dispatch("play-position-increase");
+        } else if (event->type() == muse::ui::NavigationEvent::Left) {
+            event->setAccepted(true);
+            dispatcher()->dispatch("play-position-decrease");
+        }
+    }
 }
 
 void TrackNavigationModel::moveFocusTo(const QVariant& trackId)

--- a/src/trackedit/view/tracknavigationmodel.h
+++ b/src/trackedit/view/tracknavigationmodel.h
@@ -45,6 +45,7 @@ private:
     void addPanels(const TrackId& trackId, int pos);
     void resetPanelOrder();
     void addDefaultNavigation();
+    void handleArrowKeyFallback(muse::ui::NavigationEvent* event);
 
     void activateNavigation(const TrackId& trackId, bool highlight = false);
     void activateNavigation(const TrackItemKey& itemKey, bool highlight = false);


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/10384
Resolves: https://github.com/audacity/audacity/issues/10651
Resolves: https://github.com/audacity/audacity/issues/8383

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Autobot test cases have been run
- [x] New navigation should work both for clips and labels (pressing down/up arrow should lead you to the clip/label which start time is the closest to the start time of the clip you started navigating from)
- [x] Check if that scenario works: Press tab to navigate through clips -> press Esc to escape navigation -> press arrow/left right to move the playhead
- [x] When navigation is not enabled: left/right arrow should move the playhead
- [x] When moving playhead with arrows, the view should scroll to the playhead if it was outside the view
- [x] Animation is triggered on horizontal scroll (there's no immediate view shift)-> when navigating to clips that are not visible on the screen
- [x] Pinned playhead mode: animation is triggered only on starting playback (if playhead isn’t visible in the view)
- [x] Paged playhead mode: animation is triggered on starting playback (if playhead isn’t visible in the view) AND on every page scroll
- [x] There’s no animation when zoom is too high that it takes playhead to move quicker than to finish entire animation
- [x] shift+arrow to expand selection (if there's no active selection then playhead is starting point)
- [x] shift+ctrl+arrow to contract selection

