### PR TITLE
10546 Revaluate focused track after undo redo

### DIFF
--- a/src/trackedit/internal/tracknavigationcontroller.cpp
+++ b/src/trackedit/internal/tracknavigationcontroller.cpp
@@ -4,11 +4,14 @@
 
 #include "tracknavigationcontroller.h"
 
+#include <algorithm>
+
 #include "framework/global/async/async.h"
 #include "framework/global/containers.h"
 
 #include "au3wrap/internal/domaccessor.h"
 
+#include "itrackeditproject.h"
 #include "trackedit/trackedittypes.h"
 
 using namespace au::trackedit;
@@ -80,6 +83,18 @@ void TrackNavigationController::init()
                 if (!trackList.empty()) {
                     setFocusedTrack(trackList.front().id);
                 }
+
+                prj->trackAdded().onReceive(this, [this](const Track&) {
+                    revalidateFocusedTrack();
+                });
+
+                prj->trackInserted().onReceive(this, [this](const Track&, int) {
+                    revalidateFocusedTrack();
+                });
+
+                prj->trackRemoved().onReceive(this, [this](const Track&) {
+                    revalidateFocusedTrack();
+                });
             }
         });
     });
@@ -766,4 +781,19 @@ void TrackNavigationController::au3SetTrackFocused(const TrackId& trackId)
         au3::DomAccessor::clearAllTrackFocus(*au3Project);
         au3::DomAccessor::setTrackFocused(*au3Project, trackId, true);
     }
+}
+
+void TrackNavigationController::revalidateFocusedTrack()
+{
+    const TrackId focused = focusedTrack();
+    const TrackIdList tracks = selectionController()->orderedTrackList();
+    const bool focusedExists = std::any_of(tracks.begin(), tracks.end(),
+                                           [focused](const TrackId& t) { return t == focused; });
+
+    if (focusedExists) {
+        return;
+    }
+
+    const TrackId trackId = tracks.empty() ? INVALID_TRACK : tracks.front();
+    setFocusedTrack(trackId);
 }

--- a/src/trackedit/internal/tracknavigationcontroller.h
+++ b/src/trackedit/internal/tracknavigationcontroller.h
@@ -95,6 +95,8 @@ private:
 
     void au3SetTrackFocused(const TrackId& trackId);
 
+    void revalidateFocusedTrack();
+
     bool m_isNavigationActive = false;
     muse::async::Notification m_isNavigationActiveChannel;
 


### PR DESCRIPTION
Resolves: #10546 

The focused track will emit the correct signal that will activate the correct navigation section.
This will allow the shortcuts to work again.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
