### PR TITLE
Export: One-click overwrite of file

### DIFF
--- a/src/appshell/qml/Audacity/AppShell/CMakeLists.txt
+++ b/src/appshell/qml/Audacity/AppShell/CMakeLists.txt
@@ -145,6 +145,8 @@ if (NOT OS_IS_MAC)
     target_link_libraries(appshell_qml PRIVATE Qt6::GuiPrivate)
 endif(NOT OS_IS_MAC)
 
+target_link_libraries(appshell_qml PRIVATE exporter)
+
 fixup_qml_module_dependencies(appshell_qml)
 
 # Necessary for the auto-generated sources

--- a/src/appshell/qml/Audacity/AppShell/appmenumodel.cpp
+++ b/src/appshell/qml/Audacity/AppShell/appmenumodel.cpp
@@ -202,40 +202,39 @@ void AppMenuModel::updateUndoRedoItems()
 
 void AppMenuModel::updateOverwriteOriginalTitle()
 {
-    try {
-        MenuItem& item = findItem(ActionCode("export-overwrite-original"));
+    MenuItem& item = findItem(ActionCode("export-overwrite-original"));
+    if (!item.isValid()) {
+        return;
+    }
 
-        // Try to get the current project and its original file info
-        auto currentProj = globalContext()->currentProject();
-        if (currentProj) {
-            auto au3Project = reinterpret_cast<AudacityProject*>(currentProj->au3ProjectPtr());
-            if (au3Project) {
-                auto& fileInfo = OriginalFileInfo::Get(*au3Project);
-                if (fileInfo.HasOriginalFile()) {
-                    // Get the display name (filename without path)
-                    QString displayName = fileInfo.GetOriginalFileName();
-                    if (displayName.isEmpty()) {
-                        displayName = fileInfo.GetOriginalFilePath();
-                    }
-
-                    // Extract just the filename if it's a full path
-                    QFileInfo fi(displayName);
-                    QString fileName = fi.fileName();
-                    if (fileName.isEmpty()) {
-                        fileName = displayName;
-                    }
-
-                    item.setTitle(TranslatableString("action", "Overwrite %1").arg(fileName));
-                    return;
+    // Try to get the current project and its original file info
+    auto currentProj = globalContext()->currentProject();
+    if (currentProj) {
+        auto au3Project = reinterpret_cast<AudacityProject*>(currentProj->au3ProjectPtr());
+        if (au3Project) {
+            auto& fileInfo = OriginalFileInfo::Get(*au3Project);
+            if (fileInfo.HasOriginalFile()) {
+                // Get the display name (filename without path)
+                QString displayName = fileInfo.GetOriginalFileName();
+                if (displayName.isEmpty()) {
+                    displayName = fileInfo.GetOriginalFilePath();
                 }
+
+                // Extract just the filename if it's a full path
+                QFileInfo fi(displayName);
+                QString fileName = fi.fileName();
+                if (fileName.isEmpty()) {
+                    fileName = displayName;
+                }
+
+                item.setTitle(TranslatableString("action", "Overwrite %1").arg(fileName));
+                return;
             }
         }
-
-        // Fallback: use default title if no original file
-        item.setTitle(TranslatableString("action", "Overwrite original"));
-    } catch (...) {
-        // Item not found - this is okay, menu might not be fully initialized yet
     }
+
+    // Fallback: use default title if no original file
+    item.setTitle(TranslatableString("action", "Overwrite original"));
 }
 
 MenuItem* AppMenuModel::makeMenuItem(const actions::ActionCode& actionCode, MenuItemRole menuRole)

--- a/src/appshell/qml/Audacity/AppShell/appmenumodel.cpp
+++ b/src/appshell/qml/Audacity/AppShell/appmenumodel.cpp
@@ -31,6 +31,15 @@
 
 #include "log.h"
 
+#include "context/iglobalcontext.h"
+#include "importexport/export/OriginalFileInfo.h"
+#include "project/iaudacityproject.h"
+#include "trackedit/itrackeditproject.h"
+#include <QFileInfo>
+
+// Forward declaration
+class AudacityProject;
+
 using namespace au::appshell;
 using namespace muse;
 using namespace muse::ui;
@@ -131,6 +140,8 @@ void AppMenuModel::setupConnections()
                 item.setAction(act);
             }
         }
+
+        updateOverwriteOriginalTitle();
     });
 
     effectsProvider()->effectMetaListChanged().onNotify(this, [this]() {
@@ -143,7 +154,23 @@ void AppMenuModel::setupConnections()
 
     projectHistory()->historyChanged().onReceive(this, [this](auto) {
         updateUndoRedoItems();
+        updateOverwriteOriginalTitle();
     });
+
+    auto listenTrackProjectChanges = [this]() {
+        if (auto project = globalContext()->currentTrackeditProject()) {
+            project->trackAdded().onReceive(this, [this](auto) {
+                updateOverwriteOriginalTitle();
+            }, muse::async::Asyncable::Mode::SetReplace);
+        }
+    };
+
+    globalContext()->currentTrackeditProjectChanged().onNotify(this, [this, listenTrackProjectChanges]() {
+        updateOverwriteOriginalTitle();
+        listenTrackProjectChanges();
+    });
+
+    listenTrackProjectChanges();
 
     configuration()->isEffectsPanelVisibleChanged().onNotify(this, [this]() {
         setItemIsChecked("toggle-effects", configuration()->isEffectsPanelVisible());
@@ -171,6 +198,44 @@ void AppMenuModel::updateUndoRedoItems()
     redoItem.setTitle(redoActionName.isEmpty()
                       ? TranslatableString("action", "Redo")
                       : TranslatableString("action", "Redo ‘%1’").arg(redoActionName));
+}
+
+void AppMenuModel::updateOverwriteOriginalTitle()
+{
+    try {
+        MenuItem& item = findItem(ActionCode("export-overwrite-original"));
+
+        // Try to get the current project and its original file info
+        auto currentProj = globalContext()->currentProject();
+        if (currentProj) {
+            auto au3Project = reinterpret_cast<AudacityProject*>(currentProj->au3ProjectPtr());
+            if (au3Project) {
+                auto& fileInfo = OriginalFileInfo::Get(*au3Project);
+                if (fileInfo.HasOriginalFile()) {
+                    // Get the display name (filename without path)
+                    QString displayName = fileInfo.GetOriginalFileName();
+                    if (displayName.isEmpty()) {
+                        displayName = fileInfo.GetOriginalFilePath();
+                    }
+
+                    // Extract just the filename if it's a full path
+                    QFileInfo fi(displayName);
+                    QString fileName = fi.fileName();
+                    if (fileName.isEmpty()) {
+                        fileName = displayName;
+                    }
+
+                    item.setTitle(TranslatableString("action", "Overwrite %1").arg(fileName));
+                    return;
+                }
+            }
+        }
+
+        // Fallback: use default title if no original file
+        item.setTitle(TranslatableString("action", "Overwrite original"));
+    } catch (...) {
+        // Item not found - this is okay, menu might not be fully initialized yet
+    }
 }
 
 MenuItem* AppMenuModel::makeMenuItem(const actions::ActionCode& actionCode, MenuItemRole menuRole)
@@ -207,7 +272,8 @@ MenuItem* AppMenuModel::makeFileMenu()
         makeSeparator(),
 
         makeMenuItem("export-audio"),
-        makeMenu(TranslatableString("appshell-menu-export-other", "&Export other"), makeExportItems(), "menu-export-other"),
+        makeMenuItem("export-overwrite-original"),
+        makeMenu(TranslatableString("appshell/menu/export-other", "&Export other"), makeExportItems(), "menu-export-other"),
         makeMenuItem("file-share-audio"),
 
         makeSeparator(),

--- a/src/appshell/qml/Audacity/AppShell/appmenumodel.h
+++ b/src/appshell/qml/Audacity/AppShell/appmenumodel.h
@@ -49,6 +49,7 @@ Q_MOC_INCLUDE(< QWindow >)
 //! TODO AU4
 // #include "workspace/iworkspacemanager.h"
 #include "project/irecentfilescontroller.h"
+#include "context/iglobalcontext.h"
 // #include "extensions/iextensionsprovider.h"
 #include "update/iupdateconfiguration.h"
 
@@ -72,7 +73,7 @@ public:
     muse::ContextInject<muse::ui::IUiActionsRegister> uiActionsRegister = { this };
     muse::ContextInject<effects::IEffectsMenuProvider> effectsMenuProvider = { this };
     muse::ContextInject<trackedit::IProjectHistory> projectHistory = { this };
-
+    muse::ContextInject<au::context::IGlobalContext> globalContext { this };
     //! TODO AU4
     // muse::ContextInject<workspace::IWorkspaceManager> workspacesManager = { this };
     // muse::ContextInject<extensions::IExtensionsProvider> extensionsProvider = { this };
@@ -137,6 +138,7 @@ private:
     void setItemIsChecked(const QString& itemId, bool checked);
 
     void updateUndoRedoItems();
+    void updateOverwriteOriginalTitle();
 
     std::shared_ptr<muse::uicomponents::AbstractMenuModel> m_workspacesMenuModel;
 

--- a/src/importexport/export/CMakeLists.txt
+++ b/src/importexport/export/CMakeLists.txt
@@ -15,6 +15,10 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/iexportconfiguration.h
     ${CMAKE_CURRENT_LIST_DIR}/exportutils.cpp
     ${CMAKE_CURRENT_LIST_DIR}/exportutils.h
+    ${CMAKE_CURRENT_LIST_DIR}/OriginalFileInfo.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/OriginalFileInfo.h
+    ${CMAKE_CURRENT_LIST_DIR}/overwriteoriginalsettings.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/overwriteoriginalsettings.h
 
     #internals
     ${CMAKE_CURRENT_LIST_DIR}/internal/au3/au3exporter.cpp
@@ -50,3 +54,7 @@ set(MODULE_LINK au3wrap)
 set(MODULE_USE_UNITY OFF)
 
 setup_module()
+
+if (AU_BUILD_PROJECT_TESTS)
+    add_subdirectory(tests)
+endif()

--- a/src/importexport/export/OriginalFileInfo.cpp
+++ b/src/importexport/export/OriginalFileInfo.cpp
@@ -1,0 +1,101 @@
+/**********************************************************************
+
+Audacity: A Digital Audio Editor
+
+OriginalFileInfo.cpp
+
+**********************************************************************/
+
+#include "OriginalFileInfo.h"
+
+#include "au3-project/Project.h"
+
+#include <memory>
+
+namespace {
+class OriginalFileInfoAttachment final : public ClientData::Base, public OriginalFileInfo
+{
+};
+
+static const AudacityProject::AttachedObjects::RegisteredFactory key {
+    [](AudacityProject&) {
+        return std::make_shared<OriginalFileInfoAttachment>();
+    }
+};
+}
+
+OriginalFileInfo& OriginalFileInfo::Get(AudacityProject& project)
+{
+    return project.AttachedObjects::Get<OriginalFileInfoAttachment>(key);
+}
+
+void OriginalFileInfo::SetOriginalFile(const QString& filePath, const QString& displayName)
+{
+    mOriginalFilePath = filePath;
+    mOriginalFileName = displayName;
+}
+
+const QString& OriginalFileInfo::GetOriginalFilePath() const
+{
+    return mOriginalFilePath;
+}
+
+const QString& OriginalFileInfo::GetOriginalFileName() const
+{
+    return mOriginalFileName;
+}
+
+void OriginalFileInfo::SetExportFormatID(const QString& formatID)
+{
+    mExportFormatID = formatID;
+}
+
+const QString& OriginalFileInfo::GetExportFormatID() const
+{
+    return mExportFormatID;
+}
+
+void OriginalFileInfo::SetCodecSettings(const QVariantMap& settings)
+{
+    mCodecSettings = settings;
+}
+
+const QVariantMap& OriginalFileInfo::GetCodecSettings() const
+{
+    return mCodecSettings;
+}
+
+void OriginalFileInfo::SetExportParameters(const au::importexport::ExportParameters& parameters)
+{
+    mExportParameters = parameters;
+}
+
+const au::importexport::ExportParameters& OriginalFileInfo::GetExportParameters() const
+{
+    return mExportParameters;
+}
+
+void OriginalFileInfo::IncrementImportedFileCount()
+{
+    ++mImportedFileCount;
+}
+
+int OriginalFileInfo::GetImportedFileCount() const
+{
+    return mImportedFileCount;
+}
+
+void OriginalFileInfo::Clear()
+{
+    mOriginalFilePath.clear();
+    mOriginalFileName.clear();
+    mExportFormatID.clear();
+    mCodecSettings.clear();
+    mExportParameters.clear();
+    mImportedFileCount = 0;
+}
+
+bool OriginalFileInfo::HasOriginalFile() const
+{
+    return !mOriginalFilePath.isEmpty() && mImportedFileCount == 1;
+}

--- a/src/importexport/export/OriginalFileInfo.h
+++ b/src/importexport/export/OriginalFileInfo.h
@@ -1,0 +1,92 @@
+/**********************************************************************
+
+Audacity: A Digital Audio Editor
+
+OriginalFileInfo.h
+
+Stores information about the original file that was imported,
+including the file path and export codec/format parameters.
+This allows the "Overwrite Original" feature to re-export using
+the original file's codec and format settings.
+
+**********************************************************************/
+
+#ifndef __AUDACITY_ORIGINAL_FILE_INFO__
+#define __AUDACITY_ORIGINAL_FILE_INFO__
+
+#include <QString>
+#include <QVariantMap>
+
+#include "types/exporttypes.h"
+
+class AudacityProject;
+
+/// Stores metadata about the original imported file and its export settings
+/// This is session-scoped data (not saved to project file) and cleared when
+/// the project closes or a new project is created.
+/// This is NOT part of the project file; it lives purely in the app state during a session.
+class OriginalFileInfo
+{
+public:
+    /// Get or create the OriginalFileInfo for a project
+    static OriginalFileInfo& Get(AudacityProject& project);
+
+    OriginalFileInfo() = default;
+    OriginalFileInfo(const OriginalFileInfo&) = delete;
+    OriginalFileInfo& operator=(const OriginalFileInfo&) = delete;
+    ~OriginalFileInfo() = default;
+
+    /// Set information about the originally imported file
+    /// Called when the first file is imported into the project
+    void SetOriginalFile(const QString& filePath, const QString& displayName);
+
+    /// Get the path to the original file
+    const QString& GetOriginalFilePath() const;
+
+    /// Get the display name of the original file
+    const QString& GetOriginalFileName() const;
+
+    /// Set the export format ID (e.g., "WAV", "MP3")
+    void SetExportFormatID(const QString& formatID);
+
+    /// Get the export format ID
+    const QString& GetExportFormatID() const;
+
+    /// Set codec-specific properties read from the source file.
+    /// Examples include sampleRate, bitRate, bitDepth, quality, or any
+    /// format-specific export option needed to reproduce the original file.
+    void SetCodecSettings(const QVariantMap& settings);
+
+    /// Get codec-specific properties read from the source file.
+    const QVariantMap& GetCodecSettings() const;
+
+    /// Set the exact export option values to use when overwriting.
+    void SetExportParameters(const au::importexport::ExportParameters& parameters);
+
+    /// Get the exact export option values to use when overwriting.
+    const au::importexport::ExportParameters& GetExportParameters() const;
+
+    /// Increment the count of imported files
+    /// If more than 1 file has been imported, the "Overwrite Original" menu
+    /// entry should be disabled/hidden
+    void IncrementImportedFileCount();
+
+    /// Get the count of files that have been imported into this project
+    int GetImportedFileCount() const;
+
+    /// Clear all stored information
+    void Clear();
+
+    /// Check if we have valid original file information
+    bool HasOriginalFile() const;
+
+private:
+    QString mOriginalFilePath;
+    QString mOriginalFileName;
+    QString mExportFormatID;
+    QVariantMap mCodecSettings;
+    au::importexport::ExportParameters mExportParameters;
+    int mImportedFileCount{ 0 };
+};
+
+#endif

--- a/src/importexport/export/iexporter.h
+++ b/src/importexport/export/iexporter.h
@@ -16,8 +16,6 @@
 #include "types/ret.h"
 
 namespace au::importexport {
-using ExportParameters = std::vector<std::tuple<int, OptionValue> >;
-
 class IExporter : MODULE_EXPORT_INTERFACE
 {
     INTERFACE_ID(IExporter)

--- a/src/importexport/export/overwriteoriginalsettings.cpp
+++ b/src/importexport/export/overwriteoriginalsettings.cpp
@@ -1,0 +1,175 @@
+#include "overwriteoriginalsettings.h"
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <string>
+#include <type_traits>
+#include <variant>
+
+#include "au3-import-export/ExportOptionsEditor.h"
+#include "au3-strings/TranslatableString.h"
+
+namespace au::importexport {
+std::optional<double> NumericExportValue(const ::ExportValue& value)
+{
+    return std::visit([](const auto& v) -> std::optional<double> {
+        using T = std::decay_t<decltype(v)>;
+        if constexpr (std::is_same_v<T, int> || std::is_same_v<T, double>) {
+            return static_cast<double>(v);
+        } else if constexpr (std::is_same_v<T, std::string>) {
+            try {
+                size_t parsedLength = 0;
+                const double parsed = std::stod(v, &parsedLength);
+                return parsedLength == v.size() ? std::optional<double>(parsed) : std::nullopt;
+            } catch (...) {
+                return std::nullopt;
+            }
+        } else {
+            return std::nullopt;
+        }
+    }, value);
+}
+
+namespace {
+std::optional<::ExportValue> closestNumericOptionValue(const ::ExportOption& option, double target)
+{
+    std::optional<::ExportValue> closest;
+    double closestDistance = std::numeric_limits<double>::max();
+
+    for (const auto& value : option.values) {
+        const auto numeric = NumericExportValue(value);
+        if (!numeric) {
+            continue;
+        }
+
+        const double distance = std::abs(*numeric - target);
+        if (distance < closestDistance) {
+            closest = value;
+            closestDistance = distance;
+        }
+    }
+
+    return closest;
+}
+
+bool applyMp3CodecSettings(::ExportOptionsEditor& editor, const QVariantMap& codecSettings)
+{
+    if (editor.GetName() != "mp3" || !codecSettings.contains("bitRate")) {
+        return false;
+    }
+
+    const auto vbrPreset = Mp3VbrPresetForBitRate(codecSettings.value("bitRate").toDouble());
+    if (!vbrPreset) {
+        return false;
+    }
+
+    for (int index = 0; index < editor.GetOptionsCount(); ++index) {
+        ::ExportOption option;
+        if (!editor.GetOption(index, option)) {
+            continue;
+        }
+
+        const bool isModeOption = std::any_of(option.values.cbegin(), option.values.cend(), [](const ::ExportValue& value) {
+            const auto str = std::get_if<std::string>(&value);
+            return str && *str == "VBR";
+        });
+
+        if (isModeOption) {
+            editor.SetValue(option.id, std::string("VBR"));
+            break;
+        }
+    }
+
+    for (int index = 0; index < editor.GetOptionsCount(); ++index) {
+        ::ExportOption option;
+        if (!editor.GetOption(index, option)) {
+            continue;
+        }
+
+        const bool isVisibleVbrQualityOption = (option.flags & ::ExportOption::Hidden) == 0
+                                               && option.values.size() == 10
+                                               && std::all_of(
+            option.values.cbegin(), option.values.cend(), [](const ::ExportValue& value) {
+            const auto numeric = std::get_if<int>(&value);
+            return numeric && *numeric >= 0 && *numeric <= 9;
+        });
+
+        if (isVisibleVbrQualityOption) {
+            editor.SetValue(option.id, *vbrPreset);
+            return true;
+        }
+    }
+
+    return true;
+}
+}
+
+std::optional<int> Mp3VbrPresetForBitRate(double bitRate)
+{
+    if (bitRate <= 0.0) {
+        return std::nullopt;
+    }
+
+    const double kbps = bitRate > 1000.0 ? bitRate / 1000.0 : bitRate;
+    if (kbps >= 230.0) {
+        return 0;
+    }
+    if (kbps >= 200.0) {
+        return 1;
+    }
+    if (kbps >= 180.0) {
+        return 2;
+    }
+    if (kbps >= 170.0) {
+        return 3;
+    }
+    if (kbps >= 140.0) {
+        return 4;
+    }
+    if (kbps >= 120.0) {
+        return 5;
+    }
+    return 6;
+}
+
+void ApplyCodecSettingsToExportOptions(::ExportOptionsEditor& editor, const QVariantMap& codecSettings)
+{
+    if (applyMp3CodecSettings(editor, codecSettings)) {
+        return;
+    }
+
+    const bool hasBitDepth = codecSettings.contains("bitDepth");
+    const bool hasBitRate = codecSettings.contains("bitRate");
+    const double bitDepth = codecSettings.value("bitDepth").toDouble();
+    double bitRate = codecSettings.value("bitRate").toDouble();
+    if (bitRate > 1000.0) {
+        bitRate /= 1000.0;
+    }
+
+    for (int index = 0; index < editor.GetOptionsCount(); ++index) {
+        ::ExportOption option;
+        if (!editor.GetOption(index, option)) {
+            continue;
+        }
+
+        const std::string title = option.title.Translation().Lower().ToStdString();
+        const bool isBitDepth = title.find("bit depth") != std::string::npos;
+        const bool isBitRate = title.find("bit rate") != std::string::npos
+                               || title.find("bitrate") != std::string::npos
+                               || title.find("quality") != std::string::npos;
+
+        if (hasBitDepth && isBitDepth) {
+            if (auto value = closestNumericOptionValue(option, bitDepth)) {
+                editor.SetValue(option.id, *value);
+            }
+        } else if (hasBitRate && isBitRate) {
+            const auto value = closestNumericOptionValue(option, bitRate);
+            const auto numeric = value ? NumericExportValue(*value) : std::nullopt;
+            if (value && numeric && *numeric >= 32.0) {
+                editor.SetValue(option.id, *value);
+            }
+        }
+    }
+}
+}

--- a/src/importexport/export/overwriteoriginalsettings.cpp
+++ b/src/importexport/export/overwriteoriginalsettings.cpp
@@ -107,8 +107,12 @@ bool applyMp3CodecSettings(::ExportOptionsEditor& editor, const QVariantMap& cod
         return false;
     }
 
-    editor.SetValue(MP3OptionIDMode, std::string("VBR"));
-    editor.SetValue(MP3OptionIDQualityVBR, *vbrPreset);
+    if (!editor.SetValue(MP3OptionIDMode, std::string("VBR"))) {
+        return false;
+    }
+    if (!editor.SetValue(MP3OptionIDQualityVBR, *vbrPreset)) {
+        return false;
+    }
     return true;
 }
 

--- a/src/importexport/export/overwriteoriginalsettings.cpp
+++ b/src/importexport/export/overwriteoriginalsettings.cpp
@@ -1,6 +1,7 @@
 #include "overwriteoriginalsettings.h"
 
 #include <algorithm>
+#include <cctype>
 #include <cmath>
 #include <limits>
 #include <string>
@@ -8,7 +9,6 @@
 #include <variant>
 
 #include "au3-import-export/ExportOptionsEditor.h"
-#include "au3-strings/TranslatableString.h"
 
 namespace au::importexport {
 std::optional<double> NumericExportValue(const ::ExportValue& value)
@@ -32,6 +32,11 @@ std::optional<double> NumericExportValue(const ::ExportValue& value)
 }
 
 namespace {
+constexpr auto FLACFormatID = "FLAC";
+constexpr auto FLACOptionIDBitDepth = 0;
+constexpr auto MP3OptionIDMode = 0;
+constexpr auto MP3OptionIDQualityVBR = 2;
+
 std::optional<::ExportValue> closestNumericOptionValue(const ::ExportOption& option, double target)
 {
     std::optional<::ExportValue> closest;
@@ -53,8 +58,46 @@ std::optional<::ExportValue> closestNumericOptionValue(const ::ExportOption& opt
     return closest;
 }
 
+std::string normalizedFormatID(const QVariantMap& codecSettings)
+{
+    auto format = codecSettings.value("format").toString().toStdString();
+    std::transform(format.begin(), format.end(), format.begin(), [](unsigned char c) {
+        return static_cast<char>(std::toupper(c));
+    });
+    return format;
+}
+
+std::optional<::ExportOption> optionByID(::ExportOptionsEditor& editor, ::ExportOptionID optionID)
+{
+    for (int index = 0; index < editor.GetOptionsCount(); ++index) {
+        ::ExportOption option;
+        if (editor.GetOption(index, option) && option.id == optionID) {
+            return option;
+        }
+    }
+
+    return std::nullopt;
+}
+
+bool setClosestNumericOptionValue(::ExportOptionsEditor& editor, ::ExportOptionID optionID, double target)
+{
+    const auto option = optionByID(editor, optionID);
+    if (!option) {
+        return false;
+    }
+
+    const auto value = closestNumericOptionValue(*option, target);
+    if (!value) {
+        return false;
+    }
+
+    return editor.SetValue(option->id, *value);
+}
+
 bool applyMp3CodecSettings(::ExportOptionsEditor& editor, const QVariantMap& codecSettings)
 {
+    // MP3ExportOptionsEditor::GetName() returns "mp3"; its option ids are
+    // MP3OptionIDMode == 0 and MP3OptionIDQualityVBR == 2 in ExportMP3.cpp.
     if (editor.GetName() != "mp3" || !codecSettings.contains("bitRate")) {
         return false;
     }
@@ -64,44 +107,19 @@ bool applyMp3CodecSettings(::ExportOptionsEditor& editor, const QVariantMap& cod
         return false;
     }
 
-    for (int index = 0; index < editor.GetOptionsCount(); ++index) {
-        ::ExportOption option;
-        if (!editor.GetOption(index, option)) {
-            continue;
-        }
-
-        const bool isModeOption = std::any_of(option.values.cbegin(), option.values.cend(), [](const ::ExportValue& value) {
-            const auto str = std::get_if<std::string>(&value);
-            return str && *str == "VBR";
-        });
-
-        if (isModeOption) {
-            editor.SetValue(option.id, std::string("VBR"));
-            break;
-        }
-    }
-
-    for (int index = 0; index < editor.GetOptionsCount(); ++index) {
-        ::ExportOption option;
-        if (!editor.GetOption(index, option)) {
-            continue;
-        }
-
-        const bool isVisibleVbrQualityOption = (option.flags & ::ExportOption::Hidden) == 0
-                                               && option.values.size() == 10
-                                               && std::all_of(
-            option.values.cbegin(), option.values.cend(), [](const ::ExportValue& value) {
-            const auto numeric = std::get_if<int>(&value);
-            return numeric && *numeric >= 0 && *numeric <= 9;
-        });
-
-        if (isVisibleVbrQualityOption) {
-            editor.SetValue(option.id, *vbrPreset);
-            return true;
-        }
-    }
-
+    editor.SetValue(MP3OptionIDMode, std::string("VBR"));
+    editor.SetValue(MP3OptionIDQualityVBR, *vbrPreset);
     return true;
+}
+
+bool applyFlacCodecSettings(::ExportOptionsEditor& editor, const QVariantMap& codecSettings)
+{
+    if (normalizedFormatID(codecSettings) != FLACFormatID || !codecSettings.contains("bitDepth")) {
+        return false;
+    }
+
+    // ExportFLAC exposes FlacOptionIDBitDepth as option id 0.
+    return setClosestNumericOptionValue(editor, FLACOptionIDBitDepth, codecSettings.value("bitDepth").toDouble());
 }
 }
 
@@ -139,37 +157,6 @@ void ApplyCodecSettingsToExportOptions(::ExportOptionsEditor& editor, const QVar
         return;
     }
 
-    const bool hasBitDepth = codecSettings.contains("bitDepth");
-    const bool hasBitRate = codecSettings.contains("bitRate");
-    const double bitDepth = codecSettings.value("bitDepth").toDouble();
-    double bitRate = codecSettings.value("bitRate").toDouble();
-    if (bitRate > 1000.0) {
-        bitRate /= 1000.0;
-    }
-
-    for (int index = 0; index < editor.GetOptionsCount(); ++index) {
-        ::ExportOption option;
-        if (!editor.GetOption(index, option)) {
-            continue;
-        }
-
-        const std::string title = option.title.Translation().Lower().ToStdString();
-        const bool isBitDepth = title.find("bit depth") != std::string::npos;
-        const bool isBitRate = title.find("bit rate") != std::string::npos
-                               || title.find("bitrate") != std::string::npos
-                               || title.find("quality") != std::string::npos;
-
-        if (hasBitDepth && isBitDepth) {
-            if (auto value = closestNumericOptionValue(option, bitDepth)) {
-                editor.SetValue(option.id, *value);
-            }
-        } else if (hasBitRate && isBitRate) {
-            const auto value = closestNumericOptionValue(option, bitRate);
-            const auto numeric = value ? NumericExportValue(*value) : std::nullopt;
-            if (value && numeric && *numeric >= 32.0) {
-                editor.SetValue(option.id, *value);
-            }
-        }
-    }
+    applyFlacCodecSettings(editor, codecSettings);
 }
 }

--- a/src/importexport/export/overwriteoriginalsettings.h
+++ b/src/importexport/export/overwriteoriginalsettings.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <optional>
+
+#include <QVariantMap>
+
+class ExportOptionsEditor;
+
+namespace au::importexport {
+std::optional<int> Mp3VbrPresetForBitRate(double bitRate);
+void ApplyCodecSettingsToExportOptions(::ExportOptionsEditor& editor, const QVariantMap& codecSettings);
+}

--- a/src/importexport/export/tests/CMakeLists.txt
+++ b/src/importexport/export/tests/CMakeLists.txt
@@ -1,0 +1,19 @@
+set(MODULE_TEST au_exporter_tests)
+
+set(MODULE_TEST_SRC
+    ${CMAKE_CURRENT_LIST_DIR}/originalfileinfo_tests.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/overwriteoriginalsettings_tests.cpp
+)
+
+include(${CMAKE_CURRENT_LIST_DIR}/../../../au3wrap/au3wrapDefs.cmake)
+
+set(MODULE_TEST_INCLUDE ${AU3_INCLUDE})
+set(MODULE_TEST_DEF ${AU3_DEF})
+
+set(MODULE_TEST_LINK
+    au3-project
+    au3-import-export
+    exporter
+)
+
+include(SetupGTest)

--- a/src/importexport/export/tests/originalfileinfo_tests.cpp
+++ b/src/importexport/export/tests/originalfileinfo_tests.cpp
@@ -1,0 +1,210 @@
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <vector>
+
+#include "au3-project/Project.h"
+#include "importexport/export/OriginalFileInfo.h"
+
+namespace {
+struct FormatCodecCase
+{
+    const char* extension;
+    const char* formatID;
+    int sampleRate;
+    int channels;
+    int bitDepth;
+    int bitRate;
+};
+
+AudacityProject& freshProject()
+{
+    static std::vector<std::shared_ptr<AudacityProject> > projects;
+    projects.push_back(AudacityProject::Create());
+    return *projects.back();
+}
+
+au::importexport::ExportParameters makeExportParameters()
+{
+    return {
+        { 1, 256000 },
+        { 2, 24 },
+        { 3, std::string("joint-stereo") }
+    };
+}
+}
+
+class OriginalFileInfoFormatCodecTests : public ::testing::TestWithParam<FormatCodecCase>
+{
+};
+
+TEST(OriginalFileInfoTests, InitiallyHasNoOriginalFile)
+{
+    AudacityProject& project = freshProject();
+    auto& info = OriginalFileInfo::Get(project);
+
+    EXPECT_FALSE(info.HasOriginalFile());
+    EXPECT_TRUE(info.GetOriginalFilePath().isEmpty());
+    EXPECT_TRUE(info.GetOriginalFileName().isEmpty());
+    EXPECT_TRUE(info.GetExportFormatID().isEmpty());
+    EXPECT_TRUE(info.GetCodecSettings().isEmpty());
+    EXPECT_TRUE(info.GetExportParameters().empty());
+    EXPECT_EQ(info.GetImportedFileCount(), 0);
+}
+
+TEST(OriginalFileInfoTests, RemembersImportedFilePathFormatAndCodecSettings)
+{
+    AudacityProject& project = freshProject();
+    auto& info = OriginalFileInfo::Get(project);
+
+    QVariantMap codecSettings;
+    codecSettings.insert("sampleRate", 48000);
+    codecSettings.insert("channels", 2);
+    codecSettings.insert("bitRate", 256000);
+    codecSettings.insert("bitDepth", 24);
+
+    const auto exportParameters = makeExportParameters();
+
+    info.SetOriginalFile("C:/audio/original.wav", "original.wav");
+    info.SetExportFormatID("WAV");
+    info.SetCodecSettings(codecSettings);
+    info.SetExportParameters(exportParameters);
+    info.IncrementImportedFileCount();
+
+    EXPECT_TRUE(info.HasOriginalFile());
+    EXPECT_EQ(info.GetOriginalFilePath(), "C:/audio/original.wav");
+    EXPECT_EQ(info.GetOriginalFileName(), "original.wav");
+    EXPECT_EQ(info.GetExportFormatID(), "WAV");
+    EXPECT_EQ(info.GetCodecSettings().value("sampleRate").toInt(), 48000);
+    EXPECT_EQ(info.GetCodecSettings().value("channels").toInt(), 2);
+    EXPECT_EQ(info.GetCodecSettings().value("bitRate").toInt(), 256000);
+    EXPECT_EQ(info.GetCodecSettings().value("bitDepth").toInt(), 24);
+    EXPECT_EQ(info.GetExportParameters(), exportParameters);
+}
+
+TEST_P(OriginalFileInfoFormatCodecTests, RemembersFormatBitRateBitDepthAndChannelLayout)
+{
+    const auto testCase = GetParam();
+    AudacityProject& project = freshProject();
+    auto& info = OriginalFileInfo::Get(project);
+
+    QVariantMap codecSettings;
+    codecSettings.insert("sampleRate", testCase.sampleRate);
+    codecSettings.insert("channels", testCase.channels);
+    codecSettings.insert("bitRate", testCase.bitRate);
+    codecSettings.insert("bitDepth", testCase.bitDepth);
+
+    const QString filename = QString("original.") + testCase.extension;
+    info.SetOriginalFile(QString("C:/audio/") + filename, filename);
+    info.SetExportFormatID(QString(testCase.formatID));
+    info.SetCodecSettings(codecSettings);
+    info.SetExportParameters(makeExportParameters());
+    info.IncrementImportedFileCount();
+
+    EXPECT_TRUE(info.HasOriginalFile());
+    EXPECT_EQ(info.GetOriginalFileName(), filename);
+    EXPECT_EQ(info.GetExportFormatID(), QString(testCase.formatID));
+    EXPECT_EQ(info.GetCodecSettings().value("sampleRate").toInt(), testCase.sampleRate);
+    EXPECT_EQ(info.GetCodecSettings().value("channels").toInt(), testCase.channels);
+    EXPECT_EQ(info.GetCodecSettings().value("bitRate").toInt(), testCase.bitRate);
+    EXPECT_EQ(info.GetCodecSettings().value("bitDepth").toInt(), testCase.bitDepth);
+    EXPECT_FALSE(info.GetExportParameters().empty());
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    OriginalFileInfoTests,
+    OriginalFileInfoFormatCodecTests,
+    ::testing::Values(
+        FormatCodecCase { "wav", "WAV", 44100, 1, 16, 705600 },
+        FormatCodecCase { "wav", "WAV", 48000, 2, 24, 2304000 },
+        FormatCodecCase { "flac", "FLAC", 96000, 1, 24, 900000 },
+        FormatCodecCase { "flac", "FLAC", 44100, 2, 16, 650000 },
+        FormatCodecCase { "mp3", "MP3", 44100, 1, 0, 128000 },
+        FormatCodecCase { "mp3", "MP3", 48000, 2, 0, 229000 },
+        FormatCodecCase { "ogg", "OGG", 44100, 1, 0, 96000 },
+        FormatCodecCase { "ogg", "OGG", 48000, 2, 0, 160000 }));
+
+TEST(OriginalFileInfoTests, MultipleImportsKeepMetadataButDisableOverwriteOriginal)
+{
+    AudacityProject& project = freshProject();
+    auto& info = OriginalFileInfo::Get(project);
+
+    QVariantMap codecSettings;
+    codecSettings.insert("sampleRate", 96000);
+    codecSettings.insert("bitDepth", 24);
+
+    info.SetOriginalFile("C:/audio/first.flac", "first.flac");
+    info.SetExportFormatID("FLAC");
+    info.SetCodecSettings(codecSettings);
+    info.SetExportParameters(makeExportParameters());
+
+    info.IncrementImportedFileCount();
+    info.IncrementImportedFileCount();
+
+    EXPECT_FALSE(info.HasOriginalFile());
+    EXPECT_EQ(info.GetImportedFileCount(), 2);
+    EXPECT_EQ(info.GetOriginalFilePath(), "C:/audio/first.flac");
+    EXPECT_EQ(info.GetExportFormatID(), "FLAC");
+    EXPECT_EQ(info.GetCodecSettings().value("sampleRate").toInt(), 96000);
+}
+
+TEST(OriginalFileInfoTests, ClearDropsRememberedOverwriteState)
+{
+    AudacityProject& project = freshProject();
+    auto& info = OriginalFileInfo::Get(project);
+
+    QVariantMap codecSettings;
+    codecSettings.insert("sampleRate", 44100);
+    codecSettings.insert("quality", 7);
+
+    info.SetOriginalFile("C:/audio/original.ogg", "original.ogg");
+    info.SetExportFormatID("OGG");
+    info.SetCodecSettings(codecSettings);
+    info.SetExportParameters(makeExportParameters());
+    info.IncrementImportedFileCount();
+
+    info.Clear();
+
+    EXPECT_FALSE(info.HasOriginalFile());
+    EXPECT_TRUE(info.GetOriginalFilePath().isEmpty());
+    EXPECT_TRUE(info.GetOriginalFileName().isEmpty());
+    EXPECT_TRUE(info.GetExportFormatID().isEmpty());
+    EXPECT_TRUE(info.GetCodecSettings().isEmpty());
+    EXPECT_TRUE(info.GetExportParameters().empty());
+    EXPECT_EQ(info.GetImportedFileCount(), 0);
+}
+
+TEST(OriginalFileInfoTests, StateIsScopedPerProject)
+{
+    AudacityProject& firstProject = freshProject();
+    AudacityProject& secondProject = freshProject();
+
+    auto& firstInfo = OriginalFileInfo::Get(firstProject);
+    auto& secondInfo = OriginalFileInfo::Get(secondProject);
+
+    QVariantMap firstSettings;
+    firstSettings.insert("bitRate", 192000);
+
+    QVariantMap secondSettings;
+    secondSettings.insert("sampleRate", 44100);
+    secondSettings.insert("bitDepth", 16);
+
+    firstInfo.SetOriginalFile("C:/audio/first.mp3", "first.mp3");
+    firstInfo.SetExportFormatID("MP3");
+    firstInfo.SetCodecSettings(firstSettings);
+    firstInfo.IncrementImportedFileCount();
+
+    secondInfo.SetOriginalFile("C:/audio/second.wav", "second.wav");
+    secondInfo.SetExportFormatID("WAV");
+    secondInfo.SetCodecSettings(secondSettings);
+    secondInfo.IncrementImportedFileCount();
+
+    EXPECT_EQ(firstInfo.GetOriginalFilePath(), "C:/audio/first.mp3");
+    EXPECT_EQ(firstInfo.GetExportFormatID(), "MP3");
+    EXPECT_EQ(firstInfo.GetCodecSettings().value("bitRate").toInt(), 192000);
+
+    EXPECT_EQ(secondInfo.GetOriginalFilePath(), "C:/audio/second.wav");
+    EXPECT_EQ(secondInfo.GetExportFormatID(), "WAV");
+    EXPECT_EQ(secondInfo.GetCodecSettings().value("sampleRate").toInt(), 44100);
+    EXPECT_EQ(secondInfo.GetCodecSettings().value("bitDepth").toInt(), 16);
+}

--- a/src/importexport/export/tests/overwriteoriginalsettings_tests.cpp
+++ b/src/importexport/export/tests/overwriteoriginalsettings_tests.cpp
@@ -59,6 +59,9 @@ public:
 
     bool SetValue(ExportOptionID id, const ExportValue& value) override
     {
+        if (id == m_rejectedOptionID) {
+            return false;
+        }
         if (m_values.find(id) == m_values.end()) {
             return false;
         }
@@ -89,6 +92,11 @@ public:
         return std::get<T>(m_values.at(id));
     }
 
+    void rejectSetValueFor(ExportOptionID id)
+    {
+        m_rejectedOptionID = id;
+    }
+
 private:
     void setHidden(ExportOptionID id, bool hidden)
     {
@@ -108,6 +116,7 @@ private:
     std::string m_name;
     std::vector<ExportOption> m_options;
     std::map<ExportOptionID, ExportValue> m_values;
+    ExportOptionID m_rejectedOptionID = -1;
 };
 
 ExportOption option(
@@ -203,6 +212,23 @@ TEST(OverwriteOriginalSettingsTests, AppliesMp3BitRateAsVbrModeAndPreset)
 
     EXPECT_EQ(editor.value<std::string>(0), "VBR");
     EXPECT_EQ(editor.value<int>(2), 3);
+}
+
+TEST(OverwriteOriginalSettingsTests, ContinuesWhenMp3OptionWriteFails)
+{
+    FakeExportOptionsEditor editor("mp3", {
+        option(0, "Profondeur de bits", std::string("16"), ExportOption::TypeEnum,
+               { std::string("16"), std::string("24") }),
+        option(2, "Quality", 2, ExportOption::TypeEnum, { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 }),
+    });
+    editor.rejectSetValueFor(2);
+
+    QVariantMap codecSettings = codecSettingsWithBitRate(179000.0, "FLAC");
+    codecSettings.insert("bitDepth", 24);
+    au::importexport::ApplyCodecSettingsToExportOptions(editor, codecSettings);
+
+    EXPECT_EQ(editor.value<std::string>(0), "24");
+    EXPECT_EQ(editor.value<int>(2), 2);
 }
 
 TEST(OverwriteOriginalSettingsTests, AppliesFlacStringBitDepthValues)

--- a/src/importexport/export/tests/overwriteoriginalsettings_tests.cpp
+++ b/src/importexport/export/tests/overwriteoriginalsettings_tests.cpp
@@ -138,51 +138,32 @@ FakeExportOptionsEditor makeMp3Editor()
 FakeExportOptionsEditor makeFlacEditor()
 {
     return FakeExportOptionsEditor("plain", {
-            option(0, "Bit Depth", std::string("16"), ExportOption::TypeEnum, { std::string("16"), std::string("24") }),
+            option(0, "Profondeur de bits", std::string("16"), ExportOption::TypeEnum,
+                   { std::string("16"), std::string("24") }),
             option(1, "Level", std::string("5"), ExportOption::TypeEnum,
                    { std::string("0"), std::string("1"), std::string("2"), std::string("3"), std::string("4"),
                      std::string("5"), std::string("6"), std::string("7"), std::string("8") }),
         });
 }
 
-FakeExportOptionsEditor makePcmEditor()
-{
-    return FakeExportOptionsEditor("plain", {
-            option(0, "Bit Depth", 16, ExportOption::TypeEnum, { 16, 24, 32 }),
-        });
-}
-
-FakeExportOptionsEditor makeBitRateEditor()
-{
-    return FakeExportOptionsEditor("plain", {
-            option(0, "Bit Rate", 128, ExportOption::TypeEnum, { 96, 128, 160, 192, 224, 256, 320 }),
-        });
-}
-
-QVariantMap codecSettingsWithBitRate(double bitRate)
+QVariantMap codecSettingsWithBitRate(double bitRate, const char* format = "MP3")
 {
     QVariantMap settings;
+    settings.insert("format", format);
     settings.insert("bitRate", bitRate);
     return settings;
 }
 
-QVariantMap codecSettingsWithBitDepth(int bitDepth)
+QVariantMap codecSettingsWithBitDepth(int bitDepth, const char* format = "FLAC")
 {
     QVariantMap settings;
+    settings.insert("format", format);
     settings.insert("bitDepth", bitDepth);
     return settings;
 }
 }
 
 class Mp3VbrPresetTests : public ::testing::TestWithParam<std::tuple<double, int> >
-{
-};
-
-class PcmBitDepthTests : public ::testing::TestWithParam<int>
-{
-};
-
-class GenericBitRateTests : public ::testing::TestWithParam<std::tuple<double, int> >
 {
 };
 
@@ -244,49 +225,13 @@ TEST(OverwriteOriginalSettingsTests, AppliesFlacSixteenBitDepth)
     EXPECT_EQ(editor.value<std::string>(0), "16");
 }
 
-TEST_P(PcmBitDepthTests, AppliesNumericPcmBitDepthValues)
-{
-    const auto bitDepth = GetParam();
-    auto editor = makePcmEditor();
-    editor.SetValue(0, 16);
-
-    au::importexport::ApplyCodecSettingsToExportOptions(editor, codecSettingsWithBitDepth(bitDepth));
-
-    EXPECT_EQ(editor.value<int>(0), bitDepth);
-}
-
-INSTANTIATE_TEST_SUITE_P(
-    OverwriteOriginalSettingsTests,
-    PcmBitDepthTests,
-    ::testing::Values(16, 24, 32));
-
-TEST_P(GenericBitRateTests, AppliesGenericBitRateToClosestKbpsOption)
-{
-    const auto [sourceBitRate, expectedOptionValue] = GetParam();
-    auto editor = makeBitRateEditor();
-
-    au::importexport::ApplyCodecSettingsToExportOptions(editor, codecSettingsWithBitRate(sourceBitRate));
-
-    EXPECT_EQ(editor.value<int>(0), expectedOptionValue);
-}
-
-INSTANTIATE_TEST_SUITE_P(
-    OverwriteOriginalSettingsTests,
-    GenericBitRateTests,
-    ::testing::Values(
-        std::make_tuple(96000.0, 96),
-        std::make_tuple(128.0, 128),
-        std::make_tuple(179000.0, 192),
-        std::make_tuple(229000.0, 224),
-        std::make_tuple(320000.0, 320)));
-
 TEST(OverwriteOriginalSettingsTests, DoesNotTreatLowOggStyleQualityValuesAsBitRateTargets)
 {
-    FakeExportOptionsEditor editor("plain", {
-        option(0, "Quality", 5, ExportOption::TypeEnum, { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 }),
+    FakeExportOptionsEditor editor("ogg", {
+        option(1, "Qualite", 5, ExportOption::TypeEnum, { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 }),
     });
 
-    au::importexport::ApplyCodecSettingsToExportOptions(editor, codecSettingsWithBitRate(96000.0));
+    au::importexport::ApplyCodecSettingsToExportOptions(editor, codecSettingsWithBitRate(96000.0, "OGG"));
 
-    EXPECT_EQ(editor.value<int>(0), 5);
+    EXPECT_EQ(editor.value<int>(1), 5);
 }

--- a/src/importexport/export/tests/overwriteoriginalsettings_tests.cpp
+++ b/src/importexport/export/tests/overwriteoriginalsettings_tests.cpp
@@ -1,0 +1,292 @@
+#include <gtest/gtest.h>
+
+#include <map>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <variant>
+#include <vector>
+
+#include <QVariantMap>
+
+#include "importexport/export/overwriteoriginalsettings.h"
+
+#include "au3-import-export/ExportOptionsEditor.h"
+#include "au3-strings/TranslatableString.h"
+
+namespace {
+class FakeExportOptionsEditor final : public ExportOptionsEditor
+{
+public:
+    FakeExportOptionsEditor(std::string name, std::vector<ExportOption> options)
+        : m_name(std::move(name)), m_options(std::move(options))
+    {
+        for (const auto& option : m_options) {
+            m_values[option.id] = option.defaultValue;
+        }
+    }
+
+    std::string GetName() const override
+    {
+        return m_name;
+    }
+
+    int GetOptionsCount() const override
+    {
+        return static_cast<int>(m_options.size());
+    }
+
+    bool GetOption(int index, ExportOption& option) const override
+    {
+        if (index < 0 || index >= static_cast<int>(m_options.size())) {
+            return false;
+        }
+
+        option = m_options[index];
+        return true;
+    }
+
+    bool GetValue(ExportOptionID id, ExportValue& value) const override
+    {
+        const auto it = m_values.find(id);
+        if (it == m_values.end()) {
+            return false;
+        }
+
+        value = it->second;
+        return true;
+    }
+
+    bool SetValue(ExportOptionID id, const ExportValue& value) override
+    {
+        if (m_values.find(id) == m_values.end()) {
+            return false;
+        }
+
+        m_values[id] = value;
+        const auto str = std::get_if<std::string>(&value);
+        if (str && *str == "VBR") {
+            setHidden(1, true);
+            setHidden(2, false);
+            setHidden(3, true);
+            setHidden(4, true);
+        }
+
+        return true;
+    }
+
+    SampleRateList GetSampleRateList() const override
+    {
+        return {};
+    }
+
+    void Store(audacity::BasicSettings&) const override {}
+    void Load(const audacity::BasicSettings&) override {}
+
+    template<typename T>
+    T value(ExportOptionID id) const
+    {
+        return std::get<T>(m_values.at(id));
+    }
+
+private:
+    void setHidden(ExportOptionID id, bool hidden)
+    {
+        for (auto& option : m_options) {
+            if (option.id != id) {
+                continue;
+            }
+
+            if (hidden) {
+                option.flags |= ExportOption::Hidden;
+            } else {
+                option.flags &= ~ExportOption::Hidden;
+            }
+        }
+    }
+
+    std::string m_name;
+    std::vector<ExportOption> m_options;
+    std::map<ExportOptionID, ExportValue> m_values;
+};
+
+ExportOption option(
+    ExportOptionID id, const char* title, ExportValue defaultValue, int flags, std::vector<ExportValue> values)
+{
+    return {
+        id,
+        TranslatableString("import-export", title),
+        std::move(defaultValue),
+        flags,
+        std::move(values),
+        {}
+    };
+}
+
+FakeExportOptionsEditor makeMp3Editor()
+{
+    return FakeExportOptionsEditor("mp3", {
+        option(0, "Bit Rate Mode", std::string("SET"), ExportOption::TypeEnum,
+               { std::string("SET"), std::string("VBR"), std::string("ABR"), std::string("CBR") }),
+        option(1, "Quality", 2, ExportOption::TypeEnum, { 0, 1, 2, 3 }),
+        option(2, "Quality", 2, ExportOption::TypeEnum | ExportOption::Hidden, { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 }),
+        option(3, "Quality", 192, ExportOption::TypeEnum | ExportOption::Hidden, { 320, 256, 224, 192, 160, 144, 128 }),
+        option(4, "Quality", 192, ExportOption::TypeEnum | ExportOption::Hidden, { 320, 256, 224, 192, 160, 144, 128 }),
+    });
+}
+
+FakeExportOptionsEditor makeFlacEditor()
+{
+    return FakeExportOptionsEditor("plain", {
+        option(0, "Bit Depth", std::string("16"), ExportOption::TypeEnum, { std::string("16"), std::string("24") }),
+        option(1, "Level", std::string("5"), ExportOption::TypeEnum,
+               { std::string("0"), std::string("1"), std::string("2"), std::string("3"), std::string("4"),
+                 std::string("5"), std::string("6"), std::string("7"), std::string("8") }),
+    });
+}
+
+FakeExportOptionsEditor makePcmEditor()
+{
+    return FakeExportOptionsEditor("plain", {
+        option(0, "Bit Depth", 16, ExportOption::TypeEnum, { 16, 24, 32 }),
+    });
+}
+
+FakeExportOptionsEditor makeBitRateEditor()
+{
+    return FakeExportOptionsEditor("plain", {
+        option(0, "Bit Rate", 128, ExportOption::TypeEnum, { 96, 128, 160, 192, 224, 256, 320 }),
+    });
+}
+
+QVariantMap codecSettingsWithBitRate(double bitRate)
+{
+    QVariantMap settings;
+    settings.insert("bitRate", bitRate);
+    return settings;
+}
+
+QVariantMap codecSettingsWithBitDepth(int bitDepth)
+{
+    QVariantMap settings;
+    settings.insert("bitDepth", bitDepth);
+    return settings;
+}
+}
+
+class Mp3VbrPresetTests : public ::testing::TestWithParam<std::tuple<double, int> >
+{
+};
+
+class PcmBitDepthTests : public ::testing::TestWithParam<int>
+{
+};
+
+class GenericBitRateTests : public ::testing::TestWithParam<std::tuple<double, int> >
+{
+};
+
+TEST_P(Mp3VbrPresetTests, MapsEstimatedBitRateToConfiguredPreset)
+{
+    const auto [bitRate, expectedPreset] = GetParam();
+    const auto preset = au::importexport::Mp3VbrPresetForBitRate(bitRate);
+
+    ASSERT_TRUE(preset.has_value());
+    EXPECT_EQ(*preset, expectedPreset);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    OverwriteOriginalSettingsTests,
+    Mp3VbrPresetTests,
+    ::testing::Values(
+        std::make_tuple(320000.0, 0),
+        std::make_tuple(230000.0, 0),
+        std::make_tuple(229000.0, 1),
+        std::make_tuple(200000.0, 1),
+        std::make_tuple(199000.0, 2),
+        std::make_tuple(180000.0, 2),
+        std::make_tuple(179000.0, 3),
+        std::make_tuple(170000.0, 3),
+        std::make_tuple(169000.0, 4),
+        std::make_tuple(140000.0, 4),
+        std::make_tuple(139000.0, 5),
+        std::make_tuple(120000.0, 5),
+        std::make_tuple(119000.0, 6),
+        std::make_tuple(96.0, 6)));
+
+TEST(OverwriteOriginalSettingsTests, AppliesMp3BitRateAsVbrModeAndPreset)
+{
+    auto editor = makeMp3Editor();
+
+    au::importexport::ApplyCodecSettingsToExportOptions(editor, codecSettingsWithBitRate(179000.0));
+
+    EXPECT_EQ(editor.value<std::string>(0), "VBR");
+    EXPECT_EQ(editor.value<int>(2), 3);
+}
+
+TEST(OverwriteOriginalSettingsTests, AppliesFlacStringBitDepthValues)
+{
+    auto editor = makeFlacEditor();
+
+    au::importexport::ApplyCodecSettingsToExportOptions(editor, codecSettingsWithBitDepth(24));
+
+    EXPECT_EQ(editor.value<std::string>(0), "24");
+    EXPECT_EQ(editor.value<std::string>(1), "5");
+}
+
+TEST(OverwriteOriginalSettingsTests, AppliesFlacSixteenBitDepth)
+{
+    auto editor = makeFlacEditor();
+    editor.SetValue(0, std::string("24"));
+
+    au::importexport::ApplyCodecSettingsToExportOptions(editor, codecSettingsWithBitDepth(16));
+
+    EXPECT_EQ(editor.value<std::string>(0), "16");
+}
+
+TEST_P(PcmBitDepthTests, AppliesNumericPcmBitDepthValues)
+{
+    const auto bitDepth = GetParam();
+    auto editor = makePcmEditor();
+    editor.SetValue(0, 16);
+
+    au::importexport::ApplyCodecSettingsToExportOptions(editor, codecSettingsWithBitDepth(bitDepth));
+
+    EXPECT_EQ(editor.value<int>(0), bitDepth);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    OverwriteOriginalSettingsTests,
+    PcmBitDepthTests,
+    ::testing::Values(16, 24, 32));
+
+TEST_P(GenericBitRateTests, AppliesGenericBitRateToClosestKbpsOption)
+{
+    const auto [sourceBitRate, expectedOptionValue] = GetParam();
+    auto editor = makeBitRateEditor();
+
+    au::importexport::ApplyCodecSettingsToExportOptions(editor, codecSettingsWithBitRate(sourceBitRate));
+
+    EXPECT_EQ(editor.value<int>(0), expectedOptionValue);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    OverwriteOriginalSettingsTests,
+    GenericBitRateTests,
+    ::testing::Values(
+        std::make_tuple(96000.0, 96),
+        std::make_tuple(128.0, 128),
+        std::make_tuple(179000.0, 192),
+        std::make_tuple(229000.0, 224),
+        std::make_tuple(320000.0, 320)));
+
+TEST(OverwriteOriginalSettingsTests, DoesNotTreatLowOggStyleQualityValuesAsBitRateTargets)
+{
+    FakeExportOptionsEditor editor("plain", {
+        option(0, "Quality", 5, ExportOption::TypeEnum, { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 }),
+    });
+
+    au::importexport::ApplyCodecSettingsToExportOptions(editor, codecSettingsWithBitRate(96000.0));
+
+    EXPECT_EQ(editor.value<int>(0), 5);
+}

--- a/src/importexport/export/tests/overwriteoriginalsettings_tests.cpp
+++ b/src/importexport/export/tests/overwriteoriginalsettings_tests.cpp
@@ -126,37 +126,37 @@ ExportOption option(
 FakeExportOptionsEditor makeMp3Editor()
 {
     return FakeExportOptionsEditor("mp3", {
-        option(0, "Bit Rate Mode", std::string("SET"), ExportOption::TypeEnum,
-               { std::string("SET"), std::string("VBR"), std::string("ABR"), std::string("CBR") }),
-        option(1, "Quality", 2, ExportOption::TypeEnum, { 0, 1, 2, 3 }),
-        option(2, "Quality", 2, ExportOption::TypeEnum | ExportOption::Hidden, { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 }),
-        option(3, "Quality", 192, ExportOption::TypeEnum | ExportOption::Hidden, { 320, 256, 224, 192, 160, 144, 128 }),
-        option(4, "Quality", 192, ExportOption::TypeEnum | ExportOption::Hidden, { 320, 256, 224, 192, 160, 144, 128 }),
-    });
+            option(0, "Bit Rate Mode", std::string("SET"), ExportOption::TypeEnum,
+                   { std::string("SET"), std::string("VBR"), std::string("ABR"), std::string("CBR") }),
+            option(1, "Quality", 2, ExportOption::TypeEnum, { 0, 1, 2, 3 }),
+            option(2, "Quality", 2, ExportOption::TypeEnum | ExportOption::Hidden, { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 }),
+            option(3, "Quality", 192, ExportOption::TypeEnum | ExportOption::Hidden, { 320, 256, 224, 192, 160, 144, 128 }),
+            option(4, "Quality", 192, ExportOption::TypeEnum | ExportOption::Hidden, { 320, 256, 224, 192, 160, 144, 128 }),
+        });
 }
 
 FakeExportOptionsEditor makeFlacEditor()
 {
     return FakeExportOptionsEditor("plain", {
-        option(0, "Bit Depth", std::string("16"), ExportOption::TypeEnum, { std::string("16"), std::string("24") }),
-        option(1, "Level", std::string("5"), ExportOption::TypeEnum,
-               { std::string("0"), std::string("1"), std::string("2"), std::string("3"), std::string("4"),
-                 std::string("5"), std::string("6"), std::string("7"), std::string("8") }),
-    });
+            option(0, "Bit Depth", std::string("16"), ExportOption::TypeEnum, { std::string("16"), std::string("24") }),
+            option(1, "Level", std::string("5"), ExportOption::TypeEnum,
+                   { std::string("0"), std::string("1"), std::string("2"), std::string("3"), std::string("4"),
+                     std::string("5"), std::string("6"), std::string("7"), std::string("8") }),
+        });
 }
 
 FakeExportOptionsEditor makePcmEditor()
 {
     return FakeExportOptionsEditor("plain", {
-        option(0, "Bit Depth", 16, ExportOption::TypeEnum, { 16, 24, 32 }),
-    });
+            option(0, "Bit Depth", 16, ExportOption::TypeEnum, { 16, 24, 32 }),
+        });
 }
 
 FakeExportOptionsEditor makeBitRateEditor()
 {
     return FakeExportOptionsEditor("plain", {
-        option(0, "Bit Rate", 128, ExportOption::TypeEnum, { 96, 128, 160, 192, 224, 256, 320 }),
-    });
+            option(0, "Bit Rate", 128, ExportOption::TypeEnum, { 96, 128, 160, 192, 224, 256, 320 }),
+        });
 }
 
 QVariantMap codecSettingsWithBitRate(double bitRate)

