### PR TITLE
Fix menus and toolbars disabled when opening blank project in new window

### DIFF
--- a/src/context/internal/uicontextresolver.cpp
+++ b/src/context/internal/uicontextresolver.cpp
@@ -54,36 +54,9 @@ void UiContextResolver::init()
     });
 #endif
 
-    //! TODO AU4
-    // globalContext()->currentProjectChanged().onNotify(this, [this]() {
-    //     auto project = globalContext()->currentProject();
-    //     if (notation) {
-    //         notation->interaction()->selectionChanged().onNotify(this, [this]() {
-    //             notifyAboutContextChanged();
-    //         });
-
-    //         notation->interaction()->textEditingStarted().onNotify(this, [this]() {
-    //             notifyAboutContextChanged();
-    //         });
-
-    //         notation->interaction()->textEditingEnded().onReceive(this, [this](engraving::TextBase*) {
-    //             notifyAboutContextChanged();
-    //         });
-
-    //         notation->undoStack()->stackChanged().onNotify(this, [this]() {
-    //             notifyAboutContextChanged();
-    //         });
-
-    //         notation->interaction()->noteInput()->noteInputStarted().onNotify(this, [this]() {
-    //             notifyAboutContextChanged();
-    //         });
-
-    //         notation->interaction()->noteInput()->noteInputEnded().onNotify(this, [this]() {
-    //             notifyAboutContextChanged();
-    //         });
-    //     }
-    //     notifyAboutContextChanged();
-    // });
+    globalContext()->currentProjectChanged().onNotify(this, [this]() {
+        notifyAboutContextChanged();
+    });
 
     navigationController()->navigationChanged().onNotify(this, [this]() {
         notifyAboutContextChanged();


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/10885

Fixed the bug where opening a blank project in a new window left all toolbar buttons, menus, and shortcuts non-functional by subscribing `UiContextResolver` to `currentProjectChanged` — previously, this subscription was stubbed out, causing the UI context to stay stuck at `UiCtxUnknown` after the project loaded. The fix is a 3-line change in `uicontextresolver.cpp`.

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [ ] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
