### PR TITLE
10949 menu improvements

### DIFF
--- a/src/appshell/qml/Audacity/AppShell/appmenumodel.cpp
+++ b/src/appshell/qml/Audacity/AppShell/appmenumodel.cpp
@@ -241,7 +241,6 @@ MenuItem* AppMenuModel::makeEditMenu()
         makeSeparator(),
         makeMenu(TranslatableString("appshell/menu/clip", "Clip"), makeClipItems(), "menu-clip"),
         makeMenu(TranslatableString("appshell/menu/label", "Label"), makeLabelItems(), "menu-label"),
-        makeMenuItem("silence-audio"),
         makeSeparator(),
         makeMenuItem("open-metadata-editor", TranslatableString("action", "Metadata editor")),
         makeSeparator(),

--- a/src/appshell/qml/Audacity/AppShell/appmenumodel.cpp
+++ b/src/appshell/qml/Audacity/AppShell/appmenumodel.cpp
@@ -554,7 +554,7 @@ MenuItemList AppMenuModel::makeLabelItems()
         makeMenuItem("label-add"),
         makeMenuItem("paste-new-label"),
         makeSeparator(),
-        makeMenuItem("manage-labels"),
+        makeMenuItem("open-label-editor", TranslatableString("action", "Manage labels")),
     };
 
     return items;

--- a/src/appshell/qml/Audacity/AppShell/appmenumodel.cpp
+++ b/src/appshell/qml/Audacity/AppShell/appmenumodel.cpp
@@ -204,7 +204,6 @@ MenuItem* AppMenuModel::makeFileMenu()
         makeMenuItem("file-save"),
         makeMenuItem("file-save-to-cloud"),
         makeMenuItem("file-save-as"),
-        makeMenuItem("file-save-backup"),
 
         makeSeparator(),
 

--- a/src/appshell/qml/Audacity/AppShell/appmenumodel.cpp
+++ b/src/appshell/qml/Audacity/AppShell/appmenumodel.cpp
@@ -243,7 +243,7 @@ MenuItem* AppMenuModel::makeEditMenu()
         makeMenu(TranslatableString("appshell/menu/label", "Label"), makeLabelItems(), "menu-label"),
         makeMenuItem("silence-audio"),
         makeSeparator(),
-        makeMenuItem("manage-metadata"),
+        makeMenuItem("open-metadata-editor", TranslatableString("action", "Metadata editor")),
         makeSeparator(),
         makeMenuItem("preference-dialog", MenuItemRole::PreferencesRole)
     };
@@ -299,8 +299,8 @@ MenuItem* AppMenuModel::makeViewMenu()
     }
 
     viewItems << makeSeparator()
-              << makeMenuItem("toggle-label-editor")
-              << makeMenuItem("toggle-metadata-editor")
+              << makeMenuItem("open-label-editor")
+              << makeMenuItem("open-metadata-editor")
               << makeMenuItem("toggle-history")
               << makeSeparator()
 #ifdef MUSE_MODULE_WORKSPACE

--- a/src/project/internal/projectactionscontroller.cpp
+++ b/src/project/internal/projectactionscontroller.cpp
@@ -71,7 +71,7 @@ void ProjectActionsController::init()
     dispatcher()->reg(this, "export-labels", this, &ProjectActionsController::exportLabels);
     dispatcher()->reg(this, "export-midi", this, &ProjectActionsController::exportMIDI);
 
