### PR TITLE
Fix generating tone from a macro or a script.

### DIFF
--- a/libraries/lib-builtin-effects/ToneGenBase.cpp
+++ b/libraries/lib-builtin-effects/ToneGenBase.cpp
@@ -39,18 +39,12 @@ const EnumValueSymbol ToneGenBase::kWaveStrings[nWaveforms] = {
 
 const EffectParameterMethods& ToneGenBase::Parameters() const
 {
-   static const auto postSet = [](ToneGenBase&, EffectSettings&, ToneGenBase& e,
-                                  bool updating) {
-      if (updating)
-         e.PostSet();
-      return true;
-   };
    static CapturedParameters<
       ToneGenBase, StartFreq, EndFreq, StartAmp, EndAmp, Waveform, Interp>
-      chirpParameters { postSet };
+      chirpParameters;
    static CapturedParameters<
       ToneGenBase, Frequency, Amplitude, Waveform, Interp>
-      toneParameters { postSet };
+      toneParameters;
    if (mChirp)
       return chirpParameters;
    else
@@ -95,6 +89,7 @@ bool ToneGenBase::ProcessInitialize(
    mSampleRate = sampleRate;
    mPositionInCycles = 0.0;
    mSample = 0;
+   PostSet();  // needed when generator is called from macro or script
    return true;
 }
 


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/4280

Problem.
The results of generating a tone from a macro or script are unpredicable. This is because mFrequency1 and mAmplitude are not being set. There is a function posSet(), which I presume was meant to be called by DoSet() in ShuttleAutomation.h. However the latter function appears not be be called at all.

Fix.
Remove posSet(), and simply call PosSet() in ToneGenBase::ProcessInitialize()


<!-- Use "x" to fill the checkboxes below like [x] -->

- [x ] I signed [CLA](https://www.audacityteam.org/cla/)
- [x ] The title of the pull request describes an issue it addresses
- [ x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x ] Each commit's message describes its purpose and effects
- [x ] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [ x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Test the macro in the issue works correctly when run multiple times
- [ ] Test the macro works both with TONE and CHIRP generator
- [ ] Test Tone and Chirp generators work as expected when run directly from Generate/ menu
