### PR TITLE
Fix paste into empty audio track preserving source sample rate

### DIFF
--- a/src/menus/EditMenus.cpp
+++ b/src/menus/EditMenus.cpp
@@ -646,6 +646,13 @@ void OnPaste(const CommandContext &context)
             member->TypeSwitch(
                [&](WaveTrack &wn){
                   bPastedSomething = true;
+                  // If the destination track is still empty, preserve the source
+                  // sample rate and format (16 PCM, 24PCM or 32 bits) rather than forcing project defaults.
+                  if (wn.GetNumClips() == 0) {
+                     const auto srcWaveTrack = static_cast<const WaveTrack*>(src);
+                     wn.SetRate(srcWaveTrack->GetRate());
+                     wn.ConvertToSampleFormat(srcWaveTrack->GetSampleFormat());
+                  }
                   // For correct remapping of preserved split lines:
                   PasteTimeWarper warper{ t1, t0 + src->GetEndTime() };
                   const auto newClipOnPaste =


### PR DESCRIPTION
**Explanation:** Currently,  when a destination track is newly created and empty, it usually has the project/default rate (typically 44.1 kHz 32 bits). During paste, clip insertion resample to the destination rate, so copied audio from another rate (for example 48 kHz) is unexpectedly converted.

This fix set the destination track rate to the source track rate and format **ONLY** when the destination has no clips yet and rates differ. This prevents unintended resampling in the empty-track paste scenario while keeping existing behavior for non-empty destination tracks.

**Reproduction:**
- Import one mono wave track with a sampling rate and format different from 44.1 kHz 32 bits (for example 48 kHz 16 PCM)
- Select this track (or a segment of it) and copy
- Create a new empty track
- Paste into the selected new track
- Verify that the pasted audio was resampled to 44.1 kHz 32 bits regardless of source rate and format

**Before this fix:** Pasting into a newly created empty track force the pasted audio to the destination/project default sample rate (typically 44.1 kHz 32 bits). This caused unintended sample-rate conversion and possible quality loss

**After this fix:** If the destination WaveTrack is empty, its rate and format is aligned to the source before paste
Paste behavior for non-empty destination tracks is unchanged

**Motivation:** Preserve audio fidelity and avoid unexpected resampling. 

- [ x ] I signed [CLA](https://www.audacityteam.org/cla/)
- [ x ] The title of the pull request describes an issue it addresses
- [ x ] If changes are extensive, then there is a sequence of easily reviewable commits
- [ x ] Each commit's message describes its purpose and effects
- [ x ] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [ x ] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