-    dispatcher()->reg(this, "manage-metadata", this, &ProjectActionsController::openMetadataDialog);
+    dispatcher()->reg(this, "open-metadata-editor", this, &ProjectActionsController::openMetadataDialog);
 
     dispatcher()->reg(this, "file-close", [this]() {
         // reset preferred export sample rate

--- a/src/project/internal/projectactionscontroller.cpp
+++ b/src/project/internal/projectactionscontroller.cpp
@@ -63,7 +63,6 @@ void ProjectActionsController::init()
     //! to install our own implementation of the UI (BasicUI API)
     //! right now there's only BasicUI stub which means there's no progress dialog shown on saving
     dispatcher()->reg(this, "file-save-as", [this]() { saveProject(SaveMode::SaveAs); });
-    dispatcher()->reg(this, "file-save-backup", [this]() { saveProject(SaveMode::SaveCopy); });
 
     dispatcher()->reg(this, "file-share-audio", this, &ProjectActionsController::shareAudio);
     dispatcher()->reg(this, OPEN_CLOUD_AUDIO_FILE_URI, this, &ProjectActionsController::openCloudAudioFile);
@@ -128,7 +127,6 @@ const muse::actions::ActionCodeList& ProjectActionsController::prohibitedActions
         "file-save",
         "file-save-to-cloud",
         "file-save-as",
-        "file-save-backup",
         "export-audio",
         "export-labels",
         "export-midi",

--- a/src/project/internal/projectuiactions.cpp
+++ b/src/project/internal/projectuiactions.cpp
@@ -127,12 +127,6 @@ const UiActionList ProjectUiActions::m_actions = {
              TranslatableString("action", "Split into new track"),
              TranslatableString("action", "Split into new track")
              ),
-    UiAction("silence-audio",
-             au::context::UiCtxUnknown,
-             au::context::CTX_ANY,
-             TranslatableString("action", "Silence audio"),
-             TranslatableString("action", "Silence audio")
-             ),
     UiAction("paste-new-label",
              au::context::UiCtxUnknown,
              au::context::CTX_ANY,

--- a/src/project/internal/projectuiactions.cpp
+++ b/src/project/internal/projectuiactions.cpp
@@ -139,12 +139,6 @@ const UiActionList ProjectUiActions::m_actions = {
              TranslatableString("action", "Paste new label"),
              TranslatableString("action", "Paste new label")
              ),
-    UiAction("manage-labels",
-             au::context::UiCtxUnknown,
-             au::context::CTX_ANY,
-             TranslatableString("action", "Manage labels"),
-             TranslatableString("action", "Manage labels")
-             ),
     // select menu
     UiAction("select-all",
              au::context::UiCtxAny,

--- a/src/project/internal/projectuiactions.cpp
+++ b/src/project/internal/projectuiactions.cpp
@@ -145,13 +145,6 @@ const UiActionList ProjectUiActions::m_actions = {
              TranslatableString("action", "Manage labels"),
              TranslatableString("action", "Manage labels")
              ),
-    UiAction("manage-metadata",
-             au::context::UiCtxAny,
-             au::context::CTX_ANY,
-             TranslatableString("action", "Metadata editor"),
-             TranslatableString("action", "Metadata editor")
-             ),
-
     // select menu
     UiAction("select-all",
              au::context::UiCtxAny,
@@ -264,12 +257,11 @@ const UiActionList ProjectUiActions::m_actions = {
              TranslatableString("action", "Show effects panel"),
              Checkable::Yes
              ),
-    UiAction("toggle-metadata-editor",
-             au::context::UiCtxUnknown,
+    UiAction("open-metadata-editor",
+             au::context::UiCtxAny,
              au::context::CTX_ANY,
              TranslatableString("action", "Show metadata editor"),
-             TranslatableString("action", "Show metadata editor"),
-             Checkable::Yes
+             TranslatableString("action", "Show metadata editor")
              ),
     UiAction("toggle-history",
              au::context::UiCtxAny,

--- a/src/project/internal/projectuiactions.cpp
+++ b/src/project/internal/projectuiactions.cpp
@@ -71,12 +71,6 @@ const UiActionList ProjectUiActions::m_actions = {
              TranslatableString("action", "Save &as…"),
              TranslatableString("action", "Save as…")
              ),
-    UiAction("file-save-backup",
-             au::context::UiCtxAny,
-             au::context::CTX_ANY,
-             TranslatableString("action", "Save backup"),
-             TranslatableString("action", "Save backup")
-             ),
     UiAction("export-audio",
              au::context::UiCtxAny,
              au::context::CTX_ANY,

--- a/src/projectscene/internal/projectsceneactionscontroller.cpp
+++ b/src/projectscene/internal/projectsceneactionscontroller.cpp
@@ -21,7 +21,7 @@ static const ActionCode TOGGLE_UPDATE_DISPLAY_WHILE_PLAYING_CODE("toggle-update-
 static const ActionCode TOGGLE_PINNED_PLAY_HEAD_CODE("toggle-pinned-play-head");
 static const ActionCode TOGGLE_PLAYBACK_ON_RULER_CLICK_ENABLED_CODE("toggle-playback-on-ruler-click-enabled");
 static const ActionQuery TOGGLE_TRACK_HALF_WAVE("action://projectscene/track-view-half-wave");
-static const ActionCode LABEL_OPEN_EDITOR_CODE("toggle-label-editor");
+static const ActionCode LABEL_OPEN_EDITOR_CODE("open-label-editor");
 static const ActionCode CLIP_GAIN_CODE("clip-gain");
 
 static const muse::Uri EDIT_PITCH_AND_SPEED_URI("audacity://projectscene/editpitchandspeed");

--- a/src/projectscene/internal/projectsceneuiactions.cpp
+++ b/src/projectscene/internal/projectsceneuiactions.cpp
@@ -246,7 +246,7 @@ static UiActionList STATIC_ACTIONS = {
              TranslatableString("action", "Half-wave"),
              Checkable::Yes
              ),
-    UiAction("toggle-label-editor",
+    UiAction("open-label-editor",
              au::context::UiCtxProjectOpened,
              au::context::CTX_PROJECT_OPENED,
              TranslatableString("action", "Show label editor"),


### PR DESCRIPTION
Resolves: #10949 

- Remove silence audio menu
- `Edit -> Label -> Manage` labels and `View -> Show label editor` opens label editor
- Similar as previous item but for metadata editor
- Remove save backup item from file menu

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
