### PR TITLE
Fix looping region color

### DIFF
--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/PlayRegion.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/PlayRegion.qml
@@ -18,7 +18,7 @@ Rectangle {
     y: 0
     height: parent.height / 2
 
-    color: active ? ui.theme.extra["play_region_active_color"] : ui.theme.extra["play_region_inactive_color"]
+    color: Qt.rgba(ui.theme.accentColor.r, ui.theme.accentColor.g, ui.theme.accentColor.b, active ? ui.theme.accentOpacityNormal : ui.theme.accentOpacityHover)
 
     function updatePosition() {
         let newX = context.timeToPosition(start)

--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/PlayRegion.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/PlayRegion.qml
@@ -18,7 +18,8 @@ Rectangle {
     y: 0
     height: parent.height / 2
 
-    color: Qt.rgba(ui.theme.accentColor.r, ui.theme.accentColor.g, ui.theme.accentColor.b, active ? ui.theme.accentOpacityNormal : ui.theme.accentOpacityHover)
+    color: ui.theme.accentColor
+    opacity: active ? ui.theme.accentOpacityNormal : ui.theme.accentOpacityHover
 
     function updatePosition() {
         let newX = context.timeToPosition(start)


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/9335

The looping region on the timeline ruler was painted using two hardcoded colors from `ui.theme.extra` — `play_region_active_color` and `play_region_inactive_color` — defined statically in each theme's .cfg file. These colors were fixed approximations of the default accent color and had no connection to the user's actual accent color setting in Preferences > Appearance. Changing the accent color had no effect on the region.

#### Fix

In `PlayRegion.qml`, replaced the two hardcoded extra lookups with a color derived directly from the live accent color.

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [ ] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
