### PR TITLE
Nyquist effects/generators: add text boxes for parameter values #10486

### DIFF
--- a/src/effects/effects_base/effects_base.qrc
+++ b/src/effects/effects_base/effects_base.qrc
@@ -10,6 +10,7 @@
         <file>qml/Audacity/Effects/MissingPluginsDialog.qml</file>
         <file>qml/Audacity/Effects/PresetNameDialog.qml</file>
         <file>qml/Audacity/Effects/GeneratedEffectViewer.qml</file>
+        <file>qml/Audacity/Effects/GeneratedIncrementalPropertyControl.qml</file>
         <file>qml/Audacity/Effects/ParameterControl.qml</file>
         <file>qml/Audacity/Effects/PluginManagerDialog.qml</file>
         <file>qml/Audacity/Effects/PluginManagerTableView.qml</file>

--- a/src/effects/effects_base/effectstypes.h
+++ b/src/effects/effects_base/effectstypes.h
@@ -3,6 +3,8 @@
 */
 #pragma once
 
+#include <algorithm>
+#include <cmath>
 #include <vector>
 
 #include "framework/global/types/string.h"
@@ -118,7 +120,33 @@ struct ParameterInfo {
     bool isInteger = false;
     bool canAutomate = true;
 
+    // -1 means "auto-derive from stepSize / isInteger". Effects can override
+    // for cases where display precision and stepSize differ (e.g. sliding-stretch).
+    int numDecimalsOverride = -1;
+
     bool isValid() const { return !id.empty(); }
+
+    //! Number of decimals to display for numeric input.
+    //! Honors `numDecimalsOverride` if set; otherwise derives from `stepSize`.
+    int numDecimals() const
+    {
+        if (numDecimalsOverride >= 0) {
+            return numDecimalsOverride;
+        }
+        if (isInteger) {
+            return 0;
+        }
+        if (!(stepSize > 0)) {
+            return 2;
+        }
+        int n = 0;
+        double s = stepSize;
+        while (n < 6 && std::abs(s - std::round(s)) > 1e-9 * std::max(1.0, std::abs(s))) {
+            s *= 10.0;
+            ++n;
+        }
+        return n;
+    }
 
     //! Convert current "Full Range" value to normalized [0,1] for plugin API calls
     double getNormalizedValue() const

--- a/src/effects/effects_base/internal/effectparametersprovider.cpp
+++ b/src/effects/effects_base/internal/effectparametersprovider.cpp
@@ -195,12 +195,12 @@ void EffectParametersProvider::beginParameterGesture(EffectInstanceId instanceId
     const EffectId effectId = instancesRegister()->effectIdByInstanceId(instanceId);
     const EffectFamily family = getEffectFamily(effectId);
 
-    const IParameterExtractorService* extractor = parameterExtractorRegistry()
-                                                  ? parameterExtractorRegistry()->extractorForFamily(family)
-                                                  : nullptr;
+    IParameterExtractorService* extractor = parameterExtractorRegistry()
+                                            ? parameterExtractorRegistry()->extractorForFamily(family)
+                                            : nullptr;
     if (extractor) {
         EffectSettingsAccessPtr settingsAccess = instancesRegister()->settingsAccessById(instanceId);
-        const_cast<IParameterExtractorService*>(extractor)->beginParameterGesture(instance, parameterId, settingsAccess);
+        extractor->beginParameterGesture(instance, parameterId, settingsAccess);
     }
 }
 
@@ -214,11 +214,11 @@ void EffectParametersProvider::endParameterGesture(EffectInstanceId instanceId, 
     const EffectId effectId = instancesRegister()->effectIdByInstanceId(instanceId);
     const EffectFamily family = getEffectFamily(effectId);
 
-    const IParameterExtractorService* extractor = parameterExtractorRegistry()
-                                                  ? parameterExtractorRegistry()->extractorForFamily(family)
-                                                  : nullptr;
+    IParameterExtractorService* extractor = parameterExtractorRegistry()
+                                            ? parameterExtractorRegistry()->extractorForFamily(family)
+                                            : nullptr;
     if (extractor) {
-        const_cast<IParameterExtractorService*>(extractor)->endParameterGesture(instance, parameterId);
+        extractor->endParameterGesture(instance, parameterId);
     }
 }
 

--- a/src/effects/effects_base/qml/Audacity/Effects/GeneratedEffectViewer.qml
+++ b/src/effects/effects_base/qml/Audacity/Effects/GeneratedEffectViewer.qml
@@ -48,7 +48,7 @@ Rectangle {
 
         readonly property int dialogWidth: 640
         readonly property int maxDialogHeight: 340 // real ~444px with system bar on Mac
-        readonly property int maxContentWidth: 512
+        readonly property int maxContentWidth: 580
     }
 
     property var viewModel: GeneratedEffectViewerModelFactory.createModel(root, root.instanceId)

--- a/src/effects/effects_base/qml/Audacity/Effects/GeneratedEffectViewer.qml
+++ b/src/effects/effects_base/qml/Audacity/Effects/GeneratedEffectViewer.qml
@@ -47,7 +47,7 @@ Rectangle {
         readonly property int borderRadius: 4
 
         readonly property int dialogWidth: 640
-        readonly property int maxDialogHeight: 340 // real ~444px with system bar on Mac
+        readonly property int maxDialogHeight: 348 // real ~452px with system bar on Mac
         readonly property int maxContentWidth: 580
     }
 

--- a/src/effects/effects_base/qml/Audacity/Effects/GeneratedIncrementalPropertyControl.qml
+++ b/src/effects/effects_base/qml/Audacity/Effects/GeneratedIncrementalPropertyControl.qml
@@ -1,0 +1,56 @@
+/*
+* Audacity: A Digital Audio Editor
+*/
+import QtQuick
+
+import Muse.UiComponents
+
+IncrementalPropertyControl {
+    id: root
+
+    property var parameterData: null
+
+    signal gestureStarted
+    signal gestureEnded
+    signal valueCommitted(double newValue)
+
+    currentValue: parameterData ? parameterData.currentValue : 0
+    minValue: parameterData ? parameterData.minValue : 0
+    maxValue: parameterData ? parameterData.maxValue : 1
+    step: parameterData && parameterData.stepSize > 0 ? parameterData.stepSize : 0.01
+    decimals: parameterData ? parameterData.numDecimals : 2
+    measureUnitsSymbol: parameterData ? parameterData.units : ""
+    enabled: parameterData ? !parameterData.isReadOnly : false
+
+    property bool isEditing: false
+
+    // Guard against re-entry when the model echoes back the same value.
+    property double lastCommittedValue: NaN
+
+    onActiveFocusChanged: {
+        if (activeFocus && !isEditing) {
+            isEditing = true
+            gestureStarted()
+        } else if (!activeFocus && isEditing) {
+            isEditing = false
+            gestureEnded()
+        }
+    }
+
+    onValueEdited: function (newValue) {
+        if (newValue === lastCommittedValue) {
+            return
+        }
+        lastCommittedValue = newValue
+
+        if (!isEditing) {
+            isEditing = true
+            gestureStarted()
+        }
+        valueCommitted(newValue)
+        if (!activeFocus && isEditing) {
+            isEditing = false
+            gestureEnded()
+        }
+    }
+}

--- a/src/effects/effects_base/qml/Audacity/Effects/ParameterControl.qml
+++ b/src/effects/effects_base/qml/Audacity/Effects/ParameterControl.qml
@@ -39,6 +39,7 @@ Item {
         readonly property int labelWidth: 192
         readonly property int controlWidth: 160
         readonly property int numericControlWidth: 160
+        readonly property int compactInputWidth: 80
         readonly property int valueDisplayWidth: 160
     }
 
@@ -172,13 +173,13 @@ Item {
     Component {
         id: sliderControl
 
-        Row {
+        RowLayout {
             spacing: prv.spaceL
 
             StyledSlider {
                 id: slider
-                anchors.verticalCenter: parent.verticalCenter
-                width: prv.controlWidth
+                Layout.preferredWidth: prv.controlWidth
+                Layout.alignment: Qt.AlignVCenter
 
                 from: parameterData ? parameterData.minValue : 0
                 to: parameterData ? parameterData.maxValue : 1
@@ -201,11 +202,57 @@ Item {
                 }
             }
 
-            // Display formatted value from plugin (like AU3 does)
+            IncrementalPropertyControl {
+                id: sliderInput
+                Layout.preferredWidth: prv.compactInputWidth
+                Layout.alignment: Qt.AlignVCenter
+
+                currentValue: parameterData ? parameterData.currentValue : 0
+                minValue: parameterData ? parameterData.minValue : 0
+                maxValue: parameterData ? parameterData.maxValue : 1
+                step: parameterData && parameterData.stepSize > 0 ? parameterData.stepSize : 0.01
+                decimals: parameterData && parameterData.isInteger ? 0 : 2
+                measureUnitsSymbol: ""
+                enabled: parameterData ? !parameterData.isReadOnly : false
+
+                // Track editing state for gesture
+                property bool isEditing: false
+
+                // Handle focus changes for gesture tracking
+                onActiveFocusChanged: {
+                    if (activeFocus && !isEditing) {
+                        isEditing = true
+                        root.gestureStarted(root.parameterId)
+                    } else if (!activeFocus && isEditing) {
+                        isEditing = false
+                        root.gestureEnded(root.parameterId)
+                    }
+                }
+
+                onValueEdited: function (newValue) {
+                    // If not already editing (e.g., increment/decrement button without focus), start gesture
+                    if (!isEditing) {
+                        isEditing = true
+                        root.gestureStarted(root.parameterId)
+                    }
+
+                    root.valueChanged(root.parameterId, newValue);
+
+                    // For button clicks without focus, end gesture immediately
+                    if (!activeFocus && isEditing) {
+                        isEditing = false
+                        root.gestureEnded(root.parameterId)
+                    }
+                }
+            }
+
             StyledTextLabel {
-                anchors.verticalCenter: parent.verticalCenter
-                text: parameterData ? parameterData.formattedValue : ""
+                Layout.fillWidth: true
+                Layout.alignment: Qt.AlignVCenter
+                text: parameterData ? parameterData.units : ""
+                visible: parameterData && parameterData.units && parameterData.units.length > 0
                 horizontalAlignment: Text.AlignLeft
+                elide: Text.ElideRight
             }
         }
     }

--- a/src/effects/effects_base/qml/Audacity/Effects/ParameterControl.qml
+++ b/src/effects/effects_base/qml/Audacity/Effects/ParameterControl.qml
@@ -41,6 +41,12 @@ Item {
         readonly property int numericControlWidth: 100
         readonly property int compactInputWidth: 80
         readonly property int valueDisplayWidth: 160
+        readonly property int descriptionMaxWidth: 200
+        readonly property int sliderMaxWidth: 280
+        readonly property int sliderShortMaxWidth: 200
+        readonly property int dropdownMaxWidth: 260
+        readonly property int textControlWidth: 240
+        readonly property int filePickerWidth: 320
     }
 
     RowLayout {
@@ -64,7 +70,6 @@ Item {
         // Control loader - loads different controls based on parameter type
         Loader {
             id: controlLoader
-            Layout.fillWidth: true
             Layout.alignment: Qt.AlignVCenter
 
             sourceComponent: {
@@ -93,6 +98,25 @@ Item {
                     return unknownControl
                 }
             }
+        }
+
+        // Optional human-readable hint, shared across all control types.
+        // Capped width with word-wrap so long Nyquist labels stay readable.
+        StyledTextLabel {
+            id: descriptionLabel
+            Layout.alignment: Qt.AlignVCenter
+            Layout.maximumWidth: prv.descriptionMaxWidth
+            text: parameterData ? parameterData.description : ""
+            visible: text.length > 0
+            horizontalAlignment: Text.AlignLeft
+            verticalAlignment: Text.AlignVCenter
+            wrapMode: Text.WordWrap
+        }
+
+        // Trailing fillWidth filler so the loader + description sit at their
+        // content widths (left side of the row) rather than spreading out.
+        Item {
+            Layout.fillWidth: true
         }
     }
 
@@ -126,7 +150,7 @@ Item {
 
             StyledDropdown {
                 id: dropdown
-                Layout.preferredWidth: prv.controlWidth
+                Layout.maximumWidth: prv.dropdownMaxWidth
                 Layout.alignment: Qt.AlignVCenter
 
                 currentIndex: parameterData ? parameterData.currentEnumIndex : 0
@@ -159,15 +183,6 @@ Item {
                     root.gestureEnded(root.parameterId)
                 }
             }
-
-            StyledTextLabel {
-                Layout.fillWidth: true
-                Layout.alignment: Qt.AlignVCenter
-                text: parameterData ? parameterData.units : ""
-                visible: parameterData && parameterData.units && parameterData.units.length > 0
-                horizontalAlignment: Text.AlignLeft
-                elide: Text.ElideRight
-            }
         }
     }
 
@@ -180,7 +195,10 @@ Item {
 
             StyledSlider {
                 id: slider
-                Layout.preferredWidth: prv.controlWidth
+                // Tighten the slider when there's a description label so the
+                // hint text has room and doesn't get pushed off the row.
+                Layout.preferredWidth: descriptionLabel.visible ? prv.sliderShortMaxWidth : prv.sliderMaxWidth
+                Layout.minimumWidth: prv.controlWidth
                 Layout.alignment: Qt.AlignVCenter
 
                 from: parameterData ? parameterData.minValue : 0
@@ -204,57 +222,16 @@ Item {
                 }
             }
 
-            IncrementalPropertyControl {
-                id: sliderInput
+            GeneratedIncrementalPropertyControl {
                 Layout.preferredWidth: prv.compactInputWidth
                 Layout.alignment: Qt.AlignVCenter
+                parameterData: root.parameterData
 
-                currentValue: parameterData ? parameterData.currentValue : 0
-                minValue: parameterData ? parameterData.minValue : 0
-                maxValue: parameterData ? parameterData.maxValue : 1
-                step: parameterData && parameterData.stepSize > 0 ? parameterData.stepSize : 0.01
-                decimals: parameterData && parameterData.isInteger ? 0 : 2
-                measureUnitsSymbol: ""
-                enabled: parameterData ? !parameterData.isReadOnly : false
-
-                // Track editing state for gesture
-                property bool isEditing: false
-
-                // Handle focus changes for gesture tracking
-                onActiveFocusChanged: {
-                    if (activeFocus && !isEditing) {
-                        isEditing = true
-                        root.gestureStarted(root.parameterId)
-                    } else if (!activeFocus && isEditing) {
-                        isEditing = false
-                        root.gestureEnded(root.parameterId)
-                    }
+                onGestureStarted: root.gestureStarted(root.parameterId)
+                onGestureEnded: root.gestureEnded(root.parameterId)
+                onValueCommitted: function (v) {
+                    root.valueChanged(root.parameterId, v)
                 }
-
-                onValueEdited: function (newValue) {
-                    // If not already editing (e.g., increment/decrement button without focus), start gesture
-                    if (!isEditing) {
-                        isEditing = true
-                        root.gestureStarted(root.parameterId)
-                    }
-
-                    root.valueChanged(root.parameterId, newValue);
-
-                    // For button clicks without focus, end gesture immediately
-                    if (!activeFocus && isEditing) {
-                        isEditing = false
-                        root.gestureEnded(root.parameterId)
-                    }
-                }
-            }
-
-            StyledTextLabel {
-                Layout.fillWidth: true
-                Layout.alignment: Qt.AlignVCenter
-                text: parameterData ? parameterData.units : ""
-                visible: parameterData && parameterData.units && parameterData.units.length > 0
-                horizontalAlignment: Text.AlignLeft
-                elide: Text.ElideRight
             }
         }
     }
@@ -266,59 +243,16 @@ Item {
         RowLayout {
             spacing: prv.spaceL
 
-            IncrementalPropertyControl {
-                id: numericInput
+            GeneratedIncrementalPropertyControl {
                 Layout.preferredWidth: prv.numericControlWidth
                 Layout.alignment: Qt.AlignVCenter
+                parameterData: root.parameterData
 
-                currentValue: parameterData ? parameterData.currentValue : 0
-                minValue: parameterData ? parameterData.minValue : 0
-                maxValue: parameterData ? parameterData.maxValue : 1
-                step: parameterData && parameterData.stepSize > 0 ? parameterData.stepSize : 0.01
-                decimals: parameterData && parameterData.isInteger ? 0 : 2
-                measureUnitsSymbol: ""
-                enabled: parameterData ? !parameterData.isReadOnly : false
-
-                // Track editing state for gesture
-                property bool isEditing: false
-
-                // Handle focus changes for gesture tracking
-                onActiveFocusChanged: {
-                    if (activeFocus && !isEditing) {
-                        // User focused the control - begin gesture
-                        isEditing = true
-                        root.gestureStarted(root.parameterId)
-                    } else if (!activeFocus && isEditing) {
-                        // User left the control - end gesture
-                        isEditing = false
-                        root.gestureEnded(root.parameterId)
-                    }
+                onGestureStarted: root.gestureStarted(root.parameterId)
+                onGestureEnded: root.gestureEnded(root.parameterId)
+                onValueCommitted: function (v) {
+                    root.valueChanged(root.parameterId, v)
                 }
-
-                onValueEdited: function (newValue) {
-                    // If not already editing (e.g., increment/decrement button without focus), start gesture
-                    if (!isEditing) {
-                        isEditing = true
-                        root.gestureStarted(root.parameterId)
-                    }
-
-                    root.valueChanged(root.parameterId, newValue);
-
-                    // For button clicks without focus, end gesture immediately
-                    if (!activeFocus && isEditing) {
-                        isEditing = false
-                        root.gestureEnded(root.parameterId)
-                    }
-                }
-            }
-
-            StyledTextLabel {
-                Layout.fillWidth: true
-                Layout.alignment: Qt.AlignVCenter
-                text: parameterData ? parameterData.units : ""
-                visible: parameterData && parameterData.units && parameterData.units.length > 0
-                horizontalAlignment: Text.AlignLeft
-                elide: Text.ElideRight
             }
         }
     }
@@ -327,8 +261,12 @@ Item {
     Component {
         id: timeControl
 
+        // Wrapper RowLayout + fillWidth filler so Timecode (NumericView, itself
+        // a RowLayout) keeps its content-sized implicit width when the Loader
+        // grows wider than its content. Without this, Timecode's internal
+        // items (display + arrow-menu button) spread apart with a gap.
         RowLayout {
-            spacing: prv.spaceL
+            spacing: 0
 
             Timecode {
                 id: timecode
@@ -355,13 +293,8 @@ Item {
                 }
             }
 
-            StyledTextLabel {
+            Item {
                 Layout.fillWidth: true
-                Layout.alignment: Qt.AlignVCenter
-                text: parameterData ? parameterData.units : ""
-                visible: parameterData && parameterData.units && parameterData.units.length > 0
-                horizontalAlignment: Text.AlignLeft
-                elide: Text.ElideRight
             }
         }
     }
@@ -370,44 +303,49 @@ Item {
     Component {
         id: fileControl
 
-        FilePicker {
-            id: filePicker
-            width: parent.width
+        RowLayout {
+            spacing: prv.spaceL
 
-            path: parameterData ? parameterData.currentValueString : ""
+            FilePicker {
+                id: filePicker
+                Layout.preferredWidth: prv.filePickerWidth
+                Layout.alignment: Qt.AlignVCenter
 
-            pickerType: {
-                if (!parameterData) {
+                path: parameterData ? parameterData.currentValueString : ""
+
+                pickerType: {
+                    if (!parameterData) {
+                        return FilePicker.PickerType.File
+                    }
+
+                    // If "save" flag is set, use Any type (save dialog)
+                    if (parameterData.isFileSave) {
+                        return FilePicker.PickerType.Any
+                    }
+
+                    // Otherwise use File type (open dialog)
+                    // Note: Multiple file selection is not yet fully supported in the Framework
+                    // but the flag is available for future implementation
                     return FilePicker.PickerType.File
                 }
 
-                // If "save" flag is set, use Any type (save dialog)
-                if (parameterData.isFileSave) {
-                    return FilePicker.PickerType.Any
+                enabled: parameterData ? !parameterData.isReadOnly : false
+
+                // Set file filters from parameterData
+                filter: {
+                    if (!parameterData || !parameterData.fileFilters || parameterData.fileFilters.length === 0) {
+                        return ""
+                    }
+                    // Join all filters with ";;" separator for Qt file dialog
+                    return parameterData.fileFilters.join(";;")
                 }
 
-                // Otherwise use File type (open dialog)
-                // Note: Multiple file selection is not yet fully supported in the Framework
-                // but the flag is available for future implementation
-                return FilePicker.PickerType.File
-            }
-
-            enabled: parameterData ? !parameterData.isReadOnly : false
-
-            // Set file filters from parameterData
-            filter: {
-                if (!parameterData || !parameterData.fileFilters || parameterData.fileFilters.length === 0) {
-                    return ""
+                onPathEdited: function (newPath) {
+                    // File selection is a single atomic operation - begin and end gesture immediately
+                    root.gestureStarted(root.parameterId)
+                    root.stringValueChanged(root.parameterId, newPath)
+                    root.gestureEnded(root.parameterId)
                 }
-                // Join all filters with ";;" separator for Qt file dialog
-                return parameterData.fileFilters.join(";;")
-            }
-
-            onPathEdited: function (newPath) {
-                // File selection is a single atomic operation - begin and end gesture immediately
-                root.gestureStarted(root.parameterId)
-                root.stringValueChanged(root.parameterId, newPath)
-                root.gestureEnded(root.parameterId)
             }
         }
     }
@@ -421,26 +359,23 @@ Item {
 
             TextInputField {
                 id: textField
-                Layout.preferredWidth: prv.controlWidth
+                Layout.preferredWidth: prv.textControlWidth
                 Layout.alignment: Qt.AlignVCenter
 
                 currentText: parameterData ? parameterData.currentValueString : ""
                 enabled: parameterData ? !parameterData.isReadOnly : false
 
-                onTextEdited: function (newTextValue) {
-                    root.gestureStarted(root.parameterId)
-                    root.stringValueChanged(root.parameterId, newTextValue)
-                    root.gestureEnded(root.parameterId)
+                onActiveFocusChanged: {
+                    if (activeFocus) {
+                        root.gestureStarted(root.parameterId)
+                    } else {
+                        root.gestureEnded(root.parameterId)
+                    }
                 }
-            }
 
-            StyledTextLabel {
-                Layout.fillWidth: true
-                Layout.alignment: Qt.AlignVCenter
-                text: parameterData ? parameterData.units : ""
-                visible: parameterData && parameterData.units && parameterData.units.length > 0
-                horizontalAlignment: Text.AlignLeft
-                elide: Text.ElideRight
+                onTextEdited: function (newTextValue) {
+                    root.stringValueChanged(root.parameterId, newTextValue)
+                }
             }
         }
     }
@@ -453,8 +388,6 @@ Item {
             text: parameterData ? parameterData.formattedValue : ""
             opacity: 0.7
             wrapMode: Text.WordWrap
-            Layout.alignment: Qt.AlignVCenter
-            Layout.fillWidth: true
             horizontalAlignment: Text.AlignLeft
         }
     }

--- a/src/effects/effects_base/qml/Audacity/Effects/ParameterControl.qml
+++ b/src/effects/effects_base/qml/Audacity/Effects/ParameterControl.qml
@@ -36,9 +36,9 @@ Item {
         readonly property int spaceM: 8
         readonly property int spaceL: 12
 
-        readonly property int labelWidth: 192
-        readonly property int controlWidth: 160
-        readonly property int numericControlWidth: 160
+        readonly property int labelWidth: 140
+        readonly property int controlWidth: 140
+        readonly property int numericControlWidth: 100
         readonly property int compactInputWidth: 80
         readonly property int valueDisplayWidth: 160
     }
@@ -53,9 +53,11 @@ Item {
         StyledTextLabel {
             id: paramLabel
             Layout.preferredWidth: prv.labelWidth
+            Layout.maximumWidth: prv.labelWidth
             Layout.alignment: Qt.AlignVCenter
             text: parameterData ? parameterData.name : ""
             horizontalAlignment: Text.AlignRight
+            verticalAlignment: Text.AlignVCenter
             wrapMode: Text.WordWrap
         }
 

--- a/src/effects/effects_base/qml/Audacity/Effects/ParameterControl.qml
+++ b/src/effects/effects_base/qml/Audacity/Effects/ParameterControl.qml
@@ -118,14 +118,13 @@ Item {
     Component {
         id: dropdownControl
 
-        // Wrapper Item needed to properly communicate size to parent Loader via implicitWidth/Height
-        Item {
-            implicitWidth: dropdown.width
-            implicitHeight: dropdown.height
+        RowLayout {
+            spacing: prv.spaceL
 
             StyledDropdown {
                 id: dropdown
-                width: prv.controlWidth
+                Layout.preferredWidth: prv.controlWidth
+                Layout.alignment: Qt.AlignVCenter
 
                 currentIndex: parameterData ? parameterData.currentEnumIndex : 0
 
@@ -156,6 +155,15 @@ Item {
 
                     root.gestureEnded(root.parameterId)
                 }
+            }
+
+            StyledTextLabel {
+                Layout.fillWidth: true
+                Layout.alignment: Qt.AlignVCenter
+                text: parameterData ? parameterData.units : ""
+                visible: parameterData && parameterData.units && parameterData.units.length > 0
+                horizontalAlignment: Text.AlignLeft
+                elide: Text.ElideRight
             }
         }
     }
@@ -206,22 +214,20 @@ Item {
     Component {
         id: numericControl
 
-        // Wrapper Item needed to properly communicate size to parent Loader via implicitWidth/Height
-        Item {
-            implicitWidth: numericInput.width
-            implicitHeight: numericInput.height
+        RowLayout {
+            spacing: prv.spaceL
 
             IncrementalPropertyControl {
                 id: numericInput
-                width: prv.numericControlWidth
+                Layout.preferredWidth: prv.numericControlWidth
+                Layout.alignment: Qt.AlignVCenter
 
-                // Always use normalized values (0.0 to 1.0) like AU3 does
                 currentValue: parameterData ? parameterData.currentValue : 0
                 minValue: parameterData ? parameterData.minValue : 0
                 maxValue: parameterData ? parameterData.maxValue : 1
                 step: parameterData && parameterData.stepSize > 0 ? parameterData.stepSize : 0.01
                 decimals: parameterData && parameterData.isInteger ? 0 : 2
-                measureUnitsSymbol: ""  // Don't show units here, show in formatted label
+                measureUnitsSymbol: ""
                 enabled: parameterData ? !parameterData.isReadOnly : false
 
                 // Track editing state for gesture
@@ -256,6 +262,15 @@ Item {
                     }
                 }
             }
+
+            StyledTextLabel {
+                Layout.fillWidth: true
+                Layout.alignment: Qt.AlignVCenter
+                text: parameterData ? parameterData.units : ""
+                visible: parameterData && parameterData.units && parameterData.units.length > 0
+                horizontalAlignment: Text.AlignLeft
+                elide: Text.ElideRight
+            }
         }
     }
 
@@ -263,13 +278,12 @@ Item {
     Component {
         id: timeControl
 
-        // Wrapper Item needed to properly communicate size to parent Loader via implicitWidth/Height
-        Item {
-            implicitWidth: timecode.width
-            implicitHeight: timecode.height
+        RowLayout {
+            spacing: prv.spaceL
 
             Timecode {
                 id: timecode
+                Layout.alignment: Qt.AlignVCenter
 
                 value: parameterData ? parameterData.currentValue : 0
                 mode: TimecodeModeSelector.Duration
@@ -290,6 +304,15 @@ Item {
                         root.gestureEnded(root.parameterId)
                     }
                 }
+            }
+
+            StyledTextLabel {
+                Layout.fillWidth: true
+                Layout.alignment: Qt.AlignVCenter
+                text: parameterData ? parameterData.units : ""
+                visible: parameterData && parameterData.units && parameterData.units.length > 0
+                horizontalAlignment: Text.AlignLeft
+                elide: Text.ElideRight
             }
         }
     }
@@ -344,14 +367,13 @@ Item {
     Component {
         id: textControl
 
-        // Wrapper Item needed to properly communicate size to parent Loader via implicitWidth/Height
-        Item {
-            implicitWidth: textField.width
-            implicitHeight: textField.height
+        RowLayout {
+            spacing: prv.spaceL
 
             TextInputField {
                 id: textField
-                width: prv.controlWidth
+                Layout.preferredWidth: prv.controlWidth
+                Layout.alignment: Qt.AlignVCenter
 
                 currentText: parameterData ? parameterData.currentValueString : ""
                 enabled: parameterData ? !parameterData.isReadOnly : false
@@ -361,6 +383,15 @@ Item {
                     root.stringValueChanged(root.parameterId, newTextValue)
                     root.gestureEnded(root.parameterId)
                 }
+            }
+
+            StyledTextLabel {
+                Layout.fillWidth: true
+                Layout.alignment: Qt.AlignVCenter
+                text: parameterData ? parameterData.units : ""
+                visible: parameterData && parameterData.units && parameterData.units.length > 0
+                horizontalAlignment: Text.AlignLeft
+                elide: Text.ElideRight
             }
         }
     }

--- a/src/effects/effects_base/qml/Audacity/Effects/ParameterControl.qml
+++ b/src/effects/effects_base/qml/Audacity/Effects/ParameterControl.qml
@@ -38,7 +38,7 @@ Item {
 
         readonly property int labelWidth: 140
         readonly property int controlWidth: 140
-        readonly property int numericControlWidth: 100
+        readonly property int numericControlWidth: 90
         readonly property int compactInputWidth: 80
         readonly property int valueDisplayWidth: 160
         readonly property int descriptionMaxWidth: 200

--- a/src/effects/effects_base/qml/Audacity/Effects/qmldir
+++ b/src/effects/effects_base/qml/Audacity/Effects/qmldir
@@ -4,6 +4,7 @@ EffectControlsDisablingOverlay 1.0 EffectControlsDisablingOverlay.qml
 EffectPresetsBar 1.0 EffectPresetsBar.qml
 EffectStyledDialogView 1.0 EffectStyledDialogView.qml
 GeneratedEffectViewer 1.0 GeneratedEffectViewer.qml
+GeneratedIncrementalPropertyControl 1.0 GeneratedIncrementalPropertyControl.qml
 ParameterControl 1.0 ParameterControl.qml
 PluginManagerTopPanel 1.0 PluginManagerTopPanel.qml
 PluginManagerTableView 1.0 PluginManagerTableView.qml

--- a/src/effects/effects_base/view/effectparameterslistmodel.cpp
+++ b/src/effects/effects_base/view/effectparameterslistmodel.cpp
@@ -68,6 +68,10 @@ QVariant EffectParametersListModel::data(const QModelIndex& index, int role) con
         return param.stepSize;
     case StepCountRole:
         return param.stepCount;
+    case NumDecimalsRole:
+        return param.numDecimals();
+    case DescriptionRole:
+        return param.description.toQString();
     case CurrentValueStringRole:
         return param.currentValueString.toQString();
     case FormattedValueRole:
@@ -162,6 +166,8 @@ QHash<int, QByteArray> EffectParametersListModel::roleNames() const
         { CurrentValueRole, "currentValue" },
         { StepSizeRole, "stepSize" },
         { StepCountRole, "stepCount" },
+        { NumDecimalsRole, "numDecimals" },
+        { DescriptionRole, "description" },
         { CurrentValueStringRole, "currentValueString" },
         { FormattedValueRole, "formattedValue" },
         { IsToggleCheckedRole, "isToggleChecked" },

--- a/src/effects/effects_base/view/effectparameterslistmodel.h
+++ b/src/effects/effects_base/view/effectparameterslistmodel.h
@@ -37,6 +37,8 @@ public:
         CurrentValueRole,
         StepSizeRole,
         StepCountRole,
+        NumDecimalsRole,
+        DescriptionRole,
         CurrentValueStringRole,
         FormattedValueRole,
         IsToggleCheckedRole,

--- a/src/effects/nyquist/internal/nyquistparameterextractorservice.cpp
+++ b/src/effects/nyquist/internal/nyquistparameterextractorservice.cpp
@@ -46,7 +46,9 @@ ParameterInfo convertControl(const NyqControl& ctrl)
     // Use variable name as ID
     info.id = String::fromStdString(au::au3::wxToStdString(ctrl.var));
     info.name = String::fromStdString(au::au3::wxToStdString(ctrl.name));
-    info.units = String::fromStdString(au::au3::wxToStdString(ctrl.label));
+    // Nyquist's ctrl.label is a freeform descriptor (e.g. "30 - 300 beats/minute"),
+    // not a unit symbol. Map it to `description`; leave `units` empty.
+    info.description = String::fromStdString(au::au3::wxToStdString(ctrl.label));
 
     info.type = convertControlType(ctrl.type);
 

--- a/src/effects/nyquist/internal/nyquistparameterextractorservice.cpp
+++ b/src/effects/nyquist/internal/nyquistparameterextractorservice.cpp
@@ -3,6 +3,8 @@
  */
 #include "nyquistparameterextractorservice.h"
 
+#include <cmath>
+
 #include "au3wrap/internal/wxtypes_convert.h"
 
 // AU3 Nyquist effect base class
@@ -19,9 +21,13 @@ ParameterType convertControlType(int nyqType)
     switch (nyqType) {
     case NYQ_CTRL_INT:
     case NYQ_CTRL_INT_TEXT:
+    case NYQ_CTRL_FLOAT_TEXT:
+        // `float-text` renders as a plain numeric input (no slider) to match
+        // legacy AU3 semantics (au3/src/effects/nyquist/Nyquist.cpp:487-522)
+        // and to avoid creating an unusable slider when the high bound is
+        // `nil` (parsed as FLT_MAX in NyquistBase.cpp).
         return ParameterType::Numeric;
     case NYQ_CTRL_FLOAT:
-    case NYQ_CTRL_FLOAT_TEXT:
         return ParameterType::Slider;
     case NYQ_CTRL_CHOICE:
         return ParameterType::Dropdown;
@@ -63,10 +69,17 @@ ParameterInfo convertControl(const NyqControl& ctrl)
         info.isInteger = true;
         info.stepSize = 1.0;
     } else if (ctrl.ticks > 0) {
-        // Calculate step size from ticks
+        // Calculate step size from ticks.
+        // Nyquist `float-text` / `time` controls with a `nil` bound are parsed
+        // as ±FLT_MAX in NyquistBase.cpp, and ticks is hard-coded to 1000
+        // there. Refuse to synthesise a stepSize from a non-finite or
+        // absurdly wide range: leave stepSize=0 so the QML fallback
+        // (step=0.01 in GeneratedIncrementalPropertyControl.qml) kicks in.
         const double range = ctrl.high - ctrl.low;
-        info.stepSize = range / ctrl.ticks;
-        info.stepCount = ctrl.ticks;
+        if (std::isfinite(range) && range > 0 && range < 1e15) {
+            info.stepSize = range / ctrl.ticks;
+            info.stepCount = ctrl.ticks;
+        }
     }
 
     // For choice controls, extract enum values


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/10486 

- also added missing hints to int controllers
- and changed the layout to make room for new controls and hints

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [ ] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
