### PR TITLE
9673 remove pending tracks on undo redo

### DIFF
--- a/au3/libraries/au3-track/Track.cpp
+++ b/au3/libraries/au3-track/Track.cpp
@@ -25,6 +25,8 @@ and TimeTrack.
 #include <wx/textfile.h>
 #include <wx/log.h>
 
+#include "PendingTracks.h"
+
 #include "au3-basic-ui/BasicUI.h"
 #include "au3-project/Project.h"
 
@@ -341,9 +343,8 @@ TrackListHolder TrackList::Create(AudacityProject* pOwner)
 TrackListHolder TrackList::Duplicate() const
 {
     const auto duplicate = TrackList::Create(nullptr);
-    for (auto pTrack : *this) {
-        if (pTrack->GetId() == TrackId{}) {
-            // Don't copy a pending added track
+    for (const auto* pTrack : *this) {
+        if ((mOwner != nullptr) && PendingTracks::Get(*mOwner).FindPendingTrack(*pTrack) != nullptr) {
             continue;
         }
         duplicate->Add(

--- a/src/playback/internal/playbackcontroller.cpp
+++ b/src/playback/internal/playbackcontroller.cpp
@@ -406,6 +406,10 @@ void PlaybackController::onSeekAction(const muse::actions::ActionQuery& q)
         return;
     }
 
+    if (recordController()->isRecording()) {
+        return;
+    }
+
     const muse::secs_t secs = q.param("seekTime").toDouble();
     const bool triggerPlay = q.param("triggerPlay").toBool();
 

--- a/src/record/internal/au3/au3record.cpp
+++ b/src/record/internal/au3/au3record.cpp
@@ -294,6 +294,14 @@ void Au3Record::init()
         }
         m_recordPosition.set(m_recordPosition.val);
         m_recordingFinished.notify();
+
+        muse::actions::ActionQuery q(PLAYBACK_SEEK_QUERY);
+        q.addParam("seekTime", muse::Val(m_recordPosition.val));
+        q.addParam("triggerPlay", muse::Val(false));
+        dispatcher()->dispatch(q);
+
+        m_recordData.clear();
+        rebuildRecordingClipKeys();
     });
 
     audioEngine()->commitRequested().onNotify(this, [this]() {
@@ -332,14 +340,6 @@ void Au3Record::init()
         pendingTracks.ClearPendingTracks();
 
         commitRecording();
-
-        muse::actions::ActionQuery q(PLAYBACK_SEEK_QUERY);
-        q.addParam("seekTime", muse::Val(m_recordPosition.val));
-        q.addParam("triggerPlay", muse::Val(false));
-        dispatcher()->dispatch(q);
-
-        m_recordData.clear();
-        rebuildRecordingClipKeys();
     });
 }
 

--- a/src/record/internal/au3/au3record.cpp
+++ b/src/record/internal/au3/au3record.cpp
@@ -328,6 +328,9 @@ void Au3Record::init()
             trackeditInteraction()->makeRoomForClip(clipKey);
         }
 
+        auto& pendingTracks = PendingTracks::Get(projectRef());
+        pendingTracks.ClearPendingTracks();
+
         commitRecording();
 
         muse::actions::ActionQuery q(PLAYBACK_SEEK_QUERY);
@@ -335,8 +338,6 @@ void Au3Record::init()
         q.addParam("triggerPlay", muse::Val(false));
         dispatcher()->dispatch(q);
 
-        auto& pendingTracks = PendingTracks::Get(projectRef());
-        pendingTracks.ClearPendingTracks();
         m_recordData.clear();
         rebuildRecordingClipKeys();
     });


### PR DESCRIPTION
Resolves: #9673

Remove pending tracks on undo / redo.
The PR also forbid seek while recording to remove clip visual glitches.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
