### PR TITLE
Fix gradient meter clipping indication

### DIFF
--- a/src/playback/view/common/horizontalvolumepressuremeteritem.cpp
+++ b/src/playback/view/common/horizontalvolumepressuremeteritem.cpp
@@ -142,6 +142,11 @@ void HorizontalVolumePressureMeterItem::drawBarStyleRMS(QPainter& p)
 
 void HorizontalVolumePressureMeterItem::drawBarStyleGradient(QPainter& p)
 {
+    if (isClipping()) {
+        p.fillRect(QRectF(0, 0, indicatorWidth(), height()), clippedColor());
+        return;
+    }
+
     const qreal w = sampleValueToWidth(currentVolumePressure());
     if (w > 0) {
         QLinearGradient grad(0, 0, indicatorWidth(), 0);

--- a/src/projectscene/view/trackspanel/volumepressuremeteritem.cpp
+++ b/src/projectscene/view/trackspanel/volumepressuremeteritem.cpp
@@ -188,6 +188,11 @@ void VolumePressureMeterItem::drawBarStyleRMS(QPainter& p)
 
 void VolumePressureMeterItem::drawBarStyleGradient(QPainter& p)
 {
+    if (isClipping()) {
+        p.fillRect(QRectF(0, 0, m_indicatorWidth, indicatorHeight() + m_overloadHeight), clippedColor());
+        return;
+    }
+
     const qreal h = sampleValueToHeight(updatedVolumePressure());
     if (h > 0) {
         QLinearGradient grad(0, 0, 0, indicatorHeight());


### PR DESCRIPTION
Resolves: #11040

Fix gradient meters not showing clipping indication.

- Add clipping-state handling to horizontal gradient meters
- Add clipping-state handling to vertical gradient meters
- Match the existing Default/RMS meter behavior by filling with clippedColor() when clipping occurs

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:

- [ ] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run