### PR TITLE
Revamp audio plugins module

### DIFF
--- a/au3/libraries/au3-realtime-effects/RealtimeEffectState.cpp
+++ b/au3/libraries/au3-realtime-effects/RealtimeEffectState.cpp
@@ -10,14 +10,16 @@
 
 #include "RealtimeEffectState.h"
 
+#include <wx/arrstr.h>
+
+#include <thread>
+#include <condition_variable>
+
 #include "au3-channel/Channel.h"
 #include "au3-components/EffectInterface.h"
 #include "au3-utility/MessageBuffer.h"
 #include "au3-module-manager/PluginManager.h"
 #include "au3-math/SampleCount.h"
-
-#include <thread>
-#include <condition_variable>
 
 //! Mediator of two-way inter-thread communication of changes of settings
 class RealtimeEffectState::AccessState : public NonInterferingBase
@@ -800,6 +802,50 @@ static const auto nameAttribute = "name";
 static const auto valueAttribute = "value";
 static constexpr auto activeAttribute = "active";
 
+static wxArrayString splitEffectId(const PluginID& id)
+{
+    wxArrayString parts;
+    wxString part;
+    for (size_t i = 0; i < id.length(); ++i) {
+        const wxChar ch = id[i];
+        if (ch == '\\' && i + 1 < id.length() && id[i + 1] == '_') {
+            part += '_';
+            ++i;
+        } else if (ch == '_') {
+            parts.push_back(part);
+            part.clear();
+        } else {
+            part += ch;
+        }
+    }
+    parts.push_back(part);
+    return parts;
+}
+
+static PluginID normalizeEffectIdPathSeparators(const PluginID& id)
+{
+    auto parts = splitEffectId(id);
+    if (parts.size() != 5 || parts[0] != wxString("Effect")) {
+        return id;
+    }
+
+    wxString& path = parts[4];
+    if (path.Find('\\') == wxNOT_FOUND) {
+        return id;
+    }
+
+    path.Replace("\\", "/");
+    return wxJoin(parts, '_');
+}
+
+static PluginID resolveEffectId(const PluginID& id)
+{
+    if (const PluginID resolved = RealtimeEffectState::EffectIdResolver::Call(id); !resolved.empty()) {
+        return resolved;
+    }
+    return id;
+}
+
 bool RealtimeEffectState::HandleXMLTag(
     const std::string_view& tag, const AttributesList& attrs)
 {
@@ -809,7 +855,7 @@ bool RealtimeEffectState::HandleXMLTag(
         mID.clear();
         for (auto&[attr, value] : attrs) {
             if (attr == idAttribute) {
-                SetID(value.ToWString());
+                SetID(resolveEffectId(normalizeEffectIdPathSeparators(value.ToWString())));
                 if (!mPlugin) {
                     // TODO - complain!!!!
                 }

--- a/au3/libraries/au3-realtime-effects/RealtimeEffectState.h
+++ b/au3/libraries/au3-realtime-effects/RealtimeEffectState.h
@@ -39,6 +39,9 @@ public:
     struct REALTIME_EFFECTS_API EffectFactory : GlobalHook<EffectFactory,
                                                            const EffectInstanceFactory* (const PluginID&)
                                                            > {};
+    struct REALTIME_EFFECTS_API EffectIdResolver : GlobalHook<EffectIdResolver,
+                                                              PluginID(const PluginID&)
+                                                              > {};
 
     explicit RealtimeEffectState(const PluginID& id);
     RealtimeEffectState& operator =(const RealtimeEffectState& other);

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -155,6 +155,13 @@ add_to_link_if_exists(automation)
 
 set (AUDACITY_APPEND_SRC)
 
+list(APPEND AUDACITY_APPEND_SRC backgroundprocess.h)
+if (OS_IS_MAC)
+    list(APPEND AUDACITY_APPEND_SRC internal/platform/macos/backgroundprocess.mm)
+else()
+    list(APPEND AUDACITY_APPEND_SRC internal/platform/stub/backgroundprocess.cpp)
+endif()
+
 if (OS_IS_WIN)
     list(APPEND AUDACITY_APPEND_SRC ${WINDOWS_ICONS_RC})
     list(APPEND AUDACITY_APPEND_SRC ${WINDOWS_VERSION_RC})
@@ -227,6 +234,14 @@ if (OS_IS_MAC)
     set_target_properties(audacity
         PROPERTIES MACOSX_BUNDLE_INFO_PLIST ${PROJECT_SOURCE_DIR}/buildscripts/packaging/MacOS/MacOSXBundleInfo.plist.in
         XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER ${MACOSX_BUNDLE_GUI_IDENTIFIER}
+    )
+    target_link_libraries(audacity PRIVATE "-framework Cocoa")
+
+    set_source_files_properties(
+        internal/platform/macos/backgroundprocess.mm
+        PROPERTIES
+        SKIP_UNITY_BUILD_INCLUSION ON
+        SKIP_PRECOMPILE_HEADERS ON
     )
 endif (OS_IS_MAC)
 

--- a/src/app/backgroundprocess.h
+++ b/src/app/backgroundprocess.h
@@ -1,0 +1,11 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+#ifndef AU_APP_BACKGROUNDPROCESS_H
+#define AU_APP_BACKGROUNDPROCESS_H
+
+namespace au::app {
+void makeProcessBackground();
+}
+
+#endif // AU_APP_BACKGROUNDPROCESS_H

--- a/src/app/cmdoptions.h
+++ b/src/app/cmdoptions.h
@@ -41,8 +41,7 @@ struct AudacityCmdOptions : public muse::CmdOptions {
 
     struct AudioPluginRegistration {
         muse::io::path_t pluginPath;
-        bool failedPlugin = false;
-        int failCode = 0;
+        muse::io::path_t outputPath;
         bool selfTest = false;
     } audioPluginRegistration;
 };

--- a/src/app/commandlineparser.cpp
+++ b/src/app/commandlineparser.cpp
@@ -75,7 +75,7 @@ void CommandLineParser::init()
     // Audio plugins
     m_parser.addOption(QCommandLineOption("register-audio-plugin",
                                           "Check an audio plugin for compatibility with the application and register it", "path"));
-    m_parser.addOption(QCommandLineOption("register-failed-audio-plugin", "Register an incompatible audio plugin", "path"));
+    m_parser.addOption(QCommandLineOption("out", "File to write the audio plugin validation result to", "path"));
     m_parser.addOption(QCommandLineOption("plugin-registration-self-test",
                                           "Run plugin registration app self-test (verify initialization)"));
 
@@ -165,21 +165,13 @@ void CommandLineParser::parse(int argc, char** argv)
     if (m_parser.isSet("register-audio-plugin")) {
         m_options->runMode = IApplication::RunMode::AudioPluginRegistration;
         m_options->audioPluginRegistration.pluginPath = fromUserInputPath(m_parser.value("register-audio-plugin"));
-        m_options->audioPluginRegistration.failedPlugin = false;
+        m_options->audioPluginRegistration.outputPath = fromUserInputPath(m_parser.value("out"));
     }
 
     // Self-test mode for plugin registration
     if (m_parser.isSet("plugin-registration-self-test")) {
         m_options->runMode = IApplication::RunMode::AudioPluginRegistration;
         m_options->audioPluginRegistration.selfTest = true;
-    }
-
-    if (m_parser.isSet("register-failed-audio-plugin")) {
-        QStringList args1 = m_parser.positionalArguments();
-        m_options->runMode = IApplication::RunMode::AudioPluginRegistration;
-        m_options->audioPluginRegistration.pluginPath = fromUserInputPath(m_parser.value("register-failed-audio-plugin"));
-        m_options->audioPluginRegistration.failedPlugin = true;
-        m_options->audioPluginRegistration.failCode = !args1.empty() ? args1[0].toInt() : -1;
     }
 
     // Testflow

--- a/src/app/internal/platform/macos/backgroundprocess.mm
+++ b/src/app/internal/platform/macos/backgroundprocess.mm
@@ -1,0 +1,36 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+#include "backgroundprocess.h"
+
+#import <Cocoa/Cocoa.h>
+
+#include <objc/runtime.h>
+
+namespace {
+using SetActivationPolicyFn = BOOL (*)(id, SEL, NSApplicationActivationPolicy);
+SetActivationPolicyFn s_originalSetActivationPolicy = nullptr;
+
+BOOL keepAccessoryActivationPolicy(id self, SEL cmd, NSApplicationActivationPolicy)
+{
+    return s_originalSetActivationPolicy
+           ? s_originalSetActivationPolicy(self, cmd, NSApplicationActivationPolicyAccessory)
+           : NO;
+}
+}
+
+namespace au::app {
+void makeProcessBackground()
+{
+    // LSUIElement in the live info dictionary: windows allowed, no dock icon
+    NSMutableDictionary* infoDictionary = static_cast<NSMutableDictionary*>([[NSBundle mainBundle] infoDictionary]);
+    [infoDictionary setObject:@YES forKey:@"LSUIElement"];
+
+    // later callers (Qt) would reset the activation policy; force Accessory
+    Method method = class_getInstanceMethod([NSApplication class], @selector(setActivationPolicy:));
+    if (method && !s_originalSetActivationPolicy) {
+        s_originalSetActivationPolicy = reinterpret_cast<SetActivationPolicyFn>(method_getImplementation(method));
+        method_setImplementation(method, reinterpret_cast<IMP>(&keepAccessoryActivationPolicy));
+    }
+}
+}

--- a/src/app/internal/platform/stub/backgroundprocess.cpp
+++ b/src/app/internal/platform/stub/backgroundprocess.cpp
@@ -1,0 +1,8 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+#include "backgroundprocess.h"
+
+namespace au::app {
+void makeProcessBackground() {}
+}

--- a/src/app/pluginregistrationapp.cpp
+++ b/src/app/pluginregistrationapp.cpp
@@ -5,6 +5,7 @@
 
 #include <QCoreApplication>
 
+#include "backgroundprocess.h"
 #include "modularity/ioc.h"
 #include "framework/audioplugins/iregisteraudiopluginsscenario.h"
 #include "types/ret.h"
@@ -17,6 +18,7 @@ using namespace au::app;
 PluginRegistrationApp::PluginRegistrationApp(const std::shared_ptr<AudacityCmdOptions>& options)
     : muse::BaseApplication(options)
 {
+    makeProcessBackground();
 }
 
 void PluginRegistrationApp::startupScenario(const muse::modularity::ContextPtr& ctxId)

--- a/src/app/pluginregistrationapp.cpp
+++ b/src/app/pluginregistrationapp.cpp
@@ -65,14 +65,8 @@ int PluginRegistrationApp::processAudioPluginRegistration(const muse::modularity
         return 1;
     }
 
-    Ret ret = make_ret(Ret::Code::Ok);
-
     const auto& task = options->audioPluginRegistration;
-    if (task.failedPlugin) {
-        ret = scenario->registerFailedPlugin(task.pluginPath, task.failCode);
-    } else {
-        ret = scenario->registerPlugin(task.pluginPath);
-    }
+    Ret ret = scenario->validatePlugin(task.pluginPath, task.outputPath);
 
     if (!ret) {
         LOGE() << ret.toString();

--- a/src/app/pluginregistrationapp.cpp
+++ b/src/app/pluginregistrationapp.cpp
@@ -6,7 +6,7 @@
 #include <QCoreApplication>
 
 #include "modularity/ioc.h"
-#include "audioplugins/iregisteraudiopluginsscenario.h"
+#include "framework/audioplugins/iregisteraudiopluginsscenario.h"
 #include "types/ret.h"
 
 #include "log.h"

--- a/src/effects/audio_unit/CMakeLists.txt
+++ b/src/effects/audio_unit/CMakeLists.txt
@@ -20,6 +20,7 @@ set(MODULE_SRC
 
     ${CMAKE_CURRENT_LIST_DIR}/internal/audiounitviewlauncher.cpp
     ${CMAKE_CURRENT_LIST_DIR}/internal/audiounitviewlauncher.h
+    ${CMAKE_CURRENT_LIST_DIR}/internal/audiounittypes.h
 
     ${CMAKE_CURRENT_LIST_DIR}/view/audiounitview.cpp
     ${CMAKE_CURRENT_LIST_DIR}/view/audiounitview.h

--- a/src/effects/audio_unit/audiouniteffectsmodule.cpp
+++ b/src/effects/audio_unit/audiouniteffectsmodule.cpp
@@ -3,8 +3,8 @@
 */
 #include "audiouniteffectsmodule.h"
 
-#include "audioplugins/iaudiopluginsscannerregister.h"
-#include "audioplugins/iaudiopluginmetareaderregister.h"
+#include "framework/audioplugins/iaudiopluginsscannerregister.h"
+#include "framework/audioplugins/iaudiopluginmetareaderregister.h"
 
 #include "effects/effects_base/ieffectloadersregister.h"
 #include "effects/effects_base/ieffectviewlaunchregister.h"

--- a/src/effects/audio_unit/internal/audiouniteffectloader.h
+++ b/src/effects/audio_unit/internal/audiouniteffectloader.h
@@ -11,7 +11,7 @@ class AudioUnitEffectLoader final : public Au3EffectLoader
 {
 public:
     AudioUnitEffectLoader()
-        : Au3EffectLoader(m_module, muse::audio::AudioResourceType::AudioUnit) {}
+        : Au3EffectLoader(m_module, EffectFamily::AudioUnit) {}
 
 private:
     ::AudioUnitEffectsModule m_module;

--- a/src/effects/audio_unit/internal/audiounitpluginsmetareader.cpp
+++ b/src/effects/audio_unit/internal/audiounitpluginsmetareader.cpp
@@ -8,16 +8,16 @@
 
 #include "au3-audio-unit/AudioUnitEffectsModule.h"
 
-using namespace muse::audio;
+#include "audiounittypes.h"
 
 au::effects::AudioUnitPluginsMetaReader::AudioUnitPluginsMetaReader()
     : Au3AudioPluginMetaReader(m_module)
 {
 }
 
-AudioResourceType au::effects::AudioUnitPluginsMetaReader::metaType() const
+muse::audioplugins::PluginType au::effects::AudioUnitPluginsMetaReader::metaType() const
 {
-    return AudioResourceType::AudioUnit;
+    return std::string(au::effects::audio_unit::AUDIO_RESOURCE_TYPE_NAME);
 }
 
 bool au::effects::AudioUnitPluginsMetaReader::canReadMeta(const muse::io::path_t& path) const

--- a/src/effects/audio_unit/internal/audiounitpluginsmetareader.h
+++ b/src/effects/audio_unit/internal/audiounitpluginsmetareader.h
@@ -11,7 +11,7 @@ class AudioUnitPluginsMetaReader : public Au3AudioPluginMetaReader
 {
 public:
     AudioUnitPluginsMetaReader();
-    muse::audio::AudioResourceType metaType() const override;
+    muse::audioplugins::PluginType metaType() const override;
     bool canReadMeta(const muse::io::path_t& path) const override;
 private:
     ::AudioUnitEffectsModule m_module;

--- a/src/effects/audio_unit/internal/audiounittypes.h
+++ b/src/effects/audio_unit/internal/audiounittypes.h
@@ -1,0 +1,10 @@
+/*
+* Audacity: A Digital Audio Editor
+*/
+#pragma once
+
+#include <string_view>
+
+namespace au::effects::audio_unit {
+inline constexpr std::string_view AUDIO_RESOURCE_TYPE_NAME = "AudioUnit";
+}

--- a/src/effects/builtin/CMakeLists.txt
+++ b/src/effects/builtin/CMakeLists.txt
@@ -18,6 +18,7 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/internal/builtineffectsmetareader.cpp
     ${CMAKE_CURRENT_LIST_DIR}/internal/builtineffectsmetareader.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/builtineffectsscanner.h
+    ${CMAKE_CURRENT_LIST_DIR}/internal/builtintypes.h
 
     # view
     ${CMAKE_CURRENT_LIST_DIR}/view/builtineffectinstanceaccess.cpp

--- a/src/effects/builtin/internal/builtineffectsloader.h
+++ b/src/effects/builtin/internal/builtineffectsloader.h
@@ -11,7 +11,7 @@ class BuiltinEffectsLoader final : public Au3EffectLoader
 {
 public:
     BuiltinEffectsLoader()
-        : Au3EffectLoader(m_module, muse::audio::AudioResourceType::NativeEffect) {}
+        : Au3EffectLoader(m_module, EffectFamily::Builtin) {}
 
 private:
     ::BuiltinEffectsModule m_module;

--- a/src/effects/builtin/internal/builtineffectsmetareader.cpp
+++ b/src/effects/builtin/internal/builtineffectsmetareader.cpp
@@ -2,6 +2,7 @@
  * Audacity: A Digital Audio Editor
  */
 #include "builtineffectsmetareader.h"
+#include "builtintypes.h"
 
 namespace au::effects {
 BuiltinEffectsMetaReader::BuiltinEffectsMetaReader()
@@ -9,9 +10,9 @@ BuiltinEffectsMetaReader::BuiltinEffectsMetaReader()
 {
 }
 
-muse::audio::AudioResourceType BuiltinEffectsMetaReader::metaType() const
+muse::audioplugins::PluginType BuiltinEffectsMetaReader::metaType() const
 {
-    return muse::audio::AudioResourceType::NativeEffect;
+    return std::string(au::effects::builtin::AUDIO_RESOURCE_TYPE_NAME);
 }
 
 bool BuiltinEffectsMetaReader::canReadMeta(const muse::io::path_t& pluginPath) const

--- a/src/effects/builtin/internal/builtineffectsmetareader.h
+++ b/src/effects/builtin/internal/builtineffectsmetareader.h
@@ -13,7 +13,7 @@ class BuiltinEffectsMetaReader : public Au3AudioPluginMetaReader
 public:
     BuiltinEffectsMetaReader();
 
-    muse::audio::AudioResourceType metaType() const override;
+    muse::audioplugins::PluginType metaType() const override;
     bool canReadMeta(const muse::io::path_t& pluginPath) const override;
 
 private:

--- a/src/effects/builtin/internal/builtintypes.h
+++ b/src/effects/builtin/internal/builtintypes.h
@@ -1,0 +1,10 @@
+/*
+* Audacity: A Digital Audio Editor
+*/
+#pragma once
+
+#include <string_view>
+
+namespace au::effects::builtin {
+inline constexpr std::string_view AUDIO_RESOURCE_TYPE_NAME = "BuiltIn";
+}

--- a/src/effects/builtin_collection/dynamics/compressor/compressoreffect.h
+++ b/src/effects/builtin_collection/dynamics/compressor/compressoreffect.h
@@ -36,12 +36,12 @@ public:
     DYNAMICS_EFFECT_PARAM(CompressorSettings, paramName, paramMin, paramDefault, paramMax, paramStep)
 
     COMPRESSOR_PARAM(thresholdDb, -60, compressorThresholdDbDefault, 0, 0.1);
-    COMPRESSOR_PARAM(makeupGainDb, 0, compressorMakeupGainDbDefault, 30, 0.1);
+    COMPRESSOR_PARAM(makeupGainDb, -30, compressorMakeupGainDbDefault, 30, 0.1);
     COMPRESSOR_PARAM(kneeWidthDb, 0, compressorKneeWidthDbDefault, 30, 0.1);
     COMPRESSOR_PARAM(compressionRatio, 1, compressorCompressionRatioDefault, 100, 0.01);
     COMPRESSOR_PARAM(lookaheadMs, 0, compressorLookaheadMsDefault, compressorMaxLookaheadMs, 0.1);
     COMPRESSOR_PARAM(attackMs, 0.0, compressorAttackMsDefault, 200, 0.01);
-    COMPRESSOR_PARAM(releaseMs, 0.1, compressorReleaseMsDefault, 1000, 0.1);
+    COMPRESSOR_PARAM(releaseMs, 0, compressorReleaseMsDefault, 1000, 0.1);
     COMPRESSOR_PARAM(showInput, 0, showInputDefault, 1, 1);
     COMPRESSOR_PARAM(showOutput, 0, showOutputDefault, 1, 1);
     COMPRESSOR_PARAM(showActual, 0, showActualDefault, 1, 1);

--- a/src/effects/effects_base/CMakeLists.txt
+++ b/src/effects/effects_base/CMakeLists.txt
@@ -67,6 +67,8 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/internal/effectinstancesregister.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/effectexecutionscenario.cpp
     ${CMAKE_CURRENT_LIST_DIR}/internal/effectexecutionscenario.h
+    ${CMAKE_CURRENT_LIST_DIR}/internal/knownaudiopluginsconfigurator.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/internal/knownaudiopluginsconfigurator.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/realtimeeffectrestorer.cpp
     ${CMAKE_CURRENT_LIST_DIR}/internal/realtimeeffectrestorer.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/realtimeeffectservice.cpp

--- a/src/effects/effects_base/effectsmodule.cpp
+++ b/src/effects/effects_base/effectsmodule.cpp
@@ -27,6 +27,7 @@
 #include "internal/effectloadersregister.h"
 #include "internal/effectsproviderinitializer.h"
 #include "internal/missingeffectchecker.h"
+#include "internal/knownaudiopluginsconfigurator.h"
 
 #include "view/effectpresetsbarmodel.h"
 #include "view/presetstatesregister.h"
@@ -74,6 +75,9 @@ void EffectsModule::resolveImports()
         ir->registerQmlUri(muse::Uri("audacity://effects/presets/input_name"), "Audacity/Effects/PresetNameDialog.qml");
         ir->registerQmlUri(muse::Uri("audacity://effects/plugin_manager"), "Audacity/Effects/PluginManagerDialog.qml");
     }
+
+    // must run before the audioplugins cache loads in onInit
+    KnownAudioPluginsConfigurator().init();
 }
 
 void EffectsModule::registerResources()

--- a/src/effects/effects_base/effectstypes.h
+++ b/src/effects/effects_base/effectstypes.h
@@ -6,10 +6,12 @@
 #include <algorithm>
 #include <cmath>
 #include <vector>
+#include <string>
 
 #include "framework/global/types/string.h"
 #include "framework/global/types/ratio.h"
 #include "framework/actions/actiontypes.h"
+#include "framework/audioplugins/audiopluginstypes.h"
 
 class Effect;
 class EffectInstanceEx;
@@ -241,9 +243,13 @@ struct EffectMeta {
     bool isRealtimeCapable = false;
     bool paramsAreInputAgnostic = true;
     bool isActivated = true;
-    bool isLoadable = true;
+
+    // Carried verbatim so save() round-trips Discovered/Missing/Error.
+    // Undefined marks a default-constructed meta that must not read as loadable.
+    muse::audioplugins::AudioPluginState state = muse::audioplugins::AudioPluginState::Undefined;
 
     bool isValid() const { return !id.empty(); }
+    bool isLoadable() const { return state == muse::audioplugins::AudioPluginState::Validated; }
 };
 
 using EffectMetaList = std::vector<EffectMeta>;

--- a/src/effects/effects_base/ieffectsprovider.h
+++ b/src/effects/effects_base/ieffectsprovider.h
@@ -47,8 +47,7 @@ public:
      * @brief Soft rescan: plugins already in the configuration aren't reevaluated. Use `forgetPlugins` beforehand to force re-evaluation.
      */
     virtual void rescanPlugins(const muse::modularity::ContextPtr& ctx, muse::IInteractive& interactive,
-                               muse::audioplugins::IRegisterAudioPluginsScenario& registerAudioPluginsScenario,
-                               const EffectFilter& exclude = nullptr) = 0;
+                               muse::audioplugins::IRegisterAudioPluginsScenario& registerAudioPluginsScenario) = 0;
     virtual void forgetPlugins(const EffectFilter& forget = nullptr) = 0;
 
     virtual void save() = 0;

--- a/src/effects/effects_base/internal/au3/au3audiopluginmetareader.cpp
+++ b/src/effects/effects_base/internal/au3/au3audiopluginmetareader.cpp
@@ -38,7 +38,7 @@ void Au3AudioPluginMetaReader::deinit()
     m_terminated = true;
 }
 
-muse::RetVal<muse::audio::AudioResourceMetaList> Au3AudioPluginMetaReader::readMeta(const muse::io::path_t& pluginPath) const
+muse::RetVal<muse::audioplugins::PluginMetaList> Au3AudioPluginMetaReader::readMeta(const muse::io::path_t& pluginPath) const
 {
     IF_ASSERT_FAILED(m_initialized && !m_terminated) {
         return make_ret(muse::Ret::Code::InternalError);
@@ -113,12 +113,12 @@ muse::RetVal<muse::audio::AudioResourceMetaList> Au3AudioPluginMetaReader::readM
         return effects::make_ret(effects::Err::EffectLoadFailed);
     }
 
-    muse::audio::AudioResourceMetaList metaList;
+    muse::audioplugins::PluginMetaList metaList;
     metaList.reserve(descriptors.size());
     for (const PluginDescriptor& desc : descriptors) {
         metaList.emplace_back(utils::auToMuseEffectMeta(toEffectMeta(desc)));
     }
 
-    return muse::RetVal<muse::audio::AudioResourceMetaList>::make_ok(metaList);
+    return muse::RetVal<muse::audioplugins::PluginMetaList>::make_ok(metaList);
 }
 }

--- a/src/effects/effects_base/internal/au3/au3audiopluginmetareader.h
+++ b/src/effects/effects_base/internal/au3/au3audiopluginmetareader.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "audioplugins/iaudiopluginmetareader.h"
+#include "framework/audioplugins/iaudiopluginmetareader.h"
 #include "global/iapplication.h"
 
 class PluginProvider;
@@ -17,7 +17,7 @@ public:
 
 private:
     virtual void doInit() {}
-    muse::RetVal<muse::audio::AudioResourceMetaList> readMeta(const muse::io::path_t& pluginPath) const override;
+    muse::RetVal<muse::audioplugins::PluginMetaList> readMeta(const muse::io::path_t& pluginPath) const override;
 
     PluginProvider& m_pluginProvider;
     bool m_initialized = false;

--- a/src/effects/effects_base/internal/au3/au3effectsutils.cpp
+++ b/src/effects/effects_base/internal/au3/au3effectsutils.cpp
@@ -27,7 +27,9 @@ effects::EffectMeta effects::toEffectMeta(const ::PluginDescriptor& desc)
     meta.isRealtimeCapable = desc.IsEffectRealtime();
     meta.paramsAreInputAgnostic = desc.ParamsAreInputAgnostic();
     meta.isActivated = desc.IsEnabled();
-    meta.isLoadable = desc.IsValid();
+    meta.state = desc.IsValid()
+                 ? muse::audioplugins::AudioPluginState::Validated
+                 : muse::audioplugins::AudioPluginState::Error;
 
     return meta;
 }

--- a/src/effects/effects_base/internal/au3effectloader.cpp
+++ b/src/effects/effects_base/internal/au3effectloader.cpp
@@ -14,32 +14,11 @@
 #include "framework/global/log.h"
 
 namespace au::effects {
-constexpr EffectFamily toEffectFamily(muse::audio::AudioResourceType type)
+Au3EffectLoader::Au3EffectLoader(PluginProvider& provider, EffectFamily family)
+    : m_pluginProvider{provider}, m_family{family}
 {
-    switch (type) {
-    case muse::audio::AudioResourceType::VstPlugin:      return EffectFamily::VST3;
-#ifdef Q_OS_LINUX
-    case muse::audio::AudioResourceType::Lv2Plugin:      return EffectFamily::LV2;
-#endif
-#ifdef Q_OS_MACOS
-    case muse::audio::AudioResourceType::AudioUnit:      return EffectFamily::AudioUnit;
-#endif
-    case muse::audio::AudioResourceType::NyquistPlugin:  return EffectFamily::Nyquist;
-    case muse::audio::AudioResourceType::NativeEffect:  return EffectFamily::Builtin;
-    case muse::audio::AudioResourceType::FluidSoundfont:
-    case muse::audio::AudioResourceType::MuseSamplerSoundPack:
-        return EffectFamily::Unknown;
-    default:
-        assert(false && "Unknown AudioResourceType");
-        return EffectFamily::Unknown;
-    }
-}
-
-Au3EffectLoader::Au3EffectLoader(PluginProvider& provider, muse::audio::AudioResourceType resourceType)
-    : m_pluginProvider{provider}, m_resourceType{resourceType}
-{
-    IF_ASSERT_FAILED(toEffectFamily(resourceType) != EffectFamily::Unknown) {
-        LOGE() << "Invalid AudioResourceType for Au3EffectLoader: " << static_cast<int>(resourceType);
+    IF_ASSERT_FAILED(m_family != EffectFamily::Unknown) {
+        LOGE() << "Invalid EffectFamily for Au3EffectLoader: " << static_cast<int>(m_family);
     }
 }
 
@@ -56,7 +35,7 @@ void Au3EffectLoader::deinit()
 
 EffectFamily Au3EffectLoader::family() const
 {
-    return toEffectFamily(m_resourceType);
+    return m_family;
 }
 
 bool Au3EffectLoader::ensurePluginIsLoaded(const EffectId& effectId)
@@ -74,13 +53,13 @@ bool Au3EffectLoader::ensurePluginIsLoaded(const EffectId& effectId)
         LOGE() << "plugin not in registry: " << effectId;
         return false;
     }
-    if (!it->enabled) {
-        LOGW() << "plugin disabled: " << effectId;
+    if (it->state != muse::audioplugins::AudioPluginState::Validated) {
+        LOGW() << "plugin not validated: " << effectId;
         return false;
     }
-    if (it->meta.type != m_resourceType) {
-        LOGE() << "Effect families don't match: expected " << static_cast<int>(m_resourceType)
-               << ", got " << static_cast<int>(it->meta.type);
+    if (!utils::isFamilyType(it->meta, m_family)) {
+        LOGE() << "Effect families don't match: expected " << utils::effectFamilyToCacheType(m_family)
+               << ", got " << it->meta.type;
         return false;
     }
     const muse::io::path_t& path = it->path;

--- a/src/effects/effects_base/internal/au3effectloader.h
+++ b/src/effects/effects_base/internal/au3effectloader.h
@@ -19,7 +19,7 @@ public:
     muse::GlobalInject<muse::audioplugins::IKnownAudioPluginsRegister> knownPlugins;
 
 public:
-    Au3EffectLoader(PluginProvider& provider, muse::audio::AudioResourceType resourceType);
+    Au3EffectLoader(PluginProvider& provider, EffectFamily family);
 
     void init();
     void deinit();
@@ -32,7 +32,7 @@ private:
     virtual void doInit() {}
 
     PluginProvider& m_pluginProvider;
-    const muse::audio::AudioResourceType m_resourceType;
+    const EffectFamily m_family;
     std::map<EffectId, std::unique_ptr<::ComponentInterface> > m_loadedInterfaces;
 };
 } // namespace au::effects

--- a/src/effects/effects_base/internal/effectsprovider.cpp
+++ b/src/effects/effects_base/internal/effectsprovider.cpp
@@ -61,10 +61,9 @@ void EffectsProvider::forgetPlugins(const EffectFilter& forget)
 }
 
 void EffectsProvider::rescanPlugins(const muse::modularity::ContextPtr& ctx, muse::IInteractive& interactive,
-                                    muse::audioplugins::IRegisterAudioPluginsScenario& registerAudioPluginsScenario,
-                                    const EffectFilter& exclude)
+                                    muse::audioplugins::IRegisterAudioPluginsScenario& registerAudioPluginsScenario)
 {
-    if (doScanPlugins(ctx, registerAudioPluginsScenario, {}, exclude) == NewPluginsRegistered::No) {
+    if (doScanPlugins(ctx, registerAudioPluginsScenario) == NewPluginsRegistered::No) {
         interactive.infoSync(muse::trc("audio", "Audio plugins scan completed"), muse::trc("audio", "All audio plugins are up to date."));
     }
 }
@@ -72,8 +71,7 @@ void EffectsProvider::rescanPlugins(const muse::modularity::ContextPtr& ctx, mus
 EffectsProvider::NewPluginsRegistered EffectsProvider::doScanPlugins(
     const muse::modularity::ContextPtr& ctx,
     muse::audioplugins::IRegisterAudioPluginsScenario& registerAudioPluginsScenario,
-    const std::function<bool()>& doScanThirdPartyPlugins,
-    const EffectFilter& exclude)
+    const std::function<bool()>& doScanThirdPartyPlugins)
 {
     muse::audioplugins::PluginScanResult scanResult;
     {
@@ -109,32 +107,6 @@ EffectsProvider::NewPluginsRegistered EffectsProvider::doScanPlugins(
         }
     }
 
-    if (exclude != nullptr) {
-        // Erase plugins matching exclude
-        auto it = thirdPartyPluginPaths.begin();
-        while (it != thirdPartyPluginPaths.end()) {
-            const auto& reader = pathToMetaReader.at(*it);
-            const muse::RetVal<muse::audio::AudioResourceMetaList> ret = reader->readMeta(*it);
-            IF_ASSERT_FAILED(ret.ret) {
-                it = thirdPartyPluginPaths.erase(it);
-                continue;
-            }
-
-            std::vector<EffectMeta> effectMetas;
-            std::transform(ret.val.begin(), ret.val.end(), std::back_inserter(effectMetas), [path = *it](const auto& meta) {
-                return utils::museToAuEffectMeta(path, meta);
-            });
-            // Only skip if all effects of this bundle are excluded - better be safe here.
-            if (std::all_of(effectMetas.begin(), effectMetas.end(), exclude)) {
-                it = thirdPartyPluginPaths.erase(it);
-                continue;
-            }
-
-            // All good.
-            ++it;
-        }
-    }
-
     // Audacity plugins (built-in effects and nyquist plugins) are safe. Register them in-process,
     // because out-of-process registration is slow and users may opt out. Remove them from the list of plugins.
     muse::io::paths_t audacityPluginPaths;
@@ -143,8 +115,8 @@ EffectsProvider::NewPluginsRegistered EffectsProvider::doScanPlugins(
         const auto& reader = pathToMetaReader.at(*it);
         const auto metaType = reader->metaType();
 
-        using namespace muse::audio;
-        const auto isAudacityPlugin = metaType == AudioResourceType::NyquistPlugin || metaType == AudioResourceType::NativeEffect;
+        const EffectFamily family = utils::effectFamilyFromCacheType(metaType);
+        const bool isAudacityPlugin = family == EffectFamily::Nyquist || family == EffectFamily::Builtin;
         if (isAudacityPlugin) {
             audacityPluginPaths.push_back(*it);
             it = thirdPartyPluginPaths.erase(it);
@@ -153,14 +125,27 @@ EffectsProvider::NewPluginsRegistered EffectsProvider::doScanPlugins(
         }
     }
 
-    registerAudioPluginsScenario.unregisterRemovedPlugins(scanResult.missingPluginIds);
+    // Mark missing plugins without deleting cache entries — the framework wants
+    // to preserve the meta so the user can still see "the plugin I had is gone".
+    // Rediscovered (formerly Missing, found again) paths come back in
+    // scanResult.newPluginPaths and are re-validated below, not trusted.
+    // Mirrors RegisterAudioPluginsScenario::updatePluginsRegistry().
+    knownPluginsRegister()->setPluginsState(scanResult.missingPluginPaths,
+                                            muse::audioplugins::AudioPluginState::Missing);
 
     for (const io::path_t& path : audacityPluginPaths) {
         registerAudioPluginsScenario.registerPlugin(path);
     }
 
-    if (!thirdPartyPluginPaths.empty() && (doScanThirdPartyPlugins == nullptr || doScanThirdPartyPlugins())) {
-        registerAudioPluginsScenario.registerNewPlugins(thirdPartyPluginPaths);
+    if (!thirdPartyPluginPaths.empty()) {
+        // Skip ("validate later") still records the plugins as Discovered so
+        // scanPlugins() can re-offer them on the next launch. Validate runs
+        // the full out-of-process scan.
+        const bool validate = (doScanThirdPartyPlugins == nullptr || doScanThirdPartyPlugins());
+        const muse::Ret ret = registerAudioPluginsScenario.registerNewPlugins(thirdPartyPluginPaths, validate);
+        if (!ret) {
+            LOGE() << "Failed to register new plugins: " << ret.toString();
+        }
     }
 
     reloadEffects();
@@ -179,7 +164,7 @@ void EffectsProvider::reloadEffects()
     const auto knownPlugins = knownPluginsRegister()->pluginInfoList();
     std::transform(knownPlugins.begin(), knownPlugins.end(), std::back_inserter(m_effects),
                    [](const muse::audioplugins::AudioPluginInfo& info) {
-        return utils::museToAuEffectMeta(info.path, info.meta, info.enabled);
+        return utils::museToAuEffectMeta(info.path, info.meta, info.state);
     });
 
     m_effectsChanged.notify();
@@ -306,20 +291,20 @@ void EffectsProvider::doSave(EffectFilter removeFromConfig)
         }
 
         muse::audioplugins::AudioPluginInfo info;
-        info.type = muse::audioplugins::AudioPluginType::Fx;
         info.meta = utils::auToMuseEffectMeta(meta);
         info.path = meta.path;
-        info.enabled = meta.isLoadable;
+        info.state = meta.state;
 
         newPlugins.push_back(std::move(info));
     }
 
+    // registerPlugins() merges into the register; remove the cache and reload
+    // so exactly newPlugins is persisted
     const auto filePath = audioPluginsConfiguration()->knownAudioPluginsFilePath();
     if (fileSystem()->exists(filePath)) {
-        // Remove the file and reload the register.
         fileSystem()->remove(filePath);
-        knownPluginsRegister()->load();
     }
+    knownPluginsRegister()->load();
 
     knownPluginsRegister()->registerPlugins(newPlugins);
 }

--- a/src/effects/effects_base/internal/effectsprovider.cpp
+++ b/src/effects/effects_base/internal/effectsprovider.cpp
@@ -107,40 +107,25 @@ EffectsProvider::NewPluginsRegistered EffectsProvider::doScanPlugins(
         }
     }
 
-    // Audacity plugins (built-in effects and nyquist plugins) are safe. Register them in-process,
-    // because out-of-process registration is slow and users may opt out. Remove them from the list of plugins.
-    muse::io::paths_t audacityPluginPaths;
-    auto it = thirdPartyPluginPaths.begin();
-    while (it != thirdPartyPluginPaths.end()) {
-        const auto& reader = pathToMetaReader.at(*it);
-        const auto metaType = reader->metaType();
+    const auto mid = std::stable_partition(
+        thirdPartyPluginPaths.begin(), thirdPartyPluginPaths.end(),
+        [&](const auto& path) {
+        const auto family = utils::effectFamilyFromCacheType(pathToMetaReader.at(path)->metaType());
+        return !(family == EffectFamily::Nyquist || family == EffectFamily::Builtin);
+    });
 
-        const EffectFamily family = utils::effectFamilyFromCacheType(metaType);
-        const bool isAudacityPlugin = family == EffectFamily::Nyquist || family == EffectFamily::Builtin;
-        if (isAudacityPlugin) {
-            audacityPluginPaths.push_back(*it);
-            it = thirdPartyPluginPaths.erase(it);
-        } else {
-            ++it;
-        }
-    }
+    muse::io::paths_t audacityPluginPaths(mid, thirdPartyPluginPaths.end());
+    thirdPartyPluginPaths.erase(mid, thirdPartyPluginPaths.end());
 
-    // Mark missing plugins without deleting cache entries — the framework wants
-    // to preserve the meta so the user can still see "the plugin I had is gone".
-    // Rediscovered (formerly Missing, found again) paths come back in
-    // scanResult.newPluginPaths and are re-validated below, not trusted.
-    // Mirrors RegisterAudioPluginsScenario::updatePluginsRegistry().
     knownPluginsRegister()->setPluginsState(scanResult.missingPluginPaths,
                                             muse::audioplugins::AudioPluginState::Missing);
 
+    // built-in and nyquist plugins are trusted, register in-process
     for (const io::path_t& path : audacityPluginPaths) {
         registerAudioPluginsScenario.registerPlugin(path);
     }
 
     if (!thirdPartyPluginPaths.empty()) {
-        // Skip ("validate later") still records the plugins as Discovered so
-        // scanPlugins() can re-offer them on the next launch. Validate runs
-        // the full out-of-process scan.
         const bool validate = (doScanThirdPartyPlugins == nullptr || doScanThirdPartyPlugins());
         const muse::Ret ret = registerAudioPluginsScenario.registerNewPlugins(thirdPartyPluginPaths, validate);
         if (!ret) {

--- a/src/effects/effects_base/internal/effectsprovider.h
+++ b/src/effects/effects_base/internal/effectsprovider.h
@@ -54,8 +54,7 @@ public:
     bool hasEffectFamily(EffectFamily family) const override;
 
     void rescanPlugins(const muse::modularity::ContextPtr& ctx, muse::IInteractive& interactive,
-                       muse::audioplugins::IRegisterAudioPluginsScenario& registerAudioPluginsScenario,
-                       const EffectFilter& exclude = nullptr) override;
+                       muse::audioplugins::IRegisterAudioPluginsScenario& registerAudioPluginsScenario) override;
     void forgetPlugins(const EffectFilter& forget = nullptr) override;
     void save() override;
 
@@ -70,7 +69,7 @@ private:
 
     NewPluginsRegistered doScanPlugins(const muse::modularity::ContextPtr& ctx,
                                        muse::audioplugins::IRegisterAudioPluginsScenario& registerAudioPluginsScenario,
-                                       const std::function<bool()>& doScanThirdPartyPlugins = nullptr, const EffectFilter& accept = nullptr);
+                                       const std::function<bool()>& doScanThirdPartyPlugins = nullptr);
     void doSave(EffectFilter removeFromConfig = nullptr);
 
     EffectMetaList m_effects;

--- a/src/effects/effects_base/internal/effectsutils.cpp
+++ b/src/effects/effects_base/internal/effectsutils.cpp
@@ -5,6 +5,12 @@
 #include "effectsutils.h"
 #include "effectstypes.h"
 
+#include "effects/vst/internal/vsttypes.h"
+#include "effects/audio_unit/internal/audiounittypes.h"
+#include "effects/lv2/internal/lv2types.h"
+#include "effects/nyquist/internal/nyquisttypes.h"
+#include "effects/builtin/internal/builtintypes.h"
+
 #include "au3-components/EffectInterface.h"
 
 #include "framework/global/log.h"
@@ -52,6 +58,54 @@ EffectFamily utils::effectFamilyFromString(const muse::String& family)
     }
     assert(false);
     return EffectFamily::Unknown;
+}
+
+std::string utils::effectFamilyToCacheType(EffectFamily family)
+{
+    switch (family) {
+    case EffectFamily::VST3:      return std::string(vst::AUDIO_RESOURCE_TYPE_NAME);
+#ifdef Q_OS_MACOS
+    case EffectFamily::AudioUnit: return std::string(audio_unit::AUDIO_RESOURCE_TYPE_NAME);
+#endif
+#ifdef Q_OS_LINUX
+    case EffectFamily::LV2:       return std::string(lv2::AUDIO_RESOURCE_TYPE_NAME);
+#endif
+    case EffectFamily::Nyquist:   return std::string(nyquist::AUDIO_RESOURCE_TYPE_NAME);
+    case EffectFamily::Builtin:   return std::string(builtin::AUDIO_RESOURCE_TYPE_NAME);
+    case EffectFamily::Unknown:
+    case EffectFamily::_count:
+        break;
+    }
+    return {};
+}
+
+EffectFamily utils::effectFamilyFromCacheType(const std::string& cacheType)
+{
+    if (cacheType == vst::AUDIO_RESOURCE_TYPE_NAME) {
+        return EffectFamily::VST3;
+    }
+#ifdef Q_OS_MACOS
+    if (cacheType == audio_unit::AUDIO_RESOURCE_TYPE_NAME) {
+        return EffectFamily::AudioUnit;
+    }
+#endif
+#ifdef Q_OS_LINUX
+    if (cacheType == lv2::AUDIO_RESOURCE_TYPE_NAME) {
+        return EffectFamily::LV2;
+    }
+#endif
+    if (cacheType == nyquist::AUDIO_RESOURCE_TYPE_NAME) {
+        return EffectFamily::Nyquist;
+    }
+    if (cacheType == builtin::AUDIO_RESOURCE_TYPE_NAME) {
+        return EffectFamily::Builtin;
+    }
+    return EffectFamily::Unknown;
+}
+
+bool utils::isFamilyType(const muse::audioplugins::PluginMeta& meta, EffectFamily family)
+{
+    return utils::effectFamilyFromCacheType(meta.type) == family;
 }
 
 namespace {
@@ -220,13 +274,13 @@ EffectType utils::effectTypeFromString(const muse::String& type)
     return EffectType::Unknown;
 }
 
-muse::audio::AudioResourceMeta utils::auToMuseEffectMeta(const EffectMeta& meta)
+muse::audioplugins::PluginMeta utils::auToMuseEffectMeta(const EffectMeta& meta)
 {
-    muse::audio::AudioResourceMeta museMeta;
+    muse::audioplugins::PluginMeta museMeta;
     // Use the AU3 plugin ID (same as Audio Unit does)
     // This is necessary for looking up the plugin in PluginManager later
     museMeta.id = meta.id.toStdString();
-    museMeta.type = toMuseAudioResourceType(meta.family);
+    museMeta.type = utils::effectFamilyToCacheType(meta.family);
     museMeta.vendor = meta.vendor.toStdString();
 
     // Add attributes using the map interface
@@ -258,33 +312,37 @@ bool value<bool>(const muse::String& str)
 }
 
 template<typename T = muse::String>
-T attributeValue(const muse::audio::AudioResourceMeta& meta, const muse::String& key, bool enabled)
+T attributeValue(const muse::audioplugins::PluginMeta& meta, const muse::String& key, bool isLoadable)
 {
     const auto valStr = meta.attributeVal(key);
-    IF_ASSERT_FAILED(!enabled || !valStr.empty()) {
+    IF_ASSERT_FAILED(!isLoadable || !valStr.empty()) {
         return {};
     }
     return value<T>(valStr);
 }
 }
 
-EffectMeta utils::museToAuEffectMeta(const muse::io::path_t& path, const muse::audio::AudioResourceMeta& meta, bool enabled)
+EffectMeta utils::museToAuEffectMeta(const muse::io::path_t& path, const muse::audioplugins::PluginMeta& meta,
+                                     muse::audioplugins::AudioPluginState state)
 {
+    // only Validated entries are guaranteed complete meta; gate the asserts on that
+    const bool isLoadable = (state == muse::audioplugins::AudioPluginState::Validated);
+
     EffectMeta effectMeta;
     effectMeta.path = path;
     effectMeta.id = muse::String::fromStdString(meta.id);
-    effectMeta.family = fromMuseAudioResourceType(meta.type);
+    effectMeta.family = utils::effectFamilyFromCacheType(meta.type);
     effectMeta.vendor = muse::String::fromStdString(meta.vendor);
-    effectMeta.type = utils::effectTypeFromString(attributeValue(meta, EFFECT_TYPE_ATTRIBUTE, enabled));
-    effectMeta.title = attributeValue(meta, EFFECT_TITLE_ATTRIBUTE, enabled);
-    effectMeta.description = effectMeta.title; // TODO use attributeValue(meta, EFFECT_DESCRIPTION_ATTRIBUTE, enabled);
-    effectMeta.category = attributeValue(meta, EFFECT_CATEGORY_ATTRIBUTE, enabled);
-    effectMeta.isRealtimeCapable = attributeValue<bool>(meta, EFFECT_IS_REALTIME_CAPABLE_ATTRIBUTE, enabled);
-    effectMeta.paramsAreInputAgnostic = attributeValue<bool>(meta, EFFECT_PARAMS_ARE_INPUT_AGNOSTIC_ATTRIBUTE, enabled);
-    effectMeta.version = attributeValue(meta, EFFECT_VERSION_ATTRIBUTE, enabled);
-    effectMeta.module = attributeValue(meta, EFFECT_MODULE_ATTRIBUTE, enabled);
-    effectMeta.isActivated = attributeValue<bool>(meta, EFFECT_ACTIVATED_ATTRIBUTE, enabled);
-    effectMeta.isLoadable = enabled;
+    effectMeta.type = utils::effectTypeFromString(attributeValue(meta, EFFECT_TYPE_ATTRIBUTE, isLoadable));
+    effectMeta.title = attributeValue(meta, EFFECT_TITLE_ATTRIBUTE, isLoadable);
+    effectMeta.description = effectMeta.title; // TODO use attributeValue(meta, EFFECT_DESCRIPTION_ATTRIBUTE, isLoadable);
+    effectMeta.category = attributeValue(meta, EFFECT_CATEGORY_ATTRIBUTE, isLoadable);
+    effectMeta.isRealtimeCapable = attributeValue<bool>(meta, EFFECT_IS_REALTIME_CAPABLE_ATTRIBUTE, isLoadable);
+    effectMeta.paramsAreInputAgnostic = attributeValue<bool>(meta, EFFECT_PARAMS_ARE_INPUT_AGNOSTIC_ATTRIBUTE, isLoadable);
+    effectMeta.version = attributeValue(meta, EFFECT_VERSION_ATTRIBUTE, isLoadable);
+    effectMeta.module = attributeValue(meta, EFFECT_MODULE_ATTRIBUTE, isLoadable);
+    effectMeta.isActivated = attributeValue<bool>(meta, EFFECT_ACTIVATED_ATTRIBUTE, isLoadable);
+    effectMeta.state = state;
 
     return effectMeta;
 }
@@ -513,7 +571,7 @@ MenuItemList makeFlatList(const EffectMetaList& effects, IEffectMenuItemFactory&
 void removeAlsoDisabledEffects(EffectMetaList& effects, const utils::EffectFilter& filter)
 {
     effects.erase(std::remove_if(effects.begin(), effects.end(), [&](const EffectMeta& meta) {
-        return !meta.isLoadable || !meta.isActivated || filter(meta);
+        return !meta.isLoadable() || !meta.isActivated || filter(meta);
     }), effects.end());
 }
 } // namespace

--- a/src/effects/effects_base/internal/effectsutils.cpp
+++ b/src/effects/effects_base/internal/effectsutils.cpp
@@ -22,6 +22,10 @@
 #include "au3-strings/wxArrayStringEx.h"
 #include "au3wrap/internal/wxtypes_convert.h"
 
+#include <algorithm>
+#include <cctype>
+#include <iterator>
+
 namespace au::effects {
 muse::String utils::effectFamilyToString(EffectFamily family)
 {
@@ -159,12 +163,73 @@ std::string parseEffectIdPart(const effects::EffectId& effectId, size_t partInde
     }
     return {};
 }
+
+std::string toLower(std::string value)
+{
+    std::transform(value.begin(), value.end(), value.begin(), [](unsigned char ch) {
+        return static_cast<char>(std::tolower(ch));
+    });
+    return value;
+}
+
+std::string vst3ClassId(const EffectId& effectId)
+{
+    const std::string path = utils::parseEffectPath(effectId);
+    const auto separator = path.rfind(';');
+    if (separator == std::string::npos || separator + 1 == path.size()) {
+        return {};
+    }
+    return toLower(path.substr(separator + 1));
+}
 }
 
 bool utils::isEffectId(const EffectId& effectId)
 {
     const auto strings = wxSplit(au3::wxFromString(effectId), '_');
     return strings.size() == effectIdPartCount && strings[0] == wxString("Effect");
+}
+
+EffectId utils::findRelocatedVst3EffectId(const EffectId& effectId, const EffectMetaList& metaList)
+{
+    if (utils::parseEffectFamily(effectId) != "VST3") {
+        return {};
+    }
+
+    const std::string classId = vst3ClassId(effectId);
+    if (classId.empty()) {
+        return {};
+    }
+
+    const auto exact = std::find_if(metaList.begin(), metaList.end(), [&](const EffectMeta& meta) {
+        return meta.family == EffectFamily::VST3
+               && meta.isLoadable()
+               && meta.id == effectId;
+    });
+    if (exact != metaList.end()) {
+        return {};
+    }
+
+    EffectMetaList candidates;
+    std::copy_if(metaList.begin(), metaList.end(), std::back_inserter(candidates), [&](const EffectMeta& meta) {
+        return meta.family == EffectFamily::VST3
+               && meta.isLoadable()
+               && meta.id != effectId
+               && vst3ClassId(meta.id) == classId;
+    });
+
+    if (candidates.size() == 1) {
+        return candidates.front().id;
+    }
+
+    const std::string vendor = utils::parseEffectVendor(effectId);
+    const std::string name = utils::parseEffectName(effectId);
+
+    candidates.erase(std::remove_if(candidates.begin(), candidates.end(), [&](const EffectMeta& meta) {
+        return utils::parseEffectVendor(meta.id) != vendor
+               || utils::parseEffectName(meta.id) != name;
+    }), candidates.end());
+
+    return candidates.size() == 1 ? candidates.front().id : EffectId {};
 }
 
 std::string utils::parseEffectName(const EffectId& effectId)

--- a/src/effects/effects_base/internal/effectsutils.cpp
+++ b/src/effects/effects_base/internal/effectsutils.cpp
@@ -3,8 +3,15 @@
  */
 
 #include "effectsutils.h"
-#include "effectstypes.h"
 
+#include <wx/string.h>
+
+#include "framework/global/iglobalconfiguration.h"
+#include "framework/global/modularity/ioc.h"
+#include "framework/global/log.h"
+#include "framework/global/stringutils.h"
+
+#include "effectstypes.h"
 #include "effects/vst/internal/vsttypes.h"
 #include "effects/audio_unit/internal/audiounittypes.h"
 #include "effects/lv2/internal/lv2types.h"
@@ -12,11 +19,6 @@
 #include "effects/builtin/internal/builtintypes.h"
 
 #include "au3-components/EffectInterface.h"
-
-#include "framework/global/log.h"
-#include "framework/global/stringutils.h"
-
-#include <wx/string.h>
 #include "au3-strings/wxArrayStringEx.h"
 #include "au3wrap/internal/wxtypes_convert.h"
 
@@ -125,6 +127,12 @@ static const muse::String legacyEffectCategoryString{ "Legacy" };
 
 EffectId utils::effectId(const EffectDefinitionInterface* effect)
 {
+    static muse::GlobalInject<muse::IGlobalConfiguration> globalConfiguration;
+    const muse::io::path_t rawPath = au3::wxToStdString(effect->GetPath());
+    const muse::io::path_t portablePath = globalConfiguration()->isBundledWithApp(rawPath)
+                                          ? globalConfiguration()->toBundledPath(rawPath)
+                                          : rawPath;
+
     // Using wxJoin/wxSplit for now, as they handle the presence of the separator being part of any of its constituents
     // (e.g. an effect vendor that has an underscore in its name.)
     // TODO add defense in muse::strings utils.
@@ -133,7 +141,7 @@ EffectId utils::effectId(const EffectDefinitionInterface* effect)
             effect->GetFamily().Internal(),
             effect->GetVendor().Internal(),
             effect->GetSymbol().Internal(),
-            effect->GetPath()
+            au3::wxFromStdString(portablePath.toStdString())
         }, '_'));
 }
 

