### PR TITLE
Spectrum view fixes

### DIFF
--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/ClipItem.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/ClipItem.qml
@@ -287,7 +287,7 @@ Rectangle {
     }
 
     function getSpectrogramHit(y /* relative to tracks canvas */) {
-        return spectrogramView.getSpectrogramHit(y)
+        return spectrogramViewLoader.item ? spectrogramViewLoader.item.getSpectrogramHit(y) : null
     }
 
     function setLastSample(x, y) {
@@ -310,7 +310,9 @@ Rectangle {
 
     function updateViews() {
         waveView.update()
-        spectrogramView.update()
+        if (spectrogramViewLoader.item) {
+            spectrogramViewLoader.item.update()
+        }
     }
 
     ClipContextMenuModel {
@@ -1017,51 +1019,52 @@ Rectangle {
                 }
             }
 
-            ClipSpectrogramView {
-                id: spectrogramView
+            Loader {
+                id: spectrogramViewLoader
 
-                visible: root.isSpectrogramViewVisible
+                active: root.isSpectrogramViewVisible
+                visible: active
 
                 Layout.fillWidth: true
                 Layout.fillHeight: true
 
-                canvas: root.canvas
-                clipId: root.clipKey.itemId()
-                trackId: root.clipKey.trackId()
-                selectionInProgress: root.selectionInProgress
-                selectionEditInProgress: root.selectionEditInProgress
-                verticalSelectionEditInProgress: root.verticalSelectionEditInProgress
-                spectralSelectionEnabled: root.spectralSelectionEnabled
-                pressedSpectrogram: root.pressedSpectrogram
-                isStereo: root.showChannelSplitter
-                channelHeightRatio: showChannelSplitter ? root.channelHeightRatio : 1
+                sourceComponent: ClipSpectrogramView {
+                    canvas: root.canvas
+                    clipId: root.clipKey.itemId()
+                    trackId: root.clipKey.trackId()
+                    selectionInProgress: root.selectionInProgress
+                    selectionEditInProgress: root.selectionEditInProgress
+                    verticalSelectionEditInProgress: root.verticalSelectionEditInProgress
+                    spectralSelectionEnabled: root.spectralSelectionEnabled
+                    pressedSpectrogram: root.pressedSpectrogram
+                    isStereo: root.showChannelSplitter
+                    channelHeightRatio: showChannelSplitter ? root.channelHeightRatio : 1
 
-                timelineIndentWidth: root.canvas.anchors.leftMargin
-                zoom: root.context.zoom
-                frameStartTime: root.context.frameStartTime
-                frameEndTime: root.context.frameEndTime
-                selectionStartTime: root.context.selectionStartTime
-                selectionEndTime: root.context.selectionEndTime
-                selectionStartFrequency: root.selectionStartFrequency
-                selectionEndFrequency: root.selectionEndFrequency
-                clipSelected: root.clipSelected
+                    timelineIndentWidth: root.canvas.anchors.leftMargin
+                    zoom: root.context.zoom
+                    frameStartTime: root.context.frameStartTime
+                    frameEndTime: root.context.frameEndTime
+                    selectionStartTime: root.context.selectionStartTime
+                    selectionEndTime: root.context.selectionEndTime
+                    selectionStartFrequency: root.selectionStartFrequency
+                    selectionEndFrequency: root.selectionEndFrequency
+                    clipSelected: root.clipSelected
 
-                ChannelSplitter {
-                    id: spectrogramChannelSplitter
+                    ChannelSplitter {
+                        anchors.fill: parent
 
-                    anchors.fill: parent
+                        visible: root.showChannelSplitter
 
-                    visible: root.showChannelSplitter
+                        channelHeightRatio: parent.channelHeightRatio
+                        editable: root.enableCursorInteraction && root.asymmetricStereoHeightsPossible
+                        asymmetricStereoHeightsPossible: root.asymmetricStereoHeightsPossible
 
-                    channelHeightRatio: parent.channelHeightRatio
-                    editable: root.enableCursorInteraction && root.asymmetricStereoHeightsPossible
-                    asymmetricStereoHeightsPossible: root.asymmetricStereoHeightsPossible
+                        color: ui.theme.extra["black_color"]
+                        opacity: 0.10
 
-                    color: ui.theme.extra["black_color"]
-                    opacity: 0.10
-
-                    onPositionChangeRequested: function (position) {
-                        root.splitterPositionChangeRequested(position)
+                        onPositionChangeRequested: function (position) {
+                            root.splitterPositionChangeRequested(position)
+                        }
                     }
                 }
             }

--- a/src/spectrogram/internal/au3/SpectrumCache.cpp
+++ b/src/spectrogram/internal/au3/SpectrumCache.cpp
@@ -382,7 +382,7 @@ void SpecCache::Populate(
     }
 
     const ClipParams clipParams {
-        clip.GetSequence().GetNumSamples().as_long_long(),
+        clip.GetVisibleSampleCount().as_long_long(),
         sampleRate,
         clip.GetStretchRatio()
     };
@@ -506,7 +506,7 @@ void SpecCache::PopulateConstantQ(const Au3SpectrogramSettings& settings, const 
     assert(pixelsPerSecond > 0);
     assert(numPixels > 0);
     ComputeSpectrogramGainFactors(fftLen, sampleRate, frequencyGainSetting, gainFactors);
-    const auto numSamplesInClip = clip.GetSequence().GetNumSamples();
+    const auto numSamplesInClip = clip.GetVisibleSampleCount();
 
     // Loop over the ranges before and after the copied portion and compute anew.
     // One of the ranges may be empty.


### PR DESCRIPTION
Fixes: https://github.com/audacity/audacity/issues/10995

- Fixes a crash when accessing data outside the sequence range. The initial approach didn't take clip trimming into account.
- Use loader to display clip view. this way the spectrum view is unloaded when switching back to waveform view.
Previously spectrum calculation was still active even in waveform view.

.

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
- [ ] Please check if this closes any known issue
