### PR TITLE
7568 fix memory leaks

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,6 +8,7 @@
             "cwd": "${workspaceFolder}",
             "program": "${command:cmake.launchTargetPath}",
             "args": [
+                // "--memory-leak-report", // Enable memory-leak reporting
                 // Comment this out to run audacity in plugin registration mode
                 // "--register-audio-plugin", "C:/Program Files/Common Files/VST3/Your plugin.vst3"
             ],

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -163,6 +163,8 @@ qt_add_executable(${EXECUTABLE_NAME}
     pluginregistrationapp.h
     commandlineparser.cpp
     commandlineparser.h
+    winleaktracker.cpp
+    winleaktracker.h
 )
 
 ###########################################

--- a/src/app/cmdoptions.h
+++ b/src/app/cmdoptions.h
@@ -17,6 +17,7 @@ namespace au::app {
 struct AudacityCmdOptions : public muse::CmdOptions {
     struct {
         std::optional<bool> revertToFactorySettings;
+        bool memoryLeakReport = false;
     } app;
 
     struct {

--- a/src/app/commandlineparser.cpp
+++ b/src/app/commandlineparser.cpp
@@ -55,6 +55,10 @@ void CommandLineParser::init()
 
     m_parser.addOption(QCommandLineOption({ "F", "factory-settings" }, "Use factory settings"));
 
+    m_parser.addOption(QCommandLineOption("memory-leak-report",
+                                          "Track allocations and write a leak report on shutdown"
+                                          " (Windows debug builds only; significant runtime overhead)"));
+
     m_parser.addOption(QCommandLineOption("session-type", "Startup with given session type", "type"));
     m_parser.addOption(internalCommandLineOption("import-media-file", "Import media file on startup", "path"));
     m_parser.addOption(internalCommandLineOption("remove-media-after-import", "Remove imported media files after import"));
@@ -141,6 +145,10 @@ void CommandLineParser::parse(int argc, char** argv)
 
     if (m_parser.isSet("F")) {
         m_options->app.revertToFactorySettings = true;
+    }
+
+    if (m_parser.isSet("memory-leak-report")) {
+        m_options->app.memoryLeakReport = true;
     }
 
     // Audio plugin registration

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -48,19 +48,11 @@ static void crashCallback(int signum)
 #endif
 
 #ifdef Q_OS_WIN
-#include <crtdbg.h> // _CrtSetDbgFlag
+#include "winleaktracker.h"
 #endif
 
 int main(int argc, char** argv)
 {
-#ifdef Q_OS_WIN
-    // Configure memory leak detection in debug builds.
-    // At the moment we keep it disabled because it causes shutdown to take about 10 seconds.
-    // A ticket was logged to investigate this further: https://github.com/audacity/audacity/issues/7568
-    constexpr auto enableMemoryLeakReport = false;
-    _CrtSetDbgFlag(enableMemoryLeakReport ? _CRTDBG_ALLOC_MEM_DF | _CRTDBG_LEAK_CHECK_DF : _CRTDBG_ALLOC_MEM_DF);
-#endif
-
 #ifndef MUSE_MODULE_DIAGNOSTICS_CRASHPAD_CLIENT
     signal(SIGSEGV, crashCallback);
     signal(SIGILL, crashCallback);
@@ -169,6 +161,12 @@ int main(int argc, char** argv)
     au::app::CommandLineParser commandLineParser;
     commandLineParser.init();
     commandLineParser.parse(argcFinal, argvFinal);
+
+#ifdef Q_OS_WIN
+    if (commandLineParser.options()->app.memoryLeakReport) {
+        au::app::winleaktracker::install();
+    }
+#endif
 
     // ====================================================
     // Create QApplication based on run mode

--- a/src/app/winleaktracker.cpp
+++ b/src/app/winleaktracker.cpp
@@ -1,0 +1,270 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+#include "winleaktracker.h"
+
+#include "framework/global/defer.h"
+
+#if defined(_WIN32) && defined(_DEBUG)
+
+#include <crtdbg.h>
+#include <windows.h>
+#include <dbghelp.h>
+
+#include <algorithm>
+#include <atomic>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <map>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#pragma comment(lib, "dbghelp.lib")
+
+namespace {
+constexpr int kStackDepth = 32;
+constexpr int kStackSkip = 2;   // skip allocHook + CRT allocator dispatch
+constexpr int kGroupDepth = 5;  // group leaks by top N frames
+
+// Mirrors the MSVC debug CRT block header (x64 layout). The user pointer
+// returned by malloc_dbg sits immediately after this struct. Peeking it lets
+// us recover the allocation serial on free/realloc without a second pointer
+// -> serial map. Layout is an undocumented implementation detail but has been
+// stable across MSVC 14.x.
+struct CrtBlockHeader {
+    CrtBlockHeader* next;
+    CrtBlockHeader* prev;
+    const char* fileName;
+    int lineNumber;
+    int blockUse;
+    size_t dataSize;
+    long requestNumber;
+    unsigned char gap[4];
+};
+
+struct Stack {
+    USHORT depth = 0;
+    void* frames[kStackDepth] = {};
+};
+
+struct Record {
+    size_t size = 0;
+    Stack stack;
+};
+
+thread_local bool t_inHook = false;
+std::atomic<bool> g_dumping{ false };
+std::mutex g_mutex;
+// Pointer, not value — keeps our own bookkeeping heap-allocated so we can
+// null it out before dump without worrying about container teardown.
+std::unordered_map<long, Record>* g_records = nullptr;
+
+long serialFromPtr(void* userData)
+{
+    auto* hdr = reinterpret_cast<CrtBlockHeader*>(
+        reinterpret_cast<char*>(userData) - sizeof(CrtBlockHeader));
+    return hdr->requestNumber;
+}
+
+int __cdecl allocHook(int nAllocType, void* userData, size_t size, int nBlockUse,
+                      long lRequest, const unsigned char* /*szFileName*/, int /*nLine*/)
+{
+    if (t_inHook || g_dumping.load(std::memory_order_relaxed)) {
+        return TRUE;
+    }
+    if (nBlockUse == _CRT_BLOCK || nBlockUse == _IGNORE_BLOCK) {
+        return TRUE;
+    }
+
+    t_inHook = true;
+    {
+        std::lock_guard<std::mutex> lock(g_mutex);
+        if (!g_records) {
+            g_records = new std::unordered_map<long, Record>();
+            g_records->reserve(1 << 16);
+        }
+
+        switch (nAllocType) {
+        case _HOOK_ALLOC: {
+            Record r;
+            r.size = size;
+            r.stack.depth = CaptureStackBackTrace(kStackSkip, kStackDepth, r.stack.frames, nullptr);
+            (*g_records)[lRequest] = r;
+            break;
+        }
+        case _HOOK_REALLOC: {
+            if (userData) {
+                g_records->erase(serialFromPtr(userData));
+            }
+            Record r;
+            r.size = size;
+            r.stack.depth = CaptureStackBackTrace(kStackSkip, kStackDepth, r.stack.frames, nullptr);
+            (*g_records)[lRequest] = r;
+            break;
+        }
+        case _HOOK_FREE: {
+            if (userData) {
+                g_records->erase(serialFromPtr(userData));
+            }
+            break;
+        }
+        }
+    }
+    t_inHook = false;
+    return TRUE;
+}
+
+struct SymbolInfo {
+    std::string name;
+    std::string file;
+    DWORD line = 0;
+};
+
+SymbolInfo resolveSymbol(HANDLE process, DWORD64 addr)
+{
+    SymbolInfo info;
+    alignas(SYMBOL_INFO) char buf[sizeof(SYMBOL_INFO) + 512] = {};
+    auto* sym = reinterpret_cast<SYMBOL_INFO*>(buf);
+    sym->SizeOfStruct = sizeof(SYMBOL_INFO);
+    sym->MaxNameLen = 512;
+    DWORD64 disp = 0;
+    if (SymFromAddr(process, addr, &disp, sym)) {
+        info.name = sym->Name;
+    } else {
+        char hex[32];
+        _snprintf_s(hex, sizeof(hex), _TRUNCATE, "0x%llx", static_cast<unsigned long long>(addr));
+        info.name = hex;
+    }
+
+    IMAGEHLP_LINE64 line = {};
+    line.SizeOfStruct = sizeof(line);
+    DWORD dispLine = 0;
+    if (SymGetLineFromAddr64(process, addr, &dispLine, &line)) {
+        info.file = line.FileName ? line.FileName : "";
+        info.line = line.LineNumber;
+    }
+    return info;
+}
+
+void dumpReport(const char* path)
+{
+    // Stop all tracking first; after this, the hook is a no-op on every thread.
+    g_dumping.store(true, std::memory_order_relaxed);
+    t_inHook = true;
+
+    std::unordered_map<long, Record>* records = nullptr;
+    {
+        std::lock_guard<std::mutex> lock(g_mutex);
+        records = g_records;
+        g_records = nullptr;
+    }
+    if (!records) {
+        return;
+    }
+
+    muse::Defer freeRecords([records] { delete records; });
+    if (records->empty()) {
+        return;
+    }
+
+    HANDLE process = GetCurrentProcess();
+    SymSetOptions(SYMOPT_LOAD_LINES | SYMOPT_UNDNAME | SYMOPT_DEFERRED_LOADS);
+    SymInitialize(process, nullptr, TRUE);
+
+    struct Group {
+        size_t count = 0;
+        size_t totalBytes = 0;
+        Stack example;
+    };
+    std::map<std::vector<void*>, Group> groups;
+
+    for (auto& [serial, rec] : *records) {
+        std::vector<void*> key;
+        const int d = std::min<int>(rec.stack.depth, kGroupDepth);
+        key.reserve(d);
+        for (int i = 0; i < d; ++i) {
+            key.push_back(rec.stack.frames[i]);
+        }
+        auto& g = groups[key];
+        if (g.count == 0) {
+            g.example = rec.stack;
+        }
+        g.count++;
+        g.totalBytes += rec.size;
+    }
+
+    std::vector<std::pair<const std::vector<void*>*, const Group*> > ranked;
+    ranked.reserve(groups.size());
+    for (auto& [k, v] : groups) {
+        ranked.push_back({ &k, &v });
+    }
+    std::sort(ranked.begin(), ranked.end(), [](auto& a, auto& b) {
+        return a.second->totalBytes > b.second->totalBytes;
+    });
+
+    FILE* f = nullptr;
+    if (fopen_s(&f, path, "w") != 0 || !f) {
+        SymCleanup(process);
+        return;
+    }
+
+    size_t totalCount = 0, totalBytes = 0;
+    for (auto& [k, v] : groups) {
+        totalCount += v.count;
+        totalBytes += v.totalBytes;
+    }
+
+    std::fprintf(f, "Audacity CRT leak report (aggregated by top %d call-stack frames)\n", kGroupDepth);
+    std::fprintf(f, "Total leaked blocks: %zu\n", totalCount);
+    std::fprintf(f, "Total leaked bytes:  %zu\n", totalBytes);
+    std::fprintf(f, "Unique call sites:   %zu\n\n", groups.size());
+
+    int rank = 0;
+    for (auto& [keyPtr, gPtr] : ranked) {
+        rank++;
+        std::fprintf(f, "#%d  count=%zu  total=%zu bytes\n", rank, gPtr->count, gPtr->totalBytes);
+        const int d = std::min<int>(gPtr->example.depth, kStackDepth);
+        for (int i = 0; i < d; ++i) {
+            const DWORD64 addr = reinterpret_cast<DWORD64>(gPtr->example.frames[i]);
+            SymbolInfo s = resolveSymbol(process, addr);
+            if (!s.file.empty()) {
+                std::fprintf(f, "    %s  (%s:%lu)\n", s.name.c_str(), s.file.c_str(),
+                             static_cast<unsigned long>(s.line));
+            } else {
+                std::fprintf(f, "    %s\n", s.name.c_str());
+            }
+        }
+        std::fputc('\n', f);
+    }
+
+    std::fclose(f);
+    SymCleanup(process);
+}
+} // namespace
+
+namespace au::app::winleaktracker {
+void install()
+{
+    _CrtSetDbgFlag(_CRTDBG_ALLOC_MEM_DF | _CRTDBG_LEAK_CHECK_DF);
+
+    // Build is /SUBSYSTEM:WINDOWS so stderr is unattached; redirect it to a
+    // file and route the CRT report there. The default sink is
+    // OutputDebugString, which is synchronous and adds ~10 s to shutdown for
+    // a long report.
+    FILE* crtLog = nullptr;
+    if (freopen_s(&crtLog, "audacity_crt_leaks.log", "w", stderr) == 0) {
+        _CrtSetReportMode(_CRT_WARN, _CRTDBG_MODE_FILE);
+        _CrtSetReportFile(_CRT_WARN, _CRTDBG_FILE_STDERR);
+        _CrtSetReportMode(_CRT_ERROR, _CRTDBG_MODE_FILE);
+        _CrtSetReportFile(_CRT_ERROR, _CRTDBG_FILE_STDERR);
+    }
+
+    _CrtSetAllocHook(allocHook);
+    std::atexit([] { dumpReport("audacity_leak_stacks.log"); });
+}
+} // namespace au::app::winleaktracker
+
+#endif

--- a/src/app/winleaktracker.h
+++ b/src/app/winleaktracker.h
@@ -1,0 +1,25 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+#pragma once
+
+#if defined(_WIN32) && defined(_DEBUG)
+
+namespace au::app::winleaktracker {
+// Enables the CRT leak check, redirects the CRT report sink to a file,
+// installs an allocation hook that captures a call stack per allocation,
+// and registers an at-exit dump of leaks aggregated by top call-stack
+// frames. Writes two files to the current working directory:
+//   - audacity_crt_leaks.log     (raw CRT dump, one line per unfreed block)
+//   - audacity_leak_stacks.log   (our aggregated report with symbolicated
+//                                  stacks, grouped by call site)
+void install();
+}
+
+#else
+
+namespace au::app::winleaktracker {
+inline void install() {}
+}
+
+#endif

--- a/src/uicomponents/components/bpmmodel.cpp
+++ b/src/uicomponents/components/bpmmodel.cpp
@@ -13,8 +13,6 @@ using namespace au::uicomponents;
 BPMModel::BPMModel(QObject* parent)
     : NumericViewModel(parent)
 {
-    initFieldInteractionController();
-
     reloadFormatter();
 
     setValue(0.0);

--- a/src/uicomponents/components/frequencymodel.cpp
+++ b/src/uicomponents/components/frequencymodel.cpp
@@ -10,15 +10,14 @@
 using namespace au::uicomponents;
 
 FrequencyModel::FrequencyModel(QObject* parent)
-    : NumericViewModel(parent)
+    : NumericViewModel(parent,
+                       // translate all
+                       { NumericViewFormat { static_cast<NumericViewFormatType>(FrequencyFormatType::Centihertz),
+                                             muse::qtrc("uicomponents", "Hz"), "010,01000>0100 Hz" },
+                         NumericViewFormat { static_cast<NumericViewFormatType>(FrequencyFormatType::Hertz),
+                                             muse::qtrc("uicomponents", "kHz"), "01000>01000 kHz|0.001" },
+                       })
 {
-    // translate all
-    m_availableViewFormats = {
-        { static_cast<NumericViewFormatType>(FrequencyFormatType::Centihertz), muse::qtrc("uicomponents", "Hz"),
-          "010,01000>0100 Hz" },
-        { static_cast<NumericViewFormatType>(FrequencyFormatType::Hertz), muse::qtrc("uicomponents", "kHz"), "01000>01000 kHz|0.001" },
-    };
-
     m_currentFormat = static_cast<NumericViewFormatType>(FrequencyFormatType::Centihertz);
 
     initFieldInteractionController();

--- a/src/uicomponents/components/frequencymodel.cpp
+++ b/src/uicomponents/components/frequencymodel.cpp
@@ -9,14 +9,20 @@
 
 using namespace au::uicomponents;
 
+namespace {
+QList<NumericViewFormat> makeFrequencyFormats()
+{
+    // translate all
+    return { NumericViewFormat { static_cast<NumericViewFormatType>(FrequencyFormatType::Centihertz),
+                                 muse::qtrc("uicomponents", "Hz"), "010,01000>0100 Hz" },
+             NumericViewFormat { static_cast<NumericViewFormatType>(FrequencyFormatType::Hertz),
+                                 muse::qtrc("uicomponents", "kHz"), "01000>01000 kHz|0.001" },
+    };
+}
+}
+
 FrequencyModel::FrequencyModel(QObject* parent)
-    : NumericViewModel(parent,
-                       // translate all
-                       { NumericViewFormat { static_cast<NumericViewFormatType>(FrequencyFormatType::Centihertz),
-                                             muse::qtrc("uicomponents", "Hz"), "010,01000>0100 Hz" },
-                         NumericViewFormat { static_cast<NumericViewFormatType>(FrequencyFormatType::Hertz),
-                                             muse::qtrc("uicomponents", "kHz"), "01000>01000 kHz|0.001" },
-                       })
+    : NumericViewModel(parent, makeFrequencyFormats())
 {
     setCurrentFormat(static_cast<int>(FrequencyFormatType::Centihertz));
 

--- a/src/uicomponents/components/frequencymodel.cpp
+++ b/src/uicomponents/components/frequencymodel.cpp
@@ -18,9 +18,7 @@ FrequencyModel::FrequencyModel(QObject* parent)
                                              muse::qtrc("uicomponents", "kHz"), "01000>01000 kHz|0.001" },
                        })
 {
-    m_currentFormat = static_cast<NumericViewFormatType>(FrequencyFormatType::Centihertz);
-
-    initFieldInteractionController();
+    setCurrentFormat(static_cast<int>(FrequencyFormatType::Centihertz));
 
     reloadFormatter();
 

--- a/src/uicomponents/components/internal/numeric/numericviewmodel.cpp
+++ b/src/uicomponents/components/internal/numeric/numericviewmodel.cpp
@@ -11,8 +11,28 @@
 
 using namespace au::uicomponents;
 
-NumericViewModel::NumericViewModel(QObject* parent)
-    : QAbstractListModel(parent)
+namespace {
+muse::uicomponents::MenuItemList makeMenuItemList(const QList<NumericViewFormat>& formats, QObject* parent)
+{
+    muse::uicomponents::MenuItemList list;
+    for (const NumericViewFormat& format : formats) {
+        auto* item = new muse::uicomponents::MenuItem(parent);
+        item->setId(QString::number(static_cast<int>(format.type)));
+
+        muse::ui::UiAction action;
+        action.title = muse::TranslatableString::untranslatable(format.title);
+        action.checkable = muse::ui::Checkable::Yes;
+        item->setAction(action);
+
+        list << item;
+    }
+    return list;
+}
+}
+
+NumericViewModel::NumericViewModel(QObject* parent, QList<NumericViewFormat> availableViewFormats)
+    : QAbstractListModel(parent), m_availableViewFormats(std::move(availableViewFormats)),
+    m_availableFormatsCache(makeMenuItemList(m_availableViewFormats, this))
 {
 }
 
@@ -106,6 +126,7 @@ void NumericViewModel::setCurrentFormat(int format)
 
     reloadFormatter();
     updateValueString();
+    updateAvailableFormatsCheckedState();
 
     emit currentFormatChanged();
     emit availableFormatsChanged();
@@ -136,30 +157,18 @@ void NumericViewModel::setCurrentFormatStr(const QString& title)
 
 muse::uicomponents::MenuItemList NumericViewModel::availableFormats()
 {
-    muse::uicomponents::MenuItemList result;
+    updateAvailableFormatsCheckedState();
+    return m_availableFormatsCache;
+}
 
-    for (const NumericViewFormat& viewFormat : m_availableViewFormats) {
-        muse::uicomponents::MenuItem* item = new muse::uicomponents::MenuItem(this);
-
-        int id = static_cast<int>(viewFormat.type);
-
-        item->setId(QString::number(id));
-
-        muse::ui::UiAction action;
-        action.title = muse::TranslatableString::untranslatable(viewFormat.title);
-        action.checkable = muse::ui::Checkable::Yes;
-        item->setAction(action);
-
+void NumericViewModel::updateAvailableFormatsCheckedState()
+{
+    for (int i = 0; i < m_availableFormatsCache.size(); ++i) {
         muse::ui::UiActionState state;
         state.enabled = true;
-        state.checked = m_currentFormat == viewFormat.type;
-
-        item->setState(state);
-
-        result << item;
+        state.checked = m_currentFormat == m_availableViewFormats[i].type;
+        m_availableFormatsCache[i]->setState(state);
     }
-
-    return result;
 }
 
 QVariantList NumericViewModel::availableFormats_property()

--- a/src/uicomponents/components/internal/numeric/numericviewmodel.cpp
+++ b/src/uicomponents/components/internal/numeric/numericviewmodel.cpp
@@ -31,9 +31,19 @@ muse::uicomponents::MenuItemList makeMenuItemList(const QList<NumericViewFormat>
 }
 
 NumericViewModel::NumericViewModel(QObject* parent, QList<NumericViewFormat> availableViewFormats)
-    : QAbstractListModel(parent), m_availableViewFormats(std::move(availableViewFormats)),
+    : QAbstractListModel(parent),
+    m_fieldsInteractionController(std::make_shared<FieldsInteractionController>(this)),
+    m_availableViewFormats(std::move(availableViewFormats)),
     m_availableFormatsCache(makeMenuItemList(m_availableViewFormats, this))
 {
+    connect(m_fieldsInteractionController.get(), &FieldsInteractionController::currentEditedFieldIndexChanged,
+            this, &NumericViewModel::currentEditedFieldIndexChanged);
+
+    connect(m_fieldsInteractionController.get(), &FieldsInteractionController::valueChanged,
+            this, &NumericViewModel::setValue);
+
+    connect(m_fieldsInteractionController.get(), &FieldsInteractionController::editingFinished,
+            this, &NumericViewModel::editingFinished);
 }
 
 int NumericViewModel::rowCount(const QModelIndex& parent) const
@@ -242,20 +252,6 @@ void NumericViewModel::setLowerTimeSignature(int timeSignature)
 
     initFormatter();
     updateValueString();
-}
-
-void NumericViewModel::initFieldInteractionController()
-{
-    m_fieldsInteractionController = std::make_shared<FieldsInteractionController>(this);
-
-    connect(m_fieldsInteractionController.get(), &FieldsInteractionController::currentEditedFieldIndexChanged,
-            this, &NumericViewModel::currentEditedFieldIndexChanged);
-
-    connect(m_fieldsInteractionController.get(), &FieldsInteractionController::valueChanged,
-            this, &NumericViewModel::setValue);
-
-    connect(m_fieldsInteractionController.get(), &FieldsInteractionController::editingFinished,
-            this, &NumericViewModel::editingFinished);
 }
 
 void NumericViewModel::initFormatter()

--- a/src/uicomponents/components/internal/numeric/numericviewmodel.h
+++ b/src/uicomponents/components/internal/numeric/numericviewmodel.h
@@ -47,7 +47,7 @@ class NumericViewModel : public QAbstractListModel
     Q_PROPERTY(QQuickItem * visualItem READ visualItem WRITE setVisualItem)
 
 public:
-    explicit NumericViewModel(QObject* parent = nullptr);
+    explicit NumericViewModel(QObject* parent = nullptr, QList<NumericViewFormat> availableViewFormats = {});
 
     int rowCount(const QModelIndex& parent = QModelIndex()) const override;
     QVariant data(const QModelIndex& index, int role) const override;
@@ -113,7 +113,10 @@ protected:
     int m_upperTimeSignature = 0;
     int m_lowerTimeSignature = 0;
 
-    QList<NumericViewFormat> m_availableViewFormats;
+    void updateAvailableFormatsCheckedState();
+
+    const QList<NumericViewFormat> m_availableViewFormats;
+    const muse::uicomponents::MenuItemList m_availableFormatsCache;
     NumericViewFormatType m_currentFormat = NumericViewFormatType::Undefined;
 
     std::shared_ptr<TimecodeFormatter> m_formatter;

--- a/src/uicomponents/components/internal/numeric/numericviewmodel.h
+++ b/src/uicomponents/components/internal/numeric/numericviewmodel.h
@@ -93,33 +93,33 @@ signals:
     void editingFinished();
 
 protected:
+    void initFieldInteractionController();
+    void initFormatter();
+    void updateValueString(bool toNearest = true);
+    const NumericViewFormat& currentViewFormat() const;
+
+    double m_value = -1.0;
+    QString m_valueString;
+    NumericViewFormatType m_currentFormat = NumericViewFormatType::Undefined;
+
+    std::shared_ptr<TimecodeFormatter> m_formatter;
+    std::shared_ptr<FieldsInteractionController> m_fieldsInteractionController;
+
+private:
     enum Roles {
         rSymbol = Qt::UserRole + 1,
         rIsEditable
     };
 
-    void initFieldInteractionController();
-    void initFormatter();
-    void updateValueString(bool toNearest = true);
     virtual void reloadFormatter() = 0;
 
-    const NumericViewFormat& currentViewFormat() const;
-
-    double m_value = -1.0;
-    QString m_valueString;
+    void updateAvailableFormatsCheckedState();
+    const QList<NumericViewFormat> m_availableViewFormats;
+    const muse::uicomponents::MenuItemList m_availableFormatsCache;
 
     double m_sampleRate = 1.0;
     double m_tempo = 0;
     int m_upperTimeSignature = 0;
     int m_lowerTimeSignature = 0;
-
-    void updateAvailableFormatsCheckedState();
-
-    const QList<NumericViewFormat> m_availableViewFormats;
-    const muse::uicomponents::MenuItemList m_availableFormatsCache;
-    NumericViewFormatType m_currentFormat = NumericViewFormatType::Undefined;
-
-    std::shared_ptr<TimecodeFormatter> m_formatter;
-    std::shared_ptr<FieldsInteractionController> m_fieldsInteractionController;
 };
 }

--- a/src/uicomponents/components/internal/numeric/numericviewmodel.h
+++ b/src/uicomponents/components/internal/numeric/numericviewmodel.h
@@ -93,7 +93,6 @@ signals:
     void editingFinished();
 
 protected:
-    void initFieldInteractionController();
     void initFormatter();
     void updateValueString(bool toNearest = true);
     const NumericViewFormat& currentViewFormat() const;
@@ -103,7 +102,7 @@ protected:
     NumericViewFormatType m_currentFormat = NumericViewFormatType::Undefined;
 
     std::shared_ptr<TimecodeFormatter> m_formatter;
-    std::shared_ptr<FieldsInteractionController> m_fieldsInteractionController;
+    const std::shared_ptr<FieldsInteractionController> m_fieldsInteractionController;
 
 private:
     enum Roles {

--- a/src/uicomponents/components/timecodemodel.cpp
+++ b/src/uicomponents/components/timecodemodel.cpp
@@ -11,59 +11,69 @@
 using namespace au::uicomponents;
 
 TimecodeModel::TimecodeModel(QObject* parent)
-    : NumericViewModel(parent)
+    : NumericViewModel(parent,
 {
     // translate all
-    m_availableViewFormats = {
-        { static_cast<NumericViewFormatType>(TimecodeFormatType::Seconds), muse::qtrc("uicomponents", "seconds"), "01000,01000s" },
-        { static_cast<NumericViewFormatType>(TimecodeFormatType::SecondsMilliseconds), muse::qtrc("uicomponents", "seconds + milliseconds"),
-          "01000,01000>01000 s" },
-        { static_cast<NumericViewFormatType>(TimecodeFormatType::HHMMSS), muse::qtrc("uicomponents", "hh:mm:ss"), "0100 h 060 m 060 s" },
-        { static_cast<NumericViewFormatType>(TimecodeFormatType::DDHHMMSS), muse::qtrc("uicomponents", "dd:hh:mm:ss"),
-          "0100 d 024 h 060 m 060 s" },
+    NumericViewFormat { static_cast<NumericViewFormatType>(TimecodeFormatType::Seconds), muse::qtrc("uicomponents", "seconds"),
+                        "01000,01000s" },
+    NumericViewFormat { static_cast<NumericViewFormatType>(TimecodeFormatType::SecondsMilliseconds), muse::qtrc("uicomponents",
+                                                                                                                "seconds + milliseconds"),
+                        "01000,01000>01000 s" },
+    NumericViewFormat { static_cast<NumericViewFormatType>(TimecodeFormatType::HHMMSS), muse::qtrc("uicomponents", "hh:mm:ss"),
+                        "0100 h 060 m 060 s" },
+    NumericViewFormat { static_cast<NumericViewFormatType>(TimecodeFormatType::DDHHMMSS), muse::qtrc("uicomponents", "dd:hh:mm:ss"),
+                        "0100 d 024 h 060 m 060 s" },
 
-        { static_cast<NumericViewFormatType>(TimecodeFormatType::HHMMSSHundredths), muse::qtrc("uicomponents", "hh:mm:ss + hundredths"),
-          "0100 h 060 m 060>0100 s" },
-        { static_cast<NumericViewFormatType>(TimecodeFormatType::HHMMSSMilliseconds), muse::qtrc("uicomponents", "hh:mm:ss + milliseconds"),
-          "0100 h 060 m 060>01000 s" },
+    NumericViewFormat { static_cast<NumericViewFormatType>(TimecodeFormatType::HHMMSSHundredths), muse::qtrc("uicomponents",
+                                                                                                             "hh:mm:ss + hundredths"),
+                        "0100 h 060 m 060>0100 s" },
+    NumericViewFormat { static_cast<NumericViewFormatType>(TimecodeFormatType::HHMMSSMilliseconds), muse::qtrc("uicomponents",
+                                                                                                               "hh:mm:ss + milliseconds"),
+                        "0100 h 060 m 060>01000 s" },
 
-        { static_cast<NumericViewFormatType>(TimecodeFormatType::HHMMSSSamples), muse::qtrc("uicomponents", "hh:mm:ss + samples"),
-          "0100 h 060 m 060 s+># samples" },
-        { static_cast<NumericViewFormatType>(TimecodeFormatType::Samples), muse::qtrc("uicomponents", "samples"),
-          "01000,01000,01000 samples|#" },
+    NumericViewFormat { static_cast<NumericViewFormatType>(TimecodeFormatType::HHMMSSSamples), muse::qtrc("uicomponents",
+                                                                                                          "hh:mm:ss + samples"),
+                        "0100 h 060 m 060 s+># samples" },
+    NumericViewFormat { static_cast<NumericViewFormatType>(TimecodeFormatType::Samples), muse::qtrc("uicomponents", "samples"),
+                        "01000,01000,01000 samples|#" },
 
-        { static_cast<NumericViewFormatType>(TimecodeFormatType::HHMMSSFilmFrames), muse::qtrc("uicomponents",
-                                                                                               "hh:mm:ss + film frames (24 fps)"),
-          "0100 h 060 m 060 s+>24 frames" },
-        { static_cast<NumericViewFormatType>(TimecodeFormatType::FilmFrames), muse::qtrc("uicomponents", "Film frames (24 fps)"),
-          "01000,01000 frames|24" },
+    NumericViewFormat { static_cast<NumericViewFormatType>(TimecodeFormatType::HHMMSSFilmFrames), muse::qtrc("uicomponents",
+                                                                                                             "hh:mm:ss + film frames (24 fps)"),
+                        "0100 h 060 m 060 s+>24 frames" },
+    NumericViewFormat { static_cast<NumericViewFormatType>(TimecodeFormatType::FilmFrames), muse::qtrc("uicomponents",
+                                                                                                       "Film frames (24 fps)"),
+                        "01000,01000 frames|24" },
 
-        { static_cast<NumericViewFormatType>(TimecodeFormatType::HHMMSSNTSCDropFrames), muse::qtrc("uicomponents",
-                                                                                                   "hh:mm:ss + NTSC drop frames"),
-          "0100 h 060 m 060 s+>30 frames|N" },
-        { static_cast<NumericViewFormatType>(TimecodeFormatType::HHMMSSNTSCNonDropFrames), muse::qtrc("uicomponents",
-                                                                                                      "hh:mm:ss + NTSC non-drop frames"),
-          "0100 h 060 m 060 s+>030 frames| .999000999" },
-        { static_cast<NumericViewFormatType>(TimecodeFormatType::NTSCFrames), muse::qtrc("uicomponents", "NTSC frames"),
-          "01000,01000 frames|29.97002997" },
+    NumericViewFormat { static_cast<NumericViewFormatType>(TimecodeFormatType::HHMMSSNTSCDropFrames), muse::qtrc("uicomponents",
+                                                                                                                 "hh:mm:ss + NTSC drop frames"),
+                        "0100 h 060 m 060 s+>30 frames|N" },
+    NumericViewFormat { static_cast<NumericViewFormatType>(TimecodeFormatType::HHMMSSNTSCNonDropFrames), muse::qtrc("uicomponents",
+                                                                                                                    "hh:mm:ss + NTSC non-drop frames"),
+                        "0100 h 060 m 060 s+>030 frames| .999000999" },
+    NumericViewFormat { static_cast<NumericViewFormatType>(TimecodeFormatType::NTSCFrames), muse::qtrc("uicomponents", "NTSC frames"),
+                        "01000,01000 frames|29.97002997" },
 
-        { static_cast<NumericViewFormatType>(TimecodeFormatType::HHMMSSPALFrames), muse::qtrc("uicomponents",
-                                                                                              "hh:mm:ss + PAL frames (25 fps)"),
-          "0100 h 060 m 060 s+>25 frames" },
-        { static_cast<NumericViewFormatType>(TimecodeFormatType::PALFrames), muse::qtrc("uicomponents", "PAL frames (25 fps)"),
-          "01000,01000 frames|25" },
+    NumericViewFormat { static_cast<NumericViewFormatType>(TimecodeFormatType::HHMMSSPALFrames), muse::qtrc("uicomponents",
+                                                                                                            "hh:mm:ss + PAL frames (25 fps)"),
+                        "0100 h 060 m 060 s+>25 frames" },
+    NumericViewFormat { static_cast<NumericViewFormatType>(TimecodeFormatType::PALFrames), muse::qtrc("uicomponents",
+                                                                                                      "PAL frames (25 fps)"),
+                        "01000,01000 frames|25" },
 
-        { static_cast<NumericViewFormatType>(TimecodeFormatType::HHMMSSCDDAFrames), muse::qtrc("uicomponents",
-                                                                                               "hh:mm:ss + CDDA frames (25 fps)"),
-          "0100 h 060 m 060 s+>75 frames" },
-        { static_cast<NumericViewFormatType>(TimecodeFormatType::CDDAFrames), muse::qtrc("uicomponents", "CDDA frames (75 fps)"),
-          "01000,01000 frames|75" },
+    NumericViewFormat { static_cast<NumericViewFormatType>(TimecodeFormatType::HHMMSSCDDAFrames), muse::qtrc("uicomponents",
+                                                                                                             "hh:mm:ss + CDDA frames (25 fps)"),
+                        "0100 h 060 m 060 s+>75 frames" },
+    NumericViewFormat { static_cast<NumericViewFormatType>(TimecodeFormatType::CDDAFrames), muse::qtrc("uicomponents",
+                                                                                                       "CDDA frames (75 fps)"),
+                        "01000,01000 frames|75" },
 
-        { static_cast<NumericViewFormatType>(TimecodeFormatType::BarBeat), muse::qtrc("uicomponents", "bar:beat"), "bar:beat" },
-        { static_cast<NumericViewFormatType>(TimecodeFormatType::BarBeatTick), muse::qtrc("uicomponents", "bar:beat:tick"),
-          "bar:beat:tick" },
-    };
-
+    NumericViewFormat { static_cast<NumericViewFormatType>(TimecodeFormatType::BarBeat), muse::qtrc("uicomponents", "bar:beat"),
+                        "bar:beat" },
+    NumericViewFormat { static_cast<NumericViewFormatType>(TimecodeFormatType::BarBeatTick),
+                        muse::qtrc("uicomponents", "bar:beat:tick"),
+                        "bar:beat:tick" },
+})
+{
     m_currentFormat = static_cast<NumericViewFormatType>(TimecodeFormatType::HHMMSS);
 
     initFieldInteractionController();

--- a/src/uicomponents/components/timecodemodel.cpp
+++ b/src/uicomponents/components/timecodemodel.cpp
@@ -74,9 +74,7 @@ TimecodeModel::TimecodeModel(QObject* parent)
                         "bar:beat:tick" },
 })
 {
-    m_currentFormat = static_cast<NumericViewFormatType>(TimecodeFormatType::HHMMSS);
-
-    initFieldInteractionController();
+    setCurrentFormat(static_cast<int>(TimecodeFormatType::HHMMSS));
 
     reloadFormatter();
 

--- a/src/uicomponents/components/timecodemodel.cpp
+++ b/src/uicomponents/components/timecodemodel.cpp
@@ -10,69 +10,75 @@
 
 using namespace au::uicomponents;
 
-TimecodeModel::TimecodeModel(QObject* parent)
-    : NumericViewModel(parent,
+namespace {
+QList<NumericViewFormat> makeTimecodeFormats()
 {
-    // translate all
-    NumericViewFormat { static_cast<NumericViewFormatType>(TimecodeFormatType::Seconds), muse::qtrc("uicomponents", "seconds"),
-                        "01000,01000s" },
-    NumericViewFormat { static_cast<NumericViewFormatType>(TimecodeFormatType::SecondsMilliseconds), muse::qtrc("uicomponents",
-                                                                                                                "seconds + milliseconds"),
-                        "01000,01000>01000 s" },
-    NumericViewFormat { static_cast<NumericViewFormatType>(TimecodeFormatType::HHMMSS), muse::qtrc("uicomponents", "hh:mm:ss"),
-                        "0100 h 060 m 060 s" },
-    NumericViewFormat { static_cast<NumericViewFormatType>(TimecodeFormatType::DDHHMMSS), muse::qtrc("uicomponents", "dd:hh:mm:ss"),
-                        "0100 d 024 h 060 m 060 s" },
+    return {
+        // translate all
+        NumericViewFormat { static_cast<NumericViewFormatType>(TimecodeFormatType::Seconds), muse::qtrc("uicomponents", "seconds"),
+                            "01000,01000s" },
+        NumericViewFormat { static_cast<NumericViewFormatType>(TimecodeFormatType::SecondsMilliseconds), muse::qtrc("uicomponents",
+                                                                                                                    "seconds + milliseconds"),
+                            "01000,01000>01000 s" },
+        NumericViewFormat { static_cast<NumericViewFormatType>(TimecodeFormatType::HHMMSS), muse::qtrc("uicomponents", "hh:mm:ss"),
+                            "0100 h 060 m 060 s" },
+        NumericViewFormat { static_cast<NumericViewFormatType>(TimecodeFormatType::DDHHMMSS), muse::qtrc("uicomponents", "dd:hh:mm:ss"),
+                            "0100 d 024 h 060 m 060 s" },
 
-    NumericViewFormat { static_cast<NumericViewFormatType>(TimecodeFormatType::HHMMSSHundredths), muse::qtrc("uicomponents",
-                                                                                                             "hh:mm:ss + hundredths"),
-                        "0100 h 060 m 060>0100 s" },
-    NumericViewFormat { static_cast<NumericViewFormatType>(TimecodeFormatType::HHMMSSMilliseconds), muse::qtrc("uicomponents",
-                                                                                                               "hh:mm:ss + milliseconds"),
-                        "0100 h 060 m 060>01000 s" },
+        NumericViewFormat { static_cast<NumericViewFormatType>(TimecodeFormatType::HHMMSSHundredths), muse::qtrc("uicomponents",
+                                                                                                                 "hh:mm:ss + hundredths"),
+                            "0100 h 060 m 060>0100 s" },
+        NumericViewFormat { static_cast<NumericViewFormatType>(TimecodeFormatType::HHMMSSMilliseconds), muse::qtrc("uicomponents",
+                                                                                                                   "hh:mm:ss + milliseconds"),
+                            "0100 h 060 m 060>01000 s" },
 
-    NumericViewFormat { static_cast<NumericViewFormatType>(TimecodeFormatType::HHMMSSSamples), muse::qtrc("uicomponents",
-                                                                                                          "hh:mm:ss + samples"),
-                        "0100 h 060 m 060 s+># samples" },
-    NumericViewFormat { static_cast<NumericViewFormatType>(TimecodeFormatType::Samples), muse::qtrc("uicomponents", "samples"),
-                        "01000,01000,01000 samples|#" },
+        NumericViewFormat { static_cast<NumericViewFormatType>(TimecodeFormatType::HHMMSSSamples), muse::qtrc("uicomponents",
+                                                                                                              "hh:mm:ss + samples"),
+                            "0100 h 060 m 060 s+># samples" },
+        NumericViewFormat { static_cast<NumericViewFormatType>(TimecodeFormatType::Samples), muse::qtrc("uicomponents", "samples"),
+                            "01000,01000,01000 samples|#" },
 
-    NumericViewFormat { static_cast<NumericViewFormatType>(TimecodeFormatType::HHMMSSFilmFrames), muse::qtrc("uicomponents",
-                                                                                                             "hh:mm:ss + film frames (24 fps)"),
-                        "0100 h 060 m 060 s+>24 frames" },
-    NumericViewFormat { static_cast<NumericViewFormatType>(TimecodeFormatType::FilmFrames), muse::qtrc("uicomponents",
-                                                                                                       "Film frames (24 fps)"),
-                        "01000,01000 frames|24" },
+        NumericViewFormat { static_cast<NumericViewFormatType>(TimecodeFormatType::HHMMSSFilmFrames), muse::qtrc("uicomponents",
+                                                                                                                 "hh:mm:ss + film frames (24 fps)"),
+                            "0100 h 060 m 060 s+>24 frames" },
+        NumericViewFormat { static_cast<NumericViewFormatType>(TimecodeFormatType::FilmFrames), muse::qtrc("uicomponents",
+                                                                                                           "Film frames (24 fps)"),
+                            "01000,01000 frames|24" },
 
-    NumericViewFormat { static_cast<NumericViewFormatType>(TimecodeFormatType::HHMMSSNTSCDropFrames), muse::qtrc("uicomponents",
-                                                                                                                 "hh:mm:ss + NTSC drop frames"),
-                        "0100 h 060 m 060 s+>30 frames|N" },
-    NumericViewFormat { static_cast<NumericViewFormatType>(TimecodeFormatType::HHMMSSNTSCNonDropFrames), muse::qtrc("uicomponents",
-                                                                                                                    "hh:mm:ss + NTSC non-drop frames"),
-                        "0100 h 060 m 060 s+>030 frames| .999000999" },
-    NumericViewFormat { static_cast<NumericViewFormatType>(TimecodeFormatType::NTSCFrames), muse::qtrc("uicomponents", "NTSC frames"),
-                        "01000,01000 frames|29.97002997" },
+        NumericViewFormat { static_cast<NumericViewFormatType>(TimecodeFormatType::HHMMSSNTSCDropFrames), muse::qtrc("uicomponents",
+                                                                                                                     "hh:mm:ss + NTSC drop frames"),
+                            "0100 h 060 m 060 s+>30 frames|N" },
+        NumericViewFormat { static_cast<NumericViewFormatType>(TimecodeFormatType::HHMMSSNTSCNonDropFrames), muse::qtrc("uicomponents",
+                                                                                                                        "hh:mm:ss + NTSC non-drop frames"),
+                            "0100 h 060 m 060 s+>030 frames| .999000999" },
+        NumericViewFormat { static_cast<NumericViewFormatType>(TimecodeFormatType::NTSCFrames), muse::qtrc("uicomponents", "NTSC frames"),
+                            "01000,01000 frames|29.97002997" },
 
-    NumericViewFormat { static_cast<NumericViewFormatType>(TimecodeFormatType::HHMMSSPALFrames), muse::qtrc("uicomponents",
-                                                                                                            "hh:mm:ss + PAL frames (25 fps)"),
-                        "0100 h 060 m 060 s+>25 frames" },
-    NumericViewFormat { static_cast<NumericViewFormatType>(TimecodeFormatType::PALFrames), muse::qtrc("uicomponents",
-                                                                                                      "PAL frames (25 fps)"),
-                        "01000,01000 frames|25" },
+        NumericViewFormat { static_cast<NumericViewFormatType>(TimecodeFormatType::HHMMSSPALFrames), muse::qtrc("uicomponents",
+                                                                                                                "hh:mm:ss + PAL frames (25 fps)"),
+                            "0100 h 060 m 060 s+>25 frames" },
+        NumericViewFormat { static_cast<NumericViewFormatType>(TimecodeFormatType::PALFrames), muse::qtrc("uicomponents",
+                                                                                                          "PAL frames (25 fps)"),
+                            "01000,01000 frames|25" },
 
-    NumericViewFormat { static_cast<NumericViewFormatType>(TimecodeFormatType::HHMMSSCDDAFrames), muse::qtrc("uicomponents",
-                                                                                                             "hh:mm:ss + CDDA frames (25 fps)"),
-                        "0100 h 060 m 060 s+>75 frames" },
-    NumericViewFormat { static_cast<NumericViewFormatType>(TimecodeFormatType::CDDAFrames), muse::qtrc("uicomponents",
-                                                                                                       "CDDA frames (75 fps)"),
-                        "01000,01000 frames|75" },
+        NumericViewFormat { static_cast<NumericViewFormatType>(TimecodeFormatType::HHMMSSCDDAFrames), muse::qtrc("uicomponents",
+                                                                                                                 "hh:mm:ss + CDDA frames (25 fps)"),
+                            "0100 h 060 m 060 s+>75 frames" },
+        NumericViewFormat { static_cast<NumericViewFormatType>(TimecodeFormatType::CDDAFrames), muse::qtrc("uicomponents",
+                                                                                                           "CDDA frames (75 fps)"),
+                            "01000,01000 frames|75" },
 
-    NumericViewFormat { static_cast<NumericViewFormatType>(TimecodeFormatType::BarBeat), muse::qtrc("uicomponents", "bar:beat"),
-                        "bar:beat" },
-    NumericViewFormat { static_cast<NumericViewFormatType>(TimecodeFormatType::BarBeatTick),
-                        muse::qtrc("uicomponents", "bar:beat:tick"),
-                        "bar:beat:tick" },
-})
+        NumericViewFormat { static_cast<NumericViewFormatType>(TimecodeFormatType::BarBeat), muse::qtrc("uicomponents", "bar:beat"),
+                            "bar:beat" },
+        NumericViewFormat { static_cast<NumericViewFormatType>(TimecodeFormatType::BarBeatTick),
+                            muse::qtrc("uicomponents", "bar:beat:tick"),
+                            "bar:beat:tick" },
+    };
+}
+}
+
+TimecodeModel::TimecodeModel(QObject* parent)
+    : NumericViewModel(parent, makeTimecodeFormats())
 {
     setCurrentFormat(static_cast<int>(TimecodeFormatType::HHMMSS));
 


### PR DESCRIPTION
<!-- Resolves: #7568 -->

The PR includes a bot-generated debug feature, compiled on Debug on Windows and that can be activated at runtime with the `--memory-leak-report`.

That feature provides stack traces of the construction of objects that never were deleted, which is much more human-friendly than the raw CRT report.

Most of the leaked object point to Qt internals - looks like we can ignore these.

The feature found a real leak from our side, though. Opening Audacity, opening a project (1 track 1 clip) and exiting Audacity resulted in leakage of 9519 `MenuItem`s for a total of 1.7MB. This increased each time the property `au::uicomponents::NumericViewModel::availableFormats` was queried - often.

With the fix, the trace shows that the leakage is reduced to 156 items (100KB), and this number should now stay stable, so not really a leak anymore.

Full traces:
[audacity_leak_stacks_after.log](https://github.com/user-attachments/files/27735263/audacity_leak_stacks_after.log)
[audacity_leak_stacks_before.log](https://github.com/user-attachments/files/27735265/audacity_leak_stacks_before.log)

<!-- Use "x" to fill the checkboxes below 
like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Autobot test cases have been run