--- a/src/effects/effects_base/internal/effectsutils.h
+++ b/src/effects/effects_base/internal/effectsutils.h
@@ -22,6 +22,7 @@ muse::uicomponents::MenuItemList realtimeEffectMenu(EffectMenuOrganization organ
                                                     const EffectFilter& filter, IEffectMenuItemFactory& effectMenu);
 
 EffectId effectId(const EffectDefinitionInterface* effect);
+EffectId findRelocatedVst3EffectId(const EffectId& effectId, const EffectMetaList& metaList);
 
 bool isEffectId(const EffectId& effectId);
 

--- a/src/effects/effects_base/internal/effectsutils.h
+++ b/src/effects/effects_base/internal/effectsutils.h
@@ -39,48 +39,13 @@ EffectCategory effectCategoryFromString(const muse::String& category);
 muse::String effectFamilyToString(EffectFamily family);
 EffectFamily effectFamilyFromString(const muse::String& family);
 
-muse::audio::AudioResourceMeta auToMuseEffectMeta(const EffectMeta& meta);
-EffectMeta museToAuEffectMeta(const muse::io::path_t& path, const muse::audio::AudioResourceMeta& meta, bool enabled = true);
+// Cache identifier (PluginMeta::type), not effectFamilyToString's display label.
+std::string effectFamilyToCacheType(EffectFamily family);
+EffectFamily effectFamilyFromCacheType(const std::string& cacheType);
 
