### PR TITLE
Fix indent_size typo in .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -31,4 +31,4 @@ indent_size = 4
 
 [*.{bat,ps1}]
 end_of_line = crlf
-ident_size = 4
+indent_size = 4


### PR DESCRIPTION
Resolves #8561.

- Corrects `ident_size` to `indent_size` for `.bat` and `.ps1` files in `.editorconfig`.

Validation:
- Checked the property name against the EditorConfig specification.
- Verified the `.bat`/`.ps1` section contains `indent_size = 4` and no `ident_size` entry remains.
- Ran `git diff --check`.

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] There are no behavior changes unnecessary for the stated purpose of the PR