### PR TITLE
[10510] Factory-reset: close cloud DB and unify flow                                                                                                                                                                        

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,6 +98,7 @@ set(MUSE_MODULE_UI_TESTS OFF)
 set(MUSE_MODULE_UPDATE ON)
 set(MUSE_MODULE_UPDATE_QML ON)
 set(MUSE_MODULE_WORKSPACE ON)
+set(MUSE_MODULE_WORKSPACE_TESTS ON)
 set(MUSE_MODULE_VST ON)
 set(MUSE_MODULE_VST_QML ON)
 
@@ -110,6 +111,7 @@ option(AU_BUILD_EFFECTS_BUILTIN_TESTS "Build builtin-effect tests" ON)
 option(AU_BUILD_EFFECTS_MODULE "Build effects module" ON)
 option(AU_BUILD_EFFECTS_TESTS "Build effects tests" ON)
 option(AU_BUILD_PLAYBACK_MODULE "Build playback module" ON)
+option(AU_BUILD_APPSHELL_TESTS "Build appshell tests" ON)
 option(AU_BUILD_PLAYBACK_TESTS "Build playback tests" ON)
 option(AU_BUILD_PROJECT_TESTS "Build project tests" ON)
 option(AU_BUILD_PROJECTSCENE_MODULE "Build projectscene modules" ON)
@@ -147,6 +149,10 @@ option(AU_LOAD_TIMETRACK "Load time track from Audacity 3 projects" OFF)
 
 # === Pack ===
 option(AU_RUN_LRELEASE "Generate .qm files" ON)
+
+# === Tests ===
+set(APP_WORKSPACE_CONFIG_FILE "${CMAKE_CURRENT_LIST_DIR}/src/app/configs/workspaces.cfg")
+set(APP_BUILTIN_WORKSPACES_DIR "${CMAKE_CURRENT_LIST_DIR}/share/workspaces")
 
 # === Compile ===
 option(MU_COMPILE_INSTALL_QTQML_FILES "Whether to bundle qml files along with the installation (relevant on MacOS only)" ON)

--- a/au3/libraries/au3-cloud-audiocom/sync/CloudProjectsDatabase.cpp
+++ b/au3/libraries/au3-cloud-audiocom/sync/CloudProjectsDatabase.cpp
@@ -12,11 +12,15 @@
 
 #include <cassert>
 
+#include <wx/file.h>
+
 #include "au3-string-utils/CodeConversions.h"
 #include "au3-files/FileNames.h"
 
 namespace audacity::cloud::audiocom::sync {
 namespace {
+const auto databaseFileName = "/audiocom_sync.db";
+
 const char* createTableQuery
     =
         R"(
@@ -111,6 +115,13 @@ CloudProjectsDatabase& CloudProjectsDatabase::Get()
 {
     static CloudProjectsDatabase instance;
     return instance;
+}
+
+bool CloudProjectsDatabase::DatabaseExists()
+{
+    const auto configDir  = FileNames::ConfigDir();
+    const auto configPath = configDir + databaseFileName;
+    return wxFileExists(configPath);
 }
 
 sqlite::SafeConnection::Lock CloudProjectsDatabase::GetConnection()
@@ -899,7 +910,7 @@ bool CloudProjectsDatabase::OpenConnection()
     }
 
     const auto configDir  = FileNames::ConfigDir();
-    const auto configPath = configDir + "/audiocom_sync.db";
+    const auto configPath = configDir + databaseFileName;
 
     mConnection = sqlite::SafeConnection::Open(audacity::ToUTF8(configPath));
 
@@ -917,6 +928,12 @@ bool CloudProjectsDatabase::OpenConnection()
     }
 
     return RunMigrations();
+}
+
+void CloudProjectsDatabase::CloseConnection()
+{
+    auto lock = std::lock_guard { mConnectionMutex };
+    mConnection.reset();
 }
 
 bool CloudProjectsDatabase::RunMigrations()

--- a/au3/libraries/au3-cloud-audiocom/sync/CloudProjectsDatabase.h
+++ b/au3/libraries/au3-cloud-audiocom/sync/CloudProjectsDatabase.h
@@ -81,9 +81,12 @@ class CloudProjectsDatabase final
 
 public:
     static CloudProjectsDatabase& Get();
+    static bool DatabaseExists();
 
     sqlite::SafeConnection::Lock GetConnection();
     const sqlite::SafeConnection::Lock GetConnection() const;
+
+    void CloseConnection();
 
     std::optional<DBProjectData>
     GetProjectData(std::string_view projectId) const;
@@ -104,7 +107,7 @@ public:
     GetBlockHash(std::string_view projectId, int64_t blockId) const;
 
     void UpdateBlockHashes(
-        std::string_view projectId, const std::vector<std::pair<int64_t, std::string>>& hashes);
+        std::string_view projectId, const std::vector<std::pair<int64_t, std::string> >& hashes);
 
     bool UpdateProjectData(const DBProjectData& projectData);
 

