### PR TITLE
Add default navigation panel to the track view

### DIFF
--- a/src/trackedit/view/tracknavigationmodel.cpp
+++ b/src/trackedit/view/tracknavigationmodel.cpp
@@ -1,5 +1,7 @@
 #include "tracknavigationmodel.h"
 
+#include "global/translation.h"
+
 using namespace au::trackedit;
 
 static const QString makeTrackPanelName(const TrackId& trackId)
@@ -73,9 +75,18 @@ void TrackNavigationModel::load()
         for (size_t pos = 0; pos < tracks.size(); ++pos) {
             addPanels(tracks[pos].id, static_cast<int>(pos));
         }
+
+        if (tracks.empty()) {
+            addDefaultNavigation();
+        } else {
+            removeDefaultNavigation();
+        }
     });
 
     prj->trackAdded().onReceive(this, [this](const Track& track) {
+        if (m_trackItemPanels.isEmpty()) {
+            removeDefaultNavigation();
+        }
         const int pos = m_trackItemPanels.size();
         addPanels(track.id, pos);
         resetPanelOrder();
@@ -103,9 +114,16 @@ void TrackNavigationModel::load()
         }
 
         resetPanelOrder();
+
+        if (m_trackItemPanels.isEmpty()) {
+            addDefaultNavigation();
+        }
     });
 
     prj->trackInserted().onReceive(this, [this](const Track& track, int pos) {
+        if (m_trackItemPanels.isEmpty()) {
+            removeDefaultNavigation();
+        }
         addPanels(track.id, pos);
         resetPanelOrder();
     });
@@ -135,6 +153,10 @@ void TrackNavigationModel::load()
     for (const auto& track : trackList) {
         const int pos = m_trackItemPanels.size();
         addPanels(track.id, pos);
+    }
+
+    if (trackList.empty()) {
+        addDefaultNavigation();
     }
 
     tracksNavigationController()->focusedTrackChanged().onReceive(this, [this](const TrackId& trackId, bool highlight) {
@@ -204,6 +226,53 @@ void TrackNavigationModel::resetPanelOrder()
     emit viewItemPanelsChanged();
 }
 
+void TrackNavigationModel::addDefaultNavigation()
+{
+    if (!m_section) {
+        return;
+    }
+
+    if (!m_defaultPanel) {
+        m_defaultPanel = new muse::ui::NavigationPanel(this);
+        m_defaultPanel->setName("Default Track Panel");
+        m_defaultPanel->setIndex({ 0, 0 });
+        m_defaultPanel->setOrder(0);
+        m_defaultPanel->setSection(m_section);
+        m_defaultPanel->componentComplete();
+
+        m_defaultControl = new muse::ui::NavigationControl(this);
+        m_defaultControl->setName("Default Track Control");
+        m_defaultControl->setIndex({ 0, 0 });
+        m_defaultControl->setOrder(0);
+        m_defaultControl->setPanel(m_defaultPanel);
+        m_defaultControl->componentComplete();
+
+        muse::ui::AccessibleItem* accessible = m_defaultControl->accessible();
+        accessible->setRole(muse::ui::MUAccessible::Information);
+        accessible->setName(muse::qtrc("trackedit", "Tracks: Empty"));
+        accessible->componentComplete();
+    } else {
+        m_defaultPanel->setSection(m_section);
+    }
+
+    navigationController()->setDefaultNavigationControl(m_defaultControl);
+
+    navigationController()->requestActivateByName(
+        m_section->name().toStdString(),
+        m_defaultPanel->name().toStdString(),
+        m_defaultControl->name().toStdString());
+}
+
+void TrackNavigationModel::removeDefaultNavigation()
+{
+    if (!m_defaultPanel) {
+        return;
+    }
+
+    navigationController()->setDefaultNavigationControl(nullptr);
+    m_defaultPanel->setSection(nullptr);
+}
+
 void TrackNavigationModel::handleArrowKeyFallback(muse::ui::NavigationEvent* event)
 {
     if (!tracksNavigationController()->isNavigationEnabled()) {
@@ -224,6 +293,8 @@ void TrackNavigationModel::moveFocusTo(const QVariant& trackId)
 
 void TrackNavigationModel::cleanup()
 {
+    removeDefaultNavigation();
+
     clearPanels();
 
     navigationController()->resetNavigation();

--- a/src/trackedit/view/tracknavigationmodel.h
+++ b/src/trackedit/view/tracknavigationmodel.h
@@ -2,6 +2,7 @@
 
 #include "ui/qml/Muse/Ui/navigationsection.h"
 #include "ui/qml/Muse/Ui/navigationpanel.h"
+#include "ui/qml/Muse/Ui/navigationcontrol.h"
 #include "global/async/asyncable.h"
 
 #include "global/modularity/ioc.h"
@@ -45,12 +46,16 @@ private:
     void addPanels(const TrackId& trackId, int pos);
     void resetPanelOrder();
     void addDefaultNavigation();
+    void removeDefaultNavigation();
     void handleArrowKeyFallback(muse::ui::NavigationEvent* event);
 
     void activateNavigation(const TrackId& trackId, bool highlight = false);
     void activateNavigation(const TrackItemKey& itemKey, bool highlight = false);
 
     muse::ui::INavigationSection* m_section = nullptr;
+
+    muse::ui::NavigationPanel* m_defaultPanel = nullptr;
+    muse::ui::NavigationControl* m_defaultControl = nullptr;
 
     QList<muse::ui::NavigationPanel*> m_trackItemPanels;
     QList<muse::ui::NavigationPanel*> m_viewItemPanels;


### PR DESCRIPTION
Resolves: #11001

Add default navigation panel to an empty trackview, so that track panel can be activated and receive paste actions
<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
