### PR TITLE
ProjectFileManager: remove unused newRate variable in AddImportedTracks

### DIFF
--- a/src/ProjectFileManager.cpp
+++ b/src/ProjectFileManager.cpp
@@ -1189,7 +1189,6 @@ ProjectFileManager::AddImportedTracks(const FilePath &fileName,
    wxFileName fn(fileName);
 
    bool initiallyEmpty = tracks.empty();
-   double newRate = 0;
    wxString trackNameBase = fn.GetName();
    int i = -1;
 
@@ -1228,8 +1227,6 @@ ProjectFileManager::AddImportedTracks(const FilePath &fileName,
          newTrack->SetName(trackNameBase);
 
       newTrack->TypeSwitch([&](WaveTrack &wt) {
-         if (newRate == 0)
-            newRate = wt.GetRate();
          const auto trackName = wt.GetName();
          for (const auto &interval : wt.Intervals())
             interval->SetName(trackName);


### PR DESCRIPTION
Cleanup: This PR removes dead code in `ProjectFileManager::AddImportedTracks`.

`newRate` was being initialized and assigned from imported wave tracks, but it is no longer used to update project sample rate. As a result, these lines had no functional effect.

### Changes
- Remove:
  - `double newRate = 0;`
  - `if (newRate == 0) newRate = wt.GetRate();`

### Why
- Improve readability and maintainability.
- Avoid confusion about behavior that is no longer present.

### Impact
- No behavior change intended.
- Pure cleanup/refactor of unused code.

-----
- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [ ] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

QA:

- [ ] Testflow test cases have been run
