### PR TITLE
fix increment for lead-in time and crossfade settings

### DIFF
--- a/src/preferences/qml/Audacity/Preferences/internal/LeadInRecordingSection.qml
+++ b/src/preferences/qml/Audacity/Preferences/internal/LeadInRecordingSection.qml
@@ -29,7 +29,7 @@ BaseSection {
 
         minValue: 0
         maxValue: 30
-        step: 0.5
+        step: 1
         decimals: 1
 
         measureUnitsSymbol: qsTrc("global", "seconds")
@@ -55,7 +55,7 @@ BaseSection {
         minValue: 0
         maxValue: 100
         step: 1
-        decimals: 0
+        decimals: 1
 
         measureUnitsSymbol: qsTrc("global", "ms")
 


### PR DESCRIPTION
Resolves: #10670

- Up/down arrows now move both controls in integer steps (±1).
- Manual typing now allows up to one decimal place on both controls.
- Typed fractional values are preserved (for valid one-decimal input) and are not coerced to integers.
- Backend/model path already stores doubles, and there is no forced integer cast in recording preferences model/config.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Autobot test cases have been run
