### PR TITLE
Fix crash on launch after factory reset

### DIFF
--- a/share/workspaces/CMakeLists.txt
+++ b/share/workspaces/CMakeLists.txt
@@ -2,9 +2,42 @@
 # Audacity: A Digital Audio Editor
 #
 
-# Workspaces
+set(TARGET builtin-workspaces)
+
+set(WORKSPACE_FILES
+    Classic.mws
+    Music.mws
+    Modern.mws
+)
+
+if(OS_IS_MAC)
+    set(WORKSPACES_BUILD_DEST "${CMAKE_BINARY_DIR}/src/app/${AU4_SHARE_NAME}${AU4_INSTALL_NAME}workspaces")
+elseif(OS_IS_LIN)
+    set(WORKSPACES_BUILD_DEST "${CMAKE_BINARY_DIR}/share/audacity/workspaces")
+else()
+    set(WORKSPACES_BUILD_DEST "${CMAKE_BINARY_DIR}/${AU4_SHARE_NAME}${AU4_INSTALL_NAME}workspaces")
+endif()
+
+foreach(source ${WORKSPACE_FILES})
+    set(src "${CMAKE_CURRENT_SOURCE_DIR}/${source}")
+    set(dst "${WORKSPACES_BUILD_DEST}/${source}")
+
+    add_custom_command(
+        DEPENDS "${src}"
+        COMMAND ${CMAKE_COMMAND} -E make_directory "${WORKSPACES_BUILD_DEST}"
+        COMMAND ${CMAKE_COMMAND} -E copy "${src}" "${dst}"
+        OUTPUT "${dst}"
+    )
+
+    list(APPEND SOURCES "${src}")
+    list(APPEND OUTPUTS "${dst}")
+endforeach()
+
+add_custom_target(${TARGET} ALL DEPENDS ${OUTPUTS} SOURCES ${SOURCES})
+
+# Install for release builds
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/
-        DESTINATION ${AU4_SHARE_NAME}${AU4_INSTALL_NAME}/workspaces
+        DESTINATION ${AU4_SHARE_NAME}${AU4_INSTALL_NAME}workspaces
         FILES_MATCHING PATTERN "*.mws"
         PATTERN "CMakeLists.txt" EXCLUDE
         PATTERN ".*" EXCLUDE

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -228,6 +228,8 @@ if (AU_MODULE_EFFECTS_NYQUIST)
     add_dependencies(audacity nyquist-runtime nyquist-plug-ins)
 endif()
 
+add_dependencies(audacity builtin-workspaces)
+
 ###########################################
 # INSTALL
 ###########################################


### PR DESCRIPTION
Copies built-in workspace files into the app bundle at build time so a dev build has a valid fallback when the user data dir is wiped

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:
- [x] Build Audacity locally from this branch and run. Quit, then delete the user data directory. Launch Audacity and make sure it doesn't crash. That should suffice.

