### PR TITLE
Revert "Add high DPI support on Windows"

### DIFF
--- a/win/Audacity.exe.manifest
+++ b/win/Audacity.exe.manifest
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='yes'?>
-<assembly xmlns='urn:schemas-microsoft-com:asm.v1' manifestVersion='1.0' xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
+<assembly xmlns='urn:schemas-microsoft-com:asm.v1' manifestVersion='1.0'>
   <assemblyIdentity
       version="2.3.0.0"
       processorArchitecture="x86"
@@ -19,10 +19,4 @@
       <assemblyIdentity type='win32' name='Microsoft.Windows.Common-Controls' version='6.0.0.0' processorArchitecture='*' publicKeyToken='6595b64144ccf1df' language='*' />
     </dependentAssembly>
   </dependency>
-  <asmv3:application>
-    <asmv3:windowsSettings>
-      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
-      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
-    </asmv3:windowsSettings>
-  </asmv3:application>
 </assembly>


### PR DESCRIPTION
Reverts audacity/audacity#9694 as it introduces issues with high scaling values 
<img width="2559" height="1504" alt="image" src="https://github.com/user-attachments/assets/60ef4cd1-dbf5-44db-a555-705a858e8c6d" />
