### PR TITLE
Disable Format and Rate track menu items during recording (#10888)

### DIFF
--- a/src/projectscene/view/trackspanel/trackcontextmenumodel.cpp
+++ b/src/projectscene/view/trackspanel/trackcontextmenumodel.cpp
@@ -162,6 +162,11 @@ void TrackContextMenuModel::load()
     updateTrackRateState();
     updateTrackMonoState();
     updateTrackViewCheckedState();
+    updateRecordingState();
+
+    globalContext()->isRecordingChanged().onNotify(this, [this]() {
+        updateRecordingState();
+    }, muse::async::Asyncable::Mode::SetReplace);
 }
 
 au::trackedit::TrackId TrackContextMenuModel::trackId() const
@@ -411,6 +416,25 @@ void TrackContextMenuModel::updateTrackMonoState()
     auto state = makeStereoItem.state();
     state.enabled = canMakeStereo;
     makeStereoItem.setState(state);
+}
+
+void TrackContextMenuModel::updateRecordingState()
+{
+    bool recording = globalContext()->isRecording();
+
+    MenuItem& formatMenu = findMenu(QString::fromUtf8(TRACK_FORMAT_MENU_ID));
+    if (formatMenu.isValid()) {
+        auto state = formatMenu.state();
+        state.enabled = !recording;
+        formatMenu.setState(state);
+    }
+
+    MenuItem& rateMenu = findMenu(QString::fromUtf8(TRACK_RATE_MENU_ID));
+    if (rateMenu.isValid()) {
+        auto state = rateMenu.state();
+        state.enabled = !recording;
+        rateMenu.setState(state);
+    }
 }
 
 muse::uicomponents::MenuItemList TrackContextMenuModel::makeTrackColorItems()

--- a/src/projectscene/view/trackspanel/trackcontextmenumodel.h
+++ b/src/projectscene/view/trackspanel/trackcontextmenumodel.h
@@ -59,6 +59,7 @@ private:
     void updateTrackRateState();
     void updateTrackMonoState();
     void updateTrackViewCheckedState();
+    void updateRecordingState();
 
     trackedit::TrackId m_trackId;
     muse::actions::ActionCodeList m_colorChangeActionCodeList;


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/10888

- Added updateRecordingState() to TrackContextMenuModel, which disables the Format and Rate menu items when recording is active and re-enables them when recording stops.
- Subscribed to globalContext()->isRecordingChanged() in load() using Mode::SetReplace so the subscription is safely refreshed on subsequent load() calls (e.g. triggered by track changes) without hitting a re-entrant assertion.
- The isValid() guard on findMenu() ensures Label tracks — which have no Format or Rate submenus — are unaffected.

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [ ] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:
- [x] Start recording, then right-click a track header to open the context menu. The Format and Rate submenus should appear greyed out and be unclickable.
- [x] With the context menu closed, stop recording, then right-click again. Both submenus should now be fully enabled and functional (changing format/rate should work as before).
- [x] Right-click a label track during recording. The context menu for label tracks has no Format/Rate submenus — verify it still opens correctly and nothing is broken there.