### PR TITLE
fix(lib-xml): use unsigned format for size_t XMLWriter::WriteAttr

### DIFF
--- a/libraries/lib-xml/XMLWriter.cpp
+++ b/libraries/lib-xml/XMLWriter.cpp
@@ -178,9 +178,14 @@ void XMLWriter::WriteAttr(const wxString &name, long long value)
 void XMLWriter::WriteAttr(const wxString &name, size_t value)
 // may throw from Write()
 {
-   Write(wxString::Format(wxT(" %s=\"%lld\""),
+   // Format as unsigned: size_t is unsigned, and the previous
+   // long-long-with-%lld cast produced negative decimals for any
+   // value with bit 63 set on 64-bit platforms (e.g. a uint64_t
+   // bitmap with bit 63 set, written via this overload, was saved
+   // as something like "-9223372036854775808" and lost on reload).
+   Write(wxString::Format(wxT(" %s=\"%llu\""),
       name,
-      (long long) value));
+      static_cast<unsigned long long>(value)));
 }
 
 void XMLWriter::WriteAttr(const wxString &name, float value, int digits)
@@ -510,8 +515,22 @@ void XMLUtf8BufferWriter::WriteAttr(
 
 void XMLUtf8BufferWriter::WriteAttr(const std::string_view& name, size_t value)
 {
-   // Well, that maintains the original behavior
-   WriteAttr(name, static_cast<long long>(value));
+   // Mirror of the XMLWriter::WriteAttr(size_t) fix: format as
+   // unsigned so values with bit 63 set don't render as negative
+   // decimals.  Cannot delegate to the long-long overload below
+   // (as the previous implementation did) because that overload's
+   // signed-format would round-trip the high-bit value back through
+   // the same bug.  Spell out the unsigned-formatting path here.
+   constexpr size_t bufferSize =
+      std::numeric_limits<unsigned long long>::digits10 + 1 +
+      1; // extra byte for safety (ToChars does not write a NUL)
+   char buffer[bufferSize];
+   const auto result = ToChars(
+      buffer, buffer + bufferSize,
+      static_cast<unsigned long long>(value));
+   if (result.ec != std::errc())
+      THROW_INCONSISTENCY_EXCEPTION;
+   WriteAttr(name, std::string_view(buffer, result.ptr - buffer));
 }
 
 void XMLUtf8BufferWriter::WriteAttr(


### PR DESCRIPTION
## Summary

`XMLWriter::WriteAttr(const wxString&, size_t)` and the matching `XMLUtf8BufferWriter::WriteAttr(string_view, size_t)` cast through `long long` and format with `%lld`. On 64-bit platforms any `size_t` value with bit 63 set overflows the signed range and renders as a negative decimal:

```cpp
size_t v = 1ull << 63;
WriteAttr("x", v);
// produces ' x="-9223372036854775808"' instead of
//          ' x="9223372036854775808"'
```

The corresponding readers use `TryGet(unsigned long long&)`, so the round-trip loses or corrupts bit-63 information depending on how `strtoull` handles the stray minus sign. Any code path that serializes a `uint64_t` bitmask or a large `size_t` through these overloads is affected.

This PR switches the writes to `%llu` + `unsigned long long`, making the round-trip lossless for the full 64-bit range.

## Context

Found while wiring a 64-bit bitmask attribute through this exact path on a downstream branch — high-bit values came back as zero on reload. No code currently in `audacity3` writes a `size_t` with bit 63 set, but this is a real round-trip bug for any future attribute that does, and the fix is contained to two functions.

## Test plan

- [x] Builds clean on Linux Debug (Ubuntu 24.04, GCC 11, Ninja).
- [x] All existing unit tests pass (`ctest -E "time-and-pitch|journal"` = 13/13).
- [ ] No new test added — the fix is a one-line format-string change in two functions and existing readers already use the unsigned overload. The existing round-trip tests already cover the contract; they just don't currently exercise a value with bit 63 set.