-// TODO: may `EffectFamily` be superseded by `AudioResourceType`?
-constexpr muse::audio::AudioResourceType toMuseAudioResourceType(EffectFamily family)
-{
-    switch (family) {
-    case EffectFamily::VST3: return muse::audio::AudioResourceType::VstPlugin;
-#ifdef Q_OS_LINUX
-    case EffectFamily::LV2: return muse::audio::AudioResourceType::Lv2Plugin;
-#endif
-#ifdef Q_OS_MACOS
-    case EffectFamily::AudioUnit: return muse::audio::AudioResourceType::AudioUnit;
-#endif
-    case EffectFamily::Nyquist: return muse::audio::AudioResourceType::NyquistPlugin;
-    case EffectFamily::Builtin: return muse::audio::AudioResourceType::NativeEffect;
-    case EffectFamily::Unknown: return muse::audio::AudioResourceType::Undefined;
-    default:
-        assert(false);
-        return muse::audio::AudioResourceType::Undefined;
-    }
-}
+bool isFamilyType(const muse::audioplugins::PluginMeta& meta, EffectFamily family);
 
-constexpr EffectFamily fromMuseAudioResourceType(muse::audio::AudioResourceType type)
-{
-    switch (type) {
-    case muse::audio::AudioResourceType::VstPlugin: return EffectFamily::VST3;
-#ifdef Q_OS_LINUX
-    case muse::audio::AudioResourceType::Lv2Plugin: return EffectFamily::LV2;
-#endif
-#ifdef Q_OS_MACOS
-    case muse::audio::AudioResourceType::AudioUnit: return EffectFamily::AudioUnit;
-#endif
-    case muse::audio::AudioResourceType::NyquistPlugin: return EffectFamily::Nyquist;
-    case muse::audio::AudioResourceType::NativeEffect: return EffectFamily::Builtin;
-    case muse::audio::AudioResourceType::FluidSoundfont:
-    case muse::audio::AudioResourceType::MuseSamplerSoundPack:
-    case muse::audio::AudioResourceType::Undefined:
-        return EffectFamily::Unknown;
-    default:
-        assert(false);
-        return EffectFamily::Unknown;
-    }
-}
+muse::audioplugins::PluginMeta auToMuseEffectMeta(const EffectMeta& meta);
+EffectMeta museToAuEffectMeta(const muse::io::path_t& path, const muse::audioplugins::PluginMeta& meta,
+                              muse::audioplugins::AudioPluginState state = muse::audioplugins::AudioPluginState::Validated);
 }

