### PR TITLE
10767 Modify audacity file format version

### DIFF
--- a/au3/libraries/au3-project-file-io/ProjectFileIO.cpp
+++ b/au3/libraries/au3-project-file-io/ProjectFileIO.cpp
@@ -50,9 +50,10 @@ Paul Licameli split from AudacityProject.cpp
 
 #include "au3-sqlite-helpers/sqlite/SQLiteUtils.h"
 
-// Don't change this unless the file format changes
-// in an irrevocable way
-#define AUDACITY_FILE_FORMAT_VERSION "1.3.0"
+// Identifies the XML format version embedded in the project blob.
+// Update this only when making irrevocable changes to the XML schema.
+// For db schema changes, bump PRAGMA user_version / ProjectFormatVersion instead.
+#define AUDACITY_FILE_FORMAT_VERSION "2.0.0"
 
 #undef NO_SHM
 #if !defined(__WXMSW__)

--- a/au3/libraries/au3-project/ProjectFormatVersion.cpp
+++ b/au3/libraries/au3-project/ProjectFormatVersion.cpp
@@ -49,6 +49,8 @@ bool ProjectFormatVersion::IsValid() const noexcept
     return Major != 0;
 }
 
+// ProjectFormatVersion / PRAGMA user_version tracks the SQLite database schema (tables, columns, indexes).
+// For XML schema changes, bump AUDACITY_FILE_FORMAT_VERSION instead.
 const ProjectFormatVersion SupportedProjectFormatVersion = {
     AUDACITY_VERSION, AUDACITY_RELEASE, AUDACITY_REVISION, AUDACITY_MODLEVEL
 };


### PR DESCRIPTION
Resolves: #10767 

Au4 added a FT_BLOB to store the project thumbnail.
It is now incompatible with au3 code.
Increasing the file format version will result in au3 opening a nice dialog UI the correct error message.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
