### PR TITLE
10456 Create and apply effects should trigger clip notifications

### DIFF
--- a/src/effects/effects_base/internal/effectexecutionscenario.cpp
+++ b/src/effects/effects_base/internal/effectexecutionscenario.cpp
@@ -438,6 +438,9 @@ muse::Ret EffectExecutionScenario::performGenerator(au3::Au3Project& project, Ef
             trackedit::ClipKeyList newClipsKeys;
             std::transform(newClips.begin(), newClips.end(), std::back_inserter(newClipsKeys),
                            [](const auto clip) { return clip->key; });
+            for (const auto* clip : newClips) {
+                prj->notifyAboutClipAdded(*clip);
+            }
             selectionController()->resetDataSelection();
             selectionController()->setSelectedClips(newClipsKeys, true);
         }
@@ -452,10 +455,22 @@ std::optional<au::trackedit::ClipId> EffectExecutionScenario::performEffectOnSin
                                                                                         trackedit::TrackId trackId,
                                                                                         muse::Ret& success)
 {
+    const auto prj = globalContext()->currentTrackeditProject();
+    const auto clipsBefore = prj->clipList(trackId);
+
     success = performEffectInternal(project, &effect, instance, settings);
     if (!success) {
         return std::nullopt;
     }
+
+    const auto clipsAfter = prj->clipList(trackId);
+    for (const trackedit::Clip* clip : trackedit::utils::clipSetDifference(clipsBefore, clipsAfter)) {
+        prj->notifyAboutClipRemoved(*clip);
+    }
+    for (const trackedit::Clip* clip : trackedit::utils::clipSetDifference(clipsAfter, clipsBefore)) {
+        prj->notifyAboutClipAdded(*clip);
+    }
+
     // It is possible that the backend decides to replace the processed clip with a new one.
     // Since the selection spans only one clip, we want the originally selected clip to remain selected in appearance.
     // Look for the clip on that track at that time - we should find the new one.

--- a/src/importexport/import/internal/au3/au3importer.cpp
+++ b/src/importexport/import/internal/au3/au3importer.cpp
@@ -17,6 +17,7 @@
 #include "au3wrap/au3types.h"
 #include "au3wrap/internal/wxtypes_convert.h"
 #include "au3wrap/internal/domaccessor.h"
+#include "au3wrap/internal/domconverter.h"
 #include "projectscene/view/tracksitemsview/dropcontroller.h"
 #include "trackedit/internal/au3/au3trackdata.h"
 
@@ -398,4 +399,16 @@ void au::importexport::Au3Importer::addImportedTracks(const muse::io::path_t& fi
     }
 
     applyImportedProjectTitleIfNeeded(fileName);
+
+    auto prj = globalContext()->currentTrackeditProject();
+    if (!prj) {
+        return;
+    }
+
+    for (const auto& newTrack : results) {
+        prj->notifyAboutTrackAdded(DomConverter::track(newTrack));
+        for (const auto& clip : prj->clipList(newTrack->GetId())) {
+            prj->notifyAboutClipAdded(clip);
+        }
+    }
 }


### PR DESCRIPTION
Resolves: #10456 

Effects generation and perform should also emit clip notifications.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [ ] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
