### PR TITLE
10975 handle cloud remote project deletion

### DIFF
--- a/au3/libraries/au3-cloud-audiocom/sync/CloudProjectsDatabase.cpp
+++ b/au3/libraries/au3-cloud-audiocom/sync/CloudProjectsDatabase.cpp
@@ -210,19 +210,21 @@ cloud::audiocom::sync::CloudProjectsDatabase::GetCloudProjects() const
     return result;
 }
 
-void cloud::audiocom::sync::CloudProjectsDatabase::DeleteProject(
+bool cloud::audiocom::sync::CloudProjectsDatabase::DeleteProject(
     std::string_view projectId)
 {
     auto connection = GetConnection();
 
     if (!connection) {
-        return;
+        return false;
     }
 
     auto tx = connection->BeginTransaction("DeleteProject");
-    if (DeleteProject(connection, projectId)) {
-        tx.Commit();
+    if (!DeleteProject(connection, projectId)) {
+        return false;
     }
+
+    return tx.Commit().IsOk();
 }
 
 bool CloudProjectsDatabase::MarkProjectAsSynced(

--- a/au3/libraries/au3-cloud-audiocom/sync/CloudProjectsDatabase.h
+++ b/au3/libraries/au3-cloud-audiocom/sync/CloudProjectsDatabase.h
@@ -95,7 +95,7 @@ public:
 
     std::vector<DBProjectData> GetCloudProjects() const;
 
-    void DeleteProject(std::string_view projectId);
+    bool DeleteProject(std::string_view projectId);
 
     bool
     MarkProjectAsSynced(std::string_view projectId, std::string_view snapshotId);

--- a/src/au3cloud/iau3audiocomservice.h
+++ b/src/au3cloud/iau3audiocomservice.h
@@ -24,6 +24,12 @@ enum class CachePolicy {
     Network,
 };
 
+enum class UploadMode {
+    CreateNew,
+    NormalUpdate,
+    ForceOverwrite,
+};
+
 struct FetchOptions {
     CachePolicy cachePolicy = CachePolicy::CacheFirst;
     std::optional<std::chrono::seconds> maxCacheAge = std::nullopt;
@@ -49,7 +55,7 @@ public:
 
     virtual muse::RetVal<muse::ProgressPtr> uploadProject(au::project::IAudacityProjectPtr project, const std::string& name,
                                                           std::function<bool()> projectSaveCallback = nullptr,
-                                                          bool forceOverwrite = false) = 0;
+                                                          UploadMode uploadMode = UploadMode::NormalUpdate) = 0;
 
     virtual muse::RetVal<muse::ProgressPtr> openCloudProject(const muse::io::path_t& localPath, const std::string& projectId = {},
                                                              const std::string& snapshotId = {}, bool forceOverwrite = false) = 0;
@@ -64,6 +70,8 @@ public:
     virtual std::string getCloudProjectPage(const muse::io::path_t& projectPath) const = 0;
     virtual std::string getCloudAudioPage(const std::string& slug) const = 0;
     virtual std::string getCloudProfilePage() const = 0;
+
+    virtual muse::Ret deleteCloudProject(const muse::io::path_t& localPath) = 0;
 
     virtual void deinit() = 0;
 };

--- a/src/au3cloud/internal/au3audiocomservice.cpp
+++ b/src/au3cloud/internal/au3audiocomservice.cpp
@@ -11,11 +11,13 @@
 #include <utility>
 
 #include "framework/global/async/async.h"
+#include "framework/global/log.h"
 #include "framework/global/runtime.h"
 #include "framework/global/types/ret.h"
 #include "framework/global/io/dir.h"
 #include "framework/global/progress.h"
 
+#include "au3-cloud-audiocom/sync/ProjectUploadOperation.h"
 #include "au3-cloud-audiocom/CloudSyncService.h"
 #include "au3-cloud-audiocom/OAuthService.h"
 #include "au3-cloud-audiocom/UserService.h"
@@ -77,23 +79,44 @@ std::string getCloudProjectPage(au::project::IAudacityProjectPtr project)
 
 bool needsNewSnapshot(au::project::IAudacityProjectPtr project,
                       const audacity::cloud::audiocom::sync::ProjectCloudExtension& extension,
-                      bool forceOverwrite)
+                      UploadMode uploadMode)
 {
-    if (forceOverwrite) {
+    switch (uploadMode) {
+    case UploadMode::CreateNew:
         return true;
+    case UploadMode::ForceOverwrite:
+        return true;
+    case UploadMode::NormalUpdate:
+    {
+        if (!extension.IsCloudProject()) {
+            return true;
+        }
+
+        if (project->needSave().val) {
+            return true;
+        }
+
+        const auto status = extension.GetCurrentSyncStatus();
+        return status != audacity::cloud::audiocom::sync::ProjectSyncStatus::Synced
+               && status != audacity::cloud::audiocom::sync::ProjectSyncStatus::Syncing;
+    }
+    default:
+        DO_ASSERT(false);
+    }
+}
+
+sync::UploadMode toAu3UploadMode(UploadMode mode)
+{
+    switch (mode) {
+    case UploadMode::NormalUpdate:
+        return sync::UploadMode::Normal;
+    case UploadMode::CreateNew:
+        return sync::UploadMode::CreateNew;
+    case UploadMode::ForceOverwrite:
+        return sync::UploadMode::ForceOverwrite;
     }
 
-    if (!extension.IsCloudProject()) {
-        return true;
-    }
-
-    if (project->needSave().val) {
-        return true;
-    }
-
-    const auto status = extension.GetCurrentSyncStatus();
-    return status != audacity::cloud::audiocom::sync::ProjectSyncStatus::Synced
-           && status != audacity::cloud::audiocom::sync::ProjectSyncStatus::Syncing;
+    return sync::UploadMode::Normal;
 }
 }
 
@@ -285,7 +308,7 @@ void Au3AudioComService::clearAudioListCache()
 }
 
 muse::RetVal<muse::ProgressPtr> Au3AudioComService::uploadProject(au::project::IAudacityProjectPtr project, const std::string& name,
-                                                                  std::function<bool()> projectSaveCallback, bool forceOverwrite)
+                                                                  std::function<bool()> projectSaveCallback, UploadMode uploadMode)
 {
     if (!project) {
         return muse::RetVal<muse::ProgressPtr>::make_ret(muse::Ret::Code::InternalError, muse::trc("cloud", "Invalid project"));
@@ -298,7 +321,7 @@ muse::RetVal<muse::ProgressPtr> Au3AudioComService::uploadProject(au::project::I
 
     auto& projectCloudExtension = audacity::cloud::audiocom::sync::ProjectCloudExtension::Get(*au3Project);
 
-    if (!needsNewSnapshot(project, projectCloudExtension, forceOverwrite)) {
+    if (!needsNewSnapshot(project, projectCloudExtension, uploadMode)) {
         return muse::RetVal<muse::ProgressPtr>::make_ok(nullptr);
     }
 
@@ -310,10 +333,6 @@ muse::RetVal<muse::ProgressPtr> Au3AudioComService::uploadProject(au::project::I
     }
 
     projectCloudExtension.OnSyncStarted();
-
-    const auto uploadMode = forceOverwrite
-                            ? audacity::cloud::audiocom::sync::UploadMode::ForceOverwrite
-                            : audacity::cloud::audiocom::sync::UploadMode::Normal;
 
     auto done = std::make_shared<std::atomic<bool> >(false);
     m_uploadDone = done;
@@ -340,7 +359,7 @@ muse::RetVal<muse::ProgressPtr> Au3AudioComService::uploadProject(au::project::I
     },
         false);
 
-    std::thread([weak = weak_from_this(), project, progress, name, uploadMode,
+    std::thread([weak = weak_from_this(), project, progress, name, uploadMode = toAu3UploadMode(uploadMode),
                  projectSaveCallback = std::move(projectSaveCallback)]() mutable {
         auto self = weak.lock();
         if (!self) {
@@ -556,20 +575,24 @@ muse::RetVal<muse::ProgressPtr> Au3AudioComService::downloadAudioFile(const std:
 muse::RetVal<muse::ProgressPtr> Au3AudioComService::openCloudProject(const muse::io::path_t& localPath, const std::string& projectId,
                                                                      const std::string& snapshotId, bool forceOverwrite)
 {
-    const auto dbProjectData = getProjectDataFromDatabase(localPath);
-    if (dbProjectData.has_value() && !filesystem()->exists(localPath)) {
-        removeProjectFromDatabase(localPath);
+    auto dbProjectData = getProjectDataFromDatabase(localPath);
+    std::string cloudProjectId = projectId;
+    if (cloudProjectId.empty() && dbProjectData) {
+        cloudProjectId = dbProjectData->ProjectId;
     }
 
-    std::string cloudProjectId = projectId;
+    if (dbProjectData.has_value() && !filesystem()->exists(localPath)) {
+        const auto deleteRet = deleteCloudProject(localPath);
+        if (deleteRet) {
+            dbProjectData.reset();
+        } else {
+            LOGW() << "Failed to remove stale cloud project entry: " << deleteRet.toString();
+        }
+    }
 
     if (cloudProjectId.empty()) {
-        cloudProjectId = dbProjectData ? dbProjectData->ProjectId : "";
-
-        if (cloudProjectId.empty()) {
-            return muse::RetVal<muse::ProgressPtr>::make_ret(
-                muse::Ret::Code::UnknownError, muse::trc("cloud", "Project not found in cloud database"));
-        }
+        return muse::RetVal<muse::ProgressPtr>::make_ret(
+            muse::Ret::Code::UnknownError, muse::trc("cloud", "Project not found in cloud database"));
     }
 
     if (!forceOverwrite) {
@@ -626,10 +649,6 @@ muse::RetVal<muse::ProgressPtr> Au3AudioComService::openCloudProject(const muse:
             progress->finish(muse::RetVal<muse::Val>::make_ok(muse::Val(muse::io::path_t(normalizedLocalPath))));
         } else {
             const auto err = syncResultCodeToErr(result.Result.Code);
-            if (err == Err::SyncResultNotFound) {
-                self->removeProjectFromDatabase(muse::io::Dir::fromNativeSeparators(muse::io::path_t(result.ProjectPath)));
-            }
-
             progress->finish(make_ret(err));
         }
     }).detach();
@@ -735,12 +754,19 @@ muse::RetVal<muse::ProgressPtr> Au3AudioComService::shareAudio(const std::string
     return muse::RetVal<muse::ProgressPtr>::make_ok(progress);
 }
 
-void Au3AudioComService::removeProjectFromDatabase(const muse::io::path_t& localPath)
+muse::Ret Au3AudioComService::deleteCloudProject(const muse::io::path_t& localPath)
 {
     auto dbData = sync::CloudProjectsDatabase::Get().GetProjectDataForPath(localPath.toStdString());
-    if (dbData) {
-        sync::CloudProjectsDatabase::Get().DeleteProject(dbData->ProjectId);
+    if (!dbData) {
+        // Nothing cached for this path, treat as already deleted
+        return muse::make_ok();
     }
+
+    if (!sync::CloudProjectsDatabase::Get().DeleteProject(dbData->ProjectId)) {
+        return muse::make_ret(muse::Ret::Code::UnknownError, muse::trc("cloud", "Failed to delete cloud project from database"));
+    }
+
+    return muse::make_ok();
 }
 
 bool Au3AudioComService::isSnapshotUpToDate(

--- a/src/au3cloud/internal/au3audiocomservice.h
+++ b/src/au3cloud/internal/au3audiocomservice.h
@@ -61,7 +61,7 @@ public:
     muse::async::Channel<std::string, muse::io::path_t> audioThumbnailFileUpdated() const override;
 
     muse::RetVal<muse::ProgressPtr> uploadProject(au::project::IAudacityProjectPtr project, const std::string& name,
-                                                  std::function<bool()> projectSaveCallback, bool forceOverwrite = false) override;
+                                                  std::function<bool()> projectSaveCallback, UploadMode uploadMode) override;
 
     muse::RetVal<muse::ProgressPtr> openCloudProject(const muse::io::path_t& localPath, const std::string& projectId = {},
                                                      const std::string& snapshotId = {}, bool forceOverwrite = false) override;
@@ -78,10 +78,11 @@ public:
     std::string getCloudAudioPage(const std::string& slug) const override;
     std::string getCloudProfilePage() const override;
 
+    muse::Ret deleteCloudProject(const muse::io::path_t& localPath) override;
+
     void deinit() override;
 
 private:
-    static void removeProjectFromDatabase(const muse::io::path_t& localPath);
     muse::ProgressPtr createSyncProgress();
     bool isSnapshotUpToDate(
         const std::optional<audacity::cloud::audiocom::sync::DBProjectData>& dbProjectData,

--- a/src/project/internal/projectactionscontroller.cpp
+++ b/src/project/internal/projectactionscontroller.cpp
@@ -40,6 +40,22 @@ static const muse::actions::ActionCode OPEN_METADATA_DIALOG("open-metadata-dialo
 static const muse::actions::ActionCode OPEN_CUSTOM_MAPPING("open-custom-mapping");
 static const muse::actions::ActionQuery OPEN_CLOUD_AUDIO_FILE_URI("audacity://cloud/open-audio-file");
 
+namespace {
+au::au3cloud::UploadMode toUploadMode(CloudSaveMode mode)
+{
+    switch (mode) {
+    case CloudSaveMode::CreateNew:
+        return au::au3cloud::UploadMode::CreateNew;
+    case CloudSaveMode::ForceOverwrite:
+        return au::au3cloud::UploadMode::ForceOverwrite;
+    case CloudSaveMode::NormalUpdate:
+        return au::au3cloud::UploadMode::NormalUpdate;
+    }
+
+    return au::au3cloud::UploadMode::NormalUpdate;
+}
+}
+
 ProjectActionsController::ProjectActionsController(muse::modularity::ContextPtr ctx)
     : muse::Contextable(ctx)
 {
@@ -570,42 +586,39 @@ bool ProjectActionsController::saveProject(const muse::io::path_t& path)
     return saveProject(SaveMode::Save);
 }
 
-bool ProjectActionsController::saveProjectToCloud(const CloudProjectInfo& cloudInfo, SaveMode saveMode, bool forceOverwrite)
+muse::Ret ProjectActionsController::saveProjectToCloud(const CloudProjectInfo& cloudInfo, CloudSaveMode cloudSaveMode)
 {
     if (!audioComService()->enabled()) {
-        LOGE() << "Cloud support is not available";
-        return false;
+        return make_ret(Ret::Code::NotSupported, std::string { "Cloud support is not available" });
     }
 
-    if (!ensureAuthorization()) {
-        return false;
+    if (const Ret ret = ensureAuthorization(); !ret) {
+        return ret;
     }
 
     io::path_t cloudProjectsPath = configuration()->cloudProjectsPath();
     if (cloudProjectsPath.empty()) {
-        LOGE() << "Cloud projects path is not set";
-        return false;
+        return make_ret(Ret::Code::UnknownError, std::string { "Cloud projects path is not set" });
     }
 
     io::path_t projectFilePath = cloudProjectsPath.appendingComponent(cloudInfo.name).appendingSuffix(au::project::AUP4);
 
     IAudacityProjectPtr project = currentProject();
     if (!project) {
-        LOGE() << "No project opened";
-        return false;
+        return make_ret(Ret::Code::UnknownError, std::string { "No project opened" });
     }
 
     auto [uploadRet, progress] = audioComService()->uploadProject(project, cloudInfo.name.toStdString(), [this, projectFilePath]() {
         return saveProjectLocally(projectFilePath, SaveMode::Save);
-    }, forceOverwrite);
+    }, toUploadMode(cloudSaveMode));
 
     if (!uploadRet) {
         handleCloudSaveError(uploadRet);
-        return false;
+        return uploadRet;
     }
 
     if (!progress) {
-        return true;
+        return make_ok();
     }
 
     progress->finished().onReceive(this, [this, projectFilePath](const ProgressResult& result) {
@@ -651,7 +664,7 @@ bool ProjectActionsController::saveProjectToCloud(const CloudProjectInfo& cloudI
         }
     });
 
-    return true;
+    return make_ok();
 }
 
 bool ProjectActionsController::saveProjectLocally(const muse::io::path_t& filePath, SaveMode saveMode)
@@ -862,7 +875,11 @@ bool ProjectActionsController::saveProjectAt(const SaveLocation& location, SaveM
     }
 
     if (location.isCloud()) {
-        return saveProjectToCloud(location.cloudInfo(), saveMode);
+        const Ret ret = saveProjectToCloud(location.cloudInfo());
+        if (!ret) {
+            LOGE() << ret.toString();
+        }
+        return ret;
     }
 
     return false;
@@ -1383,13 +1400,6 @@ muse::Ret ProjectActionsController::ensureAuthorization()
 void ProjectActionsController::handleCloudOpenError(const muse::Ret& error, const io::path_t& localPath,
                                                     const std::string& cloudProjectId)
 {
-    using Err = au::au3cloud::Err;
-    const auto err = static_cast<Err>(error.code());
-
-    if (err == Err::SyncResultNotFound && fileSystem()->exists(localPath)) {
-        doOpenProject(localPath);
-    }
-
     const auto ret = openSaveProjectScenario()->showCloudOpenError(error, localPath);
 
     switch (ret.code()) {
@@ -1397,24 +1407,60 @@ void ProjectActionsController::handleCloudOpenError(const muse::Ret& error, cons
         doOpenProject(localPath);
         break;
     case IOpenSaveProjectScenario::RET_CODE_SAVE_LOCALLY_AND_REMOVE_CACHE: {
+        const auto openRet = doOpenProject(localPath);
+        if (!openRet) {
+            LOGE() << openRet.toString();
+            break;
+        }
+
         IAudacityProjectPtr project = currentProject();
         if (!project) {
             break;
         }
+
         const auto askRet = openSaveProjectScenario()->askLocalPath(project, SaveMode::Save);
         if (!askRet.ret || askRet.val.empty()) {
             break;
         }
-        saveProjectLocally(askRet.val, SaveMode::Save);
-        fileSystem()->remove(localPath);
+
+        const auto deleteRet = audioComService()->deleteCloudProject(localPath);
+        if (!deleteRet) {
+            LOGW() << deleteRet.toString();
+        }
+
+        const auto newPath = askRet.val;
+        if (!saveProjectLocally(newPath, SaveMode::Save)) {
+            break;
+        }
+
+        if (newPath != localPath) {
+            const auto removeRet = fileSystem()->remove(localPath);
+            if (!removeRet) {
+                LOGW() << removeRet.toString();
+            }
+        }
         break;
     }
     case IOpenSaveProjectScenario::RET_CODE_SAVE_TO_CLOUD: {
+        const auto openRet = doOpenProject(localPath);
+        if (!openRet) {
+            LOGE() << openRet.toString();
+            break;
+        }
+
         IAudacityProjectPtr project = currentProject();
         if (!project) {
             break;
         }
-        saveProjectToCloud(CloudProjectInfo { project->displayName() }, SaveMode::Save);
+
+        const auto deleteRet = audioComService()->deleteCloudProject(localPath);
+        if (!deleteRet) {
+            LOGW() << deleteRet.toString();
+        }
+        const auto saveRet = saveProjectToCloud(CloudProjectInfo { project->displayName() }, CloudSaveMode::CreateNew);
+        if (!saveRet) {
+            LOGE() << saveRet.toString();
+        }
         break;
     }
     case IOpenSaveProjectScenario::RET_CODE_OPEN_CLOUD_FORCE:
@@ -1457,16 +1503,43 @@ void ProjectActionsController::handleCloudSaveError(const muse::Ret& error)
         if (!askRet.ret || askRet.val.empty()) {
             break;
         }
-        saveProjectLocally(askRet.val, SaveMode::Save);
-        fileSystem()->remove(oldPath);
+
+        const auto deleteRet = audioComService()->deleteCloudProject(oldPath);
+        if (!deleteRet) {
+            LOGW() << deleteRet.toString();
+        }
+
+        const auto newPath = askRet.val;
+        if (!saveProjectLocally(newPath, SaveMode::Save)) {
+            break;
+        }
+
+        if (newPath != oldPath) {
+            const auto removeRet = fileSystem()->remove(oldPath);
+            if (!removeRet) {
+                LOGW() << removeRet.toString();
+            }
+        }
         break;
     }
-    case IOpenSaveProjectScenario::RET_CODE_SAVE_TO_CLOUD:
-        saveProjectToCloud(CloudProjectInfo { project->displayName() }, SaveMode::Save);
+    case IOpenSaveProjectScenario::RET_CODE_SAVE_TO_CLOUD: {
+        const auto deleteRet = audioComService()->deleteCloudProject(project->path());
+        if (!deleteRet) {
+            LOGW() << deleteRet.toString();
+        }
+        const auto saveRet = saveProjectToCloud(CloudProjectInfo { project->displayName() }, CloudSaveMode::CreateNew);
+        if (!saveRet) {
+            LOGE() << saveRet.toString();
+        }
+    }
+    break;
+    case IOpenSaveProjectScenario::RET_CODE_SAVE_TO_CLOUD_FORCE: {
+        const auto saveRet = saveProjectToCloud(CloudProjectInfo { project->displayName() }, CloudSaveMode::ForceOverwrite);
+        if (!saveRet) {
+            LOGE() << saveRet.toString();
+        }
         break;
-    case IOpenSaveProjectScenario::RET_CODE_SAVE_TO_CLOUD_FORCE:
-        saveProjectToCloud(CloudProjectInfo { project->displayName() }, SaveMode::Save, true);
-        break;
+    }
     case IOpenSaveProjectScenario::RET_CODE_CLOSE_AND_OPEN_CLOUD_FORCE: {
         const io::path_t localPath = project->path();
         closeOpenedProject(false);

--- a/src/project/internal/projectactionscontroller.h
+++ b/src/project/internal/projectactionscontroller.h
@@ -69,7 +69,7 @@ public:
     bool closeOpenedProject(bool quitApp = false) override;
     bool saveProject(const muse::io::path_t& path = muse::io::path_t()) override;
     bool saveProjectLocally(const muse::io::path_t& filePath = muse::io::path_t(), SaveMode saveMode = SaveMode::Save) override;
-    bool saveProjectToCloud(const CloudProjectInfo& cloudInfo, SaveMode saveMode = SaveMode::Save, bool forceOverwrite = false) override;
+    muse::Ret saveProjectToCloud(const CloudProjectInfo& cloudInfo, CloudSaveMode cloudSaveMode = CloudSaveMode::NormalUpdate) override;
 
     const ProjectBeingDownloaded& projectBeingDownloaded() const override;
     muse::async::Notification projectBeingDownloadedChanged() const override;

--- a/src/project/iprojectfilescontroller.h
+++ b/src/project/iprojectfilescontroller.h
@@ -44,7 +44,7 @@ public:
     virtual bool closeOpenedProject(bool quitApp = false) = 0;
     virtual bool saveProject(const muse::io::path_t& path = muse::io::path_t()) = 0;
     virtual bool saveProjectLocally(const muse::io::path_t& path = muse::io::path_t(), SaveMode saveMode = SaveMode::Save) = 0;
-    virtual bool saveProjectToCloud(const CloudProjectInfo& cloudInfo, SaveMode saveMode = SaveMode::Save, bool forceOverwrite = false) = 0;
+    virtual muse::Ret saveProjectToCloud(const CloudProjectInfo& cloudInfo, CloudSaveMode cloudSaveMode = CloudSaveMode::NormalUpdate) = 0;
 
     virtual const ProjectBeingDownloaded& projectBeingDownloaded() const = 0;
     virtual muse::async::Notification projectBeingDownloadedChanged() const = 0;

--- a/src/project/tests/mocks/projectfilescontrollermock.h
+++ b/src/project/tests/mocks/projectfilescontrollermock.h
@@ -17,7 +17,7 @@ public:
     MOCK_METHOD(bool, closeOpenedProject, (bool), (override));
     MOCK_METHOD(bool, saveProject, (const muse::io::path_t&), (override));
     MOCK_METHOD(bool, saveProjectLocally, (const muse::io::path_t&, SaveMode), (override));
-    MOCK_METHOD(bool, saveProjectToCloud, (const CloudProjectInfo&, SaveMode, bool), (override));
+    MOCK_METHOD(muse::Ret, saveProjectToCloud, (const CloudProjectInfo&, CloudSaveMode), (override));
     MOCK_METHOD(const ProjectBeingDownloaded&, projectBeingDownloaded, (), (const, override));
     MOCK_METHOD(muse::async::Notification, projectBeingDownloadedChanged, (), (const, override));
 };

--- a/src/project/types/projecttypes.h
+++ b/src/project/types/projecttypes.h
@@ -58,6 +58,13 @@ enum class SaveMode
     AutoSave
 };
 
+enum class CloudSaveMode
+{
+    CreateNew,
+    NormalUpdate,
+    ForceOverwrite,
+};
+
 enum class SaveLocationType
 {
     Undefined,

--- a/src/stubs/au3cloud/au3audiocomservicestub.cpp
+++ b/src/stubs/au3cloud/au3audiocomservicestub.cpp
@@ -33,7 +33,7 @@ void Au3AudioComServiceStub::clearAudioListCache()
 }
 
 muse::RetVal<muse::ProgressPtr> Au3AudioComServiceStub::uploadProject(au::project::IAudacityProjectPtr, const std::string&,
-                                                                      std::function<bool()>, bool)
+                                                                      std::function<bool()>, UploadMode)
 {
     return muse::RetVal<muse::ProgressPtr>::make_ret(muse::Ret::Code::NotSupported);
 }
@@ -62,6 +62,11 @@ muse::RetVal<muse::ProgressPtr> Au3AudioComServiceStub::resumeProjectSync(au::pr
 muse::async::Channel<std::string, muse::io::path_t> Au3AudioComServiceStub::audioThumbnailFileUpdated() const
 {
     return {};
+}
+
+muse::Ret Au3AudioComServiceStub::deleteCloudProject(const muse::io::path_t&)
+{
+    return muse::make_ret(muse::Ret::Code::NotSupported);
 }
 
 std::string Au3AudioComServiceStub::getCloudAudioPage(const std::string& /*unused*/) const

--- a/src/stubs/au3cloud/au3audiocomservicestub.h
+++ b/src/stubs/au3cloud/au3audiocomservicestub.h
@@ -24,14 +24,16 @@ public:
     muse::async::Channel<std::string, muse::io::path_t> audioThumbnailFileUpdated() const override;
 
     muse::RetVal<muse::ProgressPtr> uploadProject(au::project::IAudacityProjectPtr project, const std::string& name,
-                                                  std::function<bool()> projectSaveCallback = nullptr, bool forceOverwrite = false) override;
-
+                                                  std::function<bool()> projectSaveCallback = nullptr,
+                                                  UploadMode uploadMode = UploadMode::NormalUpdate) override;
     muse::RetVal<muse::ProgressPtr> shareAudio(const std::string& title) override;
     muse::RetVal<muse::ProgressPtr> downloadAudioFile(const std::string& audioId) override;
 
     muse::RetVal<muse::ProgressPtr> openCloudProject(const muse::io::path_t& localPath, const std::string& projectId = {},
                                                      const std::string& snapshotId = {}, bool forceOverwrite = false) override;
     muse::RetVal<muse::ProgressPtr> resumeProjectSync(au::project::IAudacityProjectPtr project) override;
+
+    muse::Ret deleteCloudProject(const muse::io::path_t& localPath) override;
 
     std::string getCloudProjectPage(const std::string& projectId) const override;
     std::string getCloudProjectPage(const muse::io::path_t& projectPath) const override;


### PR DESCRIPTION
Resolves: #10975 

Better handle corner case when a remote project is removed.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
- [x] Test to remove a project from the cloud and open the project locally
- [x] Test to remove a project from the cloud and sync the project locally
- [x] For both above cases test cancel, save locally and save to the cloud
