### PR TITLE
Allow wrapping for long titles in GetEffects dialog

### DIFF
--- a/src/projectscene/qml/Audacity/ProjectScene/toolbars/EffectCard.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/toolbars/EffectCard.qml
@@ -103,8 +103,9 @@ Rectangle {
                 text: root.title
                 font: ui.theme.largeBodyBoldFont
                 horizontalAlignment: Text.AlignLeft
-                maximumLineCount: 1
+                maximumLineCount: 2
                 elide: Text.ElideRight
+                wrapMode: Text.Wrap
             }
 
             StyledTextLabel {


### PR DESCRIPTION
Allow wrapping for long titles in GetEffects dialog
<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
