### PR TITLE
BUILDING.md updated to list Qt 6.10 as macOS minimum requirement

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -9,7 +9,7 @@
 * A package manager (tested: Choco on Windows, Homebrew on macOS)
 * A CMake generator (tested: Ninja)
 * A C++ compiler (tested: MSVC on Windows, g++ on Linux)
-* Qt 6.9.1 'Desktop' (macOS), 'MSVC 2022 64-bit' (Windows) or 'MSVC 2022 ARM64' (Windows on ARM) with 'Additional Libraries':
+* Qt 6.10 'Desktop' (macOS), 'MSVC 2022 64-bit' (Windows) or 'MSVC 2022 ARM64' (Windows on ARM) with 'Additional Libraries':
   * Qt 5 Compatibility Module
   * Qt Network Authorization
   * Qt Shader Tools


### PR DESCRIPTION
Resolves: [#10923](https://github.com/audacity/audacity/issues/10923)

Updated BUILDING.md file to list Qt 6.10 as the minimum required version for macOS. The build fails with earlier versions because QSortFilterProxyModel::Direction was introduced in Qt 6.10 ([See QSortFilterProxyModel Class](https://doc.qt.io/qt-6/qsortfilterproxymodel.html#Direction-enum).)

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