--- a/au3/libraries/au3-cloud-audiocom/sync/CloudSyncHousekeeper.cpp
+++ b/au3/libraries/au3-cloud-audiocom/sync/CloudSyncHousekeeper.cpp
@@ -41,6 +41,10 @@ private:
 
     void PerformHousekeeping()
     {
+        if (!CloudProjectsDatabase::DatabaseExists()) {
+            return;
+        }
+
         const auto timeToKeep = std::chrono::hours(24 * DaysToKeepFiles.Read());
         const auto now        = std::chrono::system_clock::now();
 
@@ -83,6 +87,10 @@ private:
         mHousekeepingCancelled.store(true);
         if (mHousekeepingOperation.valid()) {
             mHousekeepingOperation.wait();
+        }
+
+        if (!CloudProjectsDatabase::DatabaseExists()) {
+            return;
         }
 
         auto& cloudProjectsDatabase = CloudProjectsDatabase::Get();

--- a/src/app/commandlineparser.cpp
+++ b/src/app/commandlineparser.cpp
@@ -54,7 +54,6 @@ void CommandLineParser::init()
     m_parser.addOption(QCommandLineOption({ "D", "monitor-resolution" }, "Specify monitor resolution", "DPI"));
 
     m_parser.addOption(QCommandLineOption({ "F", "factory-settings" }, "Use factory settings"));
-    m_parser.addOption(QCommandLineOption({ "R", "revert-settings" }, "Revert to factory settings, but keep default preferences"));
 
     m_parser.addOption(QCommandLineOption("session-type", "Startup with given session type", "type"));
     m_parser.addOption(internalCommandLineOption("import-media-file", "Import media file on startup", "path"));
@@ -135,7 +134,7 @@ void CommandLineParser::parse(int argc, char** argv)
         }
     }
 
-    if (m_parser.isSet("F") || m_parser.isSet("R")) {
+    if (m_parser.isSet("F")) {
         m_options->app.revertToFactorySettings = true;
     }
 

--- a/src/app/guiapp.cpp
+++ b/src/app/guiapp.cpp
@@ -111,6 +111,6 @@ void GuiApp::applyCommandLineOptions(const std::shared_ptr<muse::CmdOptions>& op
     }
 
     if (options->app.revertToFactorySettings) {
-        appshellConfiguration()->revertToFactorySettings(options->app.revertToFactorySettings.value());
+        appshellConfiguration()->revertToFactorySettings();
     }
 }

--- a/src/appshell/CMakeLists.txt
+++ b/src/appshell/CMakeLists.txt
@@ -101,3 +101,7 @@ target_link_libraries(appshell PRIVATE
 )
 
 add_subdirectory(qml/Audacity/AppShell)
+
+if (AU_BUILD_APPSHELL_TESTS)
+    add_subdirectory(tests)
+endif()

--- a/src/appshell/iappshellconfiguration.h
+++ b/src/appshell/iappshellconfiguration.h
@@ -22,9 +22,9 @@
 #ifndef AU_APPSHELL_IAPPSHELLCONFIGURATION_H
 #define AU_APPSHELL_IAPPSHELLCONFIGURATION_H
 
-#include "types/ret.h"
-#include "io/path.h"
-#include "async/notification.h"
+#include "framework/global/types/ret.h"
+#include "framework/global/io/path.h"
+#include "framework/global/async/notification.h"
 
 #include "modularity/imoduleinterface.h"
 
@@ -79,7 +79,8 @@ public:
     virtual void rollbackSettings() = 0;
     virtual muse::async::Notification settingsApplied() const = 0;
 
-    virtual void revertToFactorySettings(bool keepDefaultSettings = false, bool notifyAboutChanges = true) const = 0;
+    virtual void revertToFactorySettings(bool keepDefaultSettings = false, bool notifyAboutChanges = true,
+                                         bool notifyOtherInstances = true) const = 0;
 
     virtual muse::io::paths_t sessionProjectsPaths() const = 0;
     virtual muse::Ret setSessionProjectsPaths(const muse::io::paths_t& paths) = 0;

--- a/src/appshell/iappshellconfiguration.h
+++ b/src/appshell/iappshellconfiguration.h
@@ -80,7 +80,9 @@ public:
     virtual muse::async::Notification settingsApplied() const = 0;
 
     virtual void revertToFactorySettings(bool keepDefaultSettings = false, bool notifyAboutChanges = true,
-                                         bool notifyOtherInstances = true) const = 0;
+                                         bool notifyOtherInstances = true) = 0;
+
+    virtual muse::async::Notification aboutToRevertToFactorySettings() const = 0;
 
     virtual muse::io::paths_t sessionProjectsPaths() const = 0;
     virtual muse::Ret setSessionProjectsPaths(const muse::io::paths_t& paths) = 0;

