### PR TITLE
Fix Regular interval labels in the Tools menu

### DIFF
--- a/au3/libraries/au3-nyquist-effects/NyquistBase.cpp
+++ b/au3/libraries/au3-nyquist-effects/NyquistBase.cpp
@@ -1922,7 +1922,14 @@ bool NyquistBase::Parse(
     }
 
     if (len >= 2 && tokens[0] == wxT("type")) {
+        const auto isEffectTypeToken = [](const wxString& token) {
+            return token == wxT("process")
+                   || token == wxT("generate")
+                   || token == wxT("analyze");
+        };
+
         wxString tok = tokens[1];
+        int groupIndex = 2;
         mIsTool = false;
         if (tok == wxT("tool")) {
             mIsTool = true;
@@ -1934,8 +1941,9 @@ bool NyquistBase::Parse(
             // ;type tool analyze
             // The last three are placed in the tool menu, but are processed as
             // process, generate or analyze.
-            if (len >= 3) {
+            if (len >= 3 && isEffectTypeToken(tokens[2])) {
                 tok = tokens[2];
+                groupIndex = 3;
             }
         }
 
@@ -1947,8 +1955,8 @@ bool NyquistBase::Parse(
             mType = EffectTypeAnalyze;
         }
 
-        if (len >= 3) {
-            const auto& tok = tokens[2];
+        if (len > groupIndex) {
+            const auto& tok = tokens[groupIndex];
             if (tok == wxT("nogroup")) {
                 mGroup = EffectGroup::None;
             } else if (tok == wxT("volumeandcompression")) {

--- a/share/nyquist-plug-ins/equalabel.ny
+++ b/share/nyquist-plug-ins/equalabel.ny
@@ -1,6 +1,6 @@
 $nyquist plug-in
 $version 5
-$type tool nogroup
+$type tool analyze nogroup
 $debugbutton false
 $debugflags trace
 $name (_ "Regular interval labels")

--- a/src/effects/nyquist/CMakeLists.txt
+++ b/src/effects/nyquist/CMakeLists.txt
@@ -40,3 +40,7 @@ set(MODULE_LINK au3wrap effects_builtin au3-nyquist-effects)
 add_subdirectory(${CMAKE_SOURCE_DIR}/thirdparty/libnyquist libnyquist)
 
 setup_module()
+
+if (AU_BUILD_EFFECTS_TESTS)
+    add_subdirectory(tests)
+endif()

--- a/src/effects/nyquist/tests/CMakeLists.txt
+++ b/src/effects/nyquist/tests/CMakeLists.txt
@@ -1,0 +1,22 @@
+#
+# Audacity: A Digital Audio Editor
+#
+
+set(MODULE_TEST effects_nyquist_tests)
+
+set(MODULE_TEST_SRC
+    ${CMAKE_CURRENT_LIST_DIR}/nyquistbase_tests.cpp
+)
+
+# AU3 - needed because test files include AU3 headers
+include(${PROJECT_SOURCE_DIR}/src/au3wrap/au3wrapDefs.cmake)
+
+set(MODULE_TEST_INCLUDE ${AU3_INCLUDE})
+set(MODULE_TEST_DEF ${AU3_DEF})
+set(MODULE_TEST_LINK
+    au3-nyquist-effects
+    ${AU3_LINK}
+)
+set(MODULE_TEST_DATA_ROOT ${CMAKE_CURRENT_LIST_DIR})
+
+include(SetupGTest)

--- a/src/effects/nyquist/tests/nyquistbase_tests.cpp
+++ b/src/effects/nyquist/tests/nyquistbase_tests.cpp
@@ -1,0 +1,118 @@
+/*
+* Audacity: A Digital Audio Editor
+*/
+#include <gtest/gtest.h>
+
+#include "au3-nyquist-effects/NyquistBase.h"
+
+class TestNyquistBase final : public NyquistBase
+{
+public:
+    TestNyquistBase()
+        : NyquistBase(NYQUIST_WORKER_ID)
+    {
+    }
+
+    bool ParseScript(const wxString& script)
+    {
+        return ParseCommand(script);
+    }
+};
+
+static void ParseTypeLine(
+    TestNyquistBase& effect, const wxString& typeLine)
+{
+    wxString script("$nyquist plug-in\n");
+    script += typeLine;
+    script += wxString("\n(return 1)\n");
+
+    EXPECT_TRUE(effect.ParseScript(script));
+}
+
+TEST(NyquistBaseTests, ParsesToolEffectTypeAndGroup)
+{
+    TestNyquistBase effect;
+
+    ParseTypeLine(effect, "$type tool analyze nogroup");
+
+    EXPECT_EQ(EffectTypeAnalyze, effect.GetType());
+    EXPECT_EQ(EffectTypeTool, effect.GetClassification());
+    EXPECT_EQ(EffectGroup::None, effect.GetGroup());
+}
+
+TEST(NyquistBaseTests, ParsesToolGroupWithoutSubtype)
+{
+    TestNyquistBase effect;
+
+    ParseTypeLine(effect, "$type tool nogroup");
+
+    EXPECT_EQ(EffectTypeTool, effect.GetType());
+    EXPECT_EQ(EffectTypeTool, effect.GetClassification());
+    EXPECT_EQ(EffectGroup::None, effect.GetGroup());
+}
+
+TEST(NyquistBaseTests, ParsesGroupedToolSubtype)
+{
+    TestNyquistBase effect;
+
+    ParseTypeLine(effect, "$type tool process volumeandcompression");
+
+    EXPECT_EQ(EffectTypeProcess, effect.GetType());
+    EXPECT_EQ(EffectTypeTool, effect.GetClassification());
+    EXPECT_EQ(EffectGroup::VolumeAndCompression, effect.GetGroup());
+}
+
+TEST(NyquistBaseTests, ParsesGroupedToolGenerateSubtype)
+{
+    TestNyquistBase effect;
+
+    ParseTypeLine(effect, "$type tool generate eqandfilters");
+
+    EXPECT_EQ(EffectTypeGenerate, effect.GetType());
+    EXPECT_EQ(EffectTypeTool, effect.GetClassification());
+    EXPECT_EQ(EffectGroup::EqAndFilters, effect.GetGroup());
+}
+
+TEST(NyquistBaseTests, ParsesNonToolGroup)
+{
+    TestNyquistBase effect;
+
+    ParseTypeLine(effect, "$type analyze nogroup");
+
+    EXPECT_EQ(EffectTypeAnalyze, effect.GetType());
+    EXPECT_EQ(EffectTypeAnalyze, effect.GetClassification());
+    EXPECT_EQ(EffectGroup::None, effect.GetGroup());
+}
+
+TEST(NyquistBaseTests, ParsesBareToolType)
+{
+    TestNyquistBase effect;
+
+    ParseTypeLine(effect, "$type tool");
+
+    EXPECT_EQ(EffectTypeTool, effect.GetType());
+    EXPECT_EQ(EffectTypeTool, effect.GetClassification());
+    EXPECT_EQ(EffectGroup::Unspecified, effect.GetGroup());
+}
+
+TEST(NyquistBaseTests, ParsesToolAnalyzeSubtypeWithoutGroup)
+{
+    TestNyquistBase effect;
+
+    ParseTypeLine(effect, "$type tool analyze");
+
+    EXPECT_EQ(EffectTypeAnalyze, effect.GetType());
+    EXPECT_EQ(EffectTypeTool, effect.GetClassification());
+    EXPECT_EQ(EffectGroup::Unspecified, effect.GetGroup());
+}
+
+TEST(NyquistBaseTests, ParsesToolProcessSubtypeWithoutGroup)
+{
+    TestNyquistBase effect;
+
+    ParseTypeLine(effect, "$type tool process");
+
+    EXPECT_EQ(EffectTypeProcess, effect.GetType());
+    EXPECT_EQ(EffectTypeTool, effect.GetClassification());
+    EXPECT_EQ(EffectGroup::Unspecified, effect.GetGroup());
+}


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/10782

Regular interval labels was declared as a plain Tools-menu item, so it did not receive the selected audio it needs to generate labels. This change lets Nyquist tools declare an explicit process/generate/analyze subtype before an optional group token, updates Regular interval labels to run as a Tools-menu analyzer, and adds parser regression coverage for subtype/group combinations.

Validation performed:
- `cmake --build build/gitproof-app -j 8`
- `cmake --build build/gitproof-utest --target au3-nyquist-effects nyquist-plug-ins effects_nyquist_tests -j 8`
- `ctest --test-dir build/gitproof-utest -R '^effects_nyquist_tests$' -V`
- `ctest --test-dir build/gitproof-app -V`
- `build/gitproof-app/src/app/audacity.app/Contents/MacOS/audacity --plugin-registration-self-test`
- `git diff --check`

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
- Targeted parser and plugin-registration validation were run as listed above.