### PR TITLE
10980 Animate to start time only on keyboard navigation

### DIFF
--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TrackClipsContainer.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TrackClipsContainer.qml
@@ -359,7 +359,7 @@ TrackItemsContainer {
                                 navigation.column: itemData ? Math.floor(itemData.x) : 0
                                 navigation.accessible.name: Boolean(itemData) ? itemData.title : ""
                                 navigation.onActiveChanged: {
-                                    if (navigation.active) {
+                                    if (navigation.highlight) {
                                         root.context.animatedInsureVisible(itemData.time.startTime)
                                         root.insureVerticallyVisible()
                                     }

--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TrackLabelsContainer.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TrackLabelsContainer.qml
@@ -91,7 +91,9 @@ TrackItemsContainer {
                     Component.onCompleted: updateCustomCursor()
                     Connections {
                         target: root
-                        function onSelectionEditInProgressChanged() { labelsContainerMouseArea.updateCustomCursor() }
+                        function onSelectionEditInProgressChanged() {
+                            labelsContainerMouseArea.updateCustomCursor()
+                        }
                     }
 
                     onPressed: function (e) {
@@ -189,7 +191,7 @@ TrackItemsContainer {
                                 navigation.column: Boolean(itemData) ? Math.floor(itemData.x) : 0
                                 navigation.accessible.name: Boolean(itemData) ? itemData.title : ""
                                 navigation.onActiveChanged: {
-                                    if (navigation.active) {
+                                    if (navigation.highlight) {
                                         root.context.animatedInsureVisible(itemData.time.startTime)
                                         root.insureVerticallyVisible()
                                     }


### PR DESCRIPTION
Resolves: #10980 

Only animate to startTime for keyboard navigation

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
