### PR TITLE
Add cut-paste-delete action variants to shortcuts and menus

### DIFF
--- a/src/app/configs/data/shortcuts.xml
+++ b/src/app/configs/data/shortcuts.xml
@@ -323,8 +323,17 @@
         <key>curs-next-clip-boundary</key>
     </SC>
     <SC>
+        <key>cut-leave-gap</key>
+    </SC>
+    <SC>
+        <key>cut-per-clip-ripple</key>
+    </SC>
+    <SC>
         <key>cut-per-track-ripple</key>
         <seq>Ctrl+Shift+X</seq>
+    </SC>
+    <SC>
+        <key>cut-all-tracks-ripple</key>
     </SC>
     <SC>
         <key>duplicate</key>
@@ -361,6 +370,12 @@
     <SC>
         <key>preferences</key>
         <seq>Ctrl+,</seq>
+    </SC>
+    <SC>
+        <key>delete-leave-gap</key>
+    </SC>
+    <SC>
+        <key>delete-per-clip-ripple</key>
     </SC>
     <SC>
         <key>delete-per-track-ripple</key>

--- a/src/projectscene/view/tracksitemsview/canvascontextmenumodel.cpp
+++ b/src/projectscene/view/tracksitemsview/canvascontextmenumodel.cpp
@@ -21,8 +21,18 @@ void CanvasContextMenuModel::load()
 
 MenuItemList CanvasContextMenuModel::makeItems()
 {
+    MenuItemList pasteAndItems {
+        makeMenuItem("action://trackedit/paste-overlap",
+                     muse::TranslatableString("canvas", "Paste and overlap")),
+        makeMenuItem("action://trackedit/paste-insert",
+                     muse::TranslatableString("canvas", "Paste and make room on this track")),
+        makeMenuItem("action://trackedit/paste-insert-all-tracks-ripple",
+                     muse::TranslatableString("canvas", "Paste and make room on all tracks")),
+    };
+
     MenuItemList items {
         makeMenuItem("action://trackedit/paste-default"),
+        makeMenu(muse::TranslatableString("canvas", "Paste and…"), pasteAndItems, "menu-paste-and"),
         makeSeparator(),
         makeMenuItem("new-mono-track"),
         makeMenuItem("new-stereo-track"),

--- a/src/projectscene/view/tracksitemsview/clipcontextmenumodel.cpp
+++ b/src/projectscene/view/tracksitemsview/clipcontextmenumodel.cpp
@@ -41,6 +41,24 @@ void ClipContextMenuModel::load()
 
     auto colorItems = makeClipColourItems();
 
+    MenuItemList cutAndItems {
+        makeMenuItem("cut-leave-gap",
+                     muse::TranslatableString("clip", "Cut and leave gap")),
+        makeMenuItem("cut-per-track-ripple",
+                     muse::TranslatableString("clip", "Cut and close gap on this track")),
+        makeMenuItem("cut-all-tracks-ripple",
+                     muse::TranslatableString("clip", "Cut and close gap on all tracks")),
+    };
+
+    MenuItemList deleteAndItems {
+        makeMenuItem("delete-leave-gap",
+                     muse::TranslatableString("clip", "Delete and leave gap")),
+        makeMenuItem("delete-per-track-ripple",
+                     muse::TranslatableString("clip", "Delete and close gap on this track")),
+        makeMenuItem("delete-all-tracks-ripple",
+                     muse::TranslatableString("clip", "Delete and close gap on all tracks")),
+    };
+
     MenuItemList items {
         makeItemWithArg("clip-properties"),
         makeItemWithArg("rename-item", muse::TranslatableString("clip", "Rename clip")),
@@ -48,11 +66,13 @@ void ClipContextMenuModel::load()
         makeSeparator(),
         makeItemWithArg("action://trackedit/cut"),
         makeItemWithArg("action://trackedit/copy"),
-        makeItemWithArg("action://delete"),
         makeItemWithArg("duplicate"),
+        makeItemWithArg("action://trackedit/delete"),
+        makeSeparator(),
+        makeMenu(muse::TranslatableString("clip", "Cut and…"), cutAndItems, "menu-cut-and"),
+        makeMenu(muse::TranslatableString("clip", "Delete and…"), deleteAndItems, "menu-delete-and"),
         makeSeparator(),
         makeItemWithArg("split"),
-        makeSeparator(),
         makeItemWithArg("clip-export"),
         makeSeparator(),
         enableStretchItem,

--- a/src/projectscene/view/tracksitemsview/labelcontextmenumodel.cpp
+++ b/src/projectscene/view/tracksitemsview/labelcontextmenumodel.cpp
@@ -22,12 +22,43 @@ void LabelContextMenuModel::load()
         return item;
     };
 
+    MenuItemList cutAndItems {
+        makeMenuItem("cut-leave-gap",
+                     muse::TranslatableString("label", "Cut and leave gap")),
+        makeMenuItem("cut-per-track-ripple",
+                     muse::TranslatableString("label", "Cut and close gap on this track")),
+        makeMenuItem("cut-all-tracks-ripple",
+                     muse::TranslatableString("label", "Cut and close gap on all tracks")),
+    };
+
+    MenuItemList pasteAndItems {
+        makeMenuItem("action://trackedit/paste-overlap",
+                     muse::TranslatableString("label", "Paste and overlap")),
+        makeMenuItem("action://trackedit/paste-insert",
+                     muse::TranslatableString("label", "Paste and make room on this track")),
+        makeMenuItem("action://trackedit/paste-insert-all-tracks-ripple",
+                     muse::TranslatableString("label", "Paste and make room on all tracks")),
+    };
+
+    MenuItemList deleteAndItems {
+        makeMenuItem("delete-leave-gap",
+                     muse::TranslatableString("label", "Delete and leave gap")),
+        makeMenuItem("delete-per-track-ripple",
+                     muse::TranslatableString("label", "Delete and close gap on this track")),
+        makeMenuItem("delete-all-tracks-ripple",
+                     muse::TranslatableString("label", "Delete and close gap on all tracks")),
+    };
+
     MenuItemList items {
         makeItemWithArg("rename-item", muse::TranslatableString("label", "Rename label")),
         makeSeparator(),
         makeItemWithArg("action://trackedit/cut"),
         makeItemWithArg("action://trackedit/copy"),
         makeItemWithArg("label-delete"),
+        makeSeparator(),
+        makeMenu(muse::TranslatableString("label", "Cut and…"), cutAndItems, "menu-cut-and"),
+        makeMenu(muse::TranslatableString("label", "Paste and…"), pasteAndItems, "menu-paste-and"),
+        makeMenu(muse::TranslatableString("label", "Delete and…"), deleteAndItems, "menu-delete-and"),
     };
 
     setItems(items);

--- a/src/projectscene/view/tracksitemsview/multiclipcontextmenumodel.cpp
+++ b/src/projectscene/view/tracksitemsview/multiclipcontextmenumodel.cpp
@@ -21,13 +21,34 @@ void MultiClipContextMenuModel::load()
 
 MenuItemList MultiClipContextMenuModel::makeItems()
 {
+    MenuItemList cutAndItems {
+        makeMenuItem("cut-leave-gap",
+                     muse::TranslatableString("multiclip", "Cut and leave gap")),
+        makeMenuItem("cut-per-track-ripple",
+                     muse::TranslatableString("multiclip", "Cut and close gap on this track")),
+        makeMenuItem("cut-all-tracks-ripple",
+                     muse::TranslatableString("multiclip", "Cut and close gap on all tracks")),
+    };
+
+    MenuItemList deleteAndItems {
+        makeMenuItem("delete-leave-gap",
+                     muse::TranslatableString("multiclip", "Delete and leave gap")),
+        makeMenuItem("delete-per-track-ripple",
+                     muse::TranslatableString("multiclip", "Delete and close gap on this track")),
+        makeMenuItem("delete-all-tracks-ripple",
+                     muse::TranslatableString("multiclip", "Delete and close gap on all tracks")),
+    };
+
     MenuItemList items {
         makeMenuItem("action://trackedit/cut"),
         makeMenuItem("action://trackedit/copy"),
         makeMenuItem("action://trackedit/delete"),
         makeSeparator(),
+        makeMenu(muse::TranslatableString("multiclip", "Cut and…"), cutAndItems, "menu-cut-and"),
+        makeMenu(muse::TranslatableString("multiclip", "Delete and…"), deleteAndItems, "menu-delete-and"),
+        makeSeparator(),
         makeMenuItem("group-clips"),
-        makeMenuItem("ungroup-clips")
+        makeMenuItem("ungroup-clips"),
     };
 
     return items;

--- a/src/projectscene/view/tracksitemsview/selectioncontextmenumodel.cpp
+++ b/src/projectscene/view/tracksitemsview/selectioncontextmenumodel.cpp
@@ -21,12 +21,48 @@ void SelectionContextMenuModel::load()
 
 MenuItemList SelectionContextMenuModel::makeItems()
 {
+    MenuItemList cutAndItems {
+        makeMenuItem("cut-leave-gap",
+                     muse::TranslatableString("selection", "Cut and leave gap")),
+        makeMenuItem("cut-per-clip-ripple",
+                     muse::TranslatableString("selection", "Cut and close gap")),
+        makeMenuItem("cut-per-track-ripple",
+                     muse::TranslatableString("selection", "Cut and close gap on this track")),
+        makeMenuItem("cut-all-tracks-ripple",
+                     muse::TranslatableString("selection", "Cut and close gap on all tracks")),
+    };
+
+    MenuItemList pasteAndItems {
+        makeMenuItem("action://trackedit/paste-overlap",
+                     muse::TranslatableString("selection", "Paste and overlap")),
+        makeMenuItem("action://trackedit/paste-insert",
+                     muse::TranslatableString("selection", "Paste and make room on this track")),
+        makeMenuItem("action://trackedit/paste-insert-all-tracks-ripple",
+                     muse::TranslatableString("selection", "Paste and make room on all tracks")),
+    };
+
+    MenuItemList deleteAndItems {
+        makeMenuItem("delete-leave-gap",
+                     muse::TranslatableString("selection", "Delete and leave gap")),
+        makeMenuItem("delete-per-clip-ripple",
+                     muse::TranslatableString("selection", "Delete and close gap")),
+        makeMenuItem("delete-per-track-ripple",
+                     muse::TranslatableString("selection", "Delete and close gap on this track")),
+        makeMenuItem("delete-all-tracks-ripple",
+                     muse::TranslatableString("selection", "Delete and close gap on all tracks")),
+    };
+
     MenuItemList items {
         makeMenuItem("action://trackedit/cut"),
         makeMenuItem("action://trackedit/copy"),
         makeMenuItem("action://trackedit/paste-default"),
-        makeSeparator(),
         makeMenuItem("duplicate"),
+        makeMenuItem("action://trackedit/delete"),
+        makeSeparator(),
+        makeMenu(muse::TranslatableString("selection", "Cut and…"), cutAndItems, "menu-cut-and"),
+        makeMenu(muse::TranslatableString("selection", "Paste and…"), pasteAndItems, "menu-paste-and"),
+        makeMenu(muse::TranslatableString("selection", "Delete and…"), deleteAndItems, "menu-delete-and"),
+        makeSeparator(),
         makeMenuItem("split")
     };
 

--- a/src/trackedit/internal/trackeditactionscontroller.cpp
+++ b/src/trackedit/internal/trackeditactionscontroller.cpp
@@ -35,7 +35,8 @@ static const ActionCode CUT_PER_CLIP_RIPPLE_CODE("cut-per-clip-ripple");
 static const ActionCode CUT_PER_TRACK_RIPPLE_CODE("cut-per-track-ripple");
 static const ActionCode CUT_ALL_TRACKS_RIPPLE_CODE("cut-all-tracks-ripple");
 
-static const ActionCode DELETE_LEAVE_GAP_CODE("split-delete");
+static const ActionCode CUT_LEAVE_GAP_CODE("cut-leave-gap");
+static const ActionCode DELETE_LEAVE_GAP_CODE("delete-leave-gap");
 static const ActionCode DELETE_PER_CLIP_RIPPLE_CODE("delete-per-clip-ripple");
 static const ActionCode DELETE_PER_TRACK_RIPPLE_CODE("delete-per-track-ripple");
 static const ActionCode DELETE_ALL_TRACKS_RIPPLE_CODE("delete-all-tracks-ripple");
@@ -139,9 +140,12 @@ constexpr double MIN_CLIP_WIDTH = 3.0;
 // In principle, disabled are actions that modify the data involved in playback.
 static const std::vector<ActionCode> actionsDisabledDuringRecording {
     TRACKEDIT_CUT_CODE,
+    CUT_LEAVE_GAP_CODE,
     CUT_PER_CLIP_RIPPLE_CODE,
     CUT_PER_TRACK_RIPPLE_CODE,
+    CUT_ALL_TRACKS_RIPPLE_CODE,
     TRACKEDIT_DELETE_CODE,
+    DELETE_LEAVE_GAP_CODE,
     DELETE_PER_CLIP_RIPPLE_CODE,
     DELETE_PER_TRACK_RIPPLE_CODE,
     DELETE_ALL_TRACKS_RIPPLE_CODE,
@@ -213,10 +217,12 @@ void TrackeditActionsController::init()
     dispatcher()->reg(this, DISJOIN_CODE, this, &TrackeditActionsController::doGlobalDisjoin);
     dispatcher()->reg(this, DUPLICATE_CODE, this, &TrackeditActionsController::doGlobalDuplicate);
 
+    dispatcher()->reg(this, CUT_LEAVE_GAP_CODE, this, &TrackeditActionsController::doGlobalCutLeaveGap);
     dispatcher()->reg(this, CUT_PER_CLIP_RIPPLE_CODE, this, &TrackeditActionsController::doGlobalCutPerClipRipple);
     dispatcher()->reg(this, CUT_PER_TRACK_RIPPLE_CODE, this, &TrackeditActionsController::doGlobalCutPerTrackRipple);
     dispatcher()->reg(this, CUT_ALL_TRACKS_RIPPLE_CODE, this, &TrackeditActionsController::doGlobalCutAllTracksRipple);
 
+    dispatcher()->reg(this, DELETE_LEAVE_GAP_CODE, this, &TrackeditActionsController::doGlobalDeleteLeaveGap);
     dispatcher()->reg(this, DELETE_PER_CLIP_RIPPLE_CODE, this, &TrackeditActionsController::doGlobalDeletePerClipRipple);
     dispatcher()->reg(this, DELETE_PER_TRACK_RIPPLE_CODE, this, &TrackeditActionsController::doGlobalDeletePerTrackRipple);
     dispatcher()->reg(this, DELETE_ALL_TRACKS_RIPPLE_CODE, this, &TrackeditActionsController::doGlobalDeleteAllTracksRipple);
@@ -488,6 +494,31 @@ void TrackeditActionsController::doGlobalCut()
     }
 }
 
+void TrackeditActionsController::doGlobalCutLeaveGap()
+{
+    if (!selectionController()->timeSelectionIsEmpty()) {
+        auto selectedTracks = selectionController()->selectedTracks();
+        secs_t selectedStartTime = selectionController()->dataSelectedStartTime();
+        secs_t selectedEndTime = selectionController()->dataSelectedEndTime();
+
+        dispatcher()->dispatch(RANGE_SELECTION_SPLIT_CUT,
+                               ActionData::make_arg3<TrackIdList, secs_t, secs_t>(selectedTracks, selectedStartTime, selectedEndTime));
+
+        frequencySelectionController()->resetFrequencySelection();
+        return;
+    }
+
+    if (isFocusedItemClip()) {
+        dispatcher()->dispatch(MULTI_CLIP_CUT_CODE, ActionData::make_arg1(false));
+        return;
+    }
+
+    if (isFocusedItemLabel()) {
+        dispatcher()->dispatch(LABEL_CUT_MULTI_CODE, ActionData::make_arg1(false));
+        return;
+    }
+}
+
 void TrackeditActionsController::doGlobalCutPerClipRipple()
 {
     auto moveClips = ActionData::make_arg1(false);
@@ -636,13 +667,41 @@ void TrackeditActionsController::doGlobalDelete()
     }
 
     interactive()->errorSync(muse::trc("trackedit", "No audio selected"),
-                             muse::trc("trackedit", "Select the audio for Delete then try again."));
+                             muse::trc("trackedit", "Select the audio to delete and try again."));
 }
 
 void TrackeditActionsController::doGlobalCancel()
 {
     trackeditInteraction()->notifyAboutCancelDragEdit();
     trackNavigationController()->setIsNavigationActive(false);
+}
+
+void TrackeditActionsController::doGlobalDeleteLeaveGap()
+{
+    if (!selectionController()->timeSelectionIsEmpty()) {
+        auto selectedTracks = selectionController()->selectedTracks();
+        secs_t selectedStartTime = selectionController()->dataSelectedStartTime();
+        secs_t selectedEndTime = selectionController()->dataSelectedEndTime();
+
+        dispatcher()->dispatch(RANGE_SELECTION_SPLIT_DELETE,
+                               ActionData::make_arg3<TrackIdList, secs_t, secs_t>(selectedTracks, selectedStartTime, selectedEndTime));
+
+        frequencySelectionController()->resetFrequencySelection();
+        return;
+    }
+
+    if (isFocusedItemClip()) {
+        dispatcher()->dispatch(MULTI_CLIP_DELETE_CODE, ActionData::make_arg1(false));
+        return;
+    }
+
+    if (isFocusedItemLabel()) {
+        dispatcher()->dispatch(LABEL_DELETE_MULTI_CODE, ActionData::make_arg1(false));
+        return;
+    }
+
+    interactive()->errorSync(muse::trc("trackedit", "No audio selected"),
+                             muse::trc("trackedit", "Select the audio to delete and try again."));
 }
 
 void TrackeditActionsController::doGlobalDeletePerClipRipple()
@@ -665,7 +724,7 @@ void TrackeditActionsController::doGlobalDeletePerClipRipple()
     }
 
     interactive()->errorSync(muse::trc("trackedit", "No audio selected"),
-                             muse::trc("trackedit", "Select the audio for Delete then try again."));
+                             muse::trc("trackedit", "Select the audio to delete and try again."));
 }
 
 void TrackeditActionsController::doGlobalDeletePerTrackRipple()
