### PR TITLE
fix inconsistencies in timecode component usages #10876

### DIFF
--- a/src/effects/builtin_collection/dtmfgen/DtmfView.qml
+++ b/src/effects/builtin_collection/dtmfgen/DtmfView.qml
@@ -135,15 +135,6 @@ BuiltinEffectBase {
                     Layout.fillWidth: true
                     Layout.fillHeight: false
 
-                    border: Border {
-                        color: ui.theme.strokeColor
-                        width: 1
-                    }
-
-                    arrowSpacing: -2
-                    backgroundColor: ui.theme.backgroundSecondaryColor
-                    textColor: ui.theme.fontPrimaryColor
-
                     value: dtmf.duration
                     mode: TimecodeModeSelector.Duration
                     currentFormatStr: dtmf.durationFormat

--- a/src/effects/builtin_collection/noisegen/NoiseView.qml
+++ b/src/effects/builtin_collection/noisegen/NoiseView.qml
@@ -96,14 +96,6 @@ BuiltinEffectBase {
                 Layout.fillWidth: true
                 Layout.fillHeight: false
 
-                border: Border {
-                    color: ui.theme.strokeColor
-                    width: 1
-                }
-
-                arrowSpacing: -2
-                backgroundColor: ui.theme.backgroundSecondaryColor
-                textColor: ui.theme.fontPrimaryColor
                 value: noise.duration
                 mode: TimecodeModeSelector.Duration
                 currentFormatStr: noise.durationFormat

--- a/src/effects/builtin_collection/tonegen/ChirpView.qml
+++ b/src/effects/builtin_collection/tonegen/ChirpView.qml
@@ -299,15 +299,6 @@ BuiltinEffectBase {
                 Layout.fillHeight: false
                 Layout.columnSpan: 2
 
-                border: Border {
-                    color: ui.theme.strokeColor
-                    width: 1
-                }
-
-                arrowSpacing: -2
-                backgroundColor: ui.theme.backgroundSecondaryColor
-                textColor: ui.theme.fontPrimaryColor
-
                 value: chirp.duration
                 mode: TimecodeModeSelector.Duration
                 currentFormatStr: chirp.durationFormat

--- a/src/effects/builtin_collection/tonegen/ChirpView.qml
+++ b/src/effects/builtin_collection/tonegen/ChirpView.qml
@@ -300,15 +300,6 @@ BuiltinEffectBase {
                 Layout.fillHeight: false
                 Layout.columnSpan: 2
 
-                border: Border {
-                    color: ui.theme.strokeColor
-                    width: 1
-                }
-
-                arrowSpacing: -2
-                backgroundColor: ui.theme.backgroundSecondaryColor
-                textColor: ui.theme.fontPrimaryColor
-
                 value: chirp.duration
                 mode: TimecodeModeSelector.Duration
                 currentFormatStr: chirp.durationFormat

--- a/src/effects/builtin_collection/tonegen/ToneView.qml
+++ b/src/effects/builtin_collection/tonegen/ToneView.qml
@@ -131,15 +131,6 @@ BuiltinEffectBase {
                 Layout.fillHeight: false
                 Layout.columnSpan: 2
 
-                border: Border {
-                    color: ui.theme.strokeColor
-                    width: 1
-                }
-
-                arrowSpacing: -2
-                backgroundColor: ui.theme.backgroundSecondaryColor
-                textColor: ui.theme.fontPrimaryColor
-
                 value: tone.duration
                 mode: TimecodeModeSelector.Duration
                 currentFormatStr: tone.durationFormat

--- a/src/playback/qml/Audacity/Playback/dialogs/LoopRegionInOut.qml
+++ b/src/playback/qml/Audacity/Playback/dialogs/LoopRegionInOut.qml
@@ -70,15 +70,6 @@ StyledDialogView {
                 Layout.fillWidth: true
                 Layout.fillHeight: false
 
-                border: Border {
-                    color: ui.theme.strokeColor
-                    width: 1
-                }
-
-                arrowSpacing: -2
-                backgroundColor: ui.theme.backgroundSecondaryColor
-                textColor: ui.theme.fontPrimaryColor
-
                 value: start
                 mode: TimecodeModeSelector.Duration
                 currentFormat: selectionModel.currentFormat
@@ -115,15 +106,6 @@ StyledDialogView {
 
                 Layout.fillWidth: true
                 Layout.fillHeight: false
-
-                border: Border {
-                    color: ui.theme.strokeColor
-                    width: 1
-                }
-
-                arrowSpacing: -2
-                backgroundColor: ui.theme.backgroundSecondaryColor
-                textColor: ui.theme.fontPrimaryColor
 
                 value: end
                 mode: TimecodeModeSelector.Duration

--- a/src/projectscene/qml/Audacity/ProjectScene/statusbar/SelectionStatus.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/statusbar/SelectionStatus.qml
@@ -77,6 +77,8 @@ Row {
     Timecode {
         id: durationTimecode
 
+        appearance: Timecode.Appearance.Clock
+
         value: selectionModel.endTime - selectionModel.startTime
         mode: TimecodeModeSelector.Duration
 

--- a/src/projectscene/qml/Audacity/ProjectScene/toolbars/PlaybackToolBar.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/toolbars/PlaybackToolBar.qml
@@ -163,6 +163,8 @@ Item {
 
                 accessibleName: qsTrc("projectscene", "Playback position: ")
 
+                appearance: Timecode.Appearance.Clock
+
                 value: Boolean(itemData) ? itemData.currentValue : 0
 
                 mode: TimecodeModeSelector.TimePoint

--- a/src/projectscene/qml/Audacity/ProjectScene/toolbars/PlaybackToolBar.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/toolbars/PlaybackToolBar.qml
@@ -163,6 +163,8 @@ Item {
 
                 accessibleName: qsTrc("projectscene", "Playback position:")
 
+                appearance: Timecode.Appearance.Clock
+
                 value: Boolean(itemData) ? itemData.currentValue : 0
 
                 mode: TimecodeModeSelector.TimePoint

--- a/src/uicomponents/au_uicomponents.qrc
+++ b/src/uicomponents/au_uicomponents.qrc
@@ -2,6 +2,7 @@
     <qresource prefix="/">
         <file>qml/Audacity/UiComponents/qmldir</file>
         <file>qml/Audacity/UiComponents/components/Timecode.qml</file>
+        <file>qml/Audacity/UiComponents/components/internal/DualFocusBorder.qml</file>
         <file>qml/Audacity/UiComponents/components/internal/NumericField.qml</file>
         <file>qml/Audacity/UiComponents/components/internal/NumericView.qml</file>
         <file>qml/Audacity/UiComponents/components/TimecodeStartEnd.qml</file>

--- a/src/uicomponents/qml/Audacity/UiComponents/components/ArrowMenuButton.qml
+++ b/src/uicomponents/qml/Audacity/UiComponents/components/ArrowMenuButton.qml
@@ -6,6 +6,8 @@ import QtQuick
 import Muse.Ui
 import Muse.UiComponents
 
+import "internal"
+
 MenuButton {
     id: root
 
@@ -28,9 +30,10 @@ MenuButton {
         color: root.backgroundColor
         border: root.border
 
-        NavigationFocusBorder {
+        DualFocusBorder {
             navigationCtrl: root.navigation
-            drawOutsideParent: !root.drawFocusBorderInsideRect
+            outerColor: root.iconColor
+            radius: background.topRightRadius
         }
 
         states: [

--- a/src/uicomponents/qml/Audacity/UiComponents/components/Timecode.qml
+++ b/src/uicomponents/qml/Audacity/UiComponents/components/Timecode.qml
@@ -15,7 +15,8 @@ NumericView {
 
     enum Appearance {
         Themed,
-        Clock
+        Clock,
+        Embedded
     }
 
     property int appearance: Timecode.Appearance.Themed
@@ -31,11 +32,20 @@ NumericView {
     property alias currentFormat: timecodeModel.currentFormat
     property alias currentFormatStr: timecodeModel.currentFormatStr
 
-    backgroundColor: appearance === Timecode.Appearance.Clock ? ui.theme.backgroundQuarternaryColor : ui.theme.backgroundSecondaryColor
-    textColor: appearance === Timecode.Appearance.Clock ? ui.theme.fontSecondaryColor : ui.theme.fontPrimaryColor
+    backgroundColor: {
+        switch (appearance) {
+        case Timecode.Appearance.Clock:
+            return ui.theme.backgroundQuarternaryColor
+        case Timecode.Appearance.Embedded:
+            return "transparent"
+        default:
+            return ui.theme.backgroundSecondaryColor
+        }
+    }
+    textColor: appearance === Timecode.Appearance.Themed ? ui.theme.fontPrimaryColor : ui.theme.fontSecondaryColor
     border: Border {
         color: ui.theme.strokeColor
-        width: 1
+        width: root.appearance === Timecode.Appearance.Embedded ? 0 : 1
     }
     arrowSpacing: -2
 

--- a/src/uicomponents/qml/Audacity/UiComponents/components/Timecode.qml
+++ b/src/uicomponents/qml/Audacity/UiComponents/components/Timecode.qml
@@ -3,12 +3,22 @@
 */
 import QtQuick 2.15
 
+import Muse.Ui 1.0
+import Muse.UiComponents
+
 import Audacity.UiComponents 1.0
 
 import "internal"
 
 NumericView {
     id: root
+
+    enum Appearance {
+        Themed,
+        Clock
+    }
+
+    property int appearance: Timecode.Appearance.Themed
 
     property alias value: timecodeModel.value
     property alias mode: timecodeModel.mode
@@ -20,6 +30,14 @@ NumericView {
 
     property alias currentFormat: timecodeModel.currentFormat
     property alias currentFormatStr: timecodeModel.currentFormatStr
+
+    backgroundColor: appearance === Timecode.Appearance.Clock ? ui.theme.backgroundQuarternaryColor : ui.theme.backgroundSecondaryColor
+    textColor: appearance === Timecode.Appearance.Clock ? ui.theme.fontSecondaryColor : ui.theme.fontPrimaryColor
+    border: Border {
+        color: ui.theme.strokeColor
+        width: 1
+    }
+    arrowSpacing: -2
 
     model: timecodeModel
 

--- a/src/uicomponents/qml/Audacity/UiComponents/components/Timecode.qml
+++ b/src/uicomponents/qml/Audacity/UiComponents/components/Timecode.qml
@@ -45,7 +45,7 @@ NumericView {
     textColor: appearance === Timecode.Appearance.Themed ? ui.theme.fontPrimaryColor : ui.theme.fontSecondaryColor
     border: Border {
         color: ui.theme.strokeColor
-        width: root.appearance === Timecode.Appearance.Embedded ? 0 : 1
+        width: root.appearance === Timecode.Appearance.Embedded ? 0 : ui.theme.borderWidth
     }
     arrowSpacing: -2
 

--- a/src/uicomponents/qml/Audacity/UiComponents/components/TimecodeStartEnd.qml
+++ b/src/uicomponents/qml/Audacity/UiComponents/components/TimecodeStartEnd.qml
@@ -51,11 +51,7 @@ Rectangle {
         Timecode {
             id: startTimecode
 
-            appearance: Timecode.Appearance.Clock
-            backgroundColor: "transparent"
-            border: Border {
-                width: 0
-            }
+            appearance: Timecode.Appearance.Embedded
 
             mode: TimecodeModeSelector.TimePoint
             sampleRate: root.sampleRate
@@ -79,11 +75,7 @@ Rectangle {
         Timecode {
             id: endTimecode
 
-            appearance: Timecode.Appearance.Clock
-            backgroundColor: "transparent"
-            border: Border {
-                width: 0
-            }
+            appearance: Timecode.Appearance.Embedded
 
             mode: TimecodeModeSelector.TimePoint
             sampleRate: root.sampleRate
@@ -92,8 +84,6 @@ Rectangle {
             lowerTimeSignature: root.lowerTimeSignature
 
             currentFormat: root.currentFormat
-
-            backgroundLeftRadius: 0
 
             navigation.panel: root.navigationPanel
             navigation.row: startTimecode.navigation.row

--- a/src/uicomponents/qml/Audacity/UiComponents/components/TimecodeStartEnd.qml
+++ b/src/uicomponents/qml/Audacity/UiComponents/components/TimecodeStartEnd.qml
@@ -10,7 +10,7 @@ import Muse.UiComponents
 
 import Audacity.UiComponents 1.0
 
-RowLayout {
+Rectangle {
     id: root
 
     property alias startValue: startTimecode.value
@@ -34,57 +34,78 @@ RowLayout {
     signal endValueChangeRequested(var newValue)
     signal formatChangeRequested(var newFormat)
 
-    spacing: 1
+    implicitWidth: layout.implicitWidth + 2 * border.width
+    implicitHeight: layout.implicitHeight + 2 * border.width
 
-    Timecode {
-        id: startTimecode
+    color: ui.theme.backgroundQuarternaryColor
+    radius: 3
+    border.color: ui.theme.strokeColor
+    border.width: 1
 
-        appearance: Timecode.Appearance.Clock
+    RowLayout {
+        id: layout
 
-        mode: TimecodeModeSelector.TimePoint
-        sampleRate: root.sampleRate
-        tempo: root.tempo
-        upperTimeSignature: root.upperTimeSignature
-        lowerTimeSignature: root.lowerTimeSignature
+        anchors.centerIn: parent
+        spacing: 1
 
-        currentFormat: root.currentFormat
+        Timecode {
+            id: startTimecode
 
-        showMenu: false
+            appearance: Timecode.Appearance.Clock
+            backgroundColor: "transparent"
+            border: Border {
+                width: 0
+            }
 
-        navigation.panel: root.navigationPanel
-        navigation.row: 1
-        navigation.column: 1
+            mode: TimecodeModeSelector.TimePoint
+            sampleRate: root.sampleRate
+            tempo: root.tempo
+            upperTimeSignature: root.upperTimeSignature
+            lowerTimeSignature: root.lowerTimeSignature
 
-        onValueChangeRequested: function (newValue) {
-            root.startValueChangeRequested(newValue)
-        }
-    }
+            currentFormat: root.currentFormat
 
-    Timecode {
-        id: endTimecode
+            showMenu: false
 
-        appearance: Timecode.Appearance.Clock
+            navigation.panel: root.navigationPanel
+            navigation.row: 1
+            navigation.column: 1
 
-        mode: TimecodeModeSelector.TimePoint
-        sampleRate: root.sampleRate
-        tempo: root.tempo
-        upperTimeSignature: root.upperTimeSignature
-        lowerTimeSignature: root.lowerTimeSignature
-
-        currentFormat: root.currentFormat
-
-        backgroundLeftRadius: 0
-
-        navigation.panel: root.navigationPanel
-        navigation.row: startTimecode.navigation.row
-        navigation.column: startTimecode.navigationColumnEnd + 1
-
-        onValueChangeRequested: function (newValue) {
-            root.endValueChangeRequested(newValue)
+            onValueChangeRequested: function (newValue) {
+                root.startValueChangeRequested(newValue)
+            }
         }
 
-        onCurrentFormatChanged: function () {
-            root.formatChangeRequested(currentFormat)
+        Timecode {
+            id: endTimecode
+
+            appearance: Timecode.Appearance.Clock
+            backgroundColor: "transparent"
+            border: Border {
+                width: 0
+            }
+
+            mode: TimecodeModeSelector.TimePoint
+            sampleRate: root.sampleRate
+            tempo: root.tempo
+            upperTimeSignature: root.upperTimeSignature
+            lowerTimeSignature: root.lowerTimeSignature
+
+            currentFormat: root.currentFormat
+
+            backgroundLeftRadius: 0
+
+            navigation.panel: root.navigationPanel
+            navigation.row: startTimecode.navigation.row
+            navigation.column: startTimecode.navigationColumnEnd + 1
+
+            onValueChangeRequested: function (newValue) {
+                root.endValueChangeRequested(newValue)
+            }
+
+            onCurrentFormatChanged: function () {
+                root.formatChangeRequested(currentFormat)
+            }
         }
     }
 }

--- a/src/uicomponents/qml/Audacity/UiComponents/components/TimecodeStartEnd.qml
+++ b/src/uicomponents/qml/Audacity/UiComponents/components/TimecodeStartEnd.qml
@@ -34,8 +34,8 @@ Rectangle {
     signal endValueChangeRequested(var newValue)
     signal formatChangeRequested(var newFormat)
 
-    implicitWidth: layout.implicitWidth + 2 * border.width
-    implicitHeight: layout.implicitHeight + 2 * border.width
+    implicitWidth: layout.implicitWidth
+    implicitHeight: layout.implicitHeight
 
     color: ui.theme.backgroundQuarternaryColor
     radius: 3
@@ -45,7 +45,7 @@ Rectangle {
     RowLayout {
         id: layout
 
-        anchors.centerIn: parent
+        anchors.fill: parent
         spacing: 1
 
         Timecode {

--- a/src/uicomponents/qml/Audacity/UiComponents/components/TimecodeStartEnd.qml
+++ b/src/uicomponents/qml/Audacity/UiComponents/components/TimecodeStartEnd.qml
@@ -40,7 +40,7 @@ Rectangle {
     color: ui.theme.backgroundQuarternaryColor
     radius: 3
     border.color: ui.theme.strokeColor
-    border.width: 1
+    border.width: ui.theme.borderWidth
 
     RowLayout {
         id: layout

--- a/src/uicomponents/qml/Audacity/UiComponents/components/TimecodeStartEnd.qml
+++ b/src/uicomponents/qml/Audacity/UiComponents/components/TimecodeStartEnd.qml
@@ -39,6 +39,8 @@ RowLayout {
     Timecode {
         id: startTimecode
 
+        appearance: Timecode.Appearance.Clock
+
         mode: TimecodeModeSelector.TimePoint
         sampleRate: root.sampleRate
         tempo: root.tempo
@@ -60,6 +62,8 @@ RowLayout {
 
     Timecode {
         id: endTimecode
+
+        appearance: Timecode.Appearance.Clock
 
         mode: TimecodeModeSelector.TimePoint
         sampleRate: root.sampleRate

--- a/src/uicomponents/qml/Audacity/UiComponents/components/internal/DualFocusBorder.qml
+++ b/src/uicomponents/qml/Audacity/UiComponents/components/internal/DualFocusBorder.qml
@@ -1,0 +1,43 @@
+/*
+* Audacity: A Digital Audio Editor
+*/
+import QtQuick
+
+import Muse.Ui
+
+Item {
+    id: root
+
+    property AbstractNavigation navigationCtrl: null
+
+    property color outerColor: ui.theme.fontSecondaryColor
+    property color innerColor: ui.theme.isDark ? ui.theme.extra["white_color"] : ui.theme.extra["black_color"]
+
+    property real radius: 0
+
+    anchors.fill: parent
+
+    visible: navigationCtrl ? navigationCtrl.highlight : false
+
+    Rectangle {
+        anchors.fill: parent
+        anchors.margins: -3
+
+        color: "transparent"
+        radius: root.radius + 3
+
+        border.color: root.outerColor
+        border.width: 2
+    }
+
+    Rectangle {
+        anchors.fill: parent
+        anchors.margins: -2
+
+        color: "transparent"
+        radius: root.radius + 2
+
+        border.color: root.innerColor
+        border.width: 2
+    }
+}

--- a/src/uicomponents/qml/Audacity/UiComponents/components/internal/NumericField.qml
+++ b/src/uicomponents/qml/Audacity/UiComponents/components/internal/NumericField.qml
@@ -20,6 +20,8 @@ ListItemBlank {
     width: isEditable ? 12 : (value === " " ? 1 : symbolField.implicitWidth)
     height: 28
 
+    background.border.width: 0
+
     mouseArea.enabled: isEditable
 
     opacity: enabled ? 1.0 : ui.theme.itemOpacityDisabled

--- a/src/uicomponents/qml/Audacity/UiComponents/components/internal/NumericField.qml
+++ b/src/uicomponents/qml/Audacity/UiComponents/components/internal/NumericField.qml
@@ -22,12 +22,19 @@ ListItemBlank {
 
     background.border.width: 0
 
+    z: navigation.highlight ? 1 : 0
+
     mouseArea.enabled: isEditable
 
     opacity: enabled ? 1.0 : ui.theme.itemOpacityDisabled
 
     navigation.name: symbolField.text
     navigation.enabled: isEditable
+
+    DualFocusBorder {
+        navigationCtrl: root.navigation
+        outerColor: root.color
+    }
 
     StyledTextLabel {
         id: symbolField

--- a/src/uicomponents/qml/Audacity/UiComponents/components/internal/NumericView.qml
+++ b/src/uicomponents/qml/Audacity/UiComponents/components/internal/NumericView.qml
@@ -87,6 +87,8 @@ RowLayout {
         Layout.preferredWidth: contentItem.width
         Layout.fillHeight: true
 
+        z: root.navigation.highlight ? 1 : 0
+
         topLeftRadius: root.backgroundLeftRadius
         bottomLeftRadius: root.backgroundLeftRadius
 
@@ -155,9 +157,10 @@ RowLayout {
             }
         }
 
-        NavigationFocusBorder {
+        DualFocusBorder {
             navigationCtrl: root.navigation
-            drawOutsideParent: false
+            outerColor: root.textColor
+            radius: root.backgroundLeftRadius
         }
     }
 


### PR DESCRIPTION
Resolves: fix inconsistencies in timecode component usages #10876

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [ ] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run

## QA spot-check list

For each instance below: open the surface, confirm appearance matches the column on the right, verify a visible 1px border on **all four sides**, then re-test under the **dark** and **hi-contrast** themes (Edit ▸ Preferences ▸ Appearance ▸ Theme).

### Clock appearance (4 sites — main project window)

| Where to find it | Expected appearance |
|---|---|
| **Playback toolbar — playhead/current-time display.** Visible by default at the top of the project window, left of the meter. Shows e.g. `00:00:01.234`. | Clock: dark `backgroundQuarternaryColor` bg, secondary text, 1px `strokeColor` border. Click the dropdown caret to confirm border still wraps caret cleanly. |
| **Selection status bar — selection start time.** Bottom status bar. Visible after making any selection on a track. Left half of the start/end pair. | Clock. Verify the seam between **start** and **end** shows a *single* shared vertical border, not a doubled one. |
| **Selection status bar — selection end time.** Bottom status bar. Right half of the start/end pair. | Clock. Same as above — one shared seam. |
| **Selection status bar — duration.** Bottom status bar, to the right of the start/end pair, after the "Duration" label. | Clock. Standalone (no seam). |

### Themed appearance (10 sites — dialogs, effects, tables)

| Where to find it | How to reach it |
|---|---|
| **Loop region dialog — Loop in / Loop out.** Two timecode inputs in a modal. | Transport ▸ "Set Loop" / loop-region action that opens the *Loop region in/out* dialog. |
| **Custom time dialog — Position.** One timecode input in a modal. | Edit / Transport ▸ "Move to time…" or equivalent action that opens `CustomTimeDialog`. |
| **Label editor — start/end timecode columns.** Inline timecode editors inside a table. | Tracks ▸ "Edit labels" (or similar) — opens the label editor table. Click a start- or end-time cell to enter edit mode. |
| **Silence generator — Duration.** | Generate ▸ Silence… → modal. |
| **Tone generator — Duration.** | Generate ▸ Tone… → modal. |
| **Chirp generator — Duration.** | Generate ▸ Chirp… → modal. |
| **Noise generator — Duration.** | Generate ▸ Noise… → modal. |
| **DTMF tones generator — Duration.** | Generate ▸ DTMF tones… → modal. |
| **Generic effect parameter — duration controls.** Any effect that exposes a duration-typed parameter routes through `ParameterControl.qml`'s `timeControl` component. | Open any effect that has a duration parameter (built-in or 3rd-party). Common ones: legacy/3rd-party generators; some processor effects with time-based knobs. |

### Cross-theme verification (each of the 14 sites)

For *each* timecode above, repeat under:

1. Default light theme
2. Default dark theme
3. Hi-contrast theme

Confirm:

- The 1px border is visible and contrasts against the surrounding panel in **all three themes**.
- Text is legible.
- The dropdown caret button shares the same background/border treatment as the digit cell (no visual seam).
- For the selection start/end pair, the inter-cell seam renders cleanly.
