### PR TITLE
Post framework update dialog fixes

### DIFF
--- a/src/effects/effects_base/qml/Audacity/Effects/RealtimeEffectViewerDialog.qml
+++ b/src/effects/effects_base/qml/Audacity/Effects/RealtimeEffectViewerDialog.qml
@@ -47,8 +47,6 @@ EffectStyledDialogView {
         loadViewer()
     }
 
-    alwaysOnTop: true
-
     // Listen to UI mode changes from the presets bar menu
     Connections {
         target: presetsBar.presetsBarModel

--- a/src/importexport/export/qml/Export/ExportDialog.qml
+++ b/src/importexport/export/qml/Export/ExportDialog.qml
@@ -24,7 +24,6 @@ StyledDialogView {
     margins: 12
 
     modal: true
-    alwaysOnTop: true
 
     property int dropdownWidth: 358
     property int smallDropdownWidth: 364 * 0.65

--- a/src/importexport/export/qml/Export/MetadataDialog.qml
+++ b/src/importexport/export/qml/Export/MetadataDialog.qml
@@ -20,7 +20,6 @@ StyledDialogView {
     contentHeight: 625
 
     modal: true
-    alwaysOnTop: true
 
     property NavigationPanel navigation: NavigationPanel {
         name: root.title

--- a/src/importexport/export/view/channelmappingtableviewmodel.cpp
+++ b/src/importexport/export/view/channelmappingtableviewmodel.cpp
@@ -14,7 +14,7 @@ using namespace muse::uicomponents;
 using namespace au::importexport;
 
 ChannelMappingTableViewModel::ChannelMappingTableViewModel(QObject* parent)
-    : AbstractTableViewModel(parent), muse::Contextable(muse::modularity::globalCtx())
+    : AbstractTableViewModel(parent), muse::Contextable(muse::iocCtxForQmlObject(this))
 {
 }
 

--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/pitchandspeed/PitchAndSpeedChangeDialog.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/pitchandspeed/PitchAndSpeedChangeDialog.qml
@@ -21,7 +21,6 @@ StyledDialogView {
 
     modal: true
     resizable: false
-    alwaysOnTop: true
 
     PitchAndSpeedChangeModel {
         id: changeModel


### PR DESCRIPTION
[This change](https://github.com/musescore/MuseScore/commit/b8395f6db2b74bbdf4b8f4bc438e8315ce522e38) in the framework was inadvertently integrated in Audacity, breaking several dialogs.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Autobot test cases have been run