@@ -688,7 +747,7 @@ void TrackeditActionsController::doGlobalDeletePerTrackRipple()
     }
 
     interactive()->errorSync(muse::trc("trackedit", "No audio selected"),
-                             muse::trc("trackedit", "Select the audio for Delete then try again."));
+                             muse::trc("trackedit", "Select the audio to delete and try again."));
 }
 
 void TrackeditActionsController::doGlobalDeleteAllTracksRipple()
@@ -719,7 +778,7 @@ void TrackeditActionsController::doGlobalDeleteAllTracksRipple()
     }
 
     interactive()->errorSync(muse::trc("trackedit", "No audio selected"),
-                             muse::trc("trackedit", "Select the audio for Delete then try again."));
+                             muse::trc("trackedit", "Select the audio to delete and try again."));
 }
 
 void TrackeditActionsController::doGlobalSplit()

--- a/src/trackedit/internal/trackeditactionscontroller.h
+++ b/src/trackedit/internal/trackeditactionscontroller.h
@@ -81,6 +81,7 @@ private:
     void doGlobalDisjoin();
     void doGlobalDuplicate();
 
+    void doGlobalCutLeaveGap();
     void doGlobalCutPerClipRipple();
     void doGlobalCutPerTrackRipple();
     void doGlobalCutAllTracksRipple();
