### PR TITLE
10912 Keep only one progress available on cloud uploads

### DIFF
--- a/src/au3cloud/internal/au3audiocomservice.cpp
+++ b/src/au3cloud/internal/au3audiocomservice.cpp
@@ -277,8 +277,46 @@ muse::RetVal<muse::ProgressPtr> Au3AudioComService::uploadProject(au::project::I
 
     muse::ProgressPtr progress = createSyncProgress();
 
-    std::thread([weak = weak_from_this(), project, progress, name, forceOverwrite, projectSaveCallback = std::move(
-                     projectSaveCallback)]() mutable {
+    auto& projectCloudExtension = audacity::cloud::audiocom::sync::ProjectCloudExtension::Get(*au3Project);
+
+    m_resumeSyncSubscription.Reset();
+    if (m_uploadDone) {
+        m_uploadDone->store(true);
+    }
+
+    projectCloudExtension.OnSyncStarted();
+
+    const auto uploadMode = forceOverwrite
+                            ? audacity::cloud::audiocom::sync::UploadMode::ForceOverwrite
+                            : audacity::cloud::audiocom::sync::UploadMode::Normal;
+
+    auto done = std::make_shared<std::atomic<bool> >(false);
+    m_uploadDone = done;
+    m_uploadSubscription = projectCloudExtension.SubscribeStatusChanged(
+        [progress, done, project](
+            const audacity::cloud::audiocom::sync::CloudStatusChangedMessage& message) {
+        if (done->load()) {
+            return;
+        }
+
+        if (message.Status == audacity::cloud::audiocom::sync::ProjectSyncStatus::Syncing) {
+            progress->progress(message.Progress * 100, 100);
+        }
+
+        if (message.Status == audacity::cloud::audiocom::sync::ProjectSyncStatus::Synced) {
+            done->store(true);
+            progress->finish(muse::RetVal<muse::Val>::make_ok(muse::Val(::getCloudProjectPage(project))));
+        }
+
+        if (message.Status == audacity::cloud::audiocom::sync::ProjectSyncStatus::Failed) {
+            done->store(true);
+            progress->finish(make_ret(cloudSyncErrorToErr(message.Error)));
+        }
+    },
+        false);
+
+    std::thread([weak = weak_from_this(), project, progress, name, uploadMode,
+                 projectSaveCallback = std::move(projectSaveCallback)]() mutable {
         auto self = weak.lock();
         if (!self) {
             progress->finish(muse::make_ret(muse::Ret::Code::InternalError, muse::trc("cloud", "Service destroyed")));
@@ -292,42 +330,6 @@ muse::RetVal<muse::ProgressPtr> Au3AudioComService::uploadProject(au::project::I
         }
 
         auto& projectCloudExtension = audacity::cloud::audiocom::sync::ProjectCloudExtension::Get(*au3Project);
-
-        self->m_resumeSyncSubscription.Reset();
-        if (self->m_uploadDone) {
-            self->m_uploadDone->store(true);
-        }
-
-        projectCloudExtension.OnSyncStarted();
-
-        const auto uploadMode = forceOverwrite
-                                ? audacity::cloud::audiocom::sync::UploadMode::ForceOverwrite
-                                : audacity::cloud::audiocom::sync::UploadMode::Normal;
-
-        auto done = std::make_shared<std::atomic<bool> >(false);
-        self->m_uploadDone = done;
-        self->m_uploadSubscription = projectCloudExtension.SubscribeStatusChanged(
-            [progress, done, project](
-                const audacity::cloud::audiocom::sync::CloudStatusChangedMessage& message) {
-            if (done->load()) {
-                return;
-            }
-
-            if (message.Status == audacity::cloud::audiocom::sync::ProjectSyncStatus::Syncing) {
-                progress->progress(message.Progress * 100, 100);
-            }
-
-            if (message.Status == audacity::cloud::audiocom::sync::ProjectSyncStatus::Synced) {
-                done->store(true);
-                progress->finish(muse::RetVal<muse::Val>::make_ok(muse::Val(::getCloudProjectPage(project))));
-            }
-
-            if (message.Status == audacity::cloud::audiocom::sync::ProjectSyncStatus::Failed) {
-                done->store(true);
-                progress->finish(make_ret(cloudSyncErrorToErr(message.Error)));
-            }
-        },
-            false);
 
         auto future = audacity::cloud::audiocom::sync::LocalProjectSnapshot::Create(
             audacity::cloud::audiocom::GetServiceConfig(),

--- a/src/au3cloud/internal/au3audiocomservice.cpp
+++ b/src/au3cloud/internal/au3audiocomservice.cpp
@@ -3,10 +3,10 @@
 */
 #include "au3audiocomservice.h"
 
-#include <algorithm>
 #include <atomic>
 #include <chrono>
 #include <cstdint>
+#include <memory>
 #include <thread>
 #include <utility>
 
@@ -14,6 +14,7 @@
 #include "framework/global/runtime.h"
 #include "framework/global/types/ret.h"
 #include "framework/global/io/dir.h"
+#include "framework/global/progress.h"
 
 #include "au3-cloud-audiocom/CloudSyncService.h"
 #include "au3-cloud-audiocom/OAuthService.h"
@@ -291,8 +292,10 @@ muse::RetVal<muse::ProgressPtr> Au3AudioComService::uploadProject(au::project::I
         }
 
         auto& projectCloudExtension = audacity::cloud::audiocom::sync::ProjectCloudExtension::Get(*au3Project);
-        if (projectCloudExtension.IsSyncing()) {
-            projectCloudExtension.CancelSync();
+
+        self->m_resumeSyncSubscription.Reset();
+        if (self->m_uploadDone) {
+            self->m_uploadDone->store(true);
         }
 
         projectCloudExtension.OnSyncStarted();
@@ -302,41 +305,29 @@ muse::RetVal<muse::ProgressPtr> Au3AudioComService::uploadProject(au::project::I
                                 : audacity::cloud::audiocom::sync::UploadMode::Normal;
 
         auto done = std::make_shared<std::atomic<bool> >(false);
-        {
-            std::lock_guard guard(self->m_uploadSubscriptionsMutex);
+        self->m_uploadDone = done;
+        self->m_uploadSubscription = projectCloudExtension.SubscribeStatusChanged(
+            [progress, done, project](
+                const audacity::cloud::audiocom::sync::CloudStatusChangedMessage& message) {
+            if (done->load()) {
+                return;
+            }
 
-            self->m_projectUploadSubscriptions.erase(
-                std::remove_if(
-                    self->m_projectUploadSubscriptions.begin(),
-                    self->m_projectUploadSubscriptions.end(),
-                    [](const UploadSubscriptionEntry& e) { return e.done->load(); }),
-                self->m_projectUploadSubscriptions.end());
+            if (message.Status == audacity::cloud::audiocom::sync::ProjectSyncStatus::Syncing) {
+                progress->progress(message.Progress * 100, 100);
+            }
 
-            self->m_projectUploadSubscriptions.push_back(
-                { projectCloudExtension.SubscribeStatusChanged(
-                      [progress, done, project](
-                          const audacity::cloud::audiocom::sync::CloudStatusChangedMessage& message) {
-                    if (done->load()) {
-                        return;
-                    }
+            if (message.Status == audacity::cloud::audiocom::sync::ProjectSyncStatus::Synced) {
+                done->store(true);
+                progress->finish(muse::RetVal<muse::Val>::make_ok(muse::Val(::getCloudProjectPage(project))));
+            }
 
-                    if (message.Status == audacity::cloud::audiocom::sync::ProjectSyncStatus::Syncing) {
-                        progress->progress(message.Progress * 100, 100);
-                    }
-
-                    if (message.Status == audacity::cloud::audiocom::sync::ProjectSyncStatus::Synced) {
-                        done->store(true);
-                        progress->finish(muse::RetVal<muse::Val>::make_ok(muse::Val(::getCloudProjectPage(project))));
-                    }
-
-                    if (message.Status == audacity::cloud::audiocom::sync::ProjectSyncStatus::Failed) {
-                        done->store(true);
-                        progress->finish(make_ret(cloudSyncErrorToErr(message.Error)));
-                    }
-                },
-                      false),
-                  done });
-        }
+            if (message.Status == audacity::cloud::audiocom::sync::ProjectSyncStatus::Failed) {
+                done->store(true);
+                progress->finish(make_ret(cloudSyncErrorToErr(message.Error)));
+            }
+        },
+            false);
 
         auto future = audacity::cloud::audiocom::sync::LocalProjectSnapshot::Create(
             audacity::cloud::audiocom::GetServiceConfig(),
@@ -415,19 +406,12 @@ muse::ValCh<bool> Au3AudioComService::syncingInProgressChanged() const
 
 void Au3AudioComService::stopProjectSync()
 {
-    if (!m_syncInProgress.empty()) {
-        for (auto& progress : m_syncInProgress) {
-            if (progress) {
-                progress->cancel();
-            }
-        }
+    if (m_syncInProgress) {
+        m_syncInProgress->cancel();
     }
 
-    {
-        std::lock_guard guard(m_uploadSubscriptionsMutex);
-        m_projectUploadSubscriptions.clear();
-    }
-
+    m_uploadSubscription.Reset();
+    m_uploadDone.reset();
     m_resumeSyncSubscription.Reset();
 }
 
@@ -764,33 +748,24 @@ muse::Ret Au3AudioComService::checkUnsyncedProject(const std::string& cloudProje
 
 muse::ProgressPtr Au3AudioComService::createSyncProgress()
 {
-    auto progress = std::make_shared<muse::Progress>();
-    m_syncInProgress.push_back(progress);
+    if (m_syncInProgress) {
+        m_syncInProgress->finish(muse::make_ok());
+    }
 
-    progress->canceled().onNotify(this, [this, progress]() {
-        auto it = std::find(m_syncInProgress.begin(), m_syncInProgress.end(), progress);
-        if (it != m_syncInProgress.end()) {
-            m_syncInProgress.erase(it);
-        }
+    m_syncInProgress = std::make_shared<muse::Progress>();
 
-        if (m_syncInProgress.empty()) {
-            m_syncingInProgressChangedChannel.set(false);
-        }
+    m_syncInProgress->canceled().onNotify(this, [this]() {
+        m_syncInProgress.reset();
+        m_syncingInProgressChangedChannel.set(false);
     });
 
-    progress->finished().onReceive(this, [this, progress](const auto&) {
-        auto it = std::find(m_syncInProgress.begin(), m_syncInProgress.end(), progress);
-        if (it != m_syncInProgress.end()) {
-            m_syncInProgress.erase(it);
-        }
-
-        if (m_syncInProgress.empty()) {
-            m_syncingInProgressChangedChannel.set(false);
-        }
+    m_syncInProgress->finished().onReceive(this, [this](const auto&) {
+        m_syncInProgress.reset();
+        m_syncingInProgressChangedChannel.set(false);
     });
 
     m_syncingInProgressChangedChannel.set(true);
-    return progress;
+    return m_syncInProgress;
 }
 
 void Au3AudioComService::deinit()

--- a/src/au3cloud/internal/au3audiocomservice.cpp
+++ b/src/au3cloud/internal/au3audiocomservice.cpp
@@ -408,6 +408,15 @@ muse::ValCh<bool> Au3AudioComService::syncingInProgressChanged() const
 
 void Au3AudioComService::stopProjectSync()
 {
+    auto project = globalContext()->currentProject();
+    if (project) {
+        au::au3::Au3Project* au3Project = reinterpret_cast<au::au3::Au3Project*>(project->au3ProjectPtr());
+        if (au3Project) {
+            auto& projectCloudExtension = audacity::cloud::audiocom::sync::ProjectCloudExtension::Get(*au3Project);
+            projectCloudExtension.CancelSync();
+        }
+    }
+
     if (m_syncInProgress) {
         m_syncInProgress->cancel();
     }

--- a/src/au3cloud/internal/au3audiocomservice.cpp
+++ b/src/au3cloud/internal/au3audiocomservice.cpp
@@ -74,6 +74,27 @@ std::string getCloudProjectPage(au::project::IAudacityProjectPtr project)
     auto& projectCloudExtension = audacity::cloud::audiocom::sync::ProjectCloudExtension::Get(*au3Project);
     return projectCloudExtension.GetCloudProjectPage(AudiocomTrace::SaveProjectSaveToCloudMenu);
 }
+
+bool needsNewSnapshot(au::project::IAudacityProjectPtr project,
+                      const audacity::cloud::audiocom::sync::ProjectCloudExtension& extension,
+                      bool forceOverwrite)
+{
+    if (forceOverwrite) {
+        return true;
+    }
+
+    IF_ASSERT_FAILED(extension.IsCloudProject()) {
+        return true;
+    }
+
+    if (project->needSave().val) {
+        return true;
+    }
+
+    const auto status = extension.GetCurrentSyncStatus();
+    return status != audacity::cloud::audiocom::sync::ProjectSyncStatus::Synced
+           && status != audacity::cloud::audiocom::sync::ProjectSyncStatus::Syncing;
+}
 }
 
 void Au3AudioComService::init()
@@ -275,9 +296,13 @@ muse::RetVal<muse::ProgressPtr> Au3AudioComService::uploadProject(au::project::I
         return muse::RetVal<muse::ProgressPtr>::make_ret(muse::Ret::Code::InternalError, muse::trc("cloud", "Invalid project"));
     }
 
-    muse::ProgressPtr progress = createSyncProgress();
-
     auto& projectCloudExtension = audacity::cloud::audiocom::sync::ProjectCloudExtension::Get(*au3Project);
+
+    if (!needsNewSnapshot(project, projectCloudExtension, forceOverwrite)) {
+        return muse::RetVal<muse::ProgressPtr>::make_ok(nullptr);
+    }
+
+    muse::ProgressPtr progress = createSyncProgress();
 
     m_resumeSyncSubscription.Reset();
     if (m_uploadDone) {

--- a/src/au3cloud/internal/au3audiocomservice.cpp
+++ b/src/au3cloud/internal/au3audiocomservice.cpp
@@ -759,21 +759,29 @@ muse::Ret Au3AudioComService::checkUnsyncedProject(const std::string& cloudProje
 
 muse::ProgressPtr Au3AudioComService::createSyncProgress()
 {
-    if (m_syncInProgress) {
-        m_syncInProgress->cancel();
+    auto oldProgress = std::exchange(m_syncInProgress, std::make_shared<muse::Progress>());
+
+    std::weak_ptr<muse::Progress> weakProgress = m_syncInProgress;
+
+    m_syncInProgress->canceled().onNotify(this, [this, weakProgress]() {
+        if (weakProgress.lock() != m_syncInProgress) {
+            return;
+        }
+        m_syncInProgress.reset();
+        m_syncingInProgressChangedChannel.set(false);
+    });
+
+    m_syncInProgress->finished().onReceive(this, [this, weakProgress](const auto&) {
+        if (weakProgress.lock() != m_syncInProgress) {
+            return;
+        }
+        m_syncInProgress.reset();
+        m_syncingInProgressChangedChannel.set(false);
+    });
+
+    if (oldProgress) {
+        oldProgress->cancel();
     }
-
-    m_syncInProgress = std::make_shared<muse::Progress>();
-
-    m_syncInProgress->canceled().onNotify(this, [this]() {
-        m_syncInProgress.reset();
-        m_syncingInProgressChangedChannel.set(false);
-    });
-
-    m_syncInProgress->finished().onReceive(this, [this](const auto&) {
-        m_syncInProgress.reset();
-        m_syncingInProgressChangedChannel.set(false);
-    });
 
     m_syncingInProgressChangedChannel.set(true);
     return m_syncInProgress;

--- a/src/au3cloud/internal/au3audiocomservice.cpp
+++ b/src/au3cloud/internal/au3audiocomservice.cpp
@@ -380,13 +380,13 @@ muse::RetVal<muse::ProgressPtr> Au3AudioComService::resumeProjectSync(au::projec
 
     auto progress = createSyncProgress();
     m_resumeSyncSubscription = projectCloudExtension.SubscribeStatusChanged(
-        [progress](const audacity::cloud::audiocom::sync::CloudStatusChangedMessage& message) {
+        [progress, project](const audacity::cloud::audiocom::sync::CloudStatusChangedMessage& message) {
         if (message.Status == audacity::cloud::audiocom::sync::ProjectSyncStatus::Syncing) {
             progress->progress(message.Progress * 100, 100);
         }
 
         if (message.Status == audacity::cloud::audiocom::sync::ProjectSyncStatus::Synced) {
-            progress->finish(muse::make_ok());
+            progress->finish(muse::RetVal<muse::Val>::make_ok(muse::Val(::getCloudProjectPage(project))));
         }
 
         if (message.Status == audacity::cloud::audiocom::sync::ProjectSyncStatus::Failed) {
@@ -749,7 +749,7 @@ muse::Ret Au3AudioComService::checkUnsyncedProject(const std::string& cloudProje
 muse::ProgressPtr Au3AudioComService::createSyncProgress()
 {
     if (m_syncInProgress) {
-        m_syncInProgress->finish(muse::make_ok());
+        m_syncInProgress->cancel();
     }
 
     m_syncInProgress = std::make_shared<muse::Progress>();

--- a/src/au3cloud/internal/au3audiocomservice.cpp
+++ b/src/au3cloud/internal/au3audiocomservice.cpp
@@ -414,6 +414,17 @@ void Au3AudioComService::stopProjectSync()
         if (au3Project) {
             auto& projectCloudExtension = audacity::cloud::audiocom::sync::ProjectCloudExtension::Get(*au3Project);
             projectCloudExtension.CancelSync();
+
+            // Remove pending snapshots
+            auto& db = sync::CloudProjectsDatabase::Get();
+            const auto projectId = projectCloudExtension.GetCloudProjectId();
+            if (!projectId.empty()) {
+                for (const auto& snapshot : db.GetPendingSnapshots(projectId)) {
+                    db.RemovePendingProjectBlocks(projectId, snapshot.SnapshotId);
+                    db.RemovePendingProjectBlob(projectId, snapshot.SnapshotId);
+                    db.RemovePendingSnapshot(projectId, snapshot.SnapshotId);
+                }
+            }
         }
     }
 

--- a/src/au3cloud/internal/au3audiocomservice.h
+++ b/src/au3cloud/internal/au3audiocomservice.h
@@ -108,12 +108,8 @@ private:
 
     mutable std::mutex m_cacheMutex;
 
-    struct UploadSubscriptionEntry {
-        Observer::Subscription subscription;
-        std::shared_ptr<std::atomic<bool> > done;
-    };
-    std::vector<UploadSubscriptionEntry> m_projectUploadSubscriptions;
-    std::mutex m_uploadSubscriptionsMutex;
+    Observer::Subscription m_uploadSubscription;
+    std::shared_ptr<std::atomic<bool> > m_uploadDone;
 
     Observer::Subscription m_resumeSyncSubscription;
 
@@ -121,6 +117,6 @@ private:
     muse::async::Channel<std::string, muse::io::path_t> m_audioThumbnailFileUpdatedChannel;
 
     muse::ValCh<bool> m_syncingInProgressChangedChannel;
-    std::vector<muse::ProgressPtr> m_syncInProgress;
+    muse::ProgressPtr m_syncInProgress;
 };
 }

--- a/src/project/internal/projectactionscontroller.cpp
+++ b/src/project/internal/projectactionscontroller.cpp
@@ -938,7 +938,24 @@ Ret ProjectActionsController::openCloudProject(const io::path_t& localPath, cons
         syncProgress->finished().onReceive(this, [this](const ProgressResult& result) {
             if (!result.ret.success()) {
                 handleCloudSaveError(result.ret);
+                return;
             }
+
+            const bool dismissable = false;
+            toastService()->show(trc("global", "Success"),
+                                 trc("project",
+                                     "All saved changes will now update to the cloud.\nYou can manage this file from your updated projects page on audio.com"),
+                                 muse::ui::IconCode::Code::TICK,
+                                 dismissable,
+            {
+                { trc("project", "Dismiss"), au::toast::ToastActionCode::None },
+                { trc("cloud", "View on audio.com"), au::toast::ToastActionCode::Custom }
+            }
+                                 ).onResolve(this, [this, url = result.val.toQString()](au::toast::ToastActionCode actionCode) {
+                if (actionCode == au::toast::ToastActionCode::Custom) {
+                    platformInteractive()->openUrl(url);
+                }
+            });
         });
 
         const bool dismissible = false;

--- a/src/project/internal/projectactionscontroller.cpp
+++ b/src/project/internal/projectactionscontroller.cpp
@@ -552,8 +552,7 @@ bool ProjectActionsController::saveProjectToCloud(const CloudProjectInfo& cloudI
     }
 
     if (!progress) {
-        LOGE() << "Failed to start cloud upload";
-        return false;
+        return true;
     }
 
     progress->finished().onReceive(this, [this, projectFilePath](const ProgressResult& result) {

--- a/src/project/internal/projectactionscontroller.cpp
+++ b/src/project/internal/projectactionscontroller.cpp
@@ -592,8 +592,9 @@ bool ProjectActionsController::saveProjectToCloud(const CloudProjectInfo& cloudI
         { trc("global", "Stop"), au::toast::ToastActionCode::Custom }
     },
         showProgressInfo
-        ).onResolve(this, [progress = progress](const au::toast::ToastActionCode& actionCode) {
+        ).onResolve(this, [this, progress = progress](const au::toast::ToastActionCode& actionCode) {
         if (actionCode == au::toast::ToastActionCode::Custom) {
+            audioComService()->stopProjectSync();
             progress->cancel();
         }
     });
@@ -971,8 +972,9 @@ Ret ProjectActionsController::openCloudProject(const io::path_t& localPath, cons
             { trc("global", "Stop"), au::toast::ToastActionCode::Custom }
         },
             showProgressInfo
-            ).onResolve(this, [progress = syncProgress](const au::toast::ToastActionCode& actionCode) {
+            ).onResolve(this, [this, progress = syncProgress](const au::toast::ToastActionCode& actionCode) {
             if (actionCode == au::toast::ToastActionCode::Custom) {
+                audioComService()->stopProjectSync();
                 progress->cancel();
             }
         });


### PR DESCRIPTION
Resolves: #10911 #10912 #10953 

This PR also adds the toast when resume is finished.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