--- a/src/effects/effects_base/internal/knownaudiopluginsconfigurator.cpp
+++ b/src/effects/effects_base/internal/knownaudiopluginsconfigurator.cpp
@@ -1,0 +1,40 @@
+/*
+* Audacity: A Digital Audio Editor
+*/
+#include "knownaudiopluginsconfigurator.h"
+
+#include "global/serialization/json.h"
+
+#include "effects/builtin/internal/builtintypes.h"
+
+using namespace au::effects;
+
+namespace {
+// resource type builtin effects were cached under before the rename to
+// builtin::AUDIO_RESOURCE_TYPE_NAME
+constexpr std::string_view LEGACY_BUILTIN_TYPE_NAME = "NativeEffect";
+}
+
+void KnownAudioPluginsConfigurator::init()
+{
+    if (!m_migrations()) {
+        return;
+    }
+
+    // v2 -> v3: legacy caches stored builtin effects as "NativeEffect", which
+    // no longer maps to any family and would trip the asserts in effectsutils;
+    // rename it to the current builtin type.
+    m_migrations()->registerMigration(2, [](const muse::JsonArray& plugins) {
+        muse::JsonArray out;
+        for (size_t i = 0; i < plugins.size(); ++i) {
+            muse::JsonObject obj = plugins.at(i).toObject();
+            muse::JsonObject meta = obj.value("meta").toObject();
+            if (meta.value("type").toStdString() == LEGACY_BUILTIN_TYPE_NAME) {
+                meta.set("type", std::string(builtin::AUDIO_RESOURCE_TYPE_NAME));
+                obj.set("meta", meta);
+            }
+            out << obj;
+        }
+        return out;
+    });
+}