--- a/src/appshell/internal/applicationactioncontroller.cpp
+++ b/src/appshell/internal/applicationactioncontroller.cpp
@@ -238,14 +238,14 @@ bool ApplicationActionController::quit(const muse::io::path_t& installerPath)
 
 void ApplicationActionController::restart()
 {
-    if (projectFilesController()->closeOpenedProject()) {
-        // if (multiwindowsProvider()->instances().size() == 1) {
-        application()->restart();
-        // } else {
-        // multiwindowsProvider()->quitAllAndRestartLast();
+    if (projectFilesController()->closeOpenedProject(false)) {
+        if (multiwindowsProvider()->windowCount() == 1) {
+            application()->restart();
+        } else {
+            multiwindowsProvider()->quitAllAndRestartLast();
 
-        // QCoreApplication::exit();
-        // }
+            QCoreApplication::exit();
+        }
     }
 }
 
@@ -323,40 +323,47 @@ void ApplicationActionController::revertToFactorySettings()
 {
     std::string title = muse::trc("appshell", "Are you sure you want to revert to factory settings?");
     std::string question = muse::trc("appshell",
-                                     "This action will reset all your app preferences and delete all custom palettes and custom shortcuts. "
-                                     "The list of recent projects will also be cleared.\n\n"
+                                     "This action will reset all your app preferences and custom UI configurations. "
+                                     "It also deletes your custom workspaces and shortcuts. "
+                                     "You will also need to scan all third party plugins again.\n\n"
                                      "This action will not delete any of your projects.");
 
+    muse::IInteractive::ButtonData cancelBtn = interactive()->buttonData(muse::IInteractive::Button::Cancel);
+    cancelBtn.accent = true;
+
     int revertBtn = int(muse::IInteractive::Button::Apply);
-    muse::IInteractive::Result result = interactive()->warningSync(title, question,
-                                                                   { interactive()->buttonData(muse::IInteractive::Button::Cancel),
-                                                                     muse::IInteractive::ButtonData(revertBtn,
-                                                                                                    muse::trc("appshell", "Revert"),
-                                                                                                    true) },
-                                                                   revertBtn);
+    auto promise = interactive()->warning(title, question,
+                                          { cancelBtn,
+                                            muse::IInteractive::ButtonData(revertBtn, muse::trc("appshell", "Revert")) },
+                                          cancelBtn.btn, { muse::IInteractive::Option::WithIcon },
+                                          muse::trc("appshell", "Revert to factory settings"));
 
-    if (result.standardButton() == muse::IInteractive::Button::Cancel) {
-        return;
-    }
+    promise.onResolve(this, [this](const muse::IInteractive::Result& res) {
+        if (res.isButton(muse::IInteractive::Button::Cancel)) {
+            return;
+        }
 
-    static constexpr bool KEEP_DEFAULT_SETTINGS = false;
-    static constexpr bool NOTIFY_ABOUT_CHANGES = false;
-    configuration()->revertToFactorySettings(KEEP_DEFAULT_SETTINGS, NOTIFY_ABOUT_CHANGES);
+        static constexpr bool KEEP_DEFAULT_SETTINGS = false;
+        static constexpr bool NOTIFY_ABOUT_CHANGES = false;
+        static constexpr bool NOTIFY_OTHER_INSTANCES = false;
+        configuration()->revertToFactorySettings(KEEP_DEFAULT_SETTINGS, NOTIFY_ABOUT_CHANGES, NOTIFY_OTHER_INSTANCES);
 
-    title = muse::trc("appshell", "Would you like to restart Audacity now?");
-    question = muse::trc("appshell", "Audacity needs to be restarted for these changes to take effect.");
+        std::string title = muse::trc("appshell", "Would you like to restart Audacity now?");
+        std::string question = muse::trc("appshell", "Audacity needs to be restarted for these changes to take effect.");
 
-    int restartBtn = int(muse::IInteractive::Button::Apply);
-    result = interactive()->questionSync(title, question,
-                                         { interactive()->buttonData(muse::IInteractive::Button::Cancel),
-                                           muse::IInteractive::ButtonData(restartBtn, muse::trc("appshell", "Restart"), true) },
-                                         restartBtn);
+        int restartBtn = int(muse::IInteractive::Button::Apply);
+        auto promise = interactive()->question(title, question,
+                                               { interactive()->buttonData(muse::IInteractive::Button::Cancel),
+                                                 muse::IInteractive::ButtonData(restartBtn,
+                                                                                muse::trc("appshell", "Restart"), true) },
+                                               restartBtn);
 
-    if (result.standardButton() == muse::IInteractive::Button::Cancel) {
-        return;
-    }
-
-    restart();
+        promise.onResolve(this, [this](const muse::IInteractive::Result& res) {
+            if (!res.isButton(muse::IInteractive::Button::Cancel)) {
+                restart();
+            }
+        });
+    });
 }
 
 bool ApplicationActionController::isProjectOpened() const

--- a/src/appshell/internal/applicationactioncontroller.h
+++ b/src/appshell/internal/applicationactioncontroller.h
@@ -41,7 +41,6 @@
 #include "record/irecordcontroller.h"
 #include "context/iuicontextresolver.h"
 #include "context/iglobalcontext.h"
-
 //! TODO AU4
 // #include "languages/ilanguagesservice.h"
 #include "multiwindows/imultiwindowsprovider.h"
@@ -66,7 +65,11 @@ class ApplicationActionController : public QObject, public IApplicationActionCon
     muse::ContextInject<record::IRecordController> recordController { this };
     muse::ContextInject<context::IUiContextResolver> uiContextResolver { this };
     muse::ContextInject<context::IGlobalContext> globalContext { this };
+
 public:
+
+    friend class FactoryResetActionTests;
+
     ApplicationActionController(const muse::modularity::ContextPtr& ctx)
         : muse::Contextable(ctx) {}
 

--- a/src/appshell/internal/appshellconfiguration.cpp
+++ b/src/appshell/internal/appshellconfiguration.cpp
@@ -21,10 +21,8 @@
  */
 #include "appshellconfiguration.h"
 
-#include <QFileInfo>
 #include <QJsonArray>
 #include <QJsonDocument>
-#include <QStandardPaths>
 
 #include "framework/global/settings.h"
 #include "framework/global/log.h"
@@ -225,9 +223,15 @@ muse::async::Notification AppShellConfiguration::settingsApplied() const
     return m_settingsApplied;
 }
 
-void AppShellConfiguration::revertToFactorySettings(bool keepDefaultSettings, bool notifyAboutChanges, bool notifyOtherInstances) const
+void AppShellConfiguration::revertToFactorySettings(bool keepDefaultSettings, bool notifyAboutChanges, bool notifyOtherInstances)
 {
+    m_aboutToRevertToFactorySettings.notify();
     settings()->reset(keepDefaultSettings, notifyAboutChanges, notifyOtherInstances);
+}
+
+muse::async::Notification AppShellConfiguration::aboutToRevertToFactorySettings() const
+{
+    return m_aboutToRevertToFactorySettings;
 }
 
 muse::io::paths_t AppShellConfiguration::sessionProjectsPaths() const

--- a/src/appshell/internal/appshellconfiguration.cpp
+++ b/src/appshell/internal/appshellconfiguration.cpp
@@ -21,11 +21,14 @@
  */
 #include "appshellconfiguration.h"
 
+#include <QFileInfo>
 #include <QJsonArray>
 #include <QJsonDocument>
+#include <QStandardPaths>
 
-#include "global/settings.h"
-#include "global/log.h"
+#include "framework/global/settings.h"
+#include "framework/global/log.h"
+
 #include "appshell/appshelltypes.h"
 
 // #include "multiwindows/resourcelockguard.h"
