### PR TITLE
Fix truncated "Automatic" label in latency compensation preferences

### DIFF
--- a/src/preferences/qml/Audacity/Preferences/internal/BufferAndLatencySection.qml
+++ b/src/preferences/qml/Audacity/Preferences/internal/BufferAndLatencySection.qml
@@ -117,6 +117,7 @@ BaseSection {
                     checked: apiModel.automaticCompensationEnabled
                     onClicked: apiModel.setAutomaticCompensationEnabled(!checked)
 
+                    width: parent.width
                     anchors.verticalCenter: parent.verticalCenter
 
                     navigation.name: "AutomaticLatencyCompensationCheckBox"


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/10728

The CheckBox label was elided at font sizes ≥13pt because the
internal availableWidth calculation (root.width - spacing - box.width)
resolved through a circular implicitWidth chain that got stuck at the
12pt value, leaving insufficient room for the text.

Setting width: parent.width matches the established pattern used by
every other CheckBox in the preferences UI and gives the label
unambiguous room to render at any font size.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [ ] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Autobot test cases have been run
