### PR TITLE
qsTrc: Add missing plural forms for ToastProgressBar.qml

### DIFF
--- a/src/toast/qml/Audacity/Toast/ToastProgressBar.qml
+++ b/src/toast/qml/Audacity/Toast/ToastProgressBar.qml
@@ -48,13 +48,13 @@ Item {
 
             if (remainingSeconds >= SECONDS_IN_HOUR) {
                 const hours = Math.round(remainingSeconds / SECONDS_IN_HOUR)
-                text = qsTrc("toast", "%n hour remaining", "%n hours remaining", hours)
+                text = qsTrc("toast", "%n hour(s) remaining", "amount of time left until the requested operation is finished", hours)
             } else if (remainingSeconds >= SECONDS_IN_MINUTE) {
                 const minutes = Math.round(remainingSeconds / SECONDS_IN_MINUTE)
-                text = qsTrc("toast", "%n minute remaining", "%n minutes remaining", minutes)
+                text = qsTrc("toast", "%n minute(s) remaining", "amount of time left until the requested operation is finished", minutes)
             } else {
                 const seconds = Math.round(remainingSeconds)
-                text = qsTrc("toast", "%n second remaining", "%n seconds remaining", seconds)
+                text = qsTrc("toast", "%n second(s) remaining", "amount of time left until the requested operation is finished", seconds)
             }
         }
     }

--- a/src/toast/qml/Audacity/Toast/ToastProgressBar.qml
+++ b/src/toast/qml/Audacity/Toast/ToastProgressBar.qml
@@ -48,13 +48,13 @@ Item {
 
             if (remainingSeconds >= SECONDS_IN_HOUR) {
                 const hours = Math.round(remainingSeconds / SECONDS_IN_HOUR)
-                text = hours === 1 ? qsTrc("toast", "1 hour remaining") : qsTrc("toast", "%1 hours remaining").arg(hours)
+                text = qsTrc("toast", "%n hour remaining", "%n hours remaining", hours)
             } else if (remainingSeconds >= SECONDS_IN_MINUTE) {
                 const minutes = Math.round(remainingSeconds / SECONDS_IN_MINUTE)
-                text = minutes === 1 ? qsTrc("toast", "1 minute remaining") : qsTrc("toast", "%1 minutes remaining").arg(minutes)
+                text = qsTrc("toast", "%n minute remaining", "%n minutes remaining", minutes)
             } else {
                 const seconds = Math.round(remainingSeconds)
-                text = seconds === 1 ? qsTrc("toast", "1 second remaining") : qsTrc("toast", "%1 seconds remaining").arg(seconds)
+                text = qsTrc("toast", "%n second remaining", "%n seconds remaining", seconds)
             }
         }
     }


### PR DESCRIPTION
The "remaining" strings do not comply with plural forms. Not all languages have only one plural form.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