@@ -222,9 +225,9 @@ muse::async::Notification AppShellConfiguration::settingsApplied() const
     return m_settingsApplied;
 }
 
-void AppShellConfiguration::revertToFactorySettings(bool keepDefaultSettings, bool notifyAboutChanges) const
+void AppShellConfiguration::revertToFactorySettings(bool keepDefaultSettings, bool notifyAboutChanges, bool notifyOtherInstances) const
 {
-    settings()->reset(keepDefaultSettings, notifyAboutChanges);
+    settings()->reset(keepDefaultSettings, notifyAboutChanges, notifyOtherInstances);
 }
 
 muse::io::paths_t AppShellConfiguration::sessionProjectsPaths() const

--- a/src/appshell/internal/appshellconfiguration.h
+++ b/src/appshell/internal/appshellconfiguration.h
@@ -92,7 +92,8 @@ public:
     void rollbackSettings() override;
     muse::async::Notification settingsApplied() const override;
 
-    void revertToFactorySettings(bool keepDefaultSettings = false, bool notifyAboutChanges = true) const override;
+    void revertToFactorySettings(bool keepDefaultSettings = false, bool notifyAboutChanges = true,
+                                 bool notifyOtherInstances = true) const override;
 
     muse::io::paths_t sessionProjectsPaths() const override;
     muse::Ret setSessionProjectsPaths(const muse::io::paths_t& paths) override;

--- a/src/appshell/internal/appshellconfiguration.h
+++ b/src/appshell/internal/appshellconfiguration.h
@@ -93,7 +93,8 @@ public:
     muse::async::Notification settingsApplied() const override;
 
     void revertToFactorySettings(bool keepDefaultSettings = false, bool notifyAboutChanges = true,
-                                 bool notifyOtherInstances = true) const override;
+                                 bool notifyOtherInstances = true) override;
+    muse::async::Notification aboutToRevertToFactorySettings() const override;
 
     muse::io::paths_t sessionProjectsPaths() const override;
     muse::Ret setSessionProjectsPaths(const muse::io::paths_t& paths) override;
@@ -113,6 +114,7 @@ private:
 
     QString m_preferencesDialogCurrentPageId;
     muse::async::Notification m_settingsApplied;
+    muse::async::Notification m_aboutToRevertToFactorySettings;
 
     muse::async::Notification m_welcomeDialogShowOnStartupChanged;
 };

--- a/src/appshell/tests/CMakeLists.txt
+++ b/src/appshell/tests/CMakeLists.txt
@@ -1,0 +1,29 @@
+#
+# Audacity: A Digital Audio Editor
+#
+
+set(MODULE_TEST appshell_tests)
+
+set(MODULE_TEST_SRC
+    ${CMAKE_CURRENT_LIST_DIR}/factoryreset_actioncontroller_tests.cpp
+
+    ${CMAKE_CURRENT_LIST_DIR}/mocks/appshellconfigurationmock.h
+)
+
+set(MODULE_TEST_LINK
+    appshell
+    project
+)
+
+set(MODULE_TEST_INCLUDE
+    ${MUSE_FRAMEWORK_PATH}/framework/multiwindows
+    ${MUSE_FRAMEWORK_PATH}/framework/actions
+    ${MUSE_FRAMEWORK_PATH}/framework/interactive
+    ${MUSE_FRAMEWORK_PATH}/framework/global
+    ${CMAKE_SOURCE_DIR}/src/appshell
+    ${CMAKE_SOURCE_DIR}/src/record
+)
+
+set(MODULE_TEST_DATA_ROOT ${CMAKE_CURRENT_LIST_DIR})
+
+include(SetupGTest)

