### PR TITLE
Skip and unregister stale plugin cache entries missing required metadata

### DIFF
--- a/src/effects/effects_base/internal/effectsprovider.cpp
+++ b/src/effects/effects_base/internal/effectsprovider.cpp
@@ -91,12 +91,27 @@ void EffectsProvider::reloadEffects()
     m_effects.clear();
 
     const auto knownPlugins = knownPluginsRegister()->pluginInfoList();
-    std::for_each(knownPlugins.begin(), knownPlugins.end(),
-                  [this](const muse::audioplugins::AudioPluginInfo& info) {
-        if (info.enabled) {
-            m_effects.push_back(utils::museToAuEffectMeta(info.path, info.meta));
+    muse::audio::AudioResourceIdList staleIds;
+
+    for (const auto& info : knownPlugins) {
+        if (!info.enabled) {
+            continue;
         }
-    });
+        // Entries written by older code lack required attributes (e.g. "type").
+        // Unregister them so they are re-scanned with current metadata on the
+        // next plugin registration pass instead of crashing here.
+        if (info.meta.attributeVal(EFFECT_TYPE_ATTRIBUTE).empty()) {
+            staleIds.push_back(info.meta.id);
+            continue;
+        }
+        m_effects.push_back(utils::museToAuEffectMeta(info.path, info.meta));
+    }
+
+    if (!staleIds.empty()) {
+        LOGW() << "Unregistering " << staleIds.size()
+               << " plugin(s) with missing metadata — they will be re-scanned on next launch";
+        knownPluginsRegister()->unregisterPlugins(staleIds);
+    }
 
     m_effectsChanged.notify();
 }

--- a/src/effects/effects_base/internal/effectsprovider.cpp
+++ b/src/effects/effects_base/internal/effectsprovider.cpp
@@ -94,14 +94,14 @@ void EffectsProvider::reloadEffects()
     muse::audio::AudioResourceIdList staleIds;
 
     for (const auto& info : knownPlugins) {
-        if (!info.enabled) {
-            continue;
-        }
         // Entries written by older code lack required attributes (e.g. "type").
         // Unregister them so they are re-scanned with current metadata on the
         // next plugin registration pass instead of crashing here.
         if (info.meta.attributeVal(EFFECT_TYPE_ATTRIBUTE).empty()) {
             staleIds.push_back(info.meta.id);
+            continue;
+        }
+        if (!info.enabled) {
             continue;
         }
         m_effects.push_back(utils::museToAuEffectMeta(info.path, info.meta));


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/10730

Plugins cached by older code lack attributes like 'type' in known_audio_plugins.json. Reading them via museToAuEffectMeta() triggered IF_ASSERT_FAILED → abort() on every startup.

reloadEffects() now detects entries with an empty 'type' attribute (the sentinel for old-format records), unregisters them so they are evicted from the cache, and continues without crashing. They will be re-scanned with current metadata on the next plugin registration pass.

Fixes crash introduced by RIP pluginregistry.cfg (#10597).

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [ ] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Autobot test cases have been run
- [ ] Remove `known_audio_plugins.json`, run a nightly build, scan for plugins. Then run this PR's build and click 'Skip' in the plugin scan dialog. It should not crash.
- [ ] After the above launch, quit and relaunch. The previously-stale plugins should now appear in the Effects menu with correct metadata, confirming they were unregistered and re-scanned.
- [ ] On a fresh install with no pre-existing cache (or an up-to-date cache), all built-in and Nyquist effects load and appear in the Effects menu correctly, i.e. there are no regressions in the normal startup path.
