### PR TITLE
Implement keyboard navigation and accessibility for Nyquist effects #10932

### DIFF
--- a/src/effects/effects_base/qml/Audacity/Effects/DestructiveEffectsViewerDialog.qml
+++ b/src/effects/effects_base/qml/Audacity/Effects/DestructiveEffectsViewerDialog.qml
@@ -178,6 +178,7 @@ EffectStyledDialogView {
         id: generatedViewerComponent
         GeneratedEffectViewer {
             instanceId: root.instanceId
+            dialogView: root
         }
     }
 
@@ -264,7 +265,7 @@ EffectStyledDialogView {
                         width: root.contentWidth - prv.panelMargins * 2
                         spacing: prv.panelMargins
                         navigationPanel.section: root.navigationSection
-                        navigationPanel.order: (prv.showTopPanel ? 1 : 0) + (viewerModel.effectFamily == EffectFamily.Builtin ? (prv.viewer ? prv.viewer.numNavigationPanels : 2) : 0)
+                        navigationPanel.order: (prv.showTopPanel ? 1 : 0) + (prv.viewer && prv.viewer.numNavigationPanels !== undefined ? prv.viewer.numNavigationPanels : (viewerModel.effectFamily == EffectFamily.Builtin ? 2 : 0))
 
                         //! TODO Move function to ButtonBox (Muse framework)
                         function buttonById(id) {

--- a/src/effects/effects_base/qml/Audacity/Effects/GeneratedEffectViewer.qml
+++ b/src/effects/effects_base/qml/Audacity/Effects/GeneratedEffectViewer.qml
@@ -15,6 +15,28 @@ Rectangle {
 
     required property int instanceId
 
+    // Navigation wiring: the dialog passes itself in via `dialogView` so we
+    // can attach our parameters NavigationPanel to its NavigationSection.
+    // `numNavigationPanels` mirrors the BuiltinEffectBase contract used by
+    // DestructiveEffectsViewerDialog to order its bottom ButtonBox.
+    property var dialogView: null
+    property int numNavigationPanels: 1
+
+    property NavigationPanel parametersNavigationPanel: NavigationPanel {
+        name: "GeneratedEffectParameters"
+        enabled: root.enabled && root.visible
+        // Horizontal so the panel only traverses Left/Right between controls;
+        // Up/Down are left untouched and reach the focused control's own
+        // navigation handler (e.g. IncrementalPropertyControl's
+        // increment/decrement). With `Both`, the panel additionally tries
+        // to move focus on Up/Down after the control has already consumed
+        // the event, which kicks focus out after a single keypress.
+        // Matches the working pattern in AmplifyView.qml.
+        direction: NavigationPanel.Horizontal
+        section: root.dialogView ? root.dialogView.navigationSection : null
+        order: 1
+    }
+
     implicitWidth: prv.dialogWidth
     implicitHeight: {
         // why 2 times spaceXL? and 2 times spaceM?
@@ -107,6 +129,12 @@ Rectangle {
                             tempo: viewModel.tempo
                             upperTimeSignature: viewModel.upperTimeSignature
                             lowerTimeSignature: viewModel.lowerTimeSignature
+
+                            navigationPanel: root.parametersNavigationPanel
+                            // 10 slots per row leave headroom for parameter
+                            // types that pair multiple sub-controls (slider +
+                            // incremental, label + dropdown, ...).
+                            navigationOrderStart: index * 10
 
                             onGestureStarted: function (parameterId) {
                                 viewModel.parametersModel.beginGesture(parameterId)

--- a/src/effects/effects_base/qml/Audacity/Effects/ParameterControl.qml
+++ b/src/effects/effects_base/qml/Audacity/Effects/ParameterControl.qml
@@ -303,6 +303,13 @@ Item {
                 id: timecode
                 Layout.alignment: Qt.AlignVCenter
 
+                // Timecode (NumericView) does expose `navigation` -- as a
+                // `property NavigationControl` instance, not a `property
+                // alias`. Group-binding sub-properties on it still works.
+                navigation.panel: root.navigationPanel
+                navigation.order: root.navigationOrderStart
+                navigation.accessible.description: parameterData ? parameterData.description : ""
+
                 // NumericView composes accessible.name as `accessibleName +
                 // valueString`; the parameter label is the prefix here.
                 accessibleName: parameterData ? parameterData.name + ": " : ""

--- a/src/effects/effects_base/qml/Audacity/Effects/ParameterControl.qml
+++ b/src/effects/effects_base/qml/Audacity/Effects/ParameterControl.qml
@@ -133,6 +133,8 @@ Item {
         CheckBox {
             navigation.panel: root.navigationPanel
             navigation.order: root.navigationOrderStart
+            navigation.accessible.name: parameterData ? parameterData.name : ""
+            navigation.accessible.description: parameterData ? parameterData.description : ""
 
             checked: parameterData ? parameterData.isToggleChecked : false
             enabled: parameterData ? !parameterData.isReadOnly : false
@@ -164,6 +166,8 @@ Item {
 
                 navigation.panel: root.navigationPanel
                 navigation.order: root.navigationOrderStart
+                navigation.accessible.name: parameterData ? parameterData.name + (dropdown.displayText ? ": " + dropdown.displayText : "") : ""
+                navigation.accessible.description: parameterData ? parameterData.description : ""
 
                 currentIndex: parameterData ? parameterData.currentEnumIndex : 0
 
@@ -215,6 +219,8 @@ Item {
 
                 navigation.panel: root.navigationPanel
                 navigation.order: root.navigationOrderStart
+                navigation.accessible.name: parameterData ? parameterData.name : ""
+                navigation.accessible.description: parameterData ? parameterData.description : ""
 
                 from: parameterData ? parameterData.minValue : 0
                 to: parameterData ? parameterData.maxValue : 1
@@ -244,6 +250,8 @@ Item {
 
                 navigation.panel: root.navigationPanel
                 navigation.order: slider.navigation.order + 1
+                navigation.accessible.name: parameterData ? parameterData.name : ""
+                navigation.accessible.description: parameterData ? parameterData.description : ""
 
                 onGestureStarted: root.gestureStarted(root.parameterId)
                 onGestureEnded: root.gestureEnded(root.parameterId)
@@ -268,6 +276,8 @@ Item {
 
                 navigation.panel: root.navigationPanel
                 navigation.order: root.navigationOrderStart
+                navigation.accessible.name: parameterData ? parameterData.name : ""
+                navigation.accessible.description: parameterData ? parameterData.description : ""
 
                 onGestureStarted: root.gestureStarted(root.parameterId)
                 onGestureEnded: root.gestureEnded(root.parameterId)
@@ -292,6 +302,10 @@ Item {
             Timecode {
                 id: timecode
                 Layout.alignment: Qt.AlignVCenter
+
+                // NumericView composes accessible.name as `accessibleName +
+                // valueString`; the parameter label is the prefix here.
+                accessibleName: parameterData ? parameterData.name + ": " : ""
 
                 value: parameterData ? parameterData.currentValue : 0
                 mode: TimecodeModeSelector.Duration
@@ -337,6 +351,11 @@ Item {
                 // (not `navigation.panel`) and accepts row/column orders.
                 navigation: root.navigationPanel
                 navigationRowOrderStart: root.navigationOrderStart
+
+                // FilePicker prepends pathFieldTitle to its inner pathField's
+                // accessible name, which is the only hook it exposes for the
+                // parameter label.
+                pathFieldTitle: parameterData ? parameterData.name : ""
 
                 path: parameterData ? parameterData.currentValueString : ""
 
@@ -391,6 +410,8 @@ Item {
 
                 navigation.panel: root.navigationPanel
                 navigation.order: root.navigationOrderStart
+                navigation.accessible.name: parameterData ? parameterData.name + ": " + (textField.currentText || "") : ""
+                navigation.accessible.description: parameterData ? parameterData.description : ""
 
                 currentText: parameterData ? parameterData.currentValueString : ""
                 enabled: parameterData ? !parameterData.isReadOnly : false

--- a/src/effects/effects_base/qml/Audacity/Effects/ParameterControl.qml
+++ b/src/effects/effects_base/qml/Audacity/Effects/ParameterControl.qml
@@ -22,6 +22,12 @@ Item {
     property int upperTimeSignature: 0
     property int lowerTimeSignature: 0
 
+    // Navigation: provided by the parent so Up/Down/Tab can be handled by the
+    // inner controls (e.g. IncrementalPropertyControl's own NavigationEvent
+    // handler) instead of bubbling up to the dialog ButtonBox.
+    property NavigationPanel navigationPanel: null
+    property int navigationOrderStart: 0
+
     signal valueChanged(string parameterId, double value)
     signal stringValueChanged(string parameterId, string stringValue)
     signal gestureStarted(string parameterId)
@@ -125,6 +131,9 @@ Item {
         id: toggleControl
 
         CheckBox {
+            navigation.panel: root.navigationPanel
+            navigation.order: root.navigationOrderStart
+
             checked: parameterData ? parameterData.isToggleChecked : false
             enabled: parameterData ? !parameterData.isReadOnly : false
 
@@ -152,6 +161,9 @@ Item {
                 id: dropdown
                 Layout.maximumWidth: prv.dropdownMaxWidth
                 Layout.alignment: Qt.AlignVCenter
+
+                navigation.panel: root.navigationPanel
+                navigation.order: root.navigationOrderStart
 
                 currentIndex: parameterData ? parameterData.currentEnumIndex : 0
 
@@ -201,6 +213,9 @@ Item {
                 Layout.minimumWidth: prv.controlWidth
                 Layout.alignment: Qt.AlignVCenter
 
+                navigation.panel: root.navigationPanel
+                navigation.order: root.navigationOrderStart
+
                 from: parameterData ? parameterData.minValue : 0
                 to: parameterData ? parameterData.maxValue : 1
                 value: parameterData ? parameterData.currentValue : 0
@@ -227,6 +242,9 @@ Item {
                 Layout.alignment: Qt.AlignVCenter
                 parameterData: root.parameterData
 
+                navigation.panel: root.navigationPanel
+                navigation.order: slider.navigation.order + 1
+
                 onGestureStarted: root.gestureStarted(root.parameterId)
                 onGestureEnded: root.gestureEnded(root.parameterId)
                 onValueCommitted: function (v) {
@@ -247,6 +265,9 @@ Item {
                 Layout.preferredWidth: prv.numericControlWidth
                 Layout.alignment: Qt.AlignVCenter
                 parameterData: root.parameterData
+
+                navigation.panel: root.navigationPanel
+                navigation.order: root.navigationOrderStart
 
                 onGestureStarted: root.gestureStarted(root.parameterId)
                 onGestureEnded: root.gestureEnded(root.parameterId)
@@ -311,6 +332,12 @@ Item {
                 Layout.preferredWidth: prv.filePickerWidth
                 Layout.alignment: Qt.AlignVCenter
 
+                // FilePicker uses a different navigation API than the other
+                // Muse controls: it takes the panel directly via `navigation`
+                // (not `navigation.panel`) and accepts row/column orders.
+                navigation: root.navigationPanel
+                navigationRowOrderStart: root.navigationOrderStart
+
                 path: parameterData ? parameterData.currentValueString : ""
 
                 pickerType: {
@@ -361,6 +388,9 @@ Item {
                 id: textField
                 Layout.preferredWidth: prv.textControlWidth
                 Layout.alignment: Qt.AlignVCenter
+
+                navigation.panel: root.navigationPanel
+                navigation.order: root.navigationOrderStart
 
                 currentText: parameterData ? parameterData.currentValueString : ""
                 enabled: parameterData ? !parameterData.isReadOnly : false

--- a/src/effects/effects_base/view/effectparameterslistmodel.cpp
+++ b/src/effects/effects_base/view/effectparameterslistmodel.cpp
@@ -272,11 +272,37 @@ bool EffectParametersListModel::hasParameters() const
 
 void EffectParametersListModel::reloadParameters()
 {
-    beginResetModel();
+    ParameterInfoList freshParams = parametersProvider()->parameters(m_instanceId);
 
-    m_parameters = parametersProvider()->parameters(m_instanceId);
+    // Detect a structural change: count differs, or any row's id/type
+    // changed. Anything else (currentValue, stepSize, min/max, units, ...)
+    // can be updated in place via dataChanged without destroying the QML
+    // delegates -- which is what keeps keyboard focus alive when the user
+    // is arrow-keying / typing through an input field.
+    bool structural = (freshParams.size() != m_parameters.size());
+    if (!structural) {
+        for (size_t i = 0; i < freshParams.size(); ++i) {
+            if (m_parameters[i].id != freshParams[i].id
+                || m_parameters[i].type != freshParams[i].type) {
+                structural = true;
+                break;
+            }
+        }
+    }
 
-    endResetModel();
+    if (structural) {
+        beginResetModel();
+        m_parameters = std::move(freshParams);
+        endResetModel();
+    } else {
+        for (size_t i = 0; i < freshParams.size(); ++i) {
+            m_parameters[i] = std::move(freshParams[i]);
+            const QModelIndex idx = createIndex(static_cast<int>(i), 0);
+            // Empty roles list = all roles changed; lets every QML binding
+            // on parameterData.* re-evaluate.
+            emit dataChanged(idx, idx);
+        }
+    }
 
     emit hasParametersChanged();
 }


### PR DESCRIPTION
Resolves: Implement keyboard navigation and accessibility for built-in effects #10932
Resolves: https://github.com/audacity/audacity/issues/10562

- full parameter navigation 
- fix that was causing issues when changing parameters on Nyquist effects (Rhythm Track was broken https://github.com/audacity/audacity/issues/10562 and https://github.com/audacity/audacity/issues/10683 might get fixed too)
- add light Accessibility for generated parameters (ahead of https://github.com/audacity/audacity/issues/6531) as we still miss other part of the surrounding UI (expected for now)

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
