### PR TITLE
10842 Init playback meter controller after playback configuration

### DIFF
--- a/src/playback/internal/playbackmetercontroller.cpp
+++ b/src/playback/internal/playbackmetercontroller.cpp
@@ -28,7 +28,7 @@ std::shared_ptr<IPlaybackMeter> createMeter(PlaybackMeterType::MeterType meterTy
 }
 }
 
-PlaybackMeterController::PlaybackMeterController()
+void PlaybackMeterController::init()
 {
     configuration()->playbackMeterTypeChanged().onNotify(this, [this]() {
         m_meter = createMeter(configuration()->playbackMeterType(),

--- a/src/playback/internal/playbackmetercontroller.h
+++ b/src/playback/internal/playbackmetercontroller.h
@@ -16,7 +16,7 @@ class PlaybackMeterController : public IPlaybackMeterController, public muse::as
     muse::GlobalInject<IPlaybackConfiguration> configuration;
 
 public:
-    PlaybackMeterController();
+    void init();
 
     double stepToPosition(double sample) const override;
     double sampleToPosition(double sample) const override;

--- a/src/playback/playbackmodule.cpp
+++ b/src/playback/playbackmodule.cpp
@@ -43,9 +43,10 @@ std::string PlaybackModule::moduleName() const
 void PlaybackModule::registerExports()
 {
     m_configuration = std::make_shared<PlaybackConfiguration>();
+    m_playbackMeterController = std::make_shared<PlaybackMeterController>();
 
     globalIoc()->registerExport<PlaybackConfiguration>(mname, m_configuration);
-    globalIoc()->registerExport<IPlaybackMeterController>(mname, std::make_shared<PlaybackMeterController>());
+    globalIoc()->registerExport<IPlaybackMeterController>(mname, m_playbackMeterController);
 }
 
 void PlaybackModule::registerResources()
@@ -88,6 +89,7 @@ void PlaybackModule::onInit(const IApplication::RunMode& mode)
     }
 
     m_configuration->init();
+    m_playbackMeterController->init();
 }
 
 IContextSetup* PlaybackModule::newContext(const muse::modularity::ContextPtr& ctx) const

--- a/src/playback/playbackmodule.h
+++ b/src/playback/playbackmodule.h
@@ -12,6 +12,7 @@ namespace au::playback {
 class PlaybackConfiguration;
 class PlaybackController;
 class PlaybackUiActions;
+class PlaybackMeterController;
 class Au3Playback;
 
 class PlaybackModule : public muse::modularity::IModuleSetup
@@ -29,6 +30,7 @@ public:
 
 private:
     std::shared_ptr<PlaybackConfiguration> m_configuration;
+    std::shared_ptr<PlaybackMeterController> m_playbackMeterController;
 };
 
 class PlaybackContext : public muse::modularity::IContextSetup


### PR DESCRIPTION
Resolves: #10842 

PlaybackMeterController constructor was running before playback configuration init.
The controller was missing the first value once the configuration init does not emit changed signals.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
