### PR TITLE
Fix crash in DTMF generator

### DIFF
--- a/src/effects/builtin/view/builtineffectmodel.cpp
+++ b/src/effects/builtin/view/builtineffectmodel.cpp
@@ -3,6 +3,7 @@
 */
 #include "builtineffectmodel.h"
 
+#include "framework/global/defer.h"
 #include "framework/global/log.h"
 
 using namespace au::effects;
@@ -16,6 +17,9 @@ BuiltinEffectModel::BuiltinEffectModel(QObject* parent, int instanceId)
 void BuiltinEffectModel::doInit()
 {
     instancesRegister()->settingsChanged(m_instanceId).onNotify(this, [this]() {
+        if (m_selfNotificationDepth > 0) {
+            return;
+        }
         doReload();
     });
 
@@ -73,6 +77,10 @@ void BuiltinEffectModel::modifySettings(const std::function<void(EffectSettings&
         return nullptr;
     });
 
+    ++m_selfNotificationDepth;
+    DEFER {
+        --m_selfNotificationDepth;
+    };
     instancesRegister()->notifyAboutSettingsChanged(m_instanceId);
 }
 

--- a/src/effects/builtin/view/builtineffectmodel.h
+++ b/src/effects/builtin/view/builtineffectmodel.h
@@ -78,5 +78,7 @@ private:
     void doStopPreview() override;
 
     EffectSettingsAccessPtr settingsAccess() const;
+
+    int m_selfNotificationDepth = 0;
 };
 }


### PR DESCRIPTION
Resolves: #10563

Fixes stack overflow, when a model update emits modifySettings

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
