### PR TITLE
Fix setting waveform scale using a scriptable

### DIFF
--- a/src/commands/SetTrackInfoCommand.cpp
+++ b/src/commands/SetTrackInfoCommand.cpp
@@ -354,9 +354,9 @@ bool SetTrackVisualsCommand::ApplyInner(
       auto &scaleType = WaveformSettings::Get(*wt).scaleType;
       switch (mScaleType) {
       default:
-      case kLinearAmp: scaleType = WaveformSettings::stLinearAmp;
-      case kLogarithmicDb: scaleType = WaveformSettings::stLogarithmicDb;
-      case kLinearDb: scaleType = WaveformSettings::stLinearDb;
+      case kLinearAmp: scaleType = WaveformSettings::stLinearAmp; break;
+      case kLogarithmicDb: scaleType = WaveformSettings::stLogarithmicDb; break;
+      case kLinearDb: scaleType = WaveformSettings::stLinearDb; break;
       }
    }
 


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/4601

Problem:
Setting the waveform scale type using a scriptable always results in the scale type being set to Linear (db).

Fix:
In SetTrackVisualsCommand::ApplyInner(), insert missing break statements within a switch statement.



<!-- Use "x" to fill the checkboxes below like [x] -->

- [ x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x ] The title of the pull request describes an issue it addresses
- [x ] If changes are extensive, then there is a sequence of easily reviewable commits
- [ x] Each commit's message describes its purpose and effects
- [x ] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x ] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
