### PR TITLE
use correct extra color accessor

### DIFF
--- a/src/effects/builtin_collection/dynamics/timeline/ClipIndicator.qml
+++ b/src/effects/builtin_collection/dynamics/timeline/ClipIndicator.qml
@@ -21,7 +21,7 @@ Shape {
         id: prv
 
         readonly property int radius: 2
-        property color color: root.isClipping ? ui.theme.recordColor : ui.theme.backgroundSecondaryColor
+        property color color: root.isClipping ? ui.theme.extra["record_color"] : ui.theme.backgroundSecondaryColor
     }
 
     MouseArea {

--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TrackItemsContainer.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TrackItemsContainer.qml
@@ -97,7 +97,7 @@ Item {
         anchors.bottomMargin: sep.thickness
 
         width: 2
-        color: ui.theme.recordColor
+        color: ui.theme.extra["record_color"]
         opacity: 0.8
         visible: root.isLeadInRecordingTrack
         z: 2


### PR DESCRIPTION
Resolves: use correct extra color accessor
<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [ ] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
