### PR TITLE
mod-wavpack: fix 'occured' → 'occurred' in code comments

### DIFF
--- a/au3/modules/import-export/mod-wavpack/ExportWavPack.cpp
+++ b/au3/modules/import-export/mod-wavpack/ExportWavPack.cpp
@@ -443,7 +443,7 @@ int WavPackExportProcessor::WriteBlock(void* id, void* data, int32_t length)
 
     if (!outId->file) {
         // This does not match the wavpack.c but in our case if file is nullptr -
-        // the stream error has occured
+        // the stream error has occurred
         return false;
     }
 

--- a/au3/modules/import-export/mod-wavpack/ImportWavPack.cpp
+++ b/au3/modules/import-export/mod-wavpack/ImportWavPack.cpp
@@ -72,7 +72,7 @@ std::unique_ptr<ImportFileHandle> WavPackImportPlugin::Open(const FilePath& file
     WavpackContext* wavpackContext = WavpackOpenFileInput(filename.ToUTF8(), errMessage, flags, 0);
 
     if (!wavpackContext) {
-        // Some error occured(e.g. File not found or is invalid)
+        // Some error occurred (e.g. File not found or is invalid)
         wxLogDebug("WavpackOpenFileInput() failed on file %s, error = %s", filename, errMessage);
         return nullptr;
     }


### PR DESCRIPTION
Two small typo fixes in code comments inside the wavpack import/export module — no behavior change.

- `au3/modules/import-export/mod-wavpack/ImportWavPack.cpp`: "Some error occured" → "Some error occurred" (also added missing space before parenthesis)
- `au3/modules/import-export/mod-wavpack/ExportWavPack.cpp`: "the stream error has occured" → "the stream error has occurred"