@@ -90,6 +91,7 @@ private:
     void pasteInsert();
     void pasteInsertRipple();
 
+    void doGlobalDeleteLeaveGap();
     void doGlobalDeletePerClipRipple();
     void doGlobalDeletePerTrackRipple();
     void doGlobalDeleteAllTracksRipple();

--- a/src/trackedit/internal/trackedituiactions.cpp
+++ b/src/trackedit/internal/trackedituiactions.cpp
@@ -66,6 +66,13 @@ UiActionList STATIC_ACTIONS = {
              TranslatableString("action", "Clear selection"),
              TranslatableString("action", "Clear selection")
              ),
+    UiAction("cut-leave-gap",
+             au::context::UiCtxAny,
+             au::context::CTX_ANY,
+             TranslatableString("action", "Cut and leave gap"),
+             TranslatableString("action", "Cut and leave gap"),
+             IconCode::Code::CUT
+             ),
     UiAction("cut-per-clip-ripple",
              au::context::UiCtxAny,
              au::context::CTX_ANY,
@@ -86,6 +93,20 @@ UiActionList STATIC_ACTIONS = {
              TranslatableString("action", "Cut and close gap (all tracks)"),
              TranslatableString("action", "Cut and close gap (all tracks)"),
              IconCode::Code::CUT
+             ),
+    UiAction("delete-leave-gap",
+             au::context::UiCtxAny,
+             au::context::CTX_ANY,
+             TranslatableString("action", "Delete and leave gap"),
+             TranslatableString("action", "Delete and leave gap"),
+             IconCode::Code::DELETE_TANK
+             ),
+    UiAction("delete-per-clip-ripple",
+             au::context::UiCtxAny,
+             au::context::CTX_ANY,
+             TranslatableString("action", "Delete and close gap (per clip)"),
+             TranslatableString("action", "Delete and close gap (per clip)"),
+             IconCode::Code::DELETE_TANK
              ),
     UiAction("delete-per-track-ripple",
              au::context::UiCtxAny,


### PR DESCRIPTION
Resolves: #9691

Adds cut-paste-delete variants to shortcuts and context menus

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Autobot test cases have been run