--- a/src/appshell/tests/factoryreset_actioncontroller_tests.cpp
+++ b/src/appshell/tests/factoryreset_actioncontroller_tests.cpp
@@ -1,0 +1,298 @@
+/*
+* Audacity: A Digital Audio Editor
+*/
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include "actions/tests/mocks/actionsdispatchermock.h"
+#include "global/tests/mocks/applicationmock.h"
+#include "interactive/tests/mocks/interactivemock.h"
+
+#include "mocks/appshellconfigurationmock.h"
+#include "project/tests/mocks/projectfilescontrollermock.h"
+#include "multiwindows/tests/mocks/multiwindowsprovidermock.h"
+
+#include "../internal/applicationactioncontroller.h"
+
+using ::testing::_;
+using ::testing::Return;
+using ::testing::NiceMock;
+using ::testing::HasSubstr;
+
+using namespace muse;
+using namespace au::appshell;
+
+namespace au::appshell {
+class FactoryResetActionTests : public ::testing::Test
+{
+public:
+    using ActionCB = muse::actions::IActionsDispatcher::ActionCallBackWithNameAndData;
+    using WarningPromise = muse::async::Promise<IInteractive::Result>;
+    using QuestionPromise = muse::async::Promise<IInteractive::Result>;
+
+    void SetUp() override
+    {
+        m_controller = new ApplicationActionController(muse::modularity::globalCtx());
+
+        m_dispatcher = std::make_shared<NiceMock<muse::actions::ActionsDispatcherMock> >();
+        m_controller->dispatcher.set(m_dispatcher);
+
+        ON_CALL(*m_dispatcher, reg(_, _, testing::An<const ActionCB&>()))
+        .WillByDefault([this](muse::actions::Actionable*, const muse::actions::ActionCode& code,
+                              const ActionCB& cb) {
+            m_registeredActions[code] = cb;
+        });
+
+        m_interactive = std::make_shared<NiceMock<InteractiveMock> >();
+        m_controller->interactive.set(m_interactive);
+
+        ON_CALL(*m_interactive, buttonData(IInteractive::Button::Cancel))
+        .WillByDefault(Return(IInteractive::ButtonData(IInteractive::Button::Cancel, "Cancel")));
+
+        m_application = std::make_shared<NiceMock<ApplicationMock> >();
+        m_controller->application.set(m_application);
+
+        m_configuration = std::make_shared<NiceMock<AppShellConfigurationMock> >();
+        m_controller->configuration.set(m_configuration);
+
+        m_projectFilesController = std::make_shared<NiceMock<au::project::ProjectFilesControllerMock> >();
+        m_controller->projectFilesController.set(m_projectFilesController);
+
+        m_multiWindowsProvider = std::make_shared<NiceMock<muse::mi::MultiWindowsProviderMock> >();
+        m_controller->multiwindowsProvider.set(m_multiWindowsProvider);
+
+        setupWarningDialog();
+
+        m_controller->init();
+    }
+
+    void TearDown() override
+    {
+        delete m_controller;
+    }
+
+    void setupWarningDialog()
+    {
+        EXPECT_CALL(*m_interactive, warning(
+                        HasSubstr("revert to factory settings"),
+                        _, _,
+                        static_cast<int>(IInteractive::Button::Cancel),
+                        _, _))
+        .WillOnce([this](const std::string&, const IInteractive::Text&,
+                         const IInteractive::ButtonDatas&, int,
+                         const IInteractive::Options&, const std::string&) -> WarningPromise {
+            return WarningPromise([this](WarningPromise::Resolve resolve,
+                                         WarningPromise::Reject) -> WarningPromise::Result {
+                m_warningResolve = resolve;
+                return WarningPromise::Result::unchecked();
+            }, muse::async::PromiseType::AsyncByBody);
+        });
+    }
+
+    void setupRestartDialog()
+    {
+        EXPECT_CALL(*m_interactive, question(
+                        HasSubstr("restart Audacity"),
+                        _, _, _, _, _))
+        .WillOnce([this](const std::string&, const IInteractive::Text&,
+                         const IInteractive::ButtonDatas&, int,
+                         const IInteractive::Options&, const std::string&) -> QuestionPromise {
+            return QuestionPromise([this](QuestionPromise::Resolve resolve,
+                                          QuestionPromise::Reject) -> QuestionPromise::Result {
+                m_questionResolve = resolve;
+                return QuestionPromise::Result::unchecked();
+            }, muse::async::PromiseType::AsyncByBody);
+        });
+    }
+
+    void triggerRevertToFactory()
+    {
+        auto it = m_registeredActions.find("revert-factory");
+        ASSERT_NE(it, m_registeredActions.end()) << "'revert-factory' action not registered";
+        it->second("revert-factory", muse::actions::ActionData());
+    }
+
+    void confirmWarningDialog()
+    {
+        int btn = static_cast<int>(IInteractive::Button::Apply);
+        IInteractive::Result result(btn);
+        (void)m_warningResolve(result);
+    }
+
+    void cancelWarningDialog()
+    {
+        int btn = static_cast<int>(IInteractive::Button::Cancel);
+        IInteractive::Result result(btn);
+        (void)m_warningResolve(result);
+    }
+
+    void confirmRestartDialog()
+    {
+        int btn = static_cast<int>(IInteractive::Button::Apply);
+        IInteractive::Result result(btn);
+        (void)m_questionResolve(result);
+    }
+
+    void cancelRestartDialog()
+    {
+        int btn = static_cast<int>(IInteractive::Button::Cancel);
+        IInteractive::Result result(btn);
+        (void)m_questionResolve(result);
+    }
+
+protected:
+    ApplicationActionController* m_controller = nullptr;
+
+    std::shared_ptr<NiceMock<muse::actions::ActionsDispatcherMock> > m_dispatcher;
+    std::shared_ptr<NiceMock<InteractiveMock> > m_interactive;
+    std::shared_ptr<NiceMock<ApplicationMock> > m_application;
+    std::shared_ptr<NiceMock<AppShellConfigurationMock> > m_configuration;
+    std::shared_ptr<NiceMock<au::project::ProjectFilesControllerMock> > m_projectFilesController;
+    std::shared_ptr<NiceMock<muse::mi::MultiWindowsProviderMock> > m_multiWindowsProvider;
+
+    std::map<std::string, ActionCB> m_registeredActions;
+    WarningPromise::Resolve m_warningResolve;
+    QuestionPromise::Resolve m_questionResolve;
+};
+
+/**
+ * @brief Cancel the warning dialog — nothing should happen.
+ */
+TEST_F(FactoryResetActionTests, CancelWarningDialog_DoesNothing)
+{
+    //! [THEN] No reset, no restart
+    EXPECT_CALL(*m_configuration, revertToFactorySettings(_, _, _)).Times(0);
+    EXPECT_CALL(*m_application, restart()).Times(0);
+
+    //! [WHEN] User triggers factory reset and cancels the warning
+    triggerRevertToFactory();
+    cancelWarningDialog();
+}
+
+/**
+ * @brief Confirm the warning — settings are reset immediately.
+ */
+TEST_F(FactoryResetActionTests, ConfirmWarning_ResetsSettings)
+{
+    //! [GIVEN] Restart dialog will appear
+    setupRestartDialog();
+
+    //! [THEN] Settings are reset with keepDefault=false
+    EXPECT_CALL(*m_configuration, revertToFactorySettings(false, false, false))
+    .Times(1);
+
+    //! [WHEN] User confirms the warning
+    triggerRevertToFactory();
+    confirmWarningDialog();
+
+    //! [WHEN] User cancels the restart dialog
+    cancelRestartDialog();
+}
+
+/**
+ * @brief Confirm warning, cancel restart dialog — reset done but no restart.
+ */
+TEST_F(FactoryResetActionTests, ConfirmWarning_CancelRestart_NoRestart)
+{
+    //! [GIVEN] Restart dialog will appear
+    setupRestartDialog();
+
+    //! [THEN] Settings are reset
+    EXPECT_CALL(*m_configuration, revertToFactorySettings(false, false, false))
+    .Times(1);
+
+    //! [THEN] No restart, no project close
+    EXPECT_CALL(*m_projectFilesController, closeOpenedProject(_)).Times(0);
+    EXPECT_CALL(*m_application, restart()).Times(0);
+
+    //! [WHEN] User confirms warning, cancels restart
+    triggerRevertToFactory();
+    confirmWarningDialog();
+    cancelRestartDialog();
+}
+
+/**
+ * @brief Confirm both dialogs, single window — restart via application()->restart().
+ */
+TEST_F(FactoryResetActionTests, ConfirmRestart_SingleWindow_Restarts)
+{
+    //! [GIVEN] Restart dialog will appear
+    setupRestartDialog();
+
+    //! [GIVEN] Single window, project closes successfully
+    ON_CALL(*m_multiWindowsProvider, windowCount())
+    .WillByDefault(Return(size_t(1)));
+
+    EXPECT_CALL(*m_projectFilesController, closeOpenedProject(false))
+    .WillOnce(Return(true));
+
+    //! [THEN] Settings are reset and app restarts
+    EXPECT_CALL(*m_configuration, revertToFactorySettings(false, false, false))
+    .Times(1);
+
+    EXPECT_CALL(*m_application, restart())
+    .Times(1);
+
+    //! [WHEN] User confirms both dialogs
+    triggerRevertToFactory();
+    confirmWarningDialog();
+    confirmRestartDialog();
+}
+
+/**
+ * @brief Confirm both dialogs, multi-window — uses quitAllAndRestartLast().
+ */
+TEST_F(FactoryResetActionTests, ConfirmRestart_MultiWindow_QuitsAll)
+{
+    //! [GIVEN] Restart dialog will appear
+    setupRestartDialog();
+
+    //! [GIVEN] Multiple windows, project closes successfully
+    ON_CALL(*m_multiWindowsProvider, windowCount())
+    .WillByDefault(Return(size_t(3)));
+
+    EXPECT_CALL(*m_projectFilesController, closeOpenedProject(false))
+    .WillOnce(Return(true));
+
+    //! [THEN] Settings are reset
+    EXPECT_CALL(*m_configuration, revertToFactorySettings(false, false, false))
+    .Times(1);
+
+    //! [THEN] quitAllAndRestartLast is called (not application()->restart())
+    EXPECT_CALL(*m_multiWindowsProvider, quitAllAndRestartLast())
+    .Times(1);
+
+    EXPECT_CALL(*m_application, restart()).Times(0);
+
+    //! [WHEN] User confirms both dialogs
+    triggerRevertToFactory();
+    confirmWarningDialog();
+    confirmRestartDialog();
+}
+
+/**
+ * @brief Confirm both dialogs, but user rejects project close — no restart.
+ */
+TEST_F(FactoryResetActionTests, ConfirmRestart_ProjectCloseRejected_NoRestart)
+{
+    //! [GIVEN] Restart dialog will appear
+    setupRestartDialog();
+
+    //! [GIVEN] Project close is rejected by user
+    EXPECT_CALL(*m_projectFilesController, closeOpenedProject(false))
+    .WillOnce(Return(false));
+
+    //! [THEN] Settings are still reset (happens before restart attempt)
+    EXPECT_CALL(*m_configuration, revertToFactorySettings(false, false, false))
+    .Times(1);
+
+    //! [THEN] No restart occurs
+    EXPECT_CALL(*m_application, restart()).Times(0);
+    EXPECT_CALL(*m_multiWindowsProvider, quitAllAndRestartLast()).Times(0);
+
+    //! [WHEN] User confirms both dialogs
+    triggerRevertToFactory();
+    confirmWarningDialog();
+    confirmRestartDialog();
+}
+}