--- a/src/effects/effects_base/internal/knownaudiopluginsconfigurator.cpp
+++ b/src/effects/effects_base/internal/knownaudiopluginsconfigurator.cpp
@@ -37,4 +37,29 @@ void KnownAudioPluginsConfigurator::init()
         }
         return out;
     });
+
+    // v3 -> v4: bundled nyquist effects must not store a full path in the configuration file
+    const std::shared_ptr<muse::IGlobalConfiguration> globalConfiguration = m_globalConfiguration();
+    m_migrations()->registerMigration(3, [globalConfiguration](const muse::JsonArray& plugins) {
+        muse::JsonArray out;
+        for (size_t i = 0; i < plugins.size(); ++i) {
+            muse::JsonObject obj = plugins.at(i).toObject();
+
+            const std::string path = obj.value("path").toStdString();
+            if (globalConfiguration->isBundledWithApp(path)) {
+                const std::string portable = globalConfiguration->toBundledPath(path).toStdString();
+                obj.set("path", portable);
+
+                muse::JsonObject meta = obj.value("meta").toObject();
+                std::string id = meta.value("id").toStdString();
+                if (id.size() >= path.size() && id.compare(id.size() - path.size(), path.size(), path) == 0) {
+                    meta.set("id", id.substr(0, id.size() - path.size()) + portable);
+                    obj.set("meta", meta);
+                }
+            }
+
+            out << obj;
+        }
+        return out;
+    });
 }

--- a/src/effects/effects_base/internal/knownaudiopluginsconfigurator.h
+++ b/src/effects/effects_base/internal/knownaudiopluginsconfigurator.h
@@ -1,0 +1,19 @@
+/*
+* Audacity: A Digital Audio Editor
+*/
+#pragma once
+
+#include "framework/global/modularity/ioc.h"
+
+#include "framework/audioplugins/iknownaudiopluginsmigrationregister.h"
+
+namespace au::effects {
+// One-shot setup invoked from EffectsModule::resolveImports(), before the
+// audioplugins context loads the cache in onInit.
+class KnownAudioPluginsConfigurator
+{
+    muse::GlobalInject<muse::audioplugins::IKnownAudioPluginsMigrationRegister> m_migrations;
+public:
+    void init();
+};
+}

--- a/src/effects/effects_base/internal/knownaudiopluginsconfigurator.h
+++ b/src/effects/effects_base/internal/knownaudiopluginsconfigurator.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "framework/global/modularity/ioc.h"
+#include "framework/global/iglobalconfiguration.h"
 
 #include "framework/audioplugins/iknownaudiopluginsmigrationregister.h"
 
@@ -13,6 +14,7 @@ namespace au::effects {
 class KnownAudioPluginsConfigurator
 {
     muse::GlobalInject<muse::audioplugins::IKnownAudioPluginsMigrationRegister> m_migrations;
+    muse::GlobalInject<muse::IGlobalConfiguration> m_globalConfiguration;
 public:
     void init();
 };

--- a/src/effects/effects_base/internal/missingeffectchecker.cpp
+++ b/src/effects/effects_base/internal/missingeffectchecker.cpp
@@ -39,16 +39,27 @@ void MissingEffectChecker::warnIfEffectsMissing()
         return;
     }
 
-    // Missing plugins aren't in the scanner registry, so effectsProvider()->meta(id)
-    // returns an empty EffectMeta. Use the id parsers instead, which work for the
-    // missing case. Version isn't part of the id and is therefore unrecoverable here.
+    // prefer cached metadata, fall back to parsing the id (which carries no version)
     muse::ValList missingPluginInfos;
     missingPluginInfos.reserve(missingEffectIds.size());
     for (const auto& id : missingEffectIds) {
+        const EffectMeta cached = effectsProvider()->meta(id);
+        const bool hasRichMeta = cached.isValid() && !cached.title.empty();
+
+        const std::string name = hasRichMeta
+                                 ? cached.title.toStdString()
+                                 : utils::parseEffectName(id);
+        const std::string vendor = hasRichMeta
+                                   ? cached.vendor.toStdString()
+                                   : utils::parseEffectVendor(id);
+        const std::string path = hasRichMeta
+                                 ? cached.path.toStdString()
+                                 : utils::parseEffectPath(id);
+
         missingPluginInfos.push_back(muse::Val { muse::ValMap {
-                                                     { "name", muse::Val(utils::parseEffectName(id)) },
-                                                     { "vendor", muse::Val(utils::parseEffectVendor(id)) },
-                                                     { "path", muse::Val(utils::parseEffectPath(id)) }
+                                                     { "name", muse::Val(name) },
+                                                     { "vendor", muse::Val(vendor) },
+                                                     { "path", muse::Val(path) }
                                                  } });
     }
 

--- a/src/effects/effects_base/internal/missingeffectchecker.h
+++ b/src/effects/effects_base/internal/missingeffectchecker.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "imissingeffectchecker.h"
+#include "ieffectsprovider.h"
 #include "irealtimeeffectservice.h"
 
 #include "context/iglobalcontext.h"
