### PR TITLE
10814 Return saved project location from open cloud function 

### DIFF
--- a/src/au3cloud/internal/au3audiocomservice.cpp
+++ b/src/au3cloud/internal/au3audiocomservice.cpp
@@ -544,7 +544,7 @@ muse::RetVal<muse::ProgressPtr> Au3AudioComService::openCloudProject(const muse:
 
         auto cancelCheck = [progress](double) -> bool { return !progress->isCanceled(); };
         if (!forceOverwrite && self->isSnapshotUpToDate(dbProjectData, cancelCheck, cancellationContext)) {
-            progress->finish(muse::make_ok());
+            progress->finish(muse::RetVal<muse::Val>::make_ok(muse::Val(muse::io::path_t(dbProjectData->LocalPath))));
             return;
         }
 
@@ -560,7 +560,7 @@ muse::RetVal<muse::ProgressPtr> Au3AudioComService::openCloudProject(const muse:
         }
 
         if (result.Status == sync::ProjectSyncResult::StatusCode::Succeeded) {
-            progress->finish(muse::make_ok());
+            progress->finish(muse::RetVal<muse::Val>::make_ok(muse::Val(muse::io::path_t(result.ProjectPath))));
         } else {
             const auto err = syncResultCodeToErr(result.Result.Code);
             if (err == Err::SyncResultNotFound) {

--- a/src/project/internal/projectactionscontroller.cpp
+++ b/src/project/internal/projectactionscontroller.cpp
@@ -849,7 +849,8 @@ Ret ProjectActionsController::openCloudProject(const io::path_t& localPath, cons
             return;
         }
 
-        doOpenProject(localPath);
+        const io::path_t projectPath = !result.val.isNull() ? result.val.toPath() : localPath;
+        doOpenProject(projectPath);
 
         auto project = globalContext()->currentProject();
         if (!project) {


### PR DESCRIPTION
Resolves: #10814 

If the local db is removed but there is still a file on the disk the openCloudProject saves the project in a new location.
The project should refer to the save location instead.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