--- a/src/appshell/tests/mocks/appshellconfigurationmock.h
+++ b/src/appshell/tests/mocks/appshellconfigurationmock.h
@@ -52,7 +52,8 @@ public:
     MOCK_METHOD(void, rollbackSettings, (), (override));
     MOCK_METHOD(muse::async::Notification, settingsApplied, (), (const, override));
 
-    MOCK_METHOD(void, revertToFactorySettings, (bool, bool, bool), (const, override));
+    MOCK_METHOD(void, revertToFactorySettings, (bool, bool, bool), (override));
+    MOCK_METHOD(muse::async::Notification, aboutToRevertToFactorySettings, (), (const, override));
 
     MOCK_METHOD(muse::io::paths_t, sessionProjectsPaths, (), (const, override));
     MOCK_METHOD(muse::Ret, setSessionProjectsPaths, (const muse::io::paths_t&), (override));

--- a/src/appshell/tests/mocks/appshellconfigurationmock.h
+++ b/src/appshell/tests/mocks/appshellconfigurationmock.h
@@ -1,0 +1,64 @@
+/*
+* Audacity: A Digital Audio Editor
+*/
+#pragma once
+
+#include <gmock/gmock.h>
+
+#include "iappshellconfiguration.h"
+
+namespace au::appshell {
+class AppShellConfigurationMock : public IAppShellConfiguration
+{
+public:
+    MOCK_METHOD(bool, hasCompletedFirstLaunchSetup, (), (const, override));
+    MOCK_METHOD(void, setHasCompletedFirstLaunchSetup, (bool), (override));
+
+    MOCK_METHOD(bool, welcomeDialogShowOnStartup, (), (const, override));
+    MOCK_METHOD(void, setWelcomeDialogShowOnStartup, (bool), (override));
+    MOCK_METHOD(muse::async::Notification, welcomeDialogShowOnStartupChanged, (), (const, override));
+
+    MOCK_METHOD(std::string, welcomeDialogLastShownVersion, (), (const, override));
+    MOCK_METHOD(void, setWelcomeDialogLastShownVersion, (const std::string&), (override));
+
+    MOCK_METHOD(int, welcomeDialogLastShownIndex, (), (const, override));
+    MOCK_METHOD(void, setWelcomeDialogLastShownIndex, (int), (override));
+
+    MOCK_METHOD(StartupModeType, startupModeType, (), (const, override));
+    MOCK_METHOD(void, setStartupModeType, (StartupModeType), (override));
+
+    MOCK_METHOD(muse::io::path_t, startupProjectPath, (), (const, override));
+    MOCK_METHOD(void, setStartupProjectPath, (const muse::io::path_t&), (override));
+
+    MOCK_METHOD(muse::io::path_t, userDataPath, (), (const, override));
+
+    MOCK_METHOD(std::string, handbookUrl, (), (const, override));
+    MOCK_METHOD(std::string, askForHelpUrl, (), (const, override));
+    MOCK_METHOD(std::string, appUrl, (), (const, override));
+    MOCK_METHOD(std::string, forumUrl, (), (const, override));
+    MOCK_METHOD(std::string, contributionUrl, (), (const, override));
+
+    MOCK_METHOD(std::string, audacityVersion, (), (const, override));
+    MOCK_METHOD(std::string, appRevision, (), (const, override));
+
+    MOCK_METHOD(bool, needShowSplashScreen, (), (const, override));
+    MOCK_METHOD(void, setNeedShowSplashScreen, (bool), (override));
+
+    MOCK_METHOD(const QString&, preferencesDialogLastOpenedPageId, (), (const, override));
+    MOCK_METHOD(void, setPreferencesDialogLastOpenedPageId, (const QString&), (override));
+
+    MOCK_METHOD(void, startEditSettings, (), (override));
+    MOCK_METHOD(void, applySettings, (), (override));
+    MOCK_METHOD(void, rollbackSettings, (), (override));
+    MOCK_METHOD(muse::async::Notification, settingsApplied, (), (const, override));
+
+    MOCK_METHOD(void, revertToFactorySettings, (bool, bool, bool), (const, override));
+
+    MOCK_METHOD(muse::io::paths_t, sessionProjectsPaths, (), (const, override));
+    MOCK_METHOD(muse::Ret, setSessionProjectsPaths, (const muse::io::paths_t&), (override));
+
+    MOCK_METHOD(bool, isEffectsPanelVisible, (), (const, override));
+    MOCK_METHOD(void, setIsEffectsPanelVisible, (bool), (override));
+    MOCK_METHOD(muse::async::Notification, isEffectsPanelVisibleChanged, (), (const, override));
+};
+}