@@ -16,6 +17,7 @@ namespace au::effects {
 class MissingEffectChecker : public IMissingEffectChecker, public muse::Contextable, public muse::async::Asyncable
 {
     muse::ContextInject<au::context::IGlobalContext> globalContext{ this };
+    muse::GlobalInject<IEffectsProvider> effectsProvider;
     muse::ContextInject<IRealtimeEffectService> realtimeEffectService{ this };
     muse::ContextInject<muse::IInteractive> interactive{ this };
 

--- a/src/effects/effects_base/internal/realtimeeffectservice.cpp
+++ b/src/effects/effects_base/internal/realtimeeffectservice.cpp
@@ -259,7 +259,10 @@ RealtimeEffectStatePtr RealtimeEffectService::addRealtimeEffect(TrackId trackId,
         return nullptr;
     }
 
-    effectsProvider()->loadEffect(effectId);
+    if (!effectsProvider()->loadEffect(effectId)) {
+        LOGW() << "cannot load the effect: " << effectId;
+        return nullptr;
+    }
     if (const auto state = AudioIO::Get()->AddState(*data->au3Project, data->au3Track, effectId.toStdString())) {
         const auto effectName = getEffectName(*state);
         const auto trackName = effectTrackName(trackId);
@@ -308,7 +311,10 @@ RealtimeEffectStatePtr RealtimeEffectService::replaceRealtimeEffect(TrackId trac
         return nullptr;
     }
 
-    effectsProvider()->loadEffect(newEffectId);
+    if (!effectsProvider()->loadEffect(newEffectId)) {
+        LOGW() << "cannot replace with unavailable effect: " << newEffectId;
+        return nullptr;
+    }
     const auto oldState = data->effectList->GetStateAt(effectListIndex);
     if (const auto newState = AudioIO::Get()->ReplaceState(*data->au3Project, data->au3Track, effectListIndex, newEffectId.toStdString())) {
         const auto oldEffectName = getEffectName(*oldState);

--- a/src/effects/effects_base/internal/realtimeeffectservice.cpp
+++ b/src/effects/effects_base/internal/realtimeeffectservice.cpp
@@ -2,6 +2,7 @@
 
 #include "realtimeeffectrestorer.h"
 #include "realtimeeffectserviceutils.h"
+#include "effectsutils.h"
 
 #include "au3-audio-io/AudioIO.h"
 
@@ -14,6 +15,7 @@
 #include "project/iaudacityproject.h"
 
 #include "global/types/translatablestring.h"
+#include "au3wrap/internal/wxtypes_convert.h"
 
 namespace au::effects {
 /*!
@@ -438,6 +440,18 @@ const EffectInstanceFactory* RealtimeEffectService::getInstanceFactory(const Plu
     });
 }
 
+wxString RealtimeEffectService::resolveEffectId(const PluginID& id)
+{
+    const auto provider = wEffectsProvider.lock();
+    if (!provider) {
+        return {};
+    }
+
+    const EffectId resolved = utils::findRelocatedVst3EffectId(EffectId::fromStdString(id.ToStdString()),
+                                                               provider->effectMetaList());
+    return resolved.empty() ? wxString {} : au3::wxFromString(resolved);
+}
+
 bool RealtimeEffectService::isAvailable(const RealtimeEffectStatePtr& state) const
 {
     if (!state) {
@@ -452,3 +466,4 @@ bool RealtimeEffectService::isAvailable(const RealtimeEffectStatePtr& state) con
 
 // Inject a factory for realtime effects
 static RealtimeEffectState::EffectFactory::Scope scope{ &au::effects::RealtimeEffectService::getInstanceFactory };
+static RealtimeEffectState::EffectIdResolver::Scope idResolverScope{ &au::effects::RealtimeEffectService::resolveEffectId };

--- a/src/effects/effects_base/internal/realtimeeffectservice.cpp
+++ b/src/effects/effects_base/internal/realtimeeffectservice.cpp
@@ -437,8 +437,10 @@ bool RealtimeEffectService::isAvailable(const RealtimeEffectStatePtr& state) con
     if (!state) {
         return false;
     }
+    // isValid() passes for Missing/Error/Discovered entries too;
+    // only isLoadable (Validated) gates actual usability
     const auto meta = effectsProvider()->meta(muse::String::fromStdString(state->GetID().ToStdString()));
-    return meta.isValid();
+    return meta.isValid() && meta.isLoadable();
 }
 }
 

--- a/src/effects/effects_base/internal/realtimeeffectservice.h
+++ b/src/effects/effects_base/internal/realtimeeffectservice.h
@@ -72,6 +72,7 @@ public:
     void setTrackEffectsActive(TrackId trackId, bool active) override;
 
     static const EffectInstanceFactory* getInstanceFactory(const wxString&);
+    static wxString resolveEffectId(const wxString&);
 
 private:
     void onProjectChanged(const au::project::IAudacityProjectPtr& project);

--- a/src/effects/effects_base/qml/Audacity/Effects/PluginManagerDialog.qml
+++ b/src/effects/effects_base/qml/Audacity/Effects/PluginManagerDialog.qml
@@ -14,7 +14,8 @@ StyledDialogView {
 
     title: qsTrc("effects", "Manage plugins")
 
-    contentWidth: tableViewModel.totalWidth
+    // +2 for StyledTableView's 1px border per side, otherwise a horizontal scrollbar appears
+    contentWidth: tableViewModel.totalWidth + 2
     contentHeight: 528
     margins: 12
 

--- a/src/effects/effects_base/qml/Audacity/Effects/PluginManagerTopPanel.qml
+++ b/src/effects/effects_base/qml/Audacity/Effects/PluginManagerTopPanel.qml
@@ -17,7 +17,7 @@ Item {
         name: "PluginManagerTopPanel"
         direction: NavigationPanel.Horizontal
         accessible.role: MUAccessible.ComboBox
-        accessible.name: showModel.label + ", " + typeModel.label + ", " + categoryModel.label + ", " + searchField.accessible.name
+        accessible.name: showModel.label + ", " + typeModel.label + ", " + categoryModel.label + ", " + statusModel.label + ", " + searchField.accessible.name
     }
 
     signal searchTextChanged(string newText)
@@ -35,7 +35,7 @@ Item {
         id: accessibleInfo
         visualItem: root
         role: MUAccessible.ComboBox
-        name: showModel.label + ", " + typeModel.label + ", " + categoryModel.label + ", " + searchField.accessible.name
+        name: showModel.label + ", " + typeModel.label + ", " + categoryModel.label + ", " + statusModel.label + ", " + searchField.accessible.name
     }
 
     Component.onCompleted: {
@@ -47,6 +47,9 @@ Item {
         })
         tableViewModel.effectTypeSelectedIndex = Qt.binding(function () {
             return categoryModel.selectedIndex
+        })
+        tableViewModel.statusSelectedIndex = Qt.binding(function () {
+            return statusModel.selectedIndex
         })
     }
 
@@ -68,6 +71,12 @@ Item {
         options: tableViewModel.effectTypeOptions
     }
 
+    DropdownOptionsModel {
+        id: statusModel
+        label: qsTrc("effects", "Status:")
+        options: tableViewModel.statusOptions
+    }
+
     RowLayout {
         id: rowLayout
 
@@ -77,7 +86,7 @@ Item {
         Repeater {
             id: dropdownsRepeater
 
-            model: [showModel, typeModel, categoryModel]
+            model: [showModel, typeModel, categoryModel, statusModel]
 
             DropdownWithTitle {
                 id: dropdown

--- a/src/effects/effects_base/tests/CMakeLists.txt
+++ b/src/effects/effects_base/tests/CMakeLists.txt
@@ -7,6 +7,7 @@ set(MODULE_TEST effects_base_tests)
 set(MODULE_TEST_SRC
     ${CMAKE_CURRENT_LIST_DIR}/environment.cpp
     ${CMAKE_CURRENT_LIST_DIR}/config_tests.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/effectsutils_tests.cpp
     ${CMAKE_CURRENT_LIST_DIR}/pluginmigration_tests.cpp
 )
 

--- a/src/effects/effects_base/tests/CMakeLists.txt
+++ b/src/effects/effects_base/tests/CMakeLists.txt
@@ -7,10 +7,12 @@ set(MODULE_TEST effects_base_tests)
 set(MODULE_TEST_SRC
     ${CMAKE_CURRENT_LIST_DIR}/environment.cpp
     ${CMAKE_CURRENT_LIST_DIR}/config_tests.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/pluginmigration_tests.cpp
 )
 
 set(MODULE_TEST_LINK
     effects_base
+    muse_audioplugins
     au3-preferences
 )
 

--- a/src/effects/effects_base/tests/effectsutils_tests.cpp
+++ b/src/effects/effects_base/tests/effectsutils_tests.cpp
@@ -1,0 +1,91 @@
+/*
+* Audacity: A Digital Audio Editor
+*/
+#include <gtest/gtest.h>
+
+#include "../internal/effectsutils.h"
+
+using namespace au::effects;
+
+namespace {
+EffectId makeId(const std::string& vendor, const std::string& name, const std::string& path)
+{
+    return EffectId::fromStdString("Effect_VST3_" + vendor + "_" + name + "_" + path);
+}
+
+EffectMeta makeVst3Meta(const EffectId& id)
+{
+    EffectMeta meta;
+    meta.id = id;
+    meta.family = EffectFamily::VST3;
+    meta.state = muse::audioplugins::AudioPluginState::Validated;
+    return meta;
+}
+}
+
+TEST(EffectsBase_EffectsUtilsTests, FindRelocatedVst3EffectId_ReturnsUniqueClassIdMatch)
+{
+    const EffectId oldId = makeId("Soap Audio", "Soap Voice Cleaner",
+                                  "C:/Program Files/Common Files/VST3/Soap Voice Cleaner.vst3;"
+                                  "ABCDEF019182FAEB536F6170536F6170");
+    const EffectId newId = makeId("Soap Audio", "Soap Voice Cleaner",
+                                  "D:/Audio/VST3/Soap Voice Cleaner.vst3;"
+                                  "ABCDEF019182FAEB536F6170536F6170");
+
+    EXPECT_EQ(utils::findRelocatedVst3EffectId(oldId, { makeVst3Meta(newId) }), newId);
+}
+
+TEST(EffectsBase_EffectsUtilsTests, FindRelocatedVst3EffectId_UsesVendorAndNameWhenClassIdIsDuplicated)
+{
+    const EffectId oldId = makeId("Soap Audio", "Soap Voice Cleaner",
+                                  "C:/Program Files/Common Files/VST3/Soap Voice Cleaner.vst3;"
+                                  "ABCDEF019182FAEB536F6170536F6170");
+    const EffectId matchingId = makeId("Soap Audio", "Soap Voice Cleaner",
+                                       "D:/Audio/VST3/Soap Voice Cleaner.vst3;"
+                                       "ABCDEF019182FAEB536F6170536F6170");
+    const EffectId otherId = makeId("Other Vendor", "Other Effect",
+                                    "D:/Audio/VST3/Other.vst3;"
+                                    "ABCDEF019182FAEB536F6170536F6170");
+
+    EXPECT_EQ(utils::findRelocatedVst3EffectId(oldId, { makeVst3Meta(otherId), makeVst3Meta(matchingId) }), matchingId);
+}
+
+TEST(EffectsBase_EffectsUtilsTests, FindRelocatedVst3EffectId_ReturnsEmptyWhenAmbiguous)
+{
+    const EffectId oldId = makeId("Soap Audio", "Soap Voice Cleaner",
+                                  "C:/Program Files/Common Files/VST3/Soap Voice Cleaner.vst3;"
+                                  "ABCDEF019182FAEB536F6170536F6170");
+    const EffectId firstId = makeId("Soap Audio", "Soap Voice Cleaner",
+                                    "D:/Audio/VST3/Soap Voice Cleaner.vst3;"
+                                    "ABCDEF019182FAEB536F6170536F6170");
+    const EffectId secondId = makeId("Soap Audio", "Soap Voice Cleaner",
+                                     "E:/Audio/VST3/Soap Voice Cleaner.vst3;"
+                                     "ABCDEF019182FAEB536F6170536F6170");
+
+    EXPECT_TRUE(utils::findRelocatedVst3EffectId(oldId, { makeVst3Meta(firstId), makeVst3Meta(secondId) }).empty());
+}
+
+TEST(EffectsBase_EffectsUtilsTests, FindRelocatedVst3EffectId_KeepsExactLoadableMatch)
+{
+    const EffectId currentId = makeId("Soap Audio", "Soap Voice Cleaner",
+                                      "C:/Program Files/Common Files/VST3/Soap Voice Cleaner.vst3;"
+                                      "ABCDEF019182FAEB536F6170536F6170");
+    const EffectId duplicateId = makeId("Soap Audio", "Soap Voice Cleaner",
+                                        "D:/Audio/VST3/Soap Voice Cleaner.vst3;"
+                                        "ABCDEF019182FAEB536F6170536F6170");
+
+    EXPECT_TRUE(utils::findRelocatedVst3EffectId(currentId, { makeVst3Meta(currentId), makeVst3Meta(duplicateId) }).empty());
+}
+
+TEST(EffectsBase_EffectsUtilsTests, FindRelocatedVst3EffectId_IgnoresNonLoadableCandidates)
+{
+    const EffectId oldId = makeId("Soap Audio", "Soap Voice Cleaner",
+                                  "C:/Program Files/Common Files/VST3/Soap Voice Cleaner.vst3;"
+                                  "ABCDEF019182FAEB536F6170536F6170");
+    EffectMeta candidate = makeVst3Meta(makeId("Soap Audio", "Soap Voice Cleaner",
+                                               "D:/Audio/VST3/Soap Voice Cleaner.vst3;"
+                                               "ABCDEF019182FAEB536F6170536F6170"));
+    candidate.state = muse::audioplugins::AudioPluginState::Missing;
+
+    EXPECT_TRUE(utils::findRelocatedVst3EffectId(oldId, { candidate }).empty());
+}

--- a/src/effects/effects_base/tests/pluginmigration_tests.cpp
+++ b/src/effects/effects_base/tests/pluginmigration_tests.cpp
@@ -1,0 +1,151 @@
+/*
+* Audacity: A Digital Audio Editor
+*/
+#include <gtest/gtest.h>
+
+#include "global/serialization/json.h"
+#include "global/modularity/ioc.h"
+
+#include "audioplugins/internal/knownaudiopluginsmigrationregister.h"
+
+#include "effects/builtin/internal/builtintypes.h"
+
+#include "../internal/knownaudiopluginsconfigurator.h"
+
+using namespace muse;
+using namespace muse::audioplugins;
+using namespace au::effects;
+
+// Covers the Audacity-specific v2 -> v3 known-audio-plugins migration installed
+// by KnownAudioPluginsConfigurator: pre-revamp caches stored builtin effects as
+// the "NativeEffect" resource type, which no longer maps to a family (it would
+// resolve to EffectFamily::Unknown and trip the effectsutils asserts). The
+// migration renames it to the current builtin type.
+class EffectsBase_PluginMigrationTests : public ::testing::Test
+{
+protected:
+    static constexpr const char* MODULE = "effects_base_tests";
+
+    std::shared_ptr<KnownAudioPluginsMigrationRegister> m_register;
+
+    void SetUp() override
+    {
+        // export a fresh concrete register so init() installs the production
+        // migration into something we can drive directly
+        muse::modularity::globalIoc()->unregister<IKnownAudioPluginsMigrationRegister>(MODULE);
+        m_register = std::make_shared<KnownAudioPluginsMigrationRegister>();
+        muse::modularity::globalIoc()->registerExport<IKnownAudioPluginsMigrationRegister>(MODULE, m_register);
+
+        KnownAudioPluginsConfigurator configurator;
+        configurator.init();
+    }
+
+    void TearDown() override
+    {
+        muse::modularity::globalIoc()->unregister<IKnownAudioPluginsMigrationRegister>(MODULE);
+    }
+
+    static JsonObject makeEntry(const std::string& type, const std::string& id, const std::string& path)
+    {
+        JsonObject attrs;
+        attrs.set("title", std::string("Amplify"));
+
+        JsonObject meta;
+        meta.set("id", id);
+        meta.set("type", type);
+        meta.set("vendor", std::string("Audacity"));
+        meta.set("attributes", attrs);
+
+        JsonObject obj;
+        obj.set("meta", meta);
+        obj.set("path", path);
+        obj.set("state", std::string("Validated"));
+        return obj;
+    }
+
+    static std::string metaTypeAt(const JsonArray& arr, size_t i)
+    {
+        return arr.at(i).toObject().value("meta").toObject().value("type").toStdString();
+    }
+};
+
+TEST_F(EffectsBase_PluginMigrationTests, V2ToV3_RenamesLegacyNativeEffectToBuiltIn)
+{
+    const std::string builtinType(builtin::AUDIO_RESOURCE_TYPE_NAME);
+    // the rename only matters because the names differ
+    ASSERT_NE(builtinType, std::string("NativeEffect"));
+
+    // [GIVEN] a cache holding a legacy "NativeEffect" builtin entry
+    JsonArray plugins;
+    plugins << makeEntry("NativeEffect", "Effect_Audacity_Audacity_Amplify_Built-in Effect: Amplify",
+                         "Built-in Effect: Amplify");
+
+    // [WHEN] migrating from v2 to v3
+    Ret ret = m_register->migrate(2, 3, plugins);
+
+    // [THEN] the resource type is rewritten to the current builtin type
+    ASSERT_TRUE(ret);
+    ASSERT_EQ(plugins.size(), size_t(1));
+    EXPECT_EQ(metaTypeAt(plugins, 0), builtinType);
+}
+
+TEST_F(EffectsBase_PluginMigrationTests, V2ToV3_LeavesOtherPluginTypesUntouched)
+{
+    JsonArray plugins;
+    plugins << makeEntry("VstPlugin", "v", "/x/a.vst3");
+    plugins << makeEntry("AudioUnit", "a", "/x/b.component");
+    plugins << makeEntry("NyquistPlugin", "n", "/x/c.ny");
+
+    Ret ret = m_register->migrate(2, 3, plugins);
+
+    ASSERT_TRUE(ret);
+    EXPECT_EQ(metaTypeAt(plugins, 0), "VstPlugin");
+    EXPECT_EQ(metaTypeAt(plugins, 1), "AudioUnit");
+    EXPECT_EQ(metaTypeAt(plugins, 2), "NyquistPlugin");
+}
+
+TEST_F(EffectsBase_PluginMigrationTests, V2ToV3_PreservesSurroundingFields)
+{
+    JsonArray plugins;
+    plugins << makeEntry("NativeEffect", "the-id", "the-path");
+
+    Ret ret = m_register->migrate(2, 3, plugins);
+
+    ASSERT_TRUE(ret);
+    const JsonObject obj = plugins.at(0).toObject();
+    const JsonObject meta = obj.value("meta").toObject();
+    EXPECT_EQ(obj.value("path").toStdString(), "the-path");
+    EXPECT_EQ(obj.value("state").toStdString(), "Validated");
+    EXPECT_EQ(meta.value("id").toStdString(), "the-id");
+    EXPECT_EQ(meta.value("vendor").toStdString(), "Audacity");
+    EXPECT_EQ(meta.value("attributes").toObject().value("title").toStdString(), "Amplify");
+}
+
+TEST_F(EffectsBase_PluginMigrationTests, FullChain_LegacyBareArrayCacheReachesV3WithBuiltInType)
+{
+    const std::string builtinType(builtin::AUDIO_RESOURCE_TYPE_NAME);
+
+    // [GIVEN] a v0-shaped entry (carries "enabled" and the legacy "NativeEffect" type)
+    JsonObject meta;
+    meta.set("id", std::string("Effect_Audacity_Audacity_Amplify_Built-in Effect: Amplify"));
+    meta.set("type", std::string("NativeEffect"));
+
+    JsonObject obj;
+    obj.set("meta", meta);
+    obj.set("path", std::string("Built-in Effect: Amplify"));
+    obj.set("enabled", true);
+
+    JsonArray plugins;
+    plugins << obj;
+
+    // [WHEN] migrating the whole chain v0 -> current
+    Ret ret = m_register->migrate(0, CURRENT_KNOWN_AUDIO_PLUGINS_VERSION, plugins);
+
+    // [THEN] the type is renamed and the v1 -> v2 enabled -> state step also ran
+    ASSERT_TRUE(ret);
+    ASSERT_EQ(plugins.size(), size_t(1));
+    const JsonObject migrated = plugins.at(0).toObject();
+    EXPECT_EQ(migrated.value("meta").toObject().value("type").toStdString(), builtinType);
+    EXPECT_FALSE(migrated.contains("enabled"));
+    EXPECT_EQ(migrated.value("state").toStdString(), "Validated");
+}

--- a/src/effects/effects_base/tests/pluginmigration_tests.cpp
+++ b/src/effects/effects_base/tests/pluginmigration_tests.cpp
@@ -2,9 +2,12 @@
 * Audacity: A Digital Audio Editor
 */
 #include <gtest/gtest.h>
+#include <gmock/gmock.h>
 
 #include "global/serialization/json.h"
 #include "global/modularity/ioc.h"
+#include "global/iglobalconfiguration.h"
+#include "global/tests/mocks/globalconfigurationmock.h"
 
 #include "audioplugins/internal/knownaudiopluginsmigrationregister.h"
 
@@ -16,17 +19,18 @@ using namespace muse;
 using namespace muse::audioplugins;
 using namespace au::effects;
 
-// Covers the Audacity-specific v2 -> v3 known-audio-plugins migration installed
-// by KnownAudioPluginsConfigurator: pre-revamp caches stored builtin effects as
-// the "NativeEffect" resource type, which no longer maps to a family (it would
-// resolve to EffectFamily::Unknown and trip the effectsutils asserts). The
-// migration renames it to the current builtin type.
+using ::testing::NiceMock;
+using ::testing::Return;
+
+// Covers the Audacity v2 -> v3 migration installed by KnownAudioPluginsConfigurator:
+// legacy "NativeEffect" entries are renamed to the current builtin type.
 class EffectsBase_PluginMigrationTests : public ::testing::Test
 {
 protected:
     static constexpr const char* MODULE = "effects_base_tests";
 
     std::shared_ptr<KnownAudioPluginsMigrationRegister> m_register;
+    std::shared_ptr<GlobalConfigurationMock> m_globalConfiguration;
 
     void SetUp() override
     {
@@ -36,6 +40,10 @@ protected:
         m_register = std::make_shared<KnownAudioPluginsMigrationRegister>();
         muse::modularity::globalIoc()->registerExport<IKnownAudioPluginsMigrationRegister>(MODULE, m_register);
 
+        muse::modularity::globalIoc()->unregister<IGlobalConfiguration>(MODULE);
+        m_globalConfiguration = std::make_shared<NiceMock<GlobalConfigurationMock> >();
+        muse::modularity::globalIoc()->registerExport<IGlobalConfiguration>(MODULE, m_globalConfiguration);
+
         KnownAudioPluginsConfigurator configurator;
         configurator.init();
     }
@@ -43,6 +51,7 @@ protected:
     void TearDown() override
     {
         muse::modularity::globalIoc()->unregister<IKnownAudioPluginsMigrationRegister>(MODULE);
+        muse::modularity::globalIoc()->unregister<IGlobalConfiguration>(MODULE);
     }
 
     static JsonObject makeEntry(const std::string& type, const std::string& id, const std::string& path)

--- a/src/effects/effects_base/view/pluginmanagersortfilterproxy.cpp
+++ b/src/effects/effects_base/view/pluginmanagersortfilterproxy.cpp
@@ -30,9 +30,9 @@ bool PluginManagerSortFilterProxy::acceptsRow(int sourceRow) const
 
     if (!m_view->m_searchText.isEmpty()) {
         const QString searchTextLower = m_view->m_searchText.toLower();
-        const auto fields = { meta.title, meta.vendor, meta.path.toString() };
-        if (std::none_of(fields.begin(), fields.end(), [&](const auto& str) {
-            return str.toQString().toLower().contains(searchTextLower);
+        const auto fields = { effectDisplayName(meta), meta.vendor.toQString(), meta.path.toQString() };
+        if (std::none_of(fields.begin(), fields.end(), [&](const QString& str) {
+            return str.toLower().contains(searchTextLower);
         })) {
             return false;
         }
@@ -40,7 +40,8 @@ bool PluginManagerSortFilterProxy::acceptsRow(int sourceRow) const
 
     return m_view->m_acceptEnabledDisabledState(meta)
            && m_view->m_acceptFamily(meta)
-           && m_view->m_acceptType(meta);
+           && m_view->m_acceptType(meta)
+           && m_view->m_acceptStatus(meta);
 }
 
 int PluginManagerSortFilterProxy::compareCells(int column, int leftSourceRow, int rightSourceRow) const
@@ -73,7 +74,12 @@ int PluginManagerSortFilterProxy::compareCells(int column, int leftSourceRow, in
     case PluginManagerTableViewModel::s_enabledDisabledColumnIndex:
         return cmpBool(a.isActivated, b.isActivated);
     case PluginManagerTableViewModel::s_nameColumnIndex:
-        return cmpStr(a.title, b.title);
+        // compare displayed names so never-validated entries (empty title)
+        // sort by their fallback name
+        return QString::compare(effectDisplayName(a), effectDisplayName(b), Qt::CaseInsensitive);
+    case PluginManagerTableViewModel::s_statusColumnIndex:
+        // sort by the displayed label so rows group as the user sees them
+        return QString::compare(pluginStateToString(a.state), pluginStateToString(b.state), Qt::CaseInsensitive);
     case PluginManagerTableViewModel::s_pathColumnIndex:
         return cmpStr(a.path.toString(), b.path.toString());
     case PluginManagerTableViewModel::s_typeColumnIndex:

--- a/src/effects/effects_base/view/pluginmanagertableviewmodel.cpp
+++ b/src/effects/effects_base/view/pluginmanagertableviewmodel.cpp
@@ -14,13 +14,54 @@
 #include "framework/uicomponents/qml/Muse/UiComponents/internal/tableviewcell.h"
 #include "framework/uicomponents/qml/Muse/UiComponents/menuitem.h"
 
+#include <array>
+
 namespace au::effects {
 namespace {
 constexpr auto enabledColumnWidth = 100;
 constexpr auto nameColumnWidth = 152;
+constexpr auto statusColumnWidth = 120;
 constexpr auto vendorColumnWidth = 152;
 constexpr auto pathColumnWidth = 296;
 constexpr auto typeColumnWidth = 152;
+
+// dropdown order of the status filter; index 0 in the dropdown is "All"
+constexpr std::array<muse::audioplugins::AudioPluginState, 4> statusFilterOrder {
+    muse::audioplugins::AudioPluginState::Validated,
+    muse::audioplugins::AudioPluginState::Discovered,
+    muse::audioplugins::AudioPluginState::Missing,
+    muse::audioplugins::AudioPluginState::Error,
+};
+}
+
+QString effectDisplayName(const EffectMeta& meta)
+{
+    if (!meta.title.empty()) {
+        return meta.title.toQString();
+    }
+    // never-validated entries have no title; their id is the binary's basename,
+    // unless it's a full effect id we can parse a name out of
+    return utils::isEffectId(meta.id)
+           ? QString::fromStdString(utils::parseEffectName(meta.id))
+           : meta.id.toQString();
+}
+
+QString pluginStateToString(muse::audioplugins::AudioPluginState state)
+{
+    using muse::audioplugins::AudioPluginState;
+    switch (state) {
+    case AudioPluginState::Validated:
+        return muse::qtrc("effects", "OK");
+    case AudioPluginState::Discovered:
+        //: The plugin was found but the user chose to validate it later
+        return muse::qtrc("effects", "Not validated");
+    case AudioPluginState::Missing:
+        return muse::qtrc("effects", "Missing");
+    case AudioPluginState::Error:
+    case AudioPluginState::Undefined:
+    default:
+        return muse::qtrc("effects", "Broken");
+    }
 }
 
 const PluginManagerTableViewModel::EffectFilter PluginManagerTableViewModel::allPassFilter = [](const EffectMeta&) { return true; };
@@ -38,7 +79,9 @@ void PluginManagerTableViewModel::componentComplete()
     m_initialState = effectsProvider()->effectMetaList();
     m_initialState.erase(std::remove_if(m_initialState.begin(), m_initialState.end(), [](const EffectMeta& meta) {
         // 3rd-party plugins typically also have instruments (e.g. VSTi) but we don't support them yet.
-        return meta.type == EffectType::Unknown;
+        // Only validated entries carry a trustworthy type; non-validated ones
+        // (type Unknown) must stay visible so the Status column can report them.
+        return meta.isLoadable() && meta.type == EffectType::Unknown;
     }), m_initialState.end());
     rebuildSourceTable(m_initialState);
 
@@ -183,9 +226,44 @@ void PluginManagerTableViewModel::setEffectTypeSelectedIndex(int index)
     m_sortFilterProxy->invalidateFilters();
 }
 
+muse::uicomponents::MenuItemList PluginManagerTableViewModel::statusOptions()
+{
+    std::vector<DropdownOption> options = { { "all", muse::qtrc("effects", "All") } };
+    for (size_t i = 0; i < statusFilterOrder.size(); ++i) {
+        options.push_back({ QString::number(i), pluginStateToString(statusFilterOrder[i]) });
+    }
+    return utils::toMenuItemList(options, m_statusSelectedIndex, this);
+}
+
+void PluginManagerTableViewModel::setStatusSelectedIndex(int index)
+{
+    if (index == m_statusSelectedIndex) {
+        return;
+    }
+
+    m_statusSelectedIndex = index;
+    emit statusSelectedIndexChanged();
+
+    if (index == 0) {
+        m_acceptStatus = allPassFilter;
+    } else {
+        m_acceptStatus = [target = statusFilterOrder[index - 1]](const EffectMeta& meta) {
+            // Undefined shows as Broken in the Status column, so the Broken
+            // filter must catch it too
+            auto state = meta.state;
+            if (state == muse::audioplugins::AudioPluginState::Undefined) {
+                state = muse::audioplugins::AudioPluginState::Error;
+            }
+            return state == target;
+        };
+    }
+
+    m_sortFilterProxy->invalidateFilters();
+}
+
 int PluginManagerTableViewModel::totalWidth() const
 {
-    return enabledColumnWidth + nameColumnWidth + vendorColumnWidth + pathColumnWidth + typeColumnWidth;
+    return enabledColumnWidth + nameColumnWidth + statusColumnWidth + vendorColumnWidth + pathColumnWidth + typeColumnWidth;
 }
 
 void PluginManagerTableViewModel::setAlsoRescanBrokenPlugins(bool alsoRescanBrokenPlugins)
@@ -214,6 +292,8 @@ QVector<muse::uicomponents::TableViewHeader*> PluginManagerTableViewModel::makeH
                                      TableViewCellEditMode::Mode::StartInEdit, enabledColumnWidth);
     hHeaders << makeHorizontalHeader(muse::qtrc("effects", "Name"),
                                      TableViewCellType::Type::String, TableViewCellEditMode::Mode::DoubleClick, nameColumnWidth);
+    hHeaders << makeHorizontalHeader(muse::qtrc("effects", "Status"),
+                                     TableViewCellType::Type::String, TableViewCellEditMode::Mode::DoubleClick, statusColumnWidth);
     hHeaders << makeHorizontalHeader(muse::qtrc("effects", "Vendor"),
                                      TableViewCellType::Type::String, TableViewCellEditMode::Mode::DoubleClick, vendorColumnWidth);
     hHeaders << makeHorizontalHeader(muse::qtrc("effects", "Path"),
@@ -244,15 +324,10 @@ QVector<QVector<muse::uicomponents::TableViewCell*> > PluginManagerTableViewMode
     QVector<QVector<muse::uicomponents::TableViewCell*> > table;
 
     for (const auto& meta : effects) {
-        auto title = meta.title.toQString();
-        if (!meta.isLoadable) {
-            //: %1 is the name of the plugin that failed to load
-            title = muse::qtrc("effects", "“%1” (broken)").arg(title);
-        }
-
         QVector<muse::uicomponents::TableViewCell*> row;
-        row.append(makeCell(muse::Val(meta.isActivated && meta.isLoadable)));
-        row.append(makeCell(muse::Val(std::move(title))));
+        row.append(makeCell(muse::Val(meta.isActivated && meta.isLoadable())));
+        row.append(makeCell(muse::Val(effectDisplayName(meta))));
+        row.append(makeCell(muse::Val(pluginStateToString(meta.state))));
         row.append(makeCell(muse::Val(meta.vendor.toQString())));
         row.append(makeCell(muse::Val(meta.path.toQString())));
         row.append(makeCell(muse::Val(utils::effectFamilyToString(meta.family).toQString())));
@@ -275,7 +350,7 @@ void PluginManagerTableViewModel::handleEdit(int proxyRow, int column)
         return;
     }
 
-    if (!effectsProvider()->meta(verticalHeader->effectId()).isLoadable) {
+    if (!effectsProvider()->meta(verticalHeader->effectId()).isLoadable()) {
         return;
     }
 
@@ -308,7 +383,7 @@ void PluginManagerTableViewModel::rescanPlugins()
 
     if (m_alsoRescanBrokenPlugins) {
         effectsProvider()->forgetPlugins([](const EffectMeta& meta) {
-            return !meta.isLoadable;
+            return !meta.isLoadable();
         });
     }
 

--- a/src/effects/effects_base/view/pluginmanagertableviewmodel.cpp
+++ b/src/effects/effects_base/view/pluginmanagertableviewmodel.cpp
@@ -312,10 +312,7 @@ void PluginManagerTableViewModel::rescanPlugins()
         });
     }
 
-    const auto excludeFromScan = [this](const EffectMeta& meta) {
-        return !m_acceptFamily(meta) || !m_acceptType(meta);
-    };
-    effectsProvider()->rescanPlugins(iocContext(), *interactive(), *registerAudioPluginsScenario(), excludeFromScan);
+    effectsProvider()->rescanPlugins(iocContext(), *interactive(), *registerAudioPluginsScenario());
 
     rebuildSourceTable(effectsProvider()->effectMetaList());
 }

--- a/src/effects/effects_base/view/pluginmanagertableviewmodel.h
+++ b/src/effects/effects_base/view/pluginmanagertableviewmodel.h
@@ -34,6 +34,11 @@ enum class Type {
 Q_ENUM_NS(Type)
 }
 
+// Status column label; Undefined is bucketed with Error as "Broken".
+QString pluginStateToString(muse::audioplugins::AudioPluginState state);
+
+QString effectDisplayName(const EffectMeta& meta);
+
 class PluginManagerTableViewModel : public muse::uicomponents::AbstractTableViewModel, public QQmlParserStatus, muse::Contextable
 {
     Q_OBJECT
@@ -51,6 +56,9 @@ class PluginManagerTableViewModel : public muse::uicomponents::AbstractTableView
     Q_PROPERTY(muse::uicomponents::MenuItemList effectTypeOptions READ effectTypeOptions NOTIFY effectTypeSelectedIndexChanged)
     Q_PROPERTY(
         int effectTypeSelectedIndex READ effectTypeSelectedIndex WRITE setEffectTypeSelectedIndex NOTIFY effectTypeSelectedIndexChanged)
+
+    Q_PROPERTY(muse::uicomponents::MenuItemList statusOptions READ statusOptions NOTIFY statusSelectedIndexChanged)
+    Q_PROPERTY(int statusSelectedIndex READ statusSelectedIndex WRITE setStatusSelectedIndex NOTIFY statusSelectedIndexChanged)
 
     Q_PROPERTY(int totalWidth READ totalWidth CONSTANT)
     Q_PROPERTY(
@@ -79,6 +87,10 @@ public:
     int effectTypeSelectedIndex() const { return m_effectTypeSelectedIndex; }
     void setEffectTypeSelectedIndex(int index);
 
+    muse::uicomponents::MenuItemList statusOptions();
+    int statusSelectedIndex() const { return m_statusSelectedIndex; }
+    void setStatusSelectedIndex(int index);
+
     int totalWidth() const;
 
     bool alsoRescanBrokenPlugins() const { return m_alsoRescanBrokenPlugins; }
@@ -101,6 +113,7 @@ signals:
     void enabledDisabledSelectedIndexChanged();
     void effectFamilySelectedIndexChanged();
     void effectTypeSelectedIndexChanged();
+    void statusSelectedIndexChanged();
     void alsoRescanBrokenPluginsChanged();
 
 private:
@@ -108,10 +121,11 @@ private:
 
     static constexpr auto s_enabledDisabledColumnIndex = 0;
     static constexpr auto s_nameColumnIndex = 1;
-    static constexpr auto s_vendorColumnIndex = 2;
-    static constexpr auto s_pathColumnIndex = 3;
-    static constexpr auto s_typeColumnIndex = 4;
-    static constexpr auto s_columnCount = 5;
+    static constexpr auto s_statusColumnIndex = 2;
+    static constexpr auto s_vendorColumnIndex = 3;
+    static constexpr auto s_pathColumnIndex = 4;
+    static constexpr auto s_typeColumnIndex = 5;
+    static constexpr auto s_columnCount = 6;
 
     void classBegin() override {}
     void componentComplete() override;
@@ -140,6 +154,9 @@ private:
 
     int m_effectTypeSelectedIndex = 0;
     EffectFilter m_acceptType = allPassFilter;
+
+    int m_statusSelectedIndex = 0;
+    EffectFilter m_acceptStatus = allPassFilter;
 
     PluginManagerSortFilterProxy* const m_sortFilterProxy;
 };

--- a/src/effects/lv2/CMakeLists.txt
+++ b/src/effects/lv2/CMakeLists.txt
@@ -17,6 +17,7 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/internal/lv2pluginsscanner.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/lv2viewlauncher.cpp
     ${CMAKE_CURRENT_LIST_DIR}/internal/lv2viewlauncher.h
+    ${CMAKE_CURRENT_LIST_DIR}/internal/lv2types.h
 
     ${CMAKE_CURRENT_LIST_DIR}/view/externalidleui.cpp
     ${CMAKE_CURRENT_LIST_DIR}/view/externalidleui.h

--- a/src/effects/lv2/internal/lv2effectloader.h
+++ b/src/effects/lv2/internal/lv2effectloader.h
@@ -12,7 +12,7 @@ class Lv2EffectLoader final : public Au3EffectLoader
 {
 public:
     Lv2EffectLoader()
-        : Au3EffectLoader(m_module, muse::audio::AudioResourceType::Lv2Plugin) {}
+        : Au3EffectLoader(m_module, EffectFamily::LV2) {}
 
 private:
     void doInit() override

--- a/src/effects/lv2/internal/lv2pluginmetareader.cpp
+++ b/src/effects/lv2/internal/lv2pluginmetareader.cpp
@@ -2,15 +2,18 @@
  * Audacity: A Digital Audio Editor
  */
 #include "lv2pluginmetareader.h"
+
 #include "au3-module-manager/PluginManager.h"
+
+#include "lv2types.h"
 
 namespace au::effects {
 Lv2PluginMetaReader::Lv2PluginMetaReader()
     : Au3AudioPluginMetaReader{m_module} {}
 
-muse::audio::AudioResourceType Lv2PluginMetaReader::metaType() const
+muse::audioplugins::PluginType Lv2PluginMetaReader::metaType() const
 {
-    return muse::audio::AudioResourceType::Lv2Plugin;
+    return std::string(lv2::AUDIO_RESOURCE_TYPE_NAME);
 }
 
 void Lv2PluginMetaReader::doInit()

--- a/src/effects/lv2/internal/lv2pluginmetareader.h
+++ b/src/effects/lv2/internal/lv2pluginmetareader.h
@@ -11,7 +11,7 @@ class Lv2PluginMetaReader final : public Au3AudioPluginMetaReader
 {
 public:
     Lv2PluginMetaReader();
-    muse::audio::AudioResourceType metaType() const override;
+    muse::audioplugins::PluginType metaType() const override;
     bool canReadMeta(const muse::io::path_t& pluginPath) const override;
 
 private:

--- a/src/effects/lv2/internal/lv2types.h
+++ b/src/effects/lv2/internal/lv2types.h
@@ -1,0 +1,10 @@
+/*
+* Audacity: A Digital Audio Editor
+*/
+#pragma once
+
+#include <string_view>
+
+namespace au::effects::lv2 {
+inline constexpr std::string_view AUDIO_RESOURCE_TYPE_NAME = "Lv2Plugin";
+}

--- a/src/effects/lv2/lv2effectsmodule.cpp
+++ b/src/effects/lv2/lv2effectsmodule.cpp
@@ -3,8 +3,8 @@
 */
 #include "lv2effectsmodule.h"
 
-#include "audioplugins/iaudiopluginsscannerregister.h"
-#include "audioplugins/iaudiopluginmetareaderregister.h"
+#include "framework/audioplugins/iaudiopluginsscannerregister.h"
+#include "framework/audioplugins/iaudiopluginmetareaderregister.h"
 
 #include "effects/effects_base/ieffectloadersregister.h"
 #include "effects/effects_base/ieffectviewlaunchregister.h"

--- a/src/effects/nyquist/CMakeLists.txt
+++ b/src/effects/nyquist/CMakeLists.txt
@@ -20,6 +20,7 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/internal/nyquistpluginsscanner.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/nyquistpluginsmetareader.cpp
     ${CMAKE_CURRENT_LIST_DIR}/internal/nyquistpluginsmetareader.h
+    ${CMAKE_CURRENT_LIST_DIR}/internal/nyquisttypes.h
 
     ${CMAKE_CURRENT_LIST_DIR}/nyquistprompt/nyquistprompteffect.cpp
     ${CMAKE_CURRENT_LIST_DIR}/nyquistprompt/nyquistprompteffect.h

--- a/src/effects/nyquist/internal/nyquisteffectsloader.h
+++ b/src/effects/nyquist/internal/nyquisteffectsloader.h
@@ -11,7 +11,7 @@ class NyquistEffectsLoader final : public Au3EffectLoader
 {
 public:
     NyquistEffectsLoader()
-        : Au3EffectLoader(m_module, muse::audio::AudioResourceType::NyquistPlugin) {}
+        : Au3EffectLoader(m_module, EffectFamily::Nyquist) {}
 
 private:
     ::NyquistEffectsModule m_module;

--- a/src/effects/nyquist/internal/nyquisteffectsrepository.cpp
+++ b/src/effects/nyquist/internal/nyquisteffectsrepository.cpp
@@ -11,7 +11,7 @@
 #include "spectrogram/spectrogramtypes.h"
 
 au::effects::NyquistEffectsRepository::NyquistEffectsRepository()
-    : m_loader{m_module, muse::audio::AudioResourceType::NyquistPlugin}
+    : m_loader{m_module, EffectFamily::Nyquist}
 {
 }
 
@@ -69,18 +69,17 @@ void au::effects::NyquistEffectsRepository::registerSpectralEffects()
 au::effects::EffectMetaList au::effects::NyquistEffectsRepository::effectMetaList() const
 {
     using namespace muse::audioplugins;
-    using namespace muse::audio;
 
     EffectMetaList effects;
 
     const std::vector<AudioPluginInfo> allEffects = knownPlugins()->pluginInfoList();
 
     for (const AudioPluginInfo& info : allEffects) {
-        if (info.meta.type != AudioResourceType::NyquistPlugin) {
+        if (!utils::isFamilyType(info.meta, EffectFamily::Nyquist)) {
             continue;
         }
 
-        EffectMeta meta = utils::museToAuEffectMeta(info.path, info.meta);
+        EffectMeta meta = utils::museToAuEffectMeta(info.path, info.meta, info.state);
         effects.push_back(std::move(meta));
     }
 

--- a/src/effects/nyquist/internal/nyquistpluginsmetareader.cpp
+++ b/src/effects/nyquist/internal/nyquistpluginsmetareader.cpp
@@ -4,6 +4,8 @@
 
 #include "nyquistpluginsmetareader.h"
 
+#include "nyquisttypes.h"
+
 using namespace au::effects;
 using namespace muse;
 
@@ -23,7 +25,7 @@ bool NyquistPluginsMetaReader::canReadMeta(const io::path_t& pluginPath) const
     return io::suffix(pluginPath) == "ny";
 }
 
-audio::AudioResourceType NyquistPluginsMetaReader::metaType() const
+audioplugins::PluginType NyquistPluginsMetaReader::metaType() const
 {
-    return muse::audio::AudioResourceType::NyquistPlugin;
+    return std::string(nyquist::AUDIO_RESOURCE_TYPE_NAME);
 }

--- a/src/effects/nyquist/internal/nyquistpluginsmetareader.h
+++ b/src/effects/nyquist/internal/nyquistpluginsmetareader.h
@@ -12,7 +12,7 @@ class NyquistPluginsMetaReader : public Au3AudioPluginMetaReader
 {
 public:
     NyquistPluginsMetaReader();
-    muse::audio::AudioResourceType metaType() const override;
+    muse::audioplugins::PluginType metaType() const override;
     bool canReadMeta(const muse::io::path_t& pluginPath) const override;
 
 private:

--- a/src/effects/nyquist/internal/nyquisttypes.h
+++ b/src/effects/nyquist/internal/nyquisttypes.h
@@ -1,0 +1,10 @@
+/*
+* Audacity: A Digital Audio Editor
+*/
+#pragma once
+
+#include <string_view>
+
+namespace au::effects::nyquist {
+inline constexpr std::string_view AUDIO_RESOURCE_TYPE_NAME = "NyquistPlugin";
+}

--- a/src/effects/nyquist/nyquisteffectsmodule.cpp
+++ b/src/effects/nyquist/nyquisteffectsmodule.cpp
@@ -3,8 +3,8 @@
 */
 #include "nyquisteffectsmodule.h"
 
-#include "audioplugins/iaudiopluginsscannerregister.h"
-#include "audioplugins/iaudiopluginmetareaderregister.h"
+#include "framework/audioplugins/iaudiopluginsscannerregister.h"
+#include "framework/audioplugins/iaudiopluginmetareaderregister.h"
 
 #include "effects/effects_base/iparameterextractorregistry.h"
 #include "effects/effects_base/ieffectviewlaunchregister.h"

--- a/src/effects/vst/CMakeLists.txt
+++ b/src/effects/vst/CMakeLists.txt
@@ -19,6 +19,7 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/internal/vst3viewlauncher.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/vstparameterextractorservice.cpp
     ${CMAKE_CURRENT_LIST_DIR}/internal/vstparameterextractorservice.h
+    ${CMAKE_CURRENT_LIST_DIR}/internal/vsttypes.h
 
     ${CMAKE_CURRENT_LIST_DIR}/view/vstviewmodel.cpp
     ${CMAKE_CURRENT_LIST_DIR}/view/vstviewmodel.h

--- a/src/effects/vst/internal/vst3effectloader.h
+++ b/src/effects/vst/internal/vst3effectloader.h
@@ -11,7 +11,7 @@ class Vst3EffectLoader final : public Au3EffectLoader
 {
 public:
     Vst3EffectLoader()
-        : Au3EffectLoader(m_module, muse::audio::AudioResourceType::VstPlugin) {}
+        : Au3EffectLoader(m_module, EffectFamily::VST3) {}
 
 private:
     VST3EffectsModule m_module;

--- a/src/effects/vst/internal/vst3pluginsmetareader.cpp
+++ b/src/effects/vst/internal/vst3pluginsmetareader.cpp
@@ -4,20 +4,21 @@
 
 #include "vst3pluginsmetareader.h"
 
+#include "internal/vsttypes.h"
+
 using namespace au::effects;
-using namespace muse;
 
 Vst3PluginsMetaReader::Vst3PluginsMetaReader()
     : Au3AudioPluginMetaReader{m_module}
 {
 }
 
-bool Vst3PluginsMetaReader::canReadMeta(const io::path_t& pluginPath) const
+bool Vst3PluginsMetaReader::canReadMeta(const muse::io::path_t& pluginPath) const
 {
-    return io::suffix(pluginPath) == "vst3";
+    return muse::io::suffix(pluginPath) == "vst3";
 }
 
-audio::AudioResourceType Vst3PluginsMetaReader::metaType() const
+muse::audioplugins::PluginType Vst3PluginsMetaReader::metaType() const
 {
-    return audio::AudioResourceType::VstPlugin;
+    return std::string(vst::AUDIO_RESOURCE_TYPE_NAME);
 }

--- a/src/effects/vst/internal/vst3pluginsmetareader.h
+++ b/src/effects/vst/internal/vst3pluginsmetareader.h
@@ -11,7 +11,7 @@ class Vst3PluginsMetaReader : public Au3AudioPluginMetaReader
 {
 public:
     Vst3PluginsMetaReader();
-    muse::audio::AudioResourceType metaType() const override;
+    muse::audioplugins::PluginType metaType() const override;
     bool canReadMeta(const muse::io::path_t& pluginPath) const override;
 
 private:

--- a/src/effects/vst/internal/vsttypes.h
+++ b/src/effects/vst/internal/vsttypes.h
@@ -1,0 +1,10 @@
+/*
+* Audacity: A Digital Audio Editor
+*/
+#pragma once
+
+#include <string_view>
+
+namespace au::effects::vst {
+inline constexpr std::string_view AUDIO_RESOURCE_TYPE_NAME = "VstPlugin";
+}

--- a/src/effects/vst/vsteffectsmodule.cpp
+++ b/src/effects/vst/vsteffectsmodule.cpp
@@ -3,8 +3,8 @@
 */
 #include "vsteffectsmodule.h"
 
-#include "audioplugins/iaudiopluginsscannerregister.h"
-#include "audioplugins/iaudiopluginmetareaderregister.h"
+#include "framework/audioplugins/iaudiopluginsscannerregister.h"
+#include "framework/audioplugins/iaudiopluginmetareaderregister.h"
 
 #include "effects/effects_base/ieffectloadersregister.h"
 #include "effects/effects_base/ieffectviewlaunchregister.h"

--- a/src/preferences/qml/Audacity/Preferences/playbackpreferencesmodel.h
+++ b/src/preferences/qml/Audacity/Preferences/playbackpreferencesmodel.h
@@ -31,7 +31,6 @@ class PlaybackPreferencesModel : public QObject, public muse::async::Asyncable, 
     Q_PROPERTY(double shortSkip READ shortSkip NOTIFY shortSkipChanged)
     Q_PROPERTY(double longSkip READ longSkip NOTIFY longSkipChanged)
 
-    muse::GlobalInject<muse::audio::IAudioConfiguration> audioConfiguration;
     muse::GlobalInject<playback::IPlaybackConfiguration> playbackConfiguration;
 
     muse::ContextInject<audio::IAudioDevicesProvider> audioDevicesProvider { this };

--- a/src/project/tests/realtimeeffectspersistence_tests.cpp
+++ b/src/project/tests/realtimeeffectspersistence_tests.cpp
@@ -134,4 +134,55 @@ TEST_F(Project_RealtimeEffectsPersistenceTests, MasterEffectList_SurvivesSaveRel
 
     testtools::removeProjectIfExists(dstPath);
 }
+
+TEST_F(Project_RealtimeEffectsPersistenceTests, RealtimeEffectState_LoadNormalizesWindowsEffectIdPathSeparators)
+{
+    const std::string aup3Id
+        = "Effect_VST3_Soap Audio_Soap Voice Cleaner_C:\\Program Files\\Common Files\\VST3\\Soap Voice Cleaner.vst3;"
+          "ABCDEF019182FAEB536F6170536F6170";
+    const std::string aup4Id
+        = "Effect_VST3_Soap Audio_Soap Voice Cleaner_C:/Program Files/Common Files/VST3/Soap Voice Cleaner.vst3;"
+          "ABCDEF019182FAEB536F6170536F6170";
+
+    RealtimeEffectState::EffectFactory::Scope effectFactoryScope {
+        [](const PluginID&) -> const EffectInstanceFactory* { return &dummyFactory(); }
+    };
+
+    RealtimeEffectState state { {} };
+    const AttributesList attrs {
+        { "id", XMLAttributeValueView { std::string_view { aup3Id } } }
+    };
+
+    ASSERT_TRUE(state.HandleXMLTag(RealtimeEffectState::XMLTag(), attrs));
+    EXPECT_EQ(state.GetID().ToStdString(), aup4Id);
+}
+
+TEST_F(Project_RealtimeEffectsPersistenceTests, RealtimeEffectState_LoadStoresResolvedEffectId)
+{
+    const PluginID loadedId = wxString::FromUTF8(
+        "Effect_VST3_Soap Audio_Soap Voice Cleaner_C:\\Program Files\\Common Files\\VST3\\Soap Voice Cleaner.vst3;"
+        "ABCDEF019182FAEB536F6170536F6170");
+    const PluginID normalizedId = wxString::FromUTF8(
+        "Effect_VST3_Soap Audio_Soap Voice Cleaner_C:/Program Files/Common Files/VST3/Soap Voice Cleaner.vst3;"
+        "ABCDEF019182FAEB536F6170536F6170");
+    const PluginID resolvedId = wxString::FromUTF8(
+        "Effect_VST3_Soap Audio_Soap Voice Cleaner_D:/Audio/VST3/Soap Voice Cleaner.vst3;"
+        "ABCDEF019182FAEB536F6170536F6170");
+
+    RealtimeEffectState::EffectIdResolver::Scope resolverScope {
+        [&](const PluginID& id) -> PluginID { return id == normalizedId ? resolvedId : PluginID {}; }
+    };
+    RealtimeEffectState::EffectFactory::Scope effectFactoryScope {
+        [](const PluginID&) -> const EffectInstanceFactory* { return &dummyFactory(); }
+    };
+
+    RealtimeEffectState state { {} };
+    const std::string loadedIdString = loadedId.ToStdString();
+    const AttributesList attrs {
+        { "id", XMLAttributeValueView { std::string_view { loadedIdString } } }
+    };
+
+    ASSERT_TRUE(state.HandleXMLTag(RealtimeEffectState::XMLTag(), attrs));
+    EXPECT_EQ(state.GetID(), resolvedId);
+}
 }


### PR DESCRIPTION
Resolves: #10732

Framework PR: https://github.com/musescore/muse_framework/pull/47
Musescore PR: https://github.com/musescore/MuseScore/pull/33535

Adapt Audacity's effects modules to the revamped `muse::audioplugins` framework.

- See changes/description in the framework
- The plugin manager gets a Status column and filter (missing vs broken).
- Nyquist entries now do not pollute the cache when app directory is moved
- Fixed macos dock icon flashing during scanning
- Saved projects survive a VST3 plugin moving on disk or between OSes
- Fixes compressor parameter ranges to match AU3 to allow project migration

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run

Plugin manager:
- [x] effects are discovered properly
- [x] disabling a plugin persists
- [x] when removing a plugin from where it was and restarting Audacity, the plugin is shown as "missing"
- [x] when replacing the plugin and restarting, it is shown back as normal
- [x] broken plugins are listed as broken
- [x] when removing a plugin in broken state, restarting audacity, putting back the broken plugin and restarting audacity again, the plugin isn't listed as a valid plugin