--- a/src/importexport/export/types/exporttypes.h
+++ b/src/importexport/export/types/exporttypes.h
@@ -5,6 +5,8 @@
 
 #include <qobjectdefs.h>
 #include <string>
+#include <tuple>
+#include <variant>
 #include <vector>
 
 namespace au::importexport {
@@ -47,6 +49,8 @@ using OptionValue = std::variant<
     int,
     double,
     std::string>;
+
+using ExportParameters = std::vector<std::tuple<int, OptionValue> >;
 
 struct ExportOption
 {

--- a/src/importexport/import/CMakeLists.txt
+++ b/src/importexport/import/CMakeLists.txt
@@ -47,7 +47,7 @@ include(${CMAKE_CURRENT_LIST_DIR}/../../au3wrap/au3wrapDefs.cmake)
 
 set(MODULE_INCLUDE ${AU3_INCLUDE})
 set(MODULE_DEF ${AU3_DEF})
-set(MODULE_LINK au3wrap loop-tempo-estimator)
+set(MODULE_LINK au3wrap loop-tempo-estimator exporter)
 
 set(MODULE_USE_UNITY OFF)
 

--- a/src/importexport/import/internal/au3/au3importer.cpp
+++ b/src/importexport/import/internal/au3/au3importer.cpp
@@ -109,17 +109,19 @@ void recordOriginalFileImport(AudacityProject& project, const muse::io::path_t& 
     const bool captureOriginalFileInfo = fileInfo.GetImportedFileCount() == 0;
 
     wxFileName fn(wxFromString(fileName.toString()));
+    ExportPlugin* plugin = nullptr;
+    int formatIndex = -1;
     if (captureOriginalFileInfo) {
         const QString filePath = QString::fromStdString(fileName.toString().toStdString());
         const QString displayName = QString::fromStdString(fn.GetFullName().ToStdString());
         const wxString extension = fn.GetExt();
         const wxString formatID = extension.Upper();
-        auto [plugin, formatIndex] = findExportFormat(formatID, extension);
+        std::tie(plugin, formatIndex) = findExportFormat(formatID, extension);
 
         fileInfo.SetOriginalFile(filePath, displayName);
-        fileInfo.SetExportFormatID(QString::fromStdString(plugin
-                                                          ? plugin->GetFormatInfo(formatIndex).format.ToStdString()
-                                                          : formatID.ToStdString()));
+        if (plugin) {
+            fileInfo.SetExportFormatID(QString::fromStdString(plugin->GetFormatInfo(formatIndex).format.ToStdString()));
+        }
     }
 
     fileInfo.IncrementImportedFileCount();
@@ -168,7 +170,6 @@ void recordOriginalFileImport(AudacityProject& project, const muse::io::path_t& 
 
     fileInfo.SetCodecSettings(codecSettings);
 
-    auto [plugin, formatIndex] = findExportFormat(wxString(fileInfo.GetExportFormatID().toStdString()), fn.GetExt());
     if (plugin) {
         fileInfo.SetExportParameters(exportParametersFor(*plugin, formatIndex, codecSettings));
     }

--- a/src/importexport/import/internal/au3/au3importer.cpp
+++ b/src/importexport/import/internal/au3/au3importer.cpp
@@ -3,12 +3,18 @@
 #include "framework/global/io/path.h"
 
 #include "au3-basic-ui/BasicUI.h"
+#include "importexport/export/OriginalFileInfo.h"
+#include "importexport/export/overwriteoriginalsettings.h"
 #include "au3-stretching-sequence/TempoChange.h"
 #include "au3-track/Track.h"
 #include "au3-wave-track/WaveClip.h"
 #include "au3-wave-track/WaveTrack.h"
 #include "au3-import-export/ImportPlugin.h"
 #include "au3-import-export/ImportProgressListener.h"
+#include "au3-import-export/ExportPlugin.h"
+#include "au3-import-export/ExportPluginRegistry.h"
+#include "au3-import-export/ExportUtils.h"
+#include "au3-preferences/Prefs.h"
 #include "au3-numeric-formats/ProjectTimeSignature.h"
 #include "au3-project/Project.h"
 #include "au3-project-file-io/ProjectFileIO.h"
@@ -23,11 +29,151 @@
 #include "trackedit/internal/au3/au3trackdata.h"
 
 #include "tempodetection.h"
+
+#include <QFileInfo>
+#include <QVariantMap>
+
+#include <algorithm>
+#include <tuple>
+#include <variant>
+
 using au::trackedit::ITrackDataPtr;
 using au::trackedit::Au3TrackData;
 using Au3TrackDataPtr = std::shared_ptr<Au3TrackData>;
 
 using namespace au::au3;
+
+namespace {
+int bitDepthFromSampleFormat(sampleFormat format)
+{
+    if (format == int16Sample) {
+        return 16;
+    }
+    if (format == int24Sample) {
+        return 24;
+    }
+    if (format == floatSample) {
+        return 32;
+    }
+    return 0;
+}
+
+std::tuple<ExportPlugin*, int> findExportFormat(const wxString& formatID, const wxString& extension)
+{
+    if (!formatID.empty()) {
+        auto [plugin, formatIndex] = ExportPluginRegistry::Get().FindFormat(formatID);
+        if (plugin) {
+            return { plugin, formatIndex };
+        }
+    }
+
+    for (auto [plugin, formatIndex] : ExportPluginRegistry::Get()) {
+        const FormatInfo formatInfo = plugin->GetFormatInfo(formatIndex);
+        if (formatInfo.extensions.Index(extension, false) != wxNOT_FOUND) {
+            return { plugin, formatIndex };
+        }
+    }
+
+    return { nullptr, -1 };
+}
+
+au::importexport::ExportParameters exportParametersFor(ExportPlugin& plugin, int formatIndex,
+                                                       const QVariantMap& codecSettings)
+{
+    au::importexport::ExportParameters parameters;
+
+    auto editor = plugin.CreateOptionsEditor(formatIndex, nullptr);
+    if (!editor) {
+        return parameters;
+    }
+
+    if (gPrefs) {
+        editor->Load(*gPrefs);
+    }
+
+    au::importexport::ApplyCodecSettingsToExportOptions(*editor, codecSettings);
+
+    for (const auto& [id, value] : ExportUtils::ParametersFromEditor(*editor)) {
+        parameters.emplace_back(id, std::visit([](const auto& v) -> au::importexport::OptionValue {
+            return v;
+        }, value));
+    }
+
+    return parameters;
+}
+
+void recordOriginalFileImport(AudacityProject& project, const muse::io::path_t& fileName,
+                              const std::vector<WaveTrack*>& importedTracks)
+{
+    auto& fileInfo = OriginalFileInfo::Get(project);
+    const bool captureOriginalFileInfo = fileInfo.GetImportedFileCount() == 0;
+
+    wxFileName fn(wxFromString(fileName.toString()));
+    if (captureOriginalFileInfo) {
+        const QString filePath = QString::fromStdString(fileName.toString().toStdString());
+        const QString displayName = QString::fromStdString(fn.GetFullName().ToStdString());
+        const wxString extension = fn.GetExt();
+        const wxString formatID = extension.Upper();
+        auto [plugin, formatIndex] = findExportFormat(formatID, extension);
+
+        fileInfo.SetOriginalFile(filePath, displayName);
+        fileInfo.SetExportFormatID(QString::fromStdString(plugin
+                                                          ? plugin->GetFormatInfo(formatIndex).format.ToStdString()
+                                                          : formatID.ToStdString()));
+    }
+
+    fileInfo.IncrementImportedFileCount();
+
+    if (!captureOriginalFileInfo) {
+        return;
+    }
+
+    QVariantMap codecSettings;
+    codecSettings.insert("format", fileInfo.GetExportFormatID());
+    codecSettings.insert("fileExtension", QString::fromStdString(fn.GetExt().Lower().ToStdString()));
+
+    int channels = 0;
+    int bitDepth = 0;
+    double sampleRate = 0.0;
+    double importedDuration = 0.0;
+    for (const auto* wt : importedTracks) {
+        if (!wt) {
+            continue;
+        }
+
+        channels = std::max(channels, static_cast<int>(wt->NChannels()));
+        if (sampleRate <= 0.0) {
+            sampleRate = wt->GetRate();
+        }
+        if (bitDepth == 0) {
+            bitDepth = bitDepthFromSampleFormat(wt->GetSampleFormat());
+        }
+        importedDuration = std::max(importedDuration, wt->GetEndTime());
+    }
+
+    if (sampleRate > 0.0) {
+        codecSettings.insert("sampleRate", static_cast<int>(std::lround(sampleRate)));
+    }
+    if (channels > 0) {
+        codecSettings.insert("channels", channels);
+    }
+    if (bitDepth > 0) {
+        codecSettings.insert("bitDepth", bitDepth);
+    }
+
+    const QFileInfo originalFile(fileInfo.GetOriginalFilePath());
+    if (originalFile.exists() && originalFile.size() > 0 && importedDuration > 0.0) {
+        codecSettings.insert("bitRate", static_cast<qlonglong>((originalFile.size() * 8.0) / importedDuration));
+    }
+
+    fileInfo.SetCodecSettings(codecSettings);
+
+    auto [plugin, formatIndex] = findExportFormat(wxString(fileInfo.GetExportFormatID().toStdString()), fn.GetExt());
+    if (plugin) {
+        fileInfo.SetExportParameters(exportParametersFor(*plugin, formatIndex, codecSettings));
+    }
+}
+}
 
 class ImportProgress final : public ImportProgressListener
 {
@@ -239,6 +385,8 @@ bool au::importexport::Au3Importer::importIntoTrack(const muse::io::path_t& file
         return false;
     }
 
+    recordOriginalFileImport(*project, filePath, importedWaveTracks);
+
     applyImportedProjectTitleIfNeeded(filePath);
 
     std::vector<trackedit::TrackId> dstTrackIds(importedWaveTracks.size(), dstTrackId);
@@ -350,7 +498,7 @@ void au::importexport::Au3Importer::addImportedTracks(const muse::io::path_t& fi
     auto& tracks = TrackList::Get(*project);
     auto& projectFileIO = ProjectFileIO::Get(*project);
 
-    std::vector<Track*> results;
+    std::vector<WaveTrack*> results;
 
     wxFileName fn(wxFromString(fileName.toString()));
 
@@ -409,6 +557,8 @@ void au::importexport::Au3Importer::addImportedTracks(const muse::io::path_t& fi
             }
         });
     }
+
+    recordOriginalFileImport(*project, fileName, results);
 
     applyImportedProjectTitleIfNeeded(fileName);
 

--- a/src/project/CMakeLists.txt
+++ b/src/project/CMakeLists.txt
@@ -141,7 +141,7 @@ include(${CMAKE_CURRENT_LIST_DIR}/../au3wrap/au3wrapDefs.cmake)
 
 set(MODULE_INCLUDE ${AU3_INCLUDE})
 set(MODULE_DEF ${AU3_DEF})
-set(MODULE_LINK au3wrap)
+set(MODULE_LINK au3wrap exporter)
 if (QT_ADD_CONCURRENT)
     list(APPEND MODULE_LINK Qt::Concurrent)
 endif()

--- a/src/project/internal/projectactionscontroller.cpp
+++ b/src/project/internal/projectactionscontroller.cpp
@@ -218,6 +218,11 @@ bool ProjectActionsController::canReceiveAction(const muse::actions::ActionCode&
             return false;
         }
 
+        trackedit::ITrackeditProjectPtr prj = globalContext()->currentTrackeditProject();
+        if (!prj || !prj->hasAudioContent().val) {
+            return false;
+        }
+
         auto& fileInfo = OriginalFileInfo::Get(*au3Project);
         if (fileInfo.HasOriginalFile()) {
             QString path = fileInfo.GetOriginalFilePath();
@@ -1399,6 +1404,11 @@ void ProjectActionsController::exportOverwriteOriginal()
         return;
     }
 
+    auto trackeditProject = globalContext()->currentTrackeditProject();
+    if (!trackeditProject || !trackeditProject->hasAudioContent().val) {
+        return;
+    }
+
     // Get the Au3Project for export operations
     auto au3Project = reinterpret_cast<au::au3::Au3Project*>(project->au3ProjectPtr());
     if (!au3Project) {
@@ -1424,6 +1434,9 @@ void ProjectActionsController::exportOverwriteOriginal()
 
     // Get audio duration
     double endTime = tracks.GetEndTime();
+    if (endTime <= 0.0) {
+        return;
+    }
 
     // Prefer the source file's remembered audio properties. If they are not
     // available, fall back to the current project tracks.
@@ -1478,8 +1491,8 @@ void ProjectActionsController::exportOverwriteOriginal()
 
     // Show result message
     if (exportResult == ExportResult::Success) {
-        std::string fileName = QFileInfo(originalFilePath).fileName().toStdString();
-        toastService()->showSuccess("Overwrite Original", "Overwrote " + fileName);
+        std::string displayFileName = QFileInfo(originalFilePath).fileName().toStdString();
+        toastService()->showSuccess("Overwrite Original", "Overwrote " + displayFileName);
     } else if (exportResult == ExportResult::Stopped) {
         // User stopped the export - this is normal, don't show error
     } else {

--- a/src/project/internal/projectactionscontroller.cpp
+++ b/src/project/internal/projectactionscontroller.cpp
@@ -1,6 +1,11 @@
 #include "projectactionscontroller.h"
 
 #include <QFileDialog>
+#include <QString>
+#include <QFileInfo>
+#include <QDir>
+#include <tuple>
+#include <variant>
 
 #include "au3cloud/internal/au3audiocomservice.h"
 #include "framework/global/async/async.h"
@@ -19,6 +24,18 @@
 #include "audacityproject.h"
 #include "projecterrors.h"
 #include "project/types/projecttypes.h"
+#include "importexport/export/OriginalFileInfo.h"
+
+#include "au3-import-export/Export.h"
+#include "au3-import-export/ExportPluginRegistry.h"
+#include "au3-import-export/ExportProgressUI.h"
+#include "au3-import-export/ExportPlugin.h"
+#include "au3-project/Project.h"
+#include "au3-project-file-io/ProjectFileIO.h"
+#include "au3-files/wxFileNameWrapper.h"
+#include "au3wrap/au3types.h"
+#include "au3-track/Track.h"
+#include "au3-wave-track/WaveTrack.h"
 
 using namespace muse;
 using namespace au::project;
@@ -41,6 +58,37 @@ static const muse::actions::ActionCode OPEN_CUSTOM_FFMPEG_OPTIONS("open-custom-f
 static const muse::actions::ActionCode OPEN_METADATA_DIALOG("open-metadata-dialog");
 static const muse::actions::ActionCode OPEN_CUSTOM_MAPPING("open-custom-mapping");
 static const muse::actions::ActionQuery OPEN_CLOUD_AUDIO_FILE_URI("audacity://cloud/open-audio-file");
+
+namespace {
+bool canWriteOriginalFilePath(const QString& originalFilePath)
+{
+    if (originalFilePath.isEmpty()) {
+        return false;
+    }
+
+    const QFileInfo fileInfo(originalFilePath);
+    const QDir dir = fileInfo.dir();
+    if (!dir.exists() || !QFileInfo(dir.absolutePath()).isWritable()) {
+        return false;
+    }
+
+    return !fileInfo.exists() || fileInfo.isWritable();
+}
+
+ExportProcessor::Parameters toAu3ExportParameters(const au::importexport::ExportParameters& parameters)
+{
+    ExportProcessor::Parameters result;
+    result.reserve(parameters.size());
+
+    for (const auto& [id, value] : parameters) {
+        result.emplace_back(id, std::visit([](const auto& v) -> ExportValue {
+            return v;
+        }, value));
+    }
+
+    return result;
+}
+}
 
 ProjectActionsController::ProjectActionsController(muse::modularity::ContextPtr ctx)
     : muse::Contextable(ctx)
@@ -68,6 +116,7 @@ void ProjectActionsController::init()
     dispatcher()->reg(this, OPEN_CLOUD_AUDIO_FILE_URI, this, &ProjectActionsController::openCloudAudioFile);
 
     dispatcher()->reg(this, "export-audio", this, &ProjectActionsController::exportAudio);
+    dispatcher()->reg(this, "export-overwrite-original", this, &ProjectActionsController::exportOverwriteOriginal);
     dispatcher()->reg(this, "export-labels", this, &ProjectActionsController::exportLabels);
     dispatcher()->reg(this, "export-midi", this, &ProjectActionsController::exportMIDI);
 
@@ -108,10 +157,14 @@ void ProjectActionsController::listenTrackeditProjectChanges()
     }
 
     prj->hasAudioContent().ch.onReceive(this, [this](bool) {
-        m_actionEnabledChanged.send({ "file-share-audio" });
+        m_actionEnabledChanged.send({ "file-share-audio", "export-overwrite-original" });
     }, muse::async::Asyncable::Mode::SetReplace);
 
-    m_actionEnabledChanged.send({ "file-share-audio" });
+    prj->trackAdded().onReceive(this, [this](auto) {
+        m_actionEnabledChanged.send({ "export-overwrite-original" });
+    }, muse::async::Asyncable::Mode::SetReplace);
+
+    m_actionEnabledChanged.send({ "file-share-audio", "export-overwrite-original" });
 }
 
 muse::async::Channel<muse::actions::ActionCodeList> ProjectActionsController::actionEnabledChanged() const
@@ -128,6 +181,7 @@ const muse::actions::ActionCodeList& ProjectActionsController::prohibitedActions
         "file-save-to-cloud",
         "file-save-as",
         "export-audio",
+        "export-overwrite-original",
         "export-labels",
         "export-midi",
         "file-share-audio",
@@ -156,6 +210,35 @@ bool ProjectActionsController::canReceiveAction(const muse::actions::ActionCode&
     }
 
     const bool recording = recordController()->isRecording();
+
+    if (code == "export-overwrite-original") {
+        // Check if original file is a project file (not supported)
+        auto au3Project = reinterpret_cast<AudacityProject*>(currentProject()->au3ProjectPtr());
+        if (!au3Project || recording) {
+            return false;
+        }
+
+        auto& fileInfo = OriginalFileInfo::Get(*au3Project);
+        if (fileInfo.HasOriginalFile()) {
+            QString path = fileInfo.GetOriginalFilePath();
+            QString ext = QFileInfo(path).suffix().toLower();
+            // Hide menu if it's a project file
+            if (ext == "aup" || ext == "aup3" || ext == "aup4") {
+                return false;
+            }
+            if (!canWriteOriginalFilePath(path)) {
+                return false;
+            }
+
+            const auto pluginAndFormat = ExportPluginRegistry::Get().FindFormat(wxString(fileInfo.GetExportFormatID().toStdString()));
+            if (std::get<0>(pluginAndFormat) == nullptr) {
+                return false;
+            }
+        } else {
+            return false;  // Hide if no original file
+        }
+        return true;
+    }
 
     if (code == "file-share-audio") {
         trackedit::ITrackeditProjectPtr prj = globalContext()->currentTrackeditProject();
@@ -1282,6 +1365,128 @@ void ProjectActionsController::openCloudAudioFile(const muse::actions::ActionQue
 void ProjectActionsController::exportAudio()
 {
     interactive()->open(EXPORT_URI);
+}
+
+void ProjectActionsController::exportOverwriteOriginal()
+{
+    // Get current project
+    auto project = globalContext()->currentProject();
+    if (!project) {
+        return;
+    }
+
+    if (recordController()->isRecording()) {
+        return;
+    }
+
+    // Get the original file info for this project
+    auto au3ProjectPtr = reinterpret_cast<AudacityProject*>(project->au3ProjectPtr());
+    if (!au3ProjectPtr) {
+        return;
+    }
+
+    auto& fileInfo = OriginalFileInfo::Get(*au3ProjectPtr);
+
+    // Return silently if no original file info (menu should be disabled)
+    if (!fileInfo.HasOriginalFile()) {
+        return;
+    }
+
+    QString originalFilePath = fileInfo.GetOriginalFilePath();
+
+    // Return silently if the action was invoked after the menu state went stale.
+    if (!canWriteOriginalFilePath(originalFilePath)) {
+        return;
+    }
+
+    // Get the Au3Project for export operations
+    auto au3Project = reinterpret_cast<au::au3::Au3Project*>(project->au3ProjectPtr());
+    if (!au3Project) {
+        interactive()->error(
+            muse::trc("project", "Overwrite Original"),
+            muse::trc("project", "Failed to access project data."));
+        return;
+    }
+
+    const QVariantMap codecSettings = fileInfo.GetCodecSettings();
+
+    // Get the format ID and find the export plugin
+    QString formatID = fileInfo.GetExportFormatID();
+    wxString wxFormatID = wxString(formatID.toStdString());
+    auto [plugin, formatIndex] = ExportPluginRegistry::Get().FindFormat(wxFormatID);
+
+    if (plugin == nullptr) {
+        return;
+    }
+
+    // Get project info needed for export
+    auto& tracks = ::TrackList::Get(*au3Project);
+
+    // Get audio duration
+    double endTime = tracks.GetEndTime();
+
+    // Prefer the source file's remembered audio properties. If they are not
+    // available, fall back to the current project tracks.
+    const bool hasRememberedChannels = codecSettings.contains("channels");
+    const bool hasRememberedSampleRate = codecSettings.contains("sampleRate");
+    int numChannels = hasRememberedChannels ? codecSettings.value("channels").toInt() : 1;
+    double sampleRate = hasRememberedSampleRate ? codecSettings.value("sampleRate").toDouble() : 44100.0;
+
+    // Get channel info from available tracks
+    for (const auto pTrack : tracks.Any<WaveTrack>()) {
+        if (!hasRememberedChannels && pTrack && pTrack->NChannels() > numChannels) {
+            numChannels = static_cast<int>(pTrack->NChannels());
+        }
+        if (!hasRememberedSampleRate && pTrack && pTrack->GetRate() > 0) {
+            sampleRate = pTrack->GetRate();
+            break;  // Use sample rate from first track found
+        }
+    }
+
+    auto parameters = toAu3ExportParameters(fileInfo.GetExportParameters());
+
+    // Create export file wrapper (convert QString to wxString for legacy API)
+    wxFileNameWrapper fileName(wxString(originalFilePath.toStdString()));
+
+    // Build and execute export task
+    ExportResult exportResult = ExportResult::Error;
+    ExportProgressUI::ExceptionWrappedCall([&]
+    {
+        try {
+            auto builder = ExportTaskBuilder {}
+            .SetFileName(fileName)
+            .SetRange(0.0, endTime, false)
+            .SetParameters(parameters)
+            .SetPlugin(plugin, formatIndex)
+            .SetNumChannels(numChannels)
+            .SetSampleRate(sampleRate);
+
+            exportResult = ExportProgressUI::Show(builder.Build(*au3Project));
+        }
+        catch (const ExportErrorException& e) {
+            std::string message = "Export failed: " + std::string(e.GetMessage().Translation().utf8_str());
+            interactive()->error(
+                muse::trc("project", "Overwrite Original - Export Error"),
+                message);
+        }
+        catch (...) {
+            interactive()->error(
+                muse::trc("project", "Overwrite Original - Export Error"),
+                muse::trc("project", "An unexpected error occurred during export."));
+        }
+    });
+
+    // Show result message
+    if (exportResult == ExportResult::Success) {
+        std::string fileName = QFileInfo(originalFilePath).fileName().toStdString();
+        toastService()->showSuccess("Overwrite Original", "Overwrote " + fileName);
+    } else if (exportResult == ExportResult::Stopped) {
+        // User stopped the export - this is normal, don't show error
+    } else {
+        interactive()->error(
+            muse::trc("project", "Overwrite Original - Export Error"),
+            muse::trc("project", "Failed to overwrite the original file. Please try again."));
+    }
 }
 
 void ProjectActionsController::exportLabels(const actions::ActionData& args)

--- a/src/project/internal/projectactionscontroller.h
+++ b/src/project/internal/projectactionscontroller.h
@@ -113,6 +113,7 @@ private:
     void clearRecentProjects();
 
     void exportAudio();
+    void exportOverwriteOriginal();
     void exportLabels(const muse::actions::ActionData& args);
     void exportMIDI();
 

--- a/src/project/internal/projectuiactions.cpp
+++ b/src/project/internal/projectuiactions.cpp
@@ -91,6 +91,12 @@ const UiActionList ProjectUiActions::m_actions = {
              TranslatableString("action", "&Export audio…"),
              TranslatableString("action", "Export audio…")
              ),
+    UiAction("export-overwrite-original",
+             au::context::UiCtxAny,
+             au::context::CTX_ANY,
+             TranslatableString("action", "&Overwrite original"),
+             TranslatableString("action", "Overwrite original file")
+             ),
     UiAction("export-labels",
              au::context::UiCtxAny,
              au::context::CTX_ANY,


### PR DESCRIPTION
Resolves: #762

This is a vibecoded thing addressing one of the longer-standing feature requests. It seems to be working fine

@teetow I currently disable the menu item once you add a second track to the project. I'm no longer sure if we need to disable it though, like, if you only add some sfx to a file, having an overwriting option available still makes sense to me. On a somewhat related note, for named projects, it makes _some_ sense to me to have an item called "Export as <project name>.wav" as a quick option, to skip the export dialog. That's probably a separate issue/PR though. 

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
