### PR TITLE
SetClip command: fix for Name parameter

### DIFF
--- a/src/commands/SetClipCommand.cpp
+++ b/src/commands/SetClipCommand.cpp
@@ -63,6 +63,7 @@ bool SetClipCommand::VisitSettings( SettingsVisitorBase<Const> & S ){
    // Allowing a negative start time is not a mistake.
    // It will be used in demonstrating time before zero.
    S.OptionalN( bHasT0             ).Define(     mT0,             wxT("Start"),      0.0, -5.0, 1000000.0);
+   S.OptionalN( bHasName           ).Define(     mName,           wxT("Name"),       _("Unnamed"));
    return true;
 };
 bool SetClipCommand::VisitSettings( SettingsVisitor & S )


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/5915

Problem:
Name parameter of SetClip command cannot be used in Nyquist AUD-DO commands or in scripting.

Fix:
Add missing "Name" parameter to SetClipCommand::VisitSettings(). Note: I've tested this using the nyquist prompt, but not in scripting.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [ x] I signed [CLA](https://www.audacityteam.org/cla/)
- [ x] The title of the pull request describes an issue it addresses
- [x ] If changes are extensive, then there is a sequence of easily reviewable commits
- [x ] Each commit's message describes its purpose and effects
- [ x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x ] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Autobot test cases have been run
