### PR TITLE
Prevent multiple instances

### DIFF
--- a/src/app/guiapp.cpp
+++ b/src/app/guiapp.cpp
@@ -3,7 +3,13 @@
  */
 #include "guiapp.h"
 
-#include "modularity/ioc.h"
+#include <QCoreApplication>
+
+#include "framework/global/modularity/ioc.h"
+#include "framework/ui/imainwindow.h"
+#include "framework/actions/iactionsdispatcher.h"
+#include "framework/actions/actiontypes.h"
+
 #include "appshell/istartupscenario.h"
 #include "appshell/internal/splashscreen/splashscreen.h"
 #include "project/types/projecttypes.h"
@@ -113,5 +119,51 @@ void GuiApp::applyCommandLineOptions(const std::shared_ptr<muse::CmdOptions>& op
 
     if (options->app.revertToFactorySettings) {
         appshellConfiguration()->revertToFactorySettings();
+    }
+}
+
+void GuiApp::doSetup(const std::shared_ptr<muse::CmdOptions>& options)
+{
+    muse::ui::GuiApplication::doSetup(options);
+
+    const QString appId = QCoreApplication::applicationName();
+    if (!m_singleInstance.start(appId)) {
+        return;
+    }
+
+    m_singleInstance.messageReceived().onReceive(this, [this](const QStringList& args) {
+        onSecondInstanceArgs(args);
+    });
+}
+
+void GuiApp::onSecondInstanceArgs(const QStringList& args)
+{
+    LOGI() << "second instance handed off args: " << args;
+
+    // Raise the fisrt window when the instance is activated
+    // TODO: define rules which window should be activated, ie first, last, last used
+    const auto& contexts = muse::ui::GuiApplication::contexts();
+    if (contexts.empty()) {
+        return;
+    }
+    const auto& ctx = contexts.front();
+
+    auto window = muse::modularity::ioc(ctx)->resolve<muse::ui::IMainWindow>("app");
+    if (window) {
+        window->requestShowOnFront();
+    }
+
+    // parse arguments forwarded by the second instance
+    auto parsed = std::dynamic_pointer_cast<AudacityCmdOptions>(makeContextOptions(muse::StringList(args)));
+    if (!parsed) {
+        return;
+    }
+
+    if (parsed->startup.projectUrl.has_value()) {
+        auto dispatcher = muse::modularity::ioc(ctx)->resolve<muse::actions::IActionsDispatcher>("app");
+        if (dispatcher) {
+            dispatcher->dispatch("file-open",
+                                 muse::actions::ActionData::make_arg1<QUrl>(parsed->startup.projectUrl.value()));
+        }
     }
 }

