### PR TITLE
Effect fallback UI issues

### DIFF
--- a/au3/libraries/au3-vst3/VST3Utils.cpp
+++ b/au3/libraries/au3-vst3/VST3Utils.cpp
@@ -123,7 +123,7 @@ std::string VST3Utils::GetParameterUnitStdString(Steinberg::Vst::IEditController
     // Try to get unit info if the controller supports it
     try {
         auto unitInfo = Steinberg::FUnknownPtr<Steinberg::Vst::IUnitInfo>(controller);
-        if (unitInfo) {
+        if (unitInfo && info.unitId != Steinberg::Vst::kRootUnitId) {
             Steinberg::Vst::UnitInfo uInfo;
             if (unitInfo->getUnitInfo(info.unitId, uInfo) == Steinberg::kResultOk) {
                 // Check if there's a unit name

--- a/src/effects/vst/view/vstviewmodel.cpp
+++ b/src/effects/vst/view/vstviewmodel.cpp
@@ -21,6 +21,14 @@ VstViewModel::~VstViewModel()
 {
     m_settingUpdateTimer.stop();
     QObject::disconnect(&m_settingUpdateTimer, &QTimer::timeout, this, &VstViewModel::checkSettingChangesFromUiWhileIdle);
+
+    // The wrapper is owned by the effect instance and outlives this view model
+    // (e.g. when the vendor UI is swapped for the fallback UI). Clear the
+    // handler so a later endEdit doesn't invoke a lambda capturing a freed this.
+    if (m_auVst3Instance) {
+        m_auVst3Instance->GetWrapper().ParamChangedHandler = nullptr;
+    }
+
     checkSettingChangesFromUi(true);
 }
 


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/10548

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [ ] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
- [ ] After changing DeeGain plugin gain (on a fallback UI slider) -> it works correctly and doesn't crash
- [ ] No unit on a slider (vendor UI doesn't have it so don't put "Root unit" in fallback UI)