--- a/src/au3cloud/CMakeLists.txt
+++ b/src/au3cloud/CMakeLists.txt
@@ -36,8 +36,6 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/view/accountinfomodel.h
     )
 
-set(MODULE_INCLUDE ${AU3_LIBRARIES})
-
 set(MODULE_LINK au3wrap Qt6::Network Qt6::NetworkAuth)
 
 setup_module()

--- a/src/au3cloud/au3cloudmodule.cpp
+++ b/src/au3cloud/au3cloudmodule.cpp
@@ -43,6 +43,10 @@ void Au3CloudModule::onInit(const muse::IApplication::RunMode&)
     m_cloudService->init();
 }
 
+void Au3CloudModule::onDeinit()
+{
+}
+
 void Au3CloudModule::registerUiTypes()
 {
     qmlRegisterType<CloudTestsModel>("Audacity.Cloud", 1, 0, "CloudTestsModel");
@@ -78,4 +82,9 @@ void Au3CloudContext::onInit(const muse::IApplication::RunMode&)
     }
 }
 
-void Au3CloudContext::onDeinit() {}
+void Au3CloudContext::onDeinit()
+{
+    if (m_audioComService) {
+        m_audioComService->deinit();
+    }
+}

--- a/src/au3cloud/au3cloudmodule.h
+++ b/src/au3cloud/au3cloudmodule.h
@@ -20,6 +20,7 @@ public:
     void registerExports() override;
     void registerUiTypes() override;
     void onInit(const muse::IApplication::RunMode& mode) override;
+    void onDeinit() override;
 
     muse::modularity::IContextSetup* newContext(const muse::modularity::ContextPtr& ctx) const override;
 

--- a/src/au3cloud/iau3audiocomservice.h
+++ b/src/au3cloud/iau3audiocomservice.h
@@ -49,5 +49,7 @@ public:
     virtual muse::ProgressPtr openCloudProject(const muse::io::path_t& localPath, const std::string& projectId = {},
                                                bool forceOverwrite = false) = 0;
     virtual muse::ProgressPtr resumeProjectSync(au::project::IAudacityProjectPtr project) = 0;
+
+    virtual void deinit() = 0;
 };
 }

--- a/src/au3cloud/internal/au3audiocomservice.cpp
+++ b/src/au3cloud/internal/au3audiocomservice.cpp
@@ -726,3 +726,8 @@ std::optional<std::string> Au3AudioComService::getHeadSnapshotID(const std::stri
 
     return std::nullopt;
 }
+
+void Au3AudioComService::deinit()
+{
+    audacity::cloud::audiocom::sync::CloudProjectsDatabase::Get().CloseConnection();
+}

--- a/src/au3cloud/internal/au3audiocomservice.cpp
+++ b/src/au3cloud/internal/au3audiocomservice.cpp
@@ -242,6 +242,10 @@ void Au3AudioComService::init()
             }
         });
     });