--- a/src/app/guiapp.cpp
+++ b/src/app/guiapp.cpp
@@ -126,6 +126,10 @@ void GuiApp::doSetup(const std::shared_ptr<muse::CmdOptions>& options)
 {
     muse::ui::GuiApplication::doSetup(options);
 
+    if (qEnvironmentVariableIsSet("AU_ALLOW_MULTIPLE_PROCESSES")) {
+        return;
+    }
+
     const QString appId = QCoreApplication::applicationName();
     if (!m_singleInstance.start(appId)) {
         return;
@@ -140,10 +144,10 @@ void GuiApp::onSecondInstanceArgs(const QStringList& args)
 {
     LOGI() << "second instance handed off args: " << args;
 
-    // Raise the fisrt window when the instance is activated
+    // Raise the first window when the instance is activated
     // TODO: define rules which window should be activated, ie first, last, last used
     const auto& contexts = muse::ui::GuiApplication::contexts();
-    if (contexts.empty()) {
+    IF_ASSERT_FAILED(!contexts.empty()) {
         return;
     }
     const auto& ctx = contexts.front();

--- a/src/app/guiapp.h
+++ b/src/app/guiapp.h
@@ -5,9 +5,14 @@
 
 #include <memory>
 
-#include "ui/internal/guiapplication.h"
+#include <QString>
+#include <QStringList>
 
-#include "modularity/ioc.h"
+#include "framework/global/async/asyncable.h"
+#include "framework/global/modularity/ioc.h"
+#include "framework/multiwindows/singleinstance.h"
+#include "framework/ui/internal/guiapplication.h"
+
 #include "appshell/iappshellconfiguration.h"
 
 #include "cmdoptions.h"
@@ -17,7 +22,7 @@ class SplashScreen;
 }
 
 namespace au::app {
-class GuiApp : public muse::ui::GuiApplication
+class GuiApp : public muse::ui::GuiApplication, public muse::async::Asyncable
 {
     muse::GlobalInject<appshell::IAppShellConfiguration> appshellConfiguration;
 
@@ -28,9 +33,13 @@ private:
     std::shared_ptr<muse::CmdOptions> makeContextOptions(const muse::StringList& args) const override;
     QString mainWindowQmlPath(const QString& platform) const override;
     void showContextSplash(const muse::modularity::ContextPtr& ctxId) override;
+    void doSetup(const std::shared_ptr<muse::CmdOptions>& options) override;
     void doStartupScenario(const muse::modularity::ContextPtr& ctxId) override;
     void applyCommandLineOptions(const std::shared_ptr<muse::CmdOptions>& options) override;
 
+    void onSecondInstanceArgs(const QStringList& args);
+
     appshell::SplashScreen* m_splashScreen = nullptr;
+    muse::mi::SingleInstanceListener m_singleInstance;
 };
 }

--- a/src/app/guiapp.h
+++ b/src/app/guiapp.h
@@ -5,7 +5,6 @@
 
 #include <memory>
 
-#include <QString>
 #include <QStringList>
 
 #include "framework/global/async/asyncable.h"

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -12,6 +12,8 @@
 #include "commandlineparser.h"
 #include "log.h"
 
+#include "framework/multiwindows/singleinstance.h"
+
 #include "muse_framework_config.h"
 
 #if (defined (_MSCVER) || defined (_MSC_VER))
@@ -176,6 +178,17 @@ int main(int argc, char** argv)
     if (commandLineParser.runMode() == muse::IApplication::RunMode::AudioPluginRegistration) {
         qApplication = new QCoreApplication(argcFinal, argvFinal);
     } else {
+        QStringList forwardedArgs;
+        forwardedArgs.reserve(argcFinal - 1);
+        for (int i = 1; i < argcFinal; ++i) {
+            forwardedArgs.append(QString::fromUtf8(argvFinal[i]));
+        }
+        if (muse::mi::activateExistingInstance(QString::fromLatin1(appName), forwardedArgs)) {
+            LOGI() << "existing Audacity instance activated";
+            LOGI() << "exiting";
+            return 0;
+        }
+        
         QApplication* guiApp = new QApplication(argcFinal, argvFinal);
         guiApp->setQuitOnLastWindowClosed(false);
         qApplication = guiApp;

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -178,17 +178,19 @@ int main(int argc, char** argv)
     if (commandLineParser.runMode() == muse::IApplication::RunMode::AudioPluginRegistration) {
         qApplication = new QCoreApplication(argcFinal, argvFinal);
     } else {
-        QStringList forwardedArgs;
-        forwardedArgs.reserve(argcFinal - 1);
-        for (int i = 1; i < argcFinal; ++i) {
-            forwardedArgs.append(QString::fromUtf8(argvFinal[i]));
+        if (!qEnvironmentVariableIsSet("AU_ALLOW_MULTIPLE_PROCESSES")) {
+            QStringList forwardedArgs;
+            forwardedArgs.reserve(argcFinal - 1);
+            for (int i = 1; i < argcFinal; ++i) {
+                forwardedArgs.append(QString::fromUtf8(argvFinal[i]));
+            }
+            if (muse::mi::activateExistingInstance(QString::fromLatin1(appName), forwardedArgs)) {
+                LOGI() << "existing Audacity instance activated";
+                LOGI() << "exiting";
+                return 0;
+            }
         }
-        if (muse::mi::activateExistingInstance(QString::fromLatin1(appName), forwardedArgs)) {
-            LOGI() << "existing Audacity instance activated";
-            LOGI() << "exiting";
-            return 0;
-        }
-        
+
         QApplication* guiApp = new QApplication(argcFinal, argvFinal);
         guiApp->setQuitOnLastWindowClosed(false);
         qApplication = guiApp;


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/10722, https://github.com/audacity/audacity/issues/10671 (via framework update)

- Detect already running audacity instance and forward launch arguments
- Skip multi-instance check when env:AU_ALLOW_MULTIPLE_INSTANCES is set

Framework side: https://github.com/musescore/MuseScore/pull/33172

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
