### PR TITLE
Allow AltGr in label editing

### DIFF
--- a/src/tracks/labeltrack/ui/LabelTrackView.cpp
+++ b/src/tracks/labeltrack/ui/LabelTrackView.cpp
@@ -1792,12 +1792,19 @@ bool LabelTrackView::DoChar(
    AudacityProject &project, NotifyingSelectedRegion &WXUNUSED(newSel),
    wxKeyEvent & event)
 {
-   // Check for modifiers and only allow shift.
+   // Check for modifiers and only allow text-producing modifier combinations
    //
    // We still need to check this or we will eat the top level menu accelerators
    // on Windows if our capture or key down handlers skipped the event.
    const int mods = event.GetModifiers();
-   if (mods != wxMOD_NONE && mods != wxMOD_SHIFT) {
+   if ((mods & ~(wxMOD_SHIFT | wxMOD_ALTGR))
+      // Since wxMOD_ALTGR = wxMOD_ALT | wxMOD_CONTROL, we need to check
+      // if it is AltGr, Alt or Ctrl
+#ifndef __WXMAC__
+      // The Alt is used as text-producing modifier only on macOs
+      || ((mods & wxMOD_ALTGR) == wxMOD_ALT)
+#endif
+      || ((mods & wxMOD_ALTGR) == wxMOD_CONTROL)) {
       event.Skip();
       return false;
    }

--- a/src/tracks/ui/TextEditHelper.cpp
+++ b/src/tracks/ui/TextEditHelper.cpp
@@ -96,7 +96,20 @@ bool TextEditHelper::IsSelectionEmpty()
 
 bool TextEditHelper::CaptureKey(int, int mods)
 {
-   return mods == wxMOD_NONE || mods == wxMOD_SHIFT;
+   // Check for modifiers and only allow text-producing modifier combinations
+   if (mods & ~(wxMOD_SHIFT | wxMOD_ALTGR))
+      return false;
+
+   // Since wxMOD_ALTGR = wxMOD_ALT | wxMOD_CONTROL, we need to check
+   // if it is AltGr, Alt or Ctrl
+
+#ifndef __WXMAC__
+   // The Alt is used as text-producing modifier only on macOs
+   if ((mods & wxMOD_ALTGR) == wxMOD_ALT)
+      return false;
+#endif
+
+   return (mods & wxMOD_ALTGR) != wxMOD_CONTROL;
 }
 
 bool TextEditHelper::OnKeyDown(int keyCode, int mods, AudacityProject* project)
@@ -128,7 +141,7 @@ bool TextEditHelper::OnKeyDown(int keyCode, int mods, AudacityProject* project)
                     wchar = mText.at(mCurrentCursorPos - 1);
                     mText.erase(mCurrentCursorPos - 1, 1);
                     mCurrentCursorPos--;
-                    if (((int)wchar > 0xDFFF) || ((int)wchar < 0xDC00)) 
+                    if (((int)wchar > 0xDFFF) || ((int)wchar < 0xDC00))
                     {
                         delegate->OnTextModified(project, mText);
                         more = false;
@@ -158,7 +171,7 @@ bool TextEditHelper::OnKeyDown(int keyCode, int mods, AudacityProject* project)
                 while ((mCurrentCursorPos < len) && more) {
                     wchar = mText.at(mCurrentCursorPos);
                     mText.erase(mCurrentCursorPos, 1);
-                    if (((int)wchar > 0xDBFF) || ((int)wchar < 0xD800)) 
+                    if (((int)wchar > 0xDBFF) || ((int)wchar < 0xD800))
                     {
                         delegate->OnTextModified(project, mText);
                         more = false;
@@ -287,7 +300,7 @@ bool TextEditHelper::OnClick(const wxMouseEvent& event, AudacityProject*)
         bool result = false;
         if (mBBox.Contains(event.GetPosition()))
         {
-            if (event.LeftDown()) 
+            if (event.LeftDown())
             {
                 mRightDragging = false;
                 auto position = FindCursorIndex(event.GetPosition());
@@ -405,7 +418,7 @@ bool TextEditHelper::Draw(wxDC& dc, const wxRect& rect)
             dc.DrawRectangle(wxRect(left, rect.GetTop() + (rect.GetHeight() - cursorHeight) / 2, right - left, cursorHeight));
         }
 
-        
+
         dc.SetTextBackground(wxTransparentColour);
         dc.SetTextForeground(mTextColor);
         dc.SetFont(wxFont(wxFontInfo()));
@@ -511,7 +524,7 @@ int TextEditHelper::FindCursorIndex(const wxPoint& point)
 
         // Get the width of the last character
         dc.GetTextExtent(subString.Right(1), &oneWidth, NULL);
-        
+
         if (layout == wxLayout_RightToLeft)
         {
             auto bound = mBBox.GetRight() - partWidth + offsetX + oneWidth / 2;


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/2748

Previously, while editing the label text, using the AltGr modifier was inhibited. Now you can freely access the third and fourth level of keys to write.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [X] I signed [CLA](https://www.audacityteam.org/cla/)
- [X] The title of the pull request describes an issue it addresses
- [X] If changes are extensive, then there is a sequence of easily reviewable commits
- [X] Each commit's message describes its purpose and effects
- [X] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [X] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