+
+    appshellConfiguration()->aboutToRevertToFactorySettings().onNotify(this, []() {
+        audacity::cloud::audiocom::sync::CloudProjectsDatabase::Get().CloseConnection();
+    });
 }
 
 muse::async::Promise<ProjectList> Au3AudioComService::downloadProjectList(size_t projectsPerBatch, size_t batchNumber,

--- a/src/au3cloud/internal/au3audiocomservice.h
+++ b/src/au3cloud/internal/au3audiocomservice.h
@@ -56,6 +56,8 @@ public:
 
     muse::ProgressPtr resumeProjectSync(au::project::IAudacityProjectPtr project) override;
 
+    void deinit() override;
+
 private:
     std::string getCloudProjectPage(au::project::IAudacityProjectPtr project);
 

--- a/src/au3cloud/internal/au3audiocomservice.h
+++ b/src/au3cloud/internal/au3audiocomservice.h
@@ -13,6 +13,8 @@
 
 #include "framework/global/modularity/ioc.h"
 #include "framework/global/io/ifilesystem.h"
+
+#include "appshell/iappshellconfiguration.h"
 #include "project/iprojectconfiguration.h"
 #include "importexport/export/iexporter.h"
 #include "context/iglobalcontext.h"
@@ -28,6 +30,7 @@ class Au3AudioComService : public IAu3AudioComService, public muse::async::Async
 {
     muse::GlobalInject<muse::io::IFileSystem> filesystem;
     muse::GlobalInject<project::IProjectConfiguration> projectConfiguration;
+    muse::GlobalInject<appshell::IAppShellConfiguration> appshellConfiguration;
 
     muse::ContextInject<importexport::IExporter> exporter{ this };
     muse::ContextInject<context::IGlobalContext> globalContext { this };

--- a/src/effects/effects_base/effectsmodule.cpp
+++ b/src/effects/effects_base/effectsmodule.cpp
@@ -153,7 +153,3 @@ void EffectsContext::onInit(const muse::IApplication::RunMode&)
 void EffectsContext::onAllInited(const muse::IApplication::RunMode&)
 {
 }
-
-void EffectsContext::onDeinit()
-{
-}

--- a/src/effects/effects_base/effectsmodule.h
+++ b/src/effects/effects_base/effectsmodule.h
@@ -43,7 +43,6 @@ public:
     void registerExports() override;
     void onInit(const muse::IApplication::RunMode& mode) override;
     void onAllInited(const muse::IApplication::RunMode& mode) override;
-    void onDeinit() override;
 
 private:
     std::shared_ptr<EffectsMenuProvider> m_effectsMenuProvider;

--- a/src/importexport/export/CMakeLists.txt
+++ b/src/importexport/export/CMakeLists.txt
@@ -45,11 +45,6 @@ set(MODULE_SRC
 
 set(MODULE_QML_IMPORT ${CMAKE_CURRENT_LIST_DIR}/qml )
 
-# AU3
-include(${CMAKE_CURRENT_LIST_DIR}/../../au3wrap/au3wrapDefs.cmake)
-
-set(MODULE_INCLUDE ${AU3_INCLUDE})
-set(MODULE_DEF ${AU3_DEF})
 set(MODULE_LINK au3wrap)
 
 set(MODULE_USE_UNITY OFF)

--- a/src/project/tests/mocks/projectfilescontrollermock.h
+++ b/src/project/tests/mocks/projectfilescontrollermock.h
@@ -1,0 +1,24 @@
+/*
+* Audacity: A Digital Audio Editor
+*/
+#pragma once
+
+#include <gmock/gmock.h>
+
+#include "project/iprojectfilescontroller.h"
+
+namespace au::project {
+class ProjectFilesControllerMock : public IProjectFilesController
+{
+public:
+    MOCK_METHOD(bool, isUrlSupported, (const QUrl&), (const, override));
+    MOCK_METHOD(bool, isFileSupported, (const muse::io::path_t&), (const, override));
+    MOCK_METHOD(muse::Ret, openProject, (const ProjectFile&), (override));
+    MOCK_METHOD(bool, closeOpenedProject, (bool), (override));
+    MOCK_METHOD(bool, saveProject, (const muse::io::path_t&), (override));
+    MOCK_METHOD(bool, saveProjectLocally, (const muse::io::path_t&, SaveMode), (override));
+    MOCK_METHOD(bool, saveProjectToCloud, (const CloudProjectInfo&, SaveMode, bool), (override));
+    MOCK_METHOD(const ProjectBeingDownloaded&, projectBeingDownloaded, (), (const, override));
+    MOCK_METHOD(muse::async::Notification, projectBeingDownloadedChanged, (), (const, override));
+};
+}

--- a/src/stubs/au3cloud/au3audiocomservicestub.cpp
+++ b/src/stubs/au3cloud/au3audiocomservicestub.cpp
@@ -52,3 +52,7 @@ muse::ProgressPtr Au3AudioComServiceStub::resumeProjectSync(au::project::IAudaci
 {
     return nullptr;
 }
+
+void Au3AudioComServiceStub::deinit()
+{
+}

--- a/src/stubs/au3cloud/au3audiocomservicestub.h
+++ b/src/stubs/au3cloud/au3audiocomservicestub.h
@@ -29,5 +29,6 @@ public:
     muse::ProgressPtr openCloudProject(const muse::io::path_t& localPath, const std::string& projectId = {},
                                        bool forceOverwrite = false) override;
     muse::ProgressPtr resumeProjectSync(au::project::IAudacityProjectPtr project) override;
+    void deinit() override;
 };
 }


### PR DESCRIPTION
Resolves: 
Revert to factory setting crash https://github.com/audacity/audacity/issues/10510
copy update https://github.com/audacity/audacity/issues/9677

  - Unify factory-reset entry points via FactoryResetMode; close CloudProjectsDatabase before wiping config                                                                                                                   
  - Multi-window restart-confirmation handling; cancel is default                                                                                                                                                             
  - Add single- and multi-window action-controller tests; drop unused -R CLI flag

this PR replaces https://github.com/audacity/audacity/pull/10518


<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
