### PR TITLE
Snapping major fixup

### DIFF
--- a/src/projectscene/internal/projectviewstate.cpp
+++ b/src/projectscene/internal/projectviewstate.cpp
@@ -1045,12 +1045,6 @@ void ProjectViewState::updateItemsBoundaries(bool excludeCurrentSelection, const
 
     std::set<muse::secs_t> boundaries;
     const auto& selectedClips = selectionController()->selectedClips();
-    const auto& selectedLabels = selectionController()->selectedLabels();
-
-    if (selectedClips.empty() && selectedLabels.empty()) {
-        setItemsBoundaries({});
-        return;
-    }
 
     for (const auto& trackId : prj->trackIdList()) {
         // Add clips boundaries

--- a/src/projectscene/internal/projectviewstate.cpp
+++ b/src/projectscene/internal/projectviewstate.cpp
@@ -1036,6 +1036,11 @@ std::set<muse::secs_t> ProjectViewState::itemsBoundaries() const
     return m_itemsBoundaries;
 }
 
+void ProjectViewState::setEditedItem(const trackedit::TrackItemKey& key)
+{
+    m_editedItemKey = key;
+}
+
 void ProjectViewState::updateItemsBoundaries(bool excludeCurrentSelection, const trackedit::TrackItemKey& itemKeyToOmit)
 {
     auto prj = globalContext()->currentTrackeditProject();
@@ -1045,6 +1050,18 @@ void ProjectViewState::updateItemsBoundaries(bool excludeCurrentSelection, const
 
     std::set<muse::secs_t> boundaries;
     const auto& selectedClips = selectionController()->selectedClips();
+    const auto& selectedLabels = selectionController()->selectedLabels();
+
+    // An item being dragged must never snap to its own edges. The drag may rebuild the
+    // boundary set mid-flight (e.g. label moves emit trackChanged every frame, which calls
+    // updateItemsBoundaries(false)), so relying on the one-shot itemKeyToOmit argument is not
+    // enough; m_editedItemKey persists the exclusion for the whole edit.
+    const auto isEditedItem = [this, &itemKeyToOmit](const trackedit::TrackItemKey& key) {
+        if (itemKeyToOmit.isValid() && key == itemKeyToOmit) {
+            return true;
+        }
+        return m_editedItemKey.isValid() && key == m_editedItemKey;
+    };
 
     for (const auto& trackId : prj->trackIdList()) {
         // Add clips boundaries
@@ -1053,7 +1070,7 @@ void ProjectViewState::updateItemsBoundaries(bool excludeCurrentSelection, const
                 continue;
             }
 
-            if (itemKeyToOmit.isValid() && clip.key == itemKeyToOmit) {
+            if (isEditedItem(clip.key)) {
                 continue;
             }
 
@@ -1063,6 +1080,14 @@ void ProjectViewState::updateItemsBoundaries(bool excludeCurrentSelection, const
 
         // Add labels boundaries
         for (const auto& label : prj->labelList(trackId)) {
+            if (excludeCurrentSelection && muse::contains(selectedLabels, label.key)) {
+                continue;
+            }
+
+            if (isEditedItem(label.key)) {
+                continue;
+            }
+
             boundaries.insert(label.startTime);
             boundaries.insert(label.endTime);
         }

--- a/src/projectscene/internal/projectviewstate.h
+++ b/src/projectscene/internal/projectviewstate.h
@@ -110,6 +110,8 @@ public:
     void setLastEditedClip(const trackedit::ClipKey& clipKey) override;
     trackedit::ClipKey lastEditedClip() const override;
 
+    void setEditedItem(const trackedit::TrackItemKey& key) override;
+
     void setItemsBoundaries(const std::set<muse::secs_t>& boundaries) override;
     std::set<muse::secs_t> itemsBoundaries() const override;
     void updateItemsBoundaries(bool excludeCurrentSelection,
@@ -174,6 +176,10 @@ private:
     bool m_moveInitiated = false;
 
     trackedit::ClipKey m_lastEditedClip = trackedit::ClipKey{};
+
+    //! Item currently being moved/trimmed/stretched. Always omitted from m_itemsBoundaries
+    //! while valid, so a drag never snaps the item onto its own edges.
+    trackedit::TrackItemKey m_editedItemKey = trackedit::TrackItemKey{};
 
     //! start/end times the currently moved/trimmed/stretched item can snap to
     std::set<muse::secs_t> m_itemsBoundaries;

--- a/src/projectscene/iprojectviewstate.h
+++ b/src/projectscene/iprojectviewstate.h
@@ -90,6 +90,11 @@ public:
     virtual void setLastEditedClip(const trackedit::ClipKey& clipKey) = 0;
     virtual trackedit::ClipKey lastEditedClip() const = 0;
 
+    //! Key of the item currently being moved/trimmed/stretched. While set, it is always
+    //! omitted from itemsBoundaries so a drag never snaps the item to its own edges, even
+    //! when the boundary set is rebuilt mid-drag (e.g. from trackChanged notifications).
+    virtual void setEditedItem(const trackedit::TrackItemKey& key) = 0;
+
     virtual void setItemsBoundaries(const std::set<muse::secs_t>& boundaries) = 0;
     virtual std::set<muse::secs_t> itemsBoundaries() const = 0;
     virtual void updateItemsBoundaries(bool excludeCurrentSelection,

--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TrackClipsContainer.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TrackClipsContainer.qml
@@ -156,7 +156,7 @@ TrackItemsContainer {
                     propagateComposedEvents: true
                     hoverEnabled: true
                     pressAndHoldInterval: 0
-                    enabled: !root.selectionInProgress && (root.isNearSample || root.isBrush)
+                    enabled: !root.selectionInProgress
                     cursorShape: Qt.BlankCursor
 
                     // While a selection edit is in progress the cursor on the track body
@@ -185,8 +185,15 @@ TrackItemsContainer {
 
                     anchors.fill: parent
 
+                    // Only grab mouse buttons in sample/brush editing; otherwise let
+                    // presses fall through to the main area (selection, seek, etc.)
+                    // while still receiving hover moves to drive the snap guideline.
+                    onPressed: function (e) {
+                        e.accepted = root.isNearSample || root.isBrush || root.altPressed
+                    }
+
                     onDoubleClicked: function (e) {
-                        e.accepted = true
+                        e.accepted = root.isNearSample || root.isBrush || root.altPressed
                     }
 
                     onPressAndHold: function (e) {
@@ -226,19 +233,32 @@ TrackItemsContainer {
                     }
 
                     onPositionChanged: function (e) {
-                        clipsContainer.mapToAllClips(e, function (clipItem, mouseEvent) {
-                            clipItem.mousePositionChanged(mouseEvent.x, mouseEvent.y)
-                            clipItem.setLastSample(mouseEvent.x, mouseEvent.y)
-                        })
+                        if (root.isNearSample || root.isBrush) {
+                            clipsContainer.mapToAllClips(e, function (clipItem, mouseEvent) {
+                                clipItem.mousePositionChanged(mouseEvent.x, mouseEvent.y)
+                                clipItem.setLastSample(mouseEvent.x, mouseEvent.y)
+                            })
+                        }
+
+                        // Show the snap guideline while hovering the empty track body
+                        // (the area between/around clips that no ClipItem covers).
+                        let time = root.context.findGuideline(root.context.positionToTime(e.x, true))
+                        root.triggerItemGuideline(time, false)
                     }
 
                     onContainsMouseChanged: function () {
-                        clipsContainer.mapToAllClips({
-                            x: mouseX,
-                            y: mouseY
-                        }, function (clipItem, mouseEvent) {
-                            clipItem.setContainsMouse(containsMouse)
-                        })
+                        if (root.isNearSample || root.isBrush) {
+                            clipsContainer.mapToAllClips({
+                                x: mouseX,
+                                y: mouseY
+                            }, function (clipItem, mouseEvent) {
+                                clipItem.setContainsMouse(containsMouse)
+                            })
+                        }
+
+                        if (!containsMouse) {
+                            root.triggerItemGuideline(0, true)
+                        }
                     }
                 }
 

--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TrackClipsContainer.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TrackClipsContainer.qml
@@ -175,6 +175,25 @@ TrackItemsContainer {
                         }
                     }
 
+                    // True while the pointer is over any guideline-driving part of a clip in
+                    // this track: its body/header (hover) or either trim/stretch edge. The edges
+                    // are separate MouseAreas that drive the guideline but don't set the clip's
+                    // own `hover`, so they must be checked explicitly.
+                    function pointerOverAnyClip() {
+                        return clipsContainer.checkIfAnyClip(function (clipItem) {
+                            return clipItem && (clipItem.hover || clipItem.leftTrimContainsMouse || clipItem.rightTrimContainsMouse)
+                        })
+                    }
+
+                    function clearGuidelineIfPointerLeft() {
+                        // Clear only once the pointer is over neither the body nor any clip
+                        // otherwise a body->clip (or body->edge) hand-off would blink
+                        // the guideline for one frame.
+                        if (!clipsContainerMouseArea.containsMouse && !clipsContainerMouseArea.pointerOverAnyClip()) {
+                            root.clearItemGuideline()
+                        }
+                    }
+
                     Component.onCompleted: updateCustomCursor()
                     Connections {
                         target: root
@@ -257,7 +276,7 @@ TrackItemsContainer {
                         }
 
                         if (!containsMouse) {
-                            root.clearItemGuideline()
+                            Qt.callLater(clipsContainerMouseArea.clearGuidelineIfPointerLeft)
                         }
                     }
                 }

--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TrackClipsContainer.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TrackClipsContainer.qml
@@ -759,14 +759,11 @@ TrackItemsContainer {
 
     function handleClipGuideline(clipKey, direction, completed) {
         // itemMoveRequested is broadcast to every track's container, but the guideline is
-        // shared across all of them. findGuideline returns undefined when this container
-        // doesn't own the dragged clip; such containers must not touch the guideline,
-        // otherwise they clobber the owning track's guideline. A number means we own the
-        // clip: a valid time draws the guideline, -1 hides it once out of snapping range.
-        let time = clipsModel.findGuideline(clipKey, direction)
-        if (typeof time !== "number") {
+        // shared across all of them. Only the container that owns the dragged clip may touch
+        // it, otherwise non-owners clobber the owning track's guideline.
+        if (!clipsModel.containsItem(clipKey)) {
             return
         }
-        triggerItemGuideline(time, completed)
+        triggerItemGuideline(clipsModel.findGuideline(clipKey, direction), completed)
     }
 }

--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TrackClipsContainer.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TrackClipsContainer.qml
@@ -731,7 +731,7 @@ TrackItemsContainer {
 
     function handleClipGuideline(clipKey, direction, completed) {
         let guidelinePos = clipsModel.findGuideline(clipKey, direction)
-        if (guidelinePos) {
+        if (root.context.isGuidelineValid(guidelinePos)) {
             triggerItemGuideline(guidelinePos, completed)
         }
     }

--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TrackClipsContainer.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TrackClipsContainer.qml
@@ -497,6 +497,13 @@ TrackItemsContainer {
 
                                     trackItemMousePositionChanged(xWithinTrack, yWithinTrack, itemData.key)
 
+                                    // While a trim/stretch handle is held the guideline must follow the
+                                    // dragged clip edge (driven by handleClipGuideline), not the mouse
+                                    // position, so don't snap the guideline to the cursor here.
+                                    if (root.leftTrimPressedButtons || root.rightTrimPressedButtons) {
+                                        return
+                                    }
+
                                     let time = root.context.findGuideline(root.context.positionToTime(xWithinTrack, true))
                                     root.triggerItemGuideline(time, false)
                                 }
@@ -751,8 +758,12 @@ TrackItemsContainer {
 
     function handleClipGuideline(clipKey, direction, completed) {
         let guidelinePos = clipsModel.findGuideline(clipKey, direction)
-        if (root.context.isGuidelineValid(guidelinePos)) {
-            triggerItemGuideline(guidelinePos, completed)
+        // Always notify, even when there's no snap: passing an invalid time hides any
+        // guideline that was shown on a previous step, so it doesn't linger once the
+        // dragged edge moves out of snapping range.
+        if (!root.context.isGuidelineValid(guidelinePos)) {
+            guidelinePos = -1
         }
+        triggerItemGuideline(guidelinePos, completed)
     }
 }

--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TrackClipsContainer.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TrackClipsContainer.qml
@@ -257,7 +257,7 @@ TrackItemsContainer {
                         }
 
                         if (!containsMouse) {
-                            root.triggerItemGuideline(0, true)
+                            root.clearItemGuideline()
                         }
                     }
                 }
@@ -456,7 +456,7 @@ TrackItemsContainer {
                                 onClipEndEditRequested: function () {
                                     clipsModel.endEditItem(itemData.key)
 
-                                    root.triggerItemGuideline(false, -1)
+                                    root.clearItemGuideline()
                                 }
 
                                 onClipLeftTrimRequested: function (completed, action) {
@@ -757,13 +757,8 @@ TrackItemsContainer {
     }
 
     function handleClipGuideline(clipKey, direction, completed) {
-        let guidelinePos = clipsModel.findGuideline(clipKey, direction)
-        // Always notify, even when there's no snap: passing an invalid time hides any
-        // guideline that was shown on a previous step, so it doesn't linger once the
-        // dragged edge moves out of snapping range.
-        if (!root.context.isGuidelineValid(guidelinePos)) {
-            guidelinePos = -1
-        }
-        triggerItemGuideline(guidelinePos, completed)
+        // triggerItemGuideline hides the guideline when findGuideline reports no snap,
+        // so it doesn't linger once the dragged edge moves out of snapping range.
+        triggerItemGuideline(clipsModel.findGuideline(clipKey, direction), completed)
     }
 }

--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TrackClipsContainer.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TrackClipsContainer.qml
@@ -783,6 +783,11 @@ TrackItemsContainer {
         if (!clipsModel.containsItem(clipKey)) {
             return
         }
-        triggerItemGuideline(clipsModel.findGuideline(clipKey, direction), completed)
+
+        if (completed) {
+            root.clearItemGuideline()
+            return
+        }
+        triggerItemGuideline(clipsModel.findGuideline(clipKey, direction), false)
     }
 }

--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TrackClipsContainer.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TrackClipsContainer.qml
@@ -497,10 +497,11 @@ TrackItemsContainer {
 
                                     trackItemMousePositionChanged(xWithinTrack, yWithinTrack, itemData.key)
 
-                                    // While a trim/stretch handle is held the guideline must follow the
-                                    // dragged clip edge (driven by handleClipGuideline), not the mouse
-                                    // position, so don't snap the guideline to the cursor here.
-                                    if (root.leftTrimPressedButtons || root.rightTrimPressedButtons) {
+                                    // While a clip is being moved or a trim/stretch handle is held the
+                                    // guideline must follow the dragged clip edge (driven by
+                                    // handleClipGuideline), not the mouse position, so don't snap the
+                                    // guideline to the cursor here.
+                                    if (root.moveActive || root.leftTrimPressedButtons || root.rightTrimPressedButtons) {
                                         return
                                     }
 
@@ -757,8 +758,15 @@ TrackItemsContainer {
     }
 
     function handleClipGuideline(clipKey, direction, completed) {
-        // triggerItemGuideline hides the guideline when findGuideline reports no snap,
-        // so it doesn't linger once the dragged edge moves out of snapping range.
-        triggerItemGuideline(clipsModel.findGuideline(clipKey, direction), completed)
+        // itemMoveRequested is broadcast to every track's container, but the guideline is
+        // shared across all of them. findGuideline returns undefined when this container
+        // doesn't own the dragged clip; such containers must not touch the guideline,
+        // otherwise they clobber the owning track's guideline. A number means we own the
+        // clip: a valid time draws the guideline, -1 hides it once out of snapping range.
+        let time = clipsModel.findGuideline(clipKey, direction)
+        if (typeof time !== "number") {
+            return
+        }
+        triggerItemGuideline(time, completed)
     }
 }

--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TrackClipsContainer.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TrackClipsContainer.qml
@@ -262,7 +262,7 @@ TrackItemsContainer {
                         // Show the snap guideline while hovering the empty track body
                         // (the area between/around clips that no ClipItem covers).
                         let time = root.context.findGuideline(root.context.positionToTime(e.x, true))
-                        root.triggerItemGuideline(time)
+                        root.updateItemGuideline(time)
                     }
 
                     onContainsMouseChanged: function () {
@@ -525,7 +525,7 @@ TrackItemsContainer {
                                     }
 
                                     let time = root.context.findGuideline(root.context.positionToTime(xWithinTrack, true))
-                                    root.triggerItemGuideline(time)
+                                    root.updateItemGuideline(time)
                                 }
 
                                 onRequestSelected: {
@@ -788,6 +788,6 @@ TrackItemsContainer {
             root.clearItemGuideline()
             return
         }
-        triggerItemGuideline(clipsModel.findGuideline(clipKey, direction))
+        updateItemGuideline(clipsModel.findGuideline(clipKey, direction))
     }
 }

--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TrackClipsContainer.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TrackClipsContainer.qml
@@ -262,7 +262,7 @@ TrackItemsContainer {
                         // Show the snap guideline while hovering the empty track body
                         // (the area between/around clips that no ClipItem covers).
                         let time = root.context.findGuideline(root.context.positionToTime(e.x, true))
-                        root.triggerItemGuideline(time, false)
+                        root.triggerItemGuideline(time)
                     }
 
                     onContainsMouseChanged: function () {
@@ -525,7 +525,7 @@ TrackItemsContainer {
                                     }
 
                                     let time = root.context.findGuideline(root.context.positionToTime(xWithinTrack, true))
-                                    root.triggerItemGuideline(time, false)
+                                    root.triggerItemGuideline(time)
                                 }
 
                                 onRequestSelected: {
@@ -788,6 +788,6 @@ TrackItemsContainer {
             root.clearItemGuideline()
             return
         }
-        triggerItemGuideline(clipsModel.findGuideline(clipKey, direction), false)
+        triggerItemGuideline(clipsModel.findGuideline(clipKey, direction))
     }
 }

--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TrackClipsContainer.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TrackClipsContainer.qml
@@ -517,15 +517,14 @@ TrackItemsContainer {
                                     trackItemMousePositionChanged(xWithinTrack, yWithinTrack, itemData.key)
 
                                     // While a clip is being moved or a trim/stretch handle is held the
-                                    // guideline must follow the dragged clip edge (driven by
-                                    // handleClipGuideline), not the mouse position, so don't snap the
-                                    // guideline to the cursor here.
-                                    if (root.moveActive || root.leftTrimPressedButtons || root.rightTrimPressedButtons) {
-                                        return
+                                    // guideline follows the dragged clip edge (driven by handleClipGuideline),
+                                    // not the cursor — so only snap the guideline to the cursor when no such
+                                    // edit is in progress.
+                                    const editInProgress = root.moveActive || root.leftTrimPressedButtons || root.rightTrimPressedButtons
+                                    if (!editInProgress) {
+                                        let time = root.context.findGuideline(root.context.positionToTime(xWithinTrack, true))
+                                        root.updateItemGuideline(time)
                                     }
-
-                                    let time = root.context.findGuideline(root.context.positionToTime(xWithinTrack, true))
-                                    root.updateItemGuideline(time)
                                 }
 
                                 onRequestSelected: {
@@ -780,14 +779,13 @@ TrackItemsContainer {
         // itemMoveRequested is broadcast to every track's container, but the guideline is
         // shared across all of them. Only the container that owns the dragged clip may touch
         // it, otherwise non-owners clobber the owning track's guideline.
-        if (!clipsModel.containsItem(clipKey)) {
-            return
+        if (clipsModel.containsItem(clipKey)) {
+            if (completed) {
+                root.clearItemGuideline()
+            } else {
+                let time = clipsModel.findGuideline(clipKey, direction)
+                updateItemGuideline(time)
+            }
         }
-
-        if (completed) {
-            root.clearItemGuideline()
-            return
-        }
-        updateItemGuideline(clipsModel.findGuideline(clipKey, direction))
     }
 }

--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TrackItemsContainer.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TrackItemsContainer.qml
@@ -69,10 +69,6 @@ Item {
         trackId: root.trackId
     }
 
-    // Mirrors TimelineContext::INVALID_GUIDELINE_TIME (not exposed to QML). Emitting
-    // triggerItemGuideline with this time hides the guideline.
-    readonly property real invalidGuidelineTime: -1
-
     function init() {
         trackViewState.init()
 
@@ -80,7 +76,11 @@ Item {
     }
 
     function clearItemGuideline() {
-        root.triggerItemGuideline(root.invalidGuidelineTime, false)
+        if (!root.context) {
+            return
+        }
+
+        root.triggerItemGuideline(root.context.invalidGuidelineTime, false)
     }
 
     Loader {

--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TrackItemsContainer.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TrackItemsContainer.qml
@@ -56,7 +56,7 @@ Item {
     signal insureVerticallyVisible
 
     signal handleTimeGuideline(real x, bool completed)
-    signal triggerItemGuideline(real time)
+    signal updateItemGuideline(real time)
     signal itemDragEditCanceled
 
     signal initRequired
@@ -80,7 +80,7 @@ Item {
             return
         }
 
-        root.triggerItemGuideline(root.context.invalidGuidelineTime)
+        root.updateItemGuideline(root.context.invalidGuidelineTime)
     }
 
     Loader {

--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TrackItemsContainer.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TrackItemsContainer.qml
@@ -69,10 +69,18 @@ Item {
         trackId: root.trackId
     }
 
+    // Mirrors TimelineContext::INVALID_GUIDELINE_TIME (not exposed to QML). Emitting
+    // triggerItemGuideline with this time hides the guideline.
+    readonly property real invalidGuidelineTime: -1
+
     function init() {
         trackViewState.init()
 
         root.initRequired()
+    }
+
+    function clearItemGuideline() {
+        root.triggerItemGuideline(root.invalidGuidelineTime, false)
     }
 
     Loader {

--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TrackItemsContainer.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TrackItemsContainer.qml
@@ -56,7 +56,7 @@ Item {
     signal insureVerticallyVisible
 
     signal handleTimeGuideline(real x, bool completed)
-    signal triggerItemGuideline(real x, bool completed)
+    signal triggerItemGuideline(real time)
     signal itemDragEditCanceled
 
     signal initRequired
@@ -80,7 +80,7 @@ Item {
             return
         }
 
-        root.triggerItemGuideline(root.context.invalidGuidelineTime, false)
+        root.triggerItemGuideline(root.context.invalidGuidelineTime)
     }
 
     Loader {

--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TrackLabelsContainer.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TrackLabelsContainer.qml
@@ -390,6 +390,11 @@ TrackItemsContainer {
         if (!labelsModel.containsItem(labelKey)) {
             return
         }
-        triggerItemGuideline(labelsModel.findGuideline(labelKey, direction), completed)
+
+        if (completed) {
+            root.clearItemGuideline()
+            return
+        }
+        triggerItemGuideline(labelsModel.findGuideline(labelKey, direction), false)
     }
 }

--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TrackLabelsContainer.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TrackLabelsContainer.qml
@@ -350,6 +350,9 @@ TrackItemsContainer {
             labelsModel.moveSelectedLabels(itemKey, completed)
 
             // Labels neither snap nor show a snapping guideline while being dragged.
+            if (typeof labelsModel.findGuideline(itemKey, Direction.Auto) === "number") {
+                root.clearItemGuideline()
+            }
         }
 
         function onItemStartEditRequested(itemKey) {

--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TrackLabelsContainer.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TrackLabelsContainer.qml
@@ -385,7 +385,7 @@ TrackItemsContainer {
 
     function handleLabelGuideline(labelKey, direction, completed) {
         let guidelinePos = labelsModel.findGuideline(labelKey, direction)
-        if (guidelinePos) {
+        if (root.context.isGuidelineValid(guidelinePos)) {
             triggerItemGuideline(guidelinePos, completed)
         }
     }

--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TrackLabelsContainer.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TrackLabelsContainer.qml
@@ -384,6 +384,15 @@ TrackItemsContainer {
     }
 
     function handleLabelGuideline(labelKey, direction, completed) {
-        triggerItemGuideline(labelsModel.findGuideline(labelKey, direction), completed)
+        // itemMoveRequested is broadcast to every track's container, but the guideline is
+        // shared across all of them. findGuideline returns undefined when this container
+        // doesn't own the dragged item; such containers must not touch the guideline,
+        // otherwise they clobber the owning track's guideline. A number means we own the
+        // item: a valid time draws the guideline, -1 hides it once out of snapping range.
+        let time = labelsModel.findGuideline(labelKey, direction)
+        if (typeof time !== "number") {
+            return
+        }
+        triggerItemGuideline(time, completed)
     }
 }

--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TrackLabelsContainer.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TrackLabelsContainer.qml
@@ -349,10 +349,7 @@ TrackItemsContainer {
 
             labelsModel.moveSelectedLabels(itemKey, completed)
 
-            // Labels neither snap nor show a snapping guideline while being dragged.
-            if (labelsModel.containsItem(itemKey)) {
-                root.clearItemGuideline()
-            }
+            handleLabelGuideline(itemKey, Direction.Auto, completed)
         }
 
         function onItemStartEditRequested(itemKey) {

--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TrackLabelsContainer.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TrackLabelsContainer.qml
@@ -203,15 +203,14 @@ TrackItemsContainer {
 
                                     trackItemMousePositionChanged(xWithinTrack, yWithinTrack, itemData.key)
 
-                                    // While a label is being moved or stretched the guideline must follow the
-                                    // dragged label edge (driven by handleLabelGuideline), not the mouse position,
-                                    // so don't snap the guideline to the cursor here.
-                                    if (root.moveActive || itemData.isEditing) {
-                                        return
+                                    // While a label is being moved or stretched the guideline follows the
+                                    // dragged label edge (driven by handleLabelGuideline), not the cursor —
+                                    // so only snap the guideline to the cursor when no such edit is in progress.
+                                    const editInProgress = root.moveActive || itemData.isEditing
+                                    if (!editInProgress) {
+                                        let time = root.context.findGuideline(root.context.positionToTime(xWithinTrack, true))
+                                        root.updateItemGuideline(time)
                                     }
-
-                                    let time = root.context.findGuideline(root.context.positionToTime(xWithinTrack, true))
-                                    root.updateItemGuideline(time)
                                 }
 
                                 onRequestSelected: {
@@ -394,14 +393,13 @@ TrackItemsContainer {
         // itemMoveRequested is broadcast to every track's container, but the guideline is
         // shared across all of them. Only the container that owns the dragged label may touch
         // it, otherwise non-owners clobber the owning track's guideline.
-        if (!labelsModel.containsItem(labelKey)) {
-            return
+        if (labelsModel.containsItem(labelKey)) {
+            if (completed) {
+                root.clearItemGuideline()
+            } else {
+                let time = labelsModel.findGuideline(labelKey, direction)
+                updateItemGuideline(time)
+            }
         }
-
-        if (completed) {
-            root.clearItemGuideline()
-            return
-        }
-        updateItemGuideline(labelsModel.findGuideline(labelKey, direction))
     }
 }

--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TrackLabelsContainer.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TrackLabelsContainer.qml
@@ -349,7 +349,7 @@ TrackItemsContainer {
 
             labelsModel.moveSelectedLabels(itemKey, completed)
 
-            handleLabelGuideline(itemKey, Direction.Auto, completed)
+            // Labels neither snap nor show a snapping guideline while being dragged.
         }
 
         function onItemStartEditRequested(itemKey) {

--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TrackLabelsContainer.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TrackLabelsContainer.qml
@@ -350,7 +350,7 @@ TrackItemsContainer {
             labelsModel.moveSelectedLabels(itemKey, completed)
 
             // Labels neither snap nor show a snapping guideline while being dragged.
-            if (typeof labelsModel.findGuideline(itemKey, Direction.Auto) === "number") {
+            if (labelsModel.containsItem(itemKey)) {
                 root.clearItemGuideline()
             }
         }
@@ -388,14 +388,11 @@ TrackItemsContainer {
 
     function handleLabelGuideline(labelKey, direction, completed) {
         // itemMoveRequested is broadcast to every track's container, but the guideline is
-        // shared across all of them. findGuideline returns undefined when this container
-        // doesn't own the dragged item; such containers must not touch the guideline,
-        // otherwise they clobber the owning track's guideline. A number means we own the
-        // item: a valid time draws the guideline, -1 hides it once out of snapping range.
-        let time = labelsModel.findGuideline(labelKey, direction)
-        if (typeof time !== "number") {
+        // shared across all of them. Only the container that owns the dragged label may touch
+        // it, otherwise non-owners clobber the owning track's guideline.
+        if (!labelsModel.containsItem(labelKey)) {
             return
         }
-        triggerItemGuideline(time, completed)
+        triggerItemGuideline(labelsModel.findGuideline(labelKey, direction), completed)
     }
 }

--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TrackLabelsContainer.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TrackLabelsContainer.qml
@@ -203,6 +203,13 @@ TrackItemsContainer {
 
                                     trackItemMousePositionChanged(xWithinTrack, yWithinTrack, itemData.key)
 
+                                    // While a label is being moved or stretched the guideline must follow the
+                                    // dragged label edge (driven by handleLabelGuideline), not the mouse position,
+                                    // so don't snap the guideline to the cursor here.
+                                    if (root.moveActive || itemData.isEditing) {
+                                        return
+                                    }
+
                                     let time = root.context.findGuideline(root.context.positionToTime(xWithinTrack, true))
                                     root.triggerItemGuideline(time, false)
                                 }

--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TrackLabelsContainer.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TrackLabelsContainer.qml
@@ -211,7 +211,7 @@ TrackItemsContainer {
                                     }
 
                                     let time = root.context.findGuideline(root.context.positionToTime(xWithinTrack, true))
-                                    root.triggerItemGuideline(time)
+                                    root.updateItemGuideline(time)
                                 }
 
                                 onRequestSelected: {
@@ -402,6 +402,6 @@ TrackItemsContainer {
             root.clearItemGuideline()
             return
         }
-        triggerItemGuideline(labelsModel.findGuideline(labelKey, direction))
+        updateItemGuideline(labelsModel.findGuideline(labelKey, direction))
     }
 }

--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TrackLabelsContainer.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TrackLabelsContainer.qml
@@ -384,9 +384,6 @@ TrackItemsContainer {
     }
 
     function handleLabelGuideline(labelKey, direction, completed) {
-        let guidelinePos = labelsModel.findGuideline(labelKey, direction)
-        if (root.context.isGuidelineValid(guidelinePos)) {
-            triggerItemGuideline(guidelinePos, completed)
-        }
+        triggerItemGuideline(labelsModel.findGuideline(labelKey, direction), completed)
     }
 }

--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TrackLabelsContainer.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TrackLabelsContainer.qml
@@ -211,7 +211,7 @@ TrackItemsContainer {
                                     }
 
                                     let time = root.context.findGuideline(root.context.positionToTime(xWithinTrack, true))
-                                    root.triggerItemGuideline(time, false)
+                                    root.triggerItemGuideline(time)
                                 }
 
                                 onRequestSelected: {
@@ -402,6 +402,6 @@ TrackItemsContainer {
             root.clearItemGuideline()
             return
         }
-        triggerItemGuideline(labelsModel.findGuideline(labelKey, direction), false)
+        triggerItemGuideline(labelsModel.findGuideline(labelKey, direction))
     }
 }

--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TracksItemsView.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TracksItemsView.qml
@@ -1028,7 +1028,7 @@ Rectangle {
                                 })
                             }
 
-                            onTriggerItemGuideline: function (time) {
+                            onUpdateItemGuideline: function (time) {
                                 root.setGuidelineAtTime(time)
                             }
 
@@ -1155,7 +1155,7 @@ Rectangle {
                                 tracksItemsView.moveActive = !completed
                             }
 
-                            onTriggerItemGuideline: function (time) {
+                            onUpdateItemGuideline: function (time) {
                                 root.setGuidelineAtTime(time)
                             }
 
@@ -1301,11 +1301,15 @@ Rectangle {
     }
 
     function setGuidelineAtTime(time) {
-        if (!timeline.context.isGuidelineValid(time)) {
-            root.hideGuideline()
-            return
-        }
+        root.setGuidelinePosition(time)
+        root.updateGuidelineVisibility()
+    }
+
+    function setGuidelinePosition(time) {
         root.guidelinePos = timeline.context.timeToPosition(time)
+    }
+
+    function updateGuidelineVisibility() {
         root.guidelineVisible = root.guidelinePos >= 0
     }
 

--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TracksItemsView.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TracksItemsView.qml
@@ -560,7 +560,7 @@ Rectangle {
                             selectionViewController.resetSelectedItems()
                             itemsSelection.visible = true
                         }
-                        handleGuideline(e.x, false)
+                        snapGuidelineToPosition(e.x)
 
                         splitToolController.mouseDown(e.x)
                         lastItemClickKey = null
@@ -596,7 +596,7 @@ Rectangle {
                     selectionViewController.onPositionChanged(e.x, e.y)
                     let trackId = tracksViewState.trackAtPosition(e.x, e.y)
 
-                    handleGuideline(e.x, false)
+                    snapGuidelineToPosition(e.x)
                 }
             }
 
@@ -627,7 +627,7 @@ Rectangle {
                         selectionViewController.onReleased(e.x, e.y)
                         itemsSelection.visible = false
                     }
-                    handleGuideline(e.x, true)
+                    hideGuideline()
                     if (e.modifiers & (Qt.ControlModifier | Qt.ShiftModifier)) {
                         playCursorController.seekToX(timeline.context.selectionStartPosition)
                     }
@@ -689,12 +689,12 @@ Rectangle {
                 }
 
                 timeline.updateCursorPosition(pos.x, pos.y)
-                root.handleGuideline(pos.x, false)
+                root.snapGuidelineToPosition(pos.x)
             }
 
             onHoveredChanged: {
                 if (!hovered) {
-                    root.invalidateGuideline()
+                    root.hideGuideline()
                 }
             }
         }
@@ -1029,11 +1029,11 @@ Rectangle {
                             }
 
                             onTriggerItemGuideline: function (time, completed) {
-                                root.applyItemGuideline(time, completed)
+                                root.setGuidelineAtTime(time, completed)
                             }
 
                             onHandleTimeGuideline: function (x) {
-                                root.handleGuideline(x)
+                                root.snapGuidelineToPosition(x)
                             }
 
                             Connections {
@@ -1156,11 +1156,11 @@ Rectangle {
                             }
 
                             onTriggerItemGuideline: function (time, completed) {
-                                root.applyItemGuideline(time, completed)
+                                root.setGuidelineAtTime(time, completed)
                             }
 
                             onHandleTimeGuideline: function (x) {
-                                root.handleGuideline(x)
+                                root.snapGuidelineToPosition(x)
                             }
 
                             onInsureVerticallyVisible: function () {
@@ -1295,25 +1295,21 @@ Rectangle {
         }
     }
 
-    function handleGuideline(x, completed) {
-        if (completed) {
-            root.invalidateGuideline()
-            return
-        }
+    function snapGuidelineToPosition(x) {
         let time = timeline.context.applyDetectedSnap(timeline.context.positionToTime(x))
-        root.applyItemGuideline(timeline.context.findGuideline(time), false)
+        root.setGuidelineAtTime(timeline.context.findGuideline(time), false)
     }
 
-    function applyItemGuideline(time, completed) {
+    function setGuidelineAtTime(time, completed) {
         if (completed || !timeline.context.isGuidelineValid(time)) {
-            root.invalidateGuideline()
+            root.hideGuideline()
             return
         }
         root.guidelinePos = timeline.context.timeToPosition(time)
         root.guidelineVisible = root.guidelinePos >= 0
     }
 
-    function invalidateGuideline() {
+    function hideGuideline() {
         root.guidelineVisible = false
     }
 }

--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TracksItemsView.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TracksItemsView.qml
@@ -80,6 +80,14 @@ Rectangle {
                 tracksClipsView.cancelClipDragEditRequested(root.hoveredClipKey)
             }
         }
+
+        function setGuidelinePosition(time) {
+            root.guidelinePos = timeline.context.timeToPosition(time)
+        }
+
+        function updateGuidelineVisibility() {
+            root.guidelineVisible = root.guidelinePos >= 0
+        }
     }
 
     PlaybackStateModel {
@@ -1029,7 +1037,7 @@ Rectangle {
                             }
 
                             onUpdateItemGuideline: function (time) {
-                                root.setGuidelineAtTime(time)
+                                root.updateGuidelineAtTime(time)
                             }
 
                             onHandleTimeGuideline: function (x) {
@@ -1156,7 +1164,7 @@ Rectangle {
                             }
 
                             onUpdateItemGuideline: function (time) {
-                                root.setGuidelineAtTime(time)
+                                root.updateGuidelineAtTime(time)
                             }
 
                             onHandleTimeGuideline: function (x) {
@@ -1297,20 +1305,12 @@ Rectangle {
 
     function snapGuidelineToPosition(x) {
         let time = timeline.context.applyDetectedSnap(timeline.context.positionToTime(x))
-        root.setGuidelineAtTime(timeline.context.findGuideline(time))
+        root.updateGuidelineAtTime(timeline.context.findGuideline(time))
     }
 
-    function setGuidelineAtTime(time) {
-        root.setGuidelinePosition(time)
-        root.updateGuidelineVisibility()
-    }
-
-    function setGuidelinePosition(time) {
-        root.guidelinePos = timeline.context.timeToPosition(time)
-    }
-
-    function updateGuidelineVisibility() {
-        root.guidelineVisible = root.guidelinePos >= 0
+    function updateGuidelineAtTime(time) {
+        prv.setGuidelinePosition(time)
+        prv.updateGuidelineVisibility()
     }
 
     function hideGuideline() {

--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TracksItemsView.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TracksItemsView.qml
@@ -1028,8 +1028,8 @@ Rectangle {
                                 })
                             }
 
-                            onTriggerItemGuideline: function (time, completed) {
-                                root.setGuidelineAtTime(time, completed)
+                            onTriggerItemGuideline: function (time) {
+                                root.setGuidelineAtTime(time)
                             }
 
                             onHandleTimeGuideline: function (x) {
@@ -1155,8 +1155,8 @@ Rectangle {
                                 tracksItemsView.moveActive = !completed
                             }
 
-                            onTriggerItemGuideline: function (time, completed) {
-                                root.setGuidelineAtTime(time, completed)
+                            onTriggerItemGuideline: function (time) {
+                                root.setGuidelineAtTime(time)
                             }
 
                             onHandleTimeGuideline: function (x) {
@@ -1297,11 +1297,11 @@ Rectangle {
 
     function snapGuidelineToPosition(x) {
         let time = timeline.context.applyDetectedSnap(timeline.context.positionToTime(x))
-        root.setGuidelineAtTime(timeline.context.findGuideline(time), false)
+        root.setGuidelineAtTime(timeline.context.findGuideline(time))
     }
 
-    function setGuidelineAtTime(time, completed) {
-        if (completed || !timeline.context.isGuidelineValid(time)) {
+    function setGuidelineAtTime(time) {
+        if (!timeline.context.isGuidelineValid(time)) {
             root.hideGuideline()
             return
         }

--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TracksItemsView.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TracksItemsView.qml
@@ -671,6 +671,34 @@ Rectangle {
             }
         }
 
+        // Drives the snap guideline while hovering empty project space below the last track.
+        HoverHandler {
+            id: emptyAreaGuidelineHandler
+
+            enabled: root.interactionState !== TracksItemsView.State.DraggingItem
+
+            onPointChanged: {
+                if (!hovered) {
+                    return
+                }
+
+                let pos = point.position
+                if (tracksViewState.trackAtPosition(pos.x, pos.y) !== -1) {
+                    // Over a track: let the track container own the guideline.
+                    return
+                }
+
+                timeline.updateCursorPosition(pos.x, pos.y)
+                root.handleGuideline(pos.x, false)
+            }
+
+            onHoveredChanged: {
+                if (!hovered) {
+                    root.invalidateGuideline()
+                }
+            }
+        }
+
         StyledViewScrollAndZoomArea {
             id: tracksItemsViewArea
 

--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TracksItemsView.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TracksItemsView.qml
@@ -1274,7 +1274,7 @@ Rectangle {
         time = timeline.context.applyDetectedSnap(time)
         let guidelineTimePos = timeline.context.findGuideline(time)
 
-        if (guidelineTimePos !== -1) {
+        if (timeline.context.isGuidelineValid(guidelineTimePos)) {
             root.guidelinePos = timeline.context.timeToPosition(guidelineTimePos)
 
             root.guidelineVisible = root.guidelinePos >= 0 ? !completed : false

--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TracksItemsView.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TracksItemsView.qml
@@ -1295,6 +1295,11 @@ Rectangle {
         }
     }
 
+    function handleGuideline(x, completed) {
+        let time = timeline.context.applyDetectedSnap(timeline.context.positionToTime(x))
+        root.applyItemGuideline(timeline.context.findGuideline(time), completed)
+    }
+
     function applyItemGuideline(time, completed) {
         if (!timeline.context.isGuidelineValid(time)) {
             root.invalidateGuideline()
@@ -1302,20 +1307,6 @@ Rectangle {
         }
         root.guidelinePos = timeline.context.timeToPosition(time)
         root.guidelineVisible = root.guidelinePos >= 0 && !completed
-    }
-
-    function handleGuideline(x, completed) {
-        let time = timeline.context.positionToTime(x)
-        time = timeline.context.applyDetectedSnap(time)
-        let guidelineTimePos = timeline.context.findGuideline(time)
-
-        if (timeline.context.isGuidelineValid(guidelineTimePos)) {
-            root.guidelinePos = timeline.context.timeToPosition(guidelineTimePos)
-
-            root.guidelineVisible = root.guidelinePos >= 0 ? !completed : false
-        } else {
-            root.invalidateGuideline()
-        }
     }
 
     function invalidateGuideline() {

--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TracksItemsView.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TracksItemsView.qml
@@ -1029,12 +1029,7 @@ Rectangle {
                             }
 
                             onTriggerItemGuideline: function (time, completed) {
-                                if (!timeline.context.isGuidelineValid(time)) {
-                                    root.invalidateGuideline()
-                                    return
-                                }
-                                root.guidelinePos = timeline.context.timeToPosition(time)
-                                root.guidelineVisible = root.guidelinePos >= 0 && !completed
+                                root.applyItemGuideline(time, completed)
                             }
 
                             onHandleTimeGuideline: function (x) {
@@ -1161,12 +1156,7 @@ Rectangle {
                             }
 
                             onTriggerItemGuideline: function (time, completed) {
-                                if (!timeline.context.isGuidelineValid(time)) {
-                                    root.invalidateGuideline()
-                                    return
-                                }
-                                root.guidelinePos = timeline.context.timeToPosition(time)
-                                root.guidelineVisible = root.guidelinePos >= 0 && !completed
+                                root.applyItemGuideline(time, completed)
                             }
 
                             onHandleTimeGuideline: function (x) {
@@ -1303,6 +1293,15 @@ Rectangle {
             root.guidelinePos = pos
             root.guidelineVisible = visibility
         }
+    }
+
+    function applyItemGuideline(time, completed) {
+        if (!timeline.context.isGuidelineValid(time)) {
+            root.invalidateGuideline()
+            return
+        }
+        root.guidelinePos = timeline.context.timeToPosition(time)
+        root.guidelineVisible = root.guidelinePos >= 0 && !completed
     }
 
     function handleGuideline(x, completed) {

--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TracksItemsView.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TracksItemsView.qml
@@ -1296,17 +1296,21 @@ Rectangle {
     }
 
     function handleGuideline(x, completed) {
+        if (completed) {
+            root.invalidateGuideline()
+            return
+        }
         let time = timeline.context.applyDetectedSnap(timeline.context.positionToTime(x))
-        root.applyItemGuideline(timeline.context.findGuideline(time), completed)
+        root.applyItemGuideline(timeline.context.findGuideline(time), false)
     }
 
     function applyItemGuideline(time, completed) {
-        if (!timeline.context.isGuidelineValid(time)) {
+        if (completed || !timeline.context.isGuidelineValid(time)) {
             root.invalidateGuideline()
             return
         }
         root.guidelinePos = timeline.context.timeToPosition(time)
-        root.guidelineVisible = root.guidelinePos >= 0 && !completed
+        root.guidelineVisible = root.guidelinePos >= 0
     }
 
     function invalidateGuideline() {

--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TracksItemsView.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TracksItemsView.qml
@@ -1001,6 +1001,10 @@ Rectangle {
                             }
 
                             onTriggerItemGuideline: function (time, completed) {
+                                if (!timeline.context.isGuidelineValid(time)) {
+                                    root.invalidateGuideline()
+                                    return
+                                }
                                 root.guidelinePos = timeline.context.timeToPosition(time)
                                 root.guidelineVisible = root.guidelinePos >= 0 && !completed
                             }
@@ -1129,6 +1133,10 @@ Rectangle {
                             }
 
                             onTriggerItemGuideline: function (time, completed) {
+                                if (!timeline.context.isGuidelineValid(time)) {
+                                    root.invalidateGuideline()
+                                    return
+                                }
                                 root.guidelinePos = timeline.context.timeToPosition(time)
                                 root.guidelineVisible = root.guidelinePos >= 0 && !completed
                             }
@@ -1279,7 +1287,11 @@ Rectangle {
 
             root.guidelineVisible = root.guidelinePos >= 0 ? !completed : false
         } else {
-            root.guidelineVisible = false
+            root.invalidateGuideline()
         }
+    }
+
+    function invalidateGuideline() {
+        root.guidelineVisible = false
     }
 }

--- a/src/projectscene/tests/CMakeLists.txt
+++ b/src/projectscene/tests/CMakeLists.txt
@@ -11,10 +11,14 @@ set(MODULE_TEST_SRC
     ${CMAKE_CURRENT_LIST_DIR}/snaptimeformatter_tests.cpp
     ${CMAKE_CURRENT_LIST_DIR}/tracklabelslayoutmanager_tests.cpp
     ${CMAKE_CURRENT_LIST_DIR}/trackitemsselection_tests.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/findguideline_tests.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/playcursorcontroller_tests.cpp
 
+    ${CMAKE_CURRENT_LIST_DIR}/snaptestaccess.h
     ${CMAKE_CURRENT_LIST_DIR}/mocks/globalcontextmock.h
     ${CMAKE_CURRENT_LIST_DIR}/mocks/audacity4projectmock.h
     ${CMAKE_CURRENT_LIST_DIR}/mocks/projectsceneconfigurationmock.h
+    ${CMAKE_CURRENT_LIST_DIR}/mocks/audiooutputmock.h
 )
 
 set(MODULE_TEST_LINK

--- a/src/projectscene/tests/findguideline_tests.cpp
+++ b/src/projectscene/tests/findguideline_tests.cpp
@@ -1,0 +1,268 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include <set>
+
+#include "projectscene/view/timeline/timelinecontext.h"
+#include "projectscene/view/tracksitemsview/trackclipslistmodel.h"
+#include "projectscene/view/tracksitemsview/viewtrackitem.h"
+#include "projectscene/internal/projectviewstate.h"
+
+#include "snaptestaccess.h"
+
+#include "context/tests/mocks/globalcontextmock.h"
+#include "project/tests/mocks/audacityprojectmock.h"
+#include "mocks/audiooutputmock.h"
+#include "playback/tests/mocks/playbackmock.h"
+#include "trackedit/tests/mocks/trackeditprojectmock.h"
+
+using namespace ::testing;
+
+namespace au::projectscene {
+//! Wires a real (uninitialised) TimelineContext to mocks so the snap/guideline
+//! helpers can be exercised in isolation. With the default zoom (1.0) and
+//! frame start (0.0), position and time are 1:1.
+class SnapTestBase : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        m_globalContext = std::make_shared<NiceMock<context::GlobalContextMock> >();
+        m_project = std::make_shared<NiceMock<project::AudacityProjectMock> >();
+        m_trackeditProject = std::make_shared<NiceMock<trackedit::TrackeditProjectMock> >();
+        m_viewState = std::make_shared<ProjectViewState>(muse::modularity::globalCtx());
+        m_playback = std::make_shared<NiceMock<playback::PlaybackMock> >();
+        m_audioOutput = std::make_shared<NiceMock<playback::AudioOutputMock> >();
+
+        ON_CALL(*m_globalContext, currentProject())
+        .WillByDefault(Return(m_project));
+        ON_CALL(*m_globalContext, currentTrackeditProject())
+        .WillByDefault(Return(m_trackeditProject));
+        ON_CALL(*m_project, viewState())
+        .WillByDefault(Return(m_viewState));
+        ON_CALL(*m_playback, audioOutput())
+        .WillByDefault(Return(m_audioOutput));
+        ON_CALL(*m_audioOutput, sampleRate())
+        .WillByDefault(Return(static_cast<uint64_t>(44100)));
+        ON_CALL(*m_trackeditProject, timeSignature())
+        .WillByDefault(Return(trackedit::TimeSignature { 120.0, 4, 4 }));
+
+        m_context = new TimelineContext();
+        SnapTestAccess::wireContext(m_context, m_globalContext, m_playback);
+    }
+
+    void TearDown() override
+    {
+        delete m_context;
+    }
+
+    void useGridSnapOff(const std::set<muse::secs_t>& boundaries)
+    {
+        m_viewState->setIsSnapEnabled(false);
+        m_viewState->setItemsBoundaries(boundaries);
+    }
+
+    void useGridSnapOn(SnapType type)
+    {
+        m_viewState->setIsSnapEnabled(true);
+        m_viewState->setSnapType(type);
+    }
+
+    std::shared_ptr<NiceMock<context::GlobalContextMock> > m_globalContext;
+    std::shared_ptr<NiceMock<project::AudacityProjectMock> > m_project;
+    std::shared_ptr<NiceMock<trackedit::TrackeditProjectMock> > m_trackeditProject;
+    std::shared_ptr<ProjectViewState> m_viewState;
+    std::shared_ptr<NiceMock<playback::PlaybackMock> > m_playback;
+    std::shared_ptr<NiceMock<playback::AudioOutputMock> > m_audioOutput;
+
+    TimelineContext* m_context = nullptr;
+};
+
+// =====================================================================
+// TimelineContext::findGuideline / isGuidelineValid
+// =====================================================================
+
+class TimelineContextFindGuidelineTests : public SnapTestBase
+{
+};
+
+TEST_F(TimelineContextFindGuidelineTests, GridSnapOff_ExactBoundary_ReturnsBoundary)
+{
+    //! CASE With grid snap off, a time sitting exactly on an item boundary
+    //! resolves to that boundary.
+    useGridSnapOff({ 5.0, 10.0 });
+
+    const double guideline = m_context->findGuideline(5.0);
+
+    EXPECT_TRUE(m_context->isGuidelineValid(guideline));
+    EXPECT_DOUBLE_EQ(guideline, 5.0);
+}
+
+TEST_F(TimelineContextFindGuidelineTests, GridSnapOff_WithinOneSampleOfBoundary_SnapsToBoundary)
+{
+    //! CASE The regression: a clip edge quantised to a sample lands a fraction
+    //! of a sample away from a (non-sample-aligned) label boundary. It must
+    //! still resolve to the boundary so the guideline draws on the edge.
+    useGridSnapOff({ 10.0 });
+
+    const double almostBoundary = 10.0 + (0.5 / 44100.0); // half a sample away
+
+    const double guideline = m_context->findGuideline(almostBoundary);
+
+    EXPECT_TRUE(m_context->isGuidelineValid(guideline));
+    EXPECT_DOUBLE_EQ(guideline, 10.0);
+}
+
+TEST_F(TimelineContextFindGuidelineTests, GridSnapOff_FarFromBoundary_ReturnsInvalid)
+{
+    //! CASE A time more than a sample away from every boundary yields no guideline.
+    useGridSnapOff({ 5.0, 10.0 });
+
+    const double guideline = m_context->findGuideline(7.0);
+
+    EXPECT_FALSE(m_context->isGuidelineValid(guideline));
+    EXPECT_DOUBLE_EQ(guideline, TimelineContext::INVALID_GUIDELINE_TIME);
+}
+
+TEST_F(TimelineContextFindGuidelineTests, GridSnapOff_NoBoundaries_ReturnsInvalid)
+{
+    //! CASE No boundaries at all means nothing to snap to.
+    useGridSnapOff({});
+
+    EXPECT_FALSE(m_context->isGuidelineValid(m_context->findGuideline(3.0)));
+}
+
+TEST_F(TimelineContextFindGuidelineTests, GridSnapOn_OnGrid_ReturnsTime)
+{
+    //! CASE With grid snap on, a time already on the grid resolves to itself.
+    useGridSnapOn(SnapType::Seconds);
+
+    const double guideline = m_context->findGuideline(3.0);
+
+    EXPECT_TRUE(m_context->isGuidelineValid(guideline));
+    EXPECT_DOUBLE_EQ(guideline, 3.0);
+}
+
+TEST_F(TimelineContextFindGuidelineTests, GridSnapOn_OffGrid_ReturnsInvalid)
+{
+    //! CASE With grid snap on, a time away from any grid line yields no guideline.
+    useGridSnapOn(SnapType::Seconds);
+
+    EXPECT_FALSE(m_context->isGuidelineValid(m_context->findGuideline(3.4)));
+}
+
+TEST_F(TimelineContextFindGuidelineTests, IsGuidelineValid_DistinguishesSentinel)
+{
+    EXPECT_TRUE(m_context->isGuidelineValid(0.0));
+    EXPECT_TRUE(m_context->isGuidelineValid(12.5));
+    EXPECT_FALSE(m_context->isGuidelineValid(TimelineContext::INVALID_GUIDELINE_TIME));
+}
+
+// =====================================================================
+// TrackItemsListModel::findGuideline / containsItem
+// =====================================================================
+
+namespace {
+//! Minimal ViewTrackItem whose key and time can be set directly, avoiding the
+//! configuration() dependency of the concrete clip/label items.
+class TestTrackItem : public ViewTrackItem
+{
+public:
+    TestTrackItem(const trackedit::TrackItemKey& key, double start, double end, QObject* parent)
+        : ViewTrackItem(parent)
+    {
+        m_key = TrackItemKey(key);
+        TrackItemTime t;
+        t.startTime = start;
+        t.endTime = end;
+        m_time = t;
+    }
+};
+}
+
+class TrackItemsFindGuidelineTests : public SnapTestBase
+{
+protected:
+    void SetUp() override
+    {
+        SnapTestBase::SetUp();
+        m_model = new TrackClipsListModel();
+        m_model->m_context = m_context;
+    }
+
+    void TearDown() override
+    {
+        delete m_model;
+        SnapTestBase::TearDown();
+    }
+
+    void addItem(const trackedit::TrackItemKey& key, double start, double end)
+    {
+        m_model->m_items.append(new TestTrackItem(key, start, end, m_model));
+    }
+
+    TrackClipsListModel* m_model = nullptr;
+};
+
+TEST_F(TrackItemsFindGuidelineTests, ContainsItem_ReflectsMembership)
+{
+    addItem({ 1, 100 }, 5.0, 20.0);
+
+    EXPECT_TRUE(m_model->containsItem(TrackItemKey({ 1, 100 })));
+    EXPECT_FALSE(m_model->containsItem(TrackItemKey({ 1, 999 })));
+}
+
+TEST_F(TrackItemsFindGuidelineTests, FindGuideline_UnknownKey_ReturnsInvalid)
+{
+    useGridSnapOff({ 5.0 });
+    // no items added
+
+    const double guideline = m_model->findGuideline(TrackItemKey({ 1, 100 }), DirectionType::Direction::Auto);
+
+    EXPECT_FALSE(m_context->isGuidelineValid(guideline));
+    EXPECT_DOUBLE_EQ(guideline, TimelineContext::INVALID_GUIDELINE_TIME);
+}
+
+TEST_F(TrackItemsFindGuidelineTests, FindGuideline_Left_UsesStartEdgeOnly)
+{
+    //! CASE Left direction probes the item's start edge and ignores its end edge.
+    addItem({ 1, 100 }, 5.0, 20.0);
+    useGridSnapOff({ 5.0, 20.0 });
+
+    EXPECT_DOUBLE_EQ(m_model->findGuideline(TrackItemKey({ 1, 100 }), DirectionType::Direction::Left), 5.0);
+
+    // Start no longer on a boundary -> Left finds nothing even though the end still is.
+    useGridSnapOff({ 20.0 });
+    EXPECT_FALSE(m_context->isGuidelineValid(
+                     m_model->findGuideline(TrackItemKey({ 1, 100 }), DirectionType::Direction::Left)));
+}
+
+TEST_F(TrackItemsFindGuidelineTests, FindGuideline_Right_UsesEndEdgeOnly)
+{
+    //! CASE Right direction probes the item's end edge and ignores its start edge.
+    addItem({ 1, 100 }, 5.0, 20.0);
+    useGridSnapOff({ 5.0, 20.0 });
+
+    EXPECT_DOUBLE_EQ(m_model->findGuideline(TrackItemKey({ 1, 100 }), DirectionType::Direction::Right), 20.0);
+
+    // End no longer on a boundary -> Right finds nothing even though the start still is.
+    useGridSnapOff({ 5.0 });
+    EXPECT_FALSE(m_context->isGuidelineValid(
+                     m_model->findGuideline(TrackItemKey({ 1, 100 }), DirectionType::Direction::Right)));
+}
+
+TEST_F(TrackItemsFindGuidelineTests, FindGuideline_Auto_PrefersStartThenEnd)
+{
+    //! CASE Auto probes the start edge first, then falls back to the end edge.
+    addItem({ 1, 100 }, 5.0, 20.0);
+
+    useGridSnapOff({ 5.0, 20.0 });
+    EXPECT_DOUBLE_EQ(m_model->findGuideline(TrackItemKey({ 1, 100 }), DirectionType::Direction::Auto), 5.0);
+
+    useGridSnapOff({ 20.0 });
+    EXPECT_DOUBLE_EQ(m_model->findGuideline(TrackItemKey({ 1, 100 }), DirectionType::Direction::Auto), 20.0);
+}
+}

--- a/src/projectscene/tests/mocks/audiooutputmock.h
+++ b/src/projectscene/tests/mocks/audiooutputmock.h
@@ -1,0 +1,25 @@
+/*
+* Audacity: A Digital Audio Editor
+*/
+#pragma once
+
+#include <gmock/gmock.h>
+
+#include "playback/iaudiooutput.h"
+
+namespace au::playback {
+class AudioOutputMock : public IAudioOutput
+{
+public:
+    MOCK_METHOD(float, playbackVolume, (), (const, override));
+    MOCK_METHOD(void, setPlaybackVolume, (float), (override));
+    MOCK_METHOD(muse::async::Channel<float>, playbackVolumeChanged, (), (const, override));
+
+    MOCK_METHOD(audio::sample_rate_t, sampleRate, (), (const, override));
+    MOCK_METHOD(muse::async::Channel<audio::sample_rate_t>, sampleRateChanged, (), (const, override));
+
+    MOCK_METHOD((muse::async::Channel<audio::audioch_t, audio::MeterSignal>), playbackSignalChanges, (), (const, override));
+    MOCK_METHOD((muse::async::Channel<audio::audioch_t, audio::MeterSignal>), playbackTrackSignalChanges, (int64_t),
+                (const, override));
+};
+}

--- a/src/projectscene/tests/playcursorcontroller_tests.cpp
+++ b/src/projectscene/tests/playcursorcontroller_tests.cpp
@@ -1,0 +1,189 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include <set>
+
+#include "projectscene/view/playcursor/playcursorcontroller.h"
+#include "projectscene/view/timeline/timelinecontext.h"
+#include "projectscene/internal/projectviewstate.h"
+
+#include "snaptestaccess.h"
+
+#include "context/tests/mocks/globalcontextmock.h"
+#include "project/tests/mocks/audacityprojectmock.h"
+#include "mocks/audiooutputmock.h"
+#include "playback/tests/mocks/playbackmock.h"
+#include "context/tests/mocks/playbackstatemock.h"
+#include "trackedit/tests/mocks/trackeditprojectmock.h"
+#include "actions/tests/mocks/actionsdispatchermock.h"
+
+using namespace ::testing;
+
+namespace au::projectscene {
+//! Exercises PlayCursorController's seek/play-region dispatch, focusing on the
+//! play-cursor snapping: the controller must ask the
+//! TimelineContext to snap (withSnap = true) before dispatching.
+//! Default zoom (1.0) / frame start (0.0) make position and time 1:1.
+class PlayCursorControllerTests : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        m_globalContext = std::make_shared<NiceMock<context::GlobalContextMock> >();
+        m_project = std::make_shared<NiceMock<project::AudacityProjectMock> >();
+        m_trackeditProject = std::make_shared<NiceMock<trackedit::TrackeditProjectMock> >();
+        m_viewState = std::make_shared<ProjectViewState>(muse::modularity::globalCtx());
+        m_playback = std::make_shared<NiceMock<playback::PlaybackMock> >();
+        m_audioOutput = std::make_shared<NiceMock<playback::AudioOutputMock> >();
+        m_playbackState = std::make_shared<NiceMock<context::PlaybackStateMock> >();
+        m_dispatcher = std::make_shared<NiceMock<muse::actions::ActionsDispatcherMock> >();
+
+        ON_CALL(*m_globalContext, currentProject())
+        .WillByDefault(Return(m_project));
+        ON_CALL(*m_globalContext, currentTrackeditProject())
+        .WillByDefault(Return(m_trackeditProject));
+        ON_CALL(*m_globalContext, playbackState())
+        .WillByDefault(Return(m_playbackState));
+        ON_CALL(*m_project, viewState())
+        .WillByDefault(Return(m_viewState));
+        ON_CALL(*m_playback, audioOutput())
+        .WillByDefault(Return(m_audioOutput));
+        ON_CALL(*m_audioOutput, sampleRate())
+        .WillByDefault(Return(static_cast<uint64_t>(44100)));
+        ON_CALL(*m_trackeditProject, timeSignature())
+        .WillByDefault(Return(trackedit::TimeSignature { 120.0, 4, 4 }));
+        ON_CALL(*m_playbackState, isPlaying())
+        .WillByDefault(Return(false));
+        ON_CALL(*m_playbackState, playbackPosition())
+        .WillByDefault(Return(muse::secs_t(0.0)));
+
+        m_context = new TimelineContext();
+        SnapTestAccess::wireContext(m_context, m_globalContext, m_playback);
+
+        m_controller = new PlayCursorController();
+        SnapTestAccess::wireCursor(m_controller, m_globalContext, m_dispatcher);
+        m_controller->setTimelineContext(m_context);
+    }
+
+    void TearDown() override
+    {
+        delete m_controller;
+        delete m_context;
+    }
+
+    void useGridSnapOff(const std::set<muse::secs_t>& boundaries)
+    {
+        m_viewState->setIsSnapEnabled(false);
+        m_viewState->setItemsBoundaries(boundaries);
+    }
+
+    void useGridSnapOn(SnapType type)
+    {
+        m_viewState->setIsSnapEnabled(true);
+        m_viewState->setSnapType(type);
+    }
+
+    std::shared_ptr<NiceMock<context::GlobalContextMock> > m_globalContext;
+    std::shared_ptr<NiceMock<project::AudacityProjectMock> > m_project;
+    std::shared_ptr<NiceMock<trackedit::TrackeditProjectMock> > m_trackeditProject;
+    std::shared_ptr<ProjectViewState> m_viewState;
+    std::shared_ptr<NiceMock<playback::PlaybackMock> > m_playback;
+    std::shared_ptr<NiceMock<playback::AudioOutputMock> > m_audioOutput;
+    std::shared_ptr<NiceMock<context::PlaybackStateMock> > m_playbackState;
+    std::shared_ptr<NiceMock<muse::actions::ActionsDispatcherMock> > m_dispatcher;
+
+    TimelineContext* m_context = nullptr;
+    PlayCursorController* m_controller = nullptr;
+};
+
+TEST_F(PlayCursorControllerTests, SeekToX_GridSnapOff_SnapsToBoundary)
+{
+    //! CASE Seeking near an item boundary dispatches a seek at the snapped boundary.
+    useGridSnapOff({ 10.0 });
+
+    muse::actions::ActionQuery captured;
+    EXPECT_CALL(*m_dispatcher, dispatch(A<const muse::actions::ActionQuery&>()))
+    .WillOnce(SaveArg<0>(&captured));
+
+    m_controller->seekToX(10.5); // within the 4px(=4s at zoom 1) clip-snap tolerance
+
+    EXPECT_TRUE(captured.contains("seekTime"));
+    EXPECT_DOUBLE_EQ(captured.param("seekTime").toDouble(), 10.0);
+    EXPECT_FALSE(captured.param("triggerPlay").toBool());
+}
+
+TEST_F(PlayCursorControllerTests, SeekToX_GridSnapOff_FarFromBoundary_UsesRawTime)
+{
+    //! CASE Outside the snap tolerance, the raw time is used.
+    useGridSnapOff({ 10.0 });
+
+    muse::actions::ActionQuery captured;
+    EXPECT_CALL(*m_dispatcher, dispatch(A<const muse::actions::ActionQuery&>()))
+    .WillOnce(SaveArg<0>(&captured));
+
+    m_controller->seekToX(20.0); // 10s away from the only boundary
+
+    EXPECT_DOUBLE_EQ(captured.param("seekTime").toDouble(), 20.0);
+}
+
+TEST_F(PlayCursorControllerTests, SeekToX_GridSnapOn_SnapsToGrid)
+{
+    //! CASE With grid snap on, the seek lands on the nearest grid line.
+    useGridSnapOn(SnapType::Seconds);
+
+    muse::actions::ActionQuery captured;
+    EXPECT_CALL(*m_dispatcher, dispatch(A<const muse::actions::ActionQuery&>()))
+    .WillOnce(SaveArg<0>(&captured));
+
+    m_controller->seekToX(7.4);
+
+    EXPECT_DOUBLE_EQ(captured.param("seekTime").toDouble(), 7.0);
+}
+
+TEST_F(PlayCursorControllerTests, SeekToX_NegativeTime_ClampsToZero_WhenNotAtStart)
+{
+    //! CASE A negative resulting time seeks to 0, provided we are not already there.
+    useGridSnapOff({});
+    ON_CALL(*m_playbackState, playbackPosition())
+    .WillByDefault(Return(muse::secs_t(5.0)));
+
+    muse::actions::ActionQuery captured;
+    EXPECT_CALL(*m_dispatcher, dispatch(A<const muse::actions::ActionQuery&>()))
+    .WillOnce(SaveArg<0>(&captured));
+
+    m_controller->seekToX(-3.0);
+
+    EXPECT_DOUBLE_EQ(captured.param("seekTime").toDouble(), 0.0);
+}
+
+TEST_F(PlayCursorControllerTests, SeekToX_NegativeTime_AlreadyAtStart_DoesNotDispatch)
+{
+    //! CASE Negative time while already at 0 is a no-op.
+    useGridSnapOff({});
+    ON_CALL(*m_playbackState, playbackPosition())
+    .WillByDefault(Return(muse::secs_t(0.0)));
+
+    EXPECT_CALL(*m_dispatcher, dispatch(A<const muse::actions::ActionQuery&>()))
+    .Times(0);
+
+    m_controller->seekToX(-3.0);
+}
+
+TEST_F(PlayCursorControllerTests, SetPlaybackRegion_SnapsAndClampsEdges)
+{
+    //! CASE Region edges snap to boundaries and are clamped to >= 0.
+    useGridSnapOff({ 10.0 });
+
+    muse::actions::ActionQuery captured;
+    EXPECT_CALL(*m_dispatcher, dispatch(A<const muse::actions::ActionQuery&>()))
+    .WillOnce(SaveArg<0>(&captured));
+
+    m_controller->setPlaybackRegion(-3.0, 10.4); // start clamps to 0, end snaps to 10.0
+
+    EXPECT_DOUBLE_EQ(captured.param("start").toDouble(), 0.0);
+    EXPECT_DOUBLE_EQ(captured.param("end").toDouble(), 10.0);
+}
+}

--- a/src/projectscene/tests/projectviewstate_tests.cpp
+++ b/src/projectscene/tests/projectviewstate_tests.cpp
@@ -16,8 +16,12 @@
 #include "trackedit/tests/mocks/trackeditprojectmock.h"
 #include "project/tests/mocks/audacityprojectmock.h"
 #include "trackedit/trackedittypes.h"
+#include "trackedit/dom/clip.h"
+#include "trackedit/dom/label.h"
 
 #include <gtest/gtest.h>
+
+#include <set>
 
 using namespace ::testing;
 using ::testing::_;
@@ -91,6 +95,42 @@ public:
         .WillByDefault(Return(getAllTracks()));
     }
 
+    static trackedit::Clip makeClip(trackedit::TrackId trackId, trackedit::TrackItemId itemId, double start, double end)
+    {
+        trackedit::Clip clip;
+        clip.key = { trackId, itemId };
+        clip.startTime = start;
+        clip.endTime = end;
+        return clip;
+    }
+
+    static trackedit::Label makeLabel(trackedit::TrackId trackId, trackedit::TrackItemId itemId, double start, double end)
+    {
+        trackedit::Label label;
+        label.key = { trackId, itemId };
+        label.startTime = start;
+        label.endTime = end;
+        return label;
+    }
+
+    static muse::async::NotifyList<trackedit::Clip> makeClipList(std::initializer_list<trackedit::Clip> clips)
+    {
+        muse::async::NotifyList<trackedit::Clip> list;
+        for (const auto& clip : clips) {
+            list.push_back(clip);
+        }
+        return list;
+    }
+
+    static muse::async::NotifyList<trackedit::Label> makeLabelList(std::initializer_list<trackedit::Label> labels)
+    {
+        muse::async::NotifyList<trackedit::Label> list;
+        for (const auto& label : labels) {
+            list.push_back(label);
+        }
+        return list;
+    }
+
 protected:
     std::shared_ptr<ProjectViewState> m_projectViewState = nullptr;
 
@@ -150,5 +190,106 @@ TEST_F(ProjectViewStateTests, tracksInRange_InputIntervalIsClosedOpen)
 
     // Outside
     EXPECT_EQ(TrackIdList({ }), m_projectViewState->tracksInRange(tracksBottom, tracksBottom + 1));
+}
+
+TEST_F(ProjectViewStateTests, UpdateItemsBoundaries_IncludesAllClipsWhenNothingSelected)
+{
+    using namespace trackedit;
+
+    // [GIVEN] Two tracks with one clip each and nothing currently selected.
+    const TrackId track1 = 1;
+    const TrackId track2 = 2;
+
+    ON_CALL(*m_trackeditProjectMock, trackIdList())
+    .WillByDefault(Return(TrackIdList { track1, track2 }));
+    ON_CALL(*m_trackeditProjectMock, clipList(track1))
+    .WillByDefault([](const TrackId&) { return makeClipList({ makeClip(1, 100, 1.0, 3.0) }); });
+    ON_CALL(*m_trackeditProjectMock, clipList(track2))
+    .WillByDefault([](const TrackId&) { return makeClipList({ makeClip(2, 200, 5.0, 8.0) }); });
+    ON_CALL(*m_trackeditProjectMock, labelList(_))
+    .WillByDefault([](const TrackId&) { return makeLabelList({}); });
+    ON_CALL(*m_selectionControllerMock, selectedClips())
+    .WillByDefault(Return(ClipKeyList {}));
+
+    // [WHEN] Boundaries are rebuilt.
+    m_projectViewState->updateItemsBoundaries(/*excludeCurrentSelection*/ false);
+
+    // [THEN] Every clip edge is a snap target, even though nothing is selected.
+    const std::set<muse::secs_t> expected { 1.0, 3.0, 5.0, 8.0 };
+    EXPECT_EQ(m_projectViewState->itemsBoundaries(), expected);
+}
+
+TEST_F(ProjectViewStateTests, UpdateItemsBoundaries_RangeSelectionKeepsSelectedClipEdges)
+{
+    using namespace trackedit;
+
+    // [GIVEN] One track with a selected clip and another, unselected clip.
+    const TrackId track1 = 1;
+    const Clip selected = makeClip(track1, 100, 2.0, 4.0);
+    const Clip other = makeClip(track1, 200, 6.0, 9.0);
+
+    ON_CALL(*m_trackeditProjectMock, trackIdList())
+    .WillByDefault(Return(TrackIdList { track1 }));
+    ON_CALL(*m_trackeditProjectMock, clipList(track1))
+    .WillByDefault([selected, other](const TrackId&) { return makeClipList({ selected, other }); });
+    ON_CALL(*m_trackeditProjectMock, labelList(_))
+    .WillByDefault([](const TrackId&) { return makeLabelList({}); });
+    ON_CALL(*m_selectionControllerMock, selectedClips())
+    .WillByDefault(Return(ClipKeyList { selected.key }));
+
+    // [WHEN/THEN] Without excluding the selection, both ends of the selected clip
+    // remain snap targets (so a range selection snaps at start AND end).
+    m_projectViewState->updateItemsBoundaries(/*excludeCurrentSelection*/ false);
+    EXPECT_EQ(m_projectViewState->itemsBoundaries(), (std::set<muse::secs_t> { 2.0, 4.0, 6.0, 9.0 }));
+
+    // [WHEN/THEN] Excluding the selection drops the selected clip's edges.
+    m_projectViewState->updateItemsBoundaries(/*excludeCurrentSelection*/ true);
+    EXPECT_EQ(m_projectViewState->itemsBoundaries(), (std::set<muse::secs_t> { 6.0, 9.0 }));
+}
+
+TEST_F(ProjectViewStateTests, UpdateItemsBoundaries_OmitsSpecifiedItemKey)
+{
+    using namespace trackedit;
+
+    // [GIVEN] A clip being dragged and a neighbour it could snap to.
+    const TrackId track1 = 1;
+    const Clip dragged = makeClip(track1, 100, 1.0, 2.0);
+    const Clip neighbour = makeClip(track1, 200, 4.0, 7.0);
+
+    ON_CALL(*m_trackeditProjectMock, trackIdList())
+    .WillByDefault(Return(TrackIdList { track1 }));
+    ON_CALL(*m_trackeditProjectMock, clipList(track1))
+    .WillByDefault([dragged, neighbour](const TrackId&) { return makeClipList({ dragged, neighbour }); });
+    ON_CALL(*m_trackeditProjectMock, labelList(_))
+    .WillByDefault([](const TrackId&) { return makeLabelList({}); });
+    ON_CALL(*m_selectionControllerMock, selectedClips())
+    .WillByDefault(Return(ClipKeyList {}));
+
+    // [WHEN] Boundaries are rebuilt omitting the dragged clip.
+    m_projectViewState->updateItemsBoundaries(/*excludeCurrentSelection*/ false, dragged.key);
+
+    // [THEN] The dragged clip's own edges are not snap targets (no snapping to itself).
+    EXPECT_EQ(m_projectViewState->itemsBoundaries(), (std::set<muse::secs_t> { 4.0, 7.0 }));
+}
+
+TEST_F(ProjectViewStateTests, UpdateItemsBoundaries_IncludesLabelBoundaries)
+{
+    using namespace trackedit;
+
+    // [GIVEN] A track whose label edges should also be snap targets.
+    const TrackId track1 = 1;
+
+    ON_CALL(*m_trackeditProjectMock, trackIdList())
+    .WillByDefault(Return(TrackIdList { track1 }));
+    ON_CALL(*m_trackeditProjectMock, clipList(_))
+    .WillByDefault([](const TrackId&) { return makeClipList({}); });
+    ON_CALL(*m_trackeditProjectMock, labelList(track1))
+    .WillByDefault([](const TrackId&) { return makeLabelList({ makeLabel(1, 300, 1.5, 3.5) }); });
+    ON_CALL(*m_selectionControllerMock, selectedClips())
+    .WillByDefault(Return(ClipKeyList {}));
+
+    m_projectViewState->updateItemsBoundaries(/*excludeCurrentSelection*/ false);
+
+    EXPECT_EQ(m_projectViewState->itemsBoundaries(), (std::set<muse::secs_t> { 1.5, 3.5 }));
 }
 } // namespace au::projectscene

--- a/src/projectscene/tests/snaptestaccess.h
+++ b/src/projectscene/tests/snaptestaccess.h
@@ -1,0 +1,39 @@
+/*
+* Audacity: A Digital Audio Editor
+*/
+#pragma once
+
+#include <memory>
+
+#include "modularity/ioc.h"
+#include "context/iglobalcontext.h"
+#include "playback/iplayback.h"
+#include "actions/iactionsdispatcher.h"
+
+#include "projectscene/view/timeline/timelinecontext.h"
+#include "projectscene/view/timeline/snaptimeformatter.h"
+#include "projectscene/view/playcursor/playcursorcontroller.h"
+
+namespace au::projectscene {
+//! Test-only helper that reaches the private injects of TimelineContext and
+//! PlayCursorController so the snapping/guideline logic can be exercised without
+//! running their full init() machinery.
+struct SnapTestAccess {
+    static void wireContext(TimelineContext* ctx,
+                            const std::shared_ptr<context::IGlobalContext>& globalContext,
+                            const std::shared_ptr<playback::IPlayback>& playback)
+    {
+        ctx->globalContext.set(globalContext);
+        ctx->playback.set(playback);
+        ctx->m_snapTimeFormatter = std::make_shared<SnapTimeFormatter>(muse::modularity::globalCtx());
+    }
+
+    static void wireCursor(PlayCursorController* cursor,
+                           const std::shared_ptr<context::IGlobalContext>& globalContext,
+                           const std::shared_ptr<muse::actions::IActionsDispatcher>& dispatcher)
+    {
+        cursor->globalContext.set(globalContext);
+        cursor->dispatcher.set(dispatcher);
+    }
+};
+}

--- a/src/projectscene/tests/snaptimeformatter_tests.cpp
+++ b/src/projectscene/tests/snaptimeformatter_tests.cpp
@@ -3,6 +3,8 @@
  */
 #include <gtest/gtest.h>
 
+#include <set>
+
 #include "../view/timeline/snaptimeformatter.h"
 
 namespace au::projectscene {
@@ -137,5 +139,51 @@ TEST_F(SnapTimeFormatterTests, SingleStep_Beats)
     snap = { SnapType::HundredTwentyEighth, true, false };
     EXPECT_EQ(m_formatter->singleStep(0.0, snap, Direction::Right, m_timeSignature), 0.015625);
     EXPECT_EQ(m_formatter->singleStep(2.0, snap, Direction::Left, m_timeSignature), 1.984375);
+}
+
+TEST_F(SnapTimeFormatterTests, SnapToItem_EmptyBoundaries_ReturnsInput)
+{
+    const std::set<muse::secs_t> boundaries;
+    EXPECT_EQ(m_formatter->snapToItem(1.234, 0.5, boundaries), 1.234);
+}
+
+TEST_F(SnapTimeFormatterTests, SnapToItem_WithinTolerance_SnapsToBoundary)
+{
+    const std::set<muse::secs_t> boundaries{ 1.0, 5.0, 9.0 };
+    const muse::secs_t tolerance = 0.2;
+
+    // Approaching a boundary from either side snaps to it.
+    EXPECT_EQ(m_formatter->snapToItem(4.85, tolerance, boundaries), 5.0);
+    EXPECT_EQ(m_formatter->snapToItem(5.15, tolerance, boundaries), 5.0);
+    // Already exactly on a boundary.
+    EXPECT_EQ(m_formatter->snapToItem(9.0, tolerance, boundaries), 9.0);
+}
+
+TEST_F(SnapTimeFormatterTests, SnapToItem_OutsideTolerance_ReturnsInput)
+{
+    const std::set<muse::secs_t> boundaries{ 1.0, 5.0 };
+    const muse::secs_t tolerance = 0.1;
+
+    EXPECT_EQ(m_formatter->snapToItem(5.5, tolerance, boundaries), 5.5);
+    EXPECT_EQ(m_formatter->snapToItem(3.0, tolerance, boundaries), 3.0);
+}
+
+TEST_F(SnapTimeFormatterTests, SnapToItem_PicksClosestOfStraddlingBoundaries)
+{
+    const std::set<muse::secs_t> boundaries{ 2.0, 3.0 };
+    const muse::secs_t tolerance = 1.0;
+
+    EXPECT_EQ(m_formatter->snapToItem(2.4, tolerance, boundaries), 2.0);
+    EXPECT_EQ(m_formatter->snapToItem(2.6, tolerance, boundaries), 3.0);
+}
+
+TEST_F(SnapTimeFormatterTests, SnapToItem_SnapsToBoundaryAtZero)
+{
+    // A boundary at t=0 is a legitimate snap target, not a "no snap" sentinel.
+    const std::set<muse::secs_t> boundaries{ 0.0, 4.0 };
+    const muse::secs_t tolerance = 0.2;
+
+    EXPECT_EQ(m_formatter->snapToItem(0.1, tolerance, boundaries), 0.0);
+    EXPECT_EQ(m_formatter->snapToItem(0.0, tolerance, boundaries), 0.0);
 }
 }

--- a/src/projectscene/view/playcursor/playcursorcontroller.cpp
+++ b/src/projectscene/view/playcursor/playcursorcontroller.cpp
@@ -61,10 +61,7 @@ void PlayCursorController::seekToX(double x, bool triggerPlay)
         return;
     }
 
-    const IProjectViewStatePtr viewState = projectViewState();
-    const bool snapEnabled = viewState ? viewState->isSnapEnabled() : false;
-
-    const double secs = m_context->positionToTime(x, snapEnabled);
+    const double secs = m_context->positionToTime(x, /*withSnap*/ true);
     muse::actions::ActionQuery q(PLAYBACK_SEEK_QUERY);
     q.addParam("triggerPlay", muse::Val(triggerPlay));
     if (muse::RealIsEqualOrMore(secs, 0.0)) {
@@ -78,11 +75,8 @@ void PlayCursorController::seekToX(double x, bool triggerPlay)
 
 void PlayCursorController::setPlaybackRegion(double x1, double x2)
 {
-    const IProjectViewStatePtr viewState = projectViewState();
-    const bool snapEnabled = viewState ? viewState->isSnapEnabled() : false;
-
-    const double start = std::max(0.0, m_context->positionToTime(x1, snapEnabled));
-    const double end = std::max(0.0, m_context->positionToTime(x2, snapEnabled));
+    const double start = std::max(0.0, m_context->positionToTime(x1, /*withSnap*/ true));
+    const double end = std::max(0.0, m_context->positionToTime(x2, /*withSnap*/ true));
 
     muse::actions::ActionQuery q(PLAYBACK_CHANGE_PLAY_REGION_QUERY);
     q.addParam("start", muse::Val(start));
@@ -93,12 +87,6 @@ void PlayCursorController::setPlaybackRegion(double x1, double x2)
 au::context::IPlaybackStatePtr PlayCursorController::playbackState() const
 {
     return globalContext()->playbackState();
-}
-
-IProjectViewStatePtr PlayCursorController::projectViewState() const
-{
-    project::IAudacityProjectPtr project = globalContext()->currentProject();
-    return project ? project->viewState() : nullptr;
 }
 
 void PlayCursorController::updatePositionX(muse::secs_t secs)

--- a/src/projectscene/view/playcursor/playcursorcontroller.h
+++ b/src/projectscene/view/playcursor/playcursorcontroller.h
@@ -66,7 +66,6 @@ private slots:
 
 private:
     context::IPlaybackStatePtr playbackState() const;
-    projectscene::IProjectViewStatePtr projectViewState() const;
 
     void updatePositionX(muse::secs_t secs);
     void ensureCursorAtCenter(muse::secs_t secs) const;

--- a/src/projectscene/view/playcursor/playcursorcontroller.h
+++ b/src/projectscene/view/playcursor/playcursorcontroller.h
@@ -79,5 +79,7 @@ private:
 
     QTimer m_scrollSuppressionTimer;
     bool m_viewUpdatesSuppressed = false;
+
+    friend struct SnapTestAccess;
 };
 }

--- a/src/projectscene/view/timeline/playregioncontroller.cpp
+++ b/src/projectscene/view/timeline/playregioncontroller.cpp
@@ -274,7 +274,7 @@ double PlayRegionController::calculateSnappedPosition(double pos) const
     bool snapEnabled = true;
     double guideline = context()->findGuideline(context()->positionToTime(pos, snapEnabled));
 
-    if (muse::RealIsEqualOrMore(guideline, 0)) {
+    if (context()->isGuidelineValid(guideline)) {
         return context()->timeToPosition(guideline);
     }
     return pos;

--- a/src/projectscene/view/timeline/timelinecontext.cpp
+++ b/src/projectscene/view/timeline/timelinecontext.cpp
@@ -860,8 +860,20 @@ double TimelineContext::findGuideline(double time) const
             return time;
         }
     } else {
-        if (muse::contains(vs->itemsBoundaries(), static_cast<muse::secs_t>(time))) {
-            return time;
+        // A clip can snap to a label whose boundary is not sample-aligned, but the snapped
+        // clip edge is quantized to a sample, so the two land a fraction of a sample apart.
+        // Match the nearest boundary within a sample (like the snap-enabled branch above)
+        // and return the boundary itself so the guideline draws precisely on its edge.
+        const std::set<muse::secs_t> boundaries = vs->itemsBoundaries();
+        const auto upper = boundaries.lower_bound(time);
+        if (upper != boundaries.end() && muse::RealIsEqualOrLess(std::abs(*upper - time), LIMIT)) {
+            return *upper;
+        }
+        if (upper != boundaries.begin()) {
+            const auto lower = std::prev(upper);
+            if (muse::RealIsEqualOrLess(std::abs(*lower - time), LIMIT)) {
+                return *lower;
+            }
         }
     }
 

--- a/src/projectscene/view/timeline/timelinecontext.cpp
+++ b/src/projectscene/view/timeline/timelinecontext.cpp
@@ -865,7 +865,12 @@ double TimelineContext::findGuideline(double time) const
         }
     }
 
-    return -1.0;
+    return INVALID_GUIDELINE_TIME;
+}
+
+bool TimelineContext::isGuidelineValid(double guidelineTime) const
+{
+    return !muse::RealIsEqual(guidelineTime, INVALID_GUIDELINE_TIME);
 }
 
 void TimelineContext::updateMousePositionTime(double mouseX)

--- a/src/projectscene/view/timeline/timelinecontext.h
+++ b/src/projectscene/view/timeline/timelinecontext.h
@@ -75,6 +75,7 @@ class TimelineContext : public QObject, public muse::async::Asyncable, public mu
 public:
 
     static constexpr int ANIMATION_DURATION_MS = 500;
+    static constexpr double INVALID_GUIDELINE_TIME = -1.0;
 
     TimelineContext(QObject* parent = nullptr);
 
@@ -132,7 +133,9 @@ public:
     double applySnapToTime(double time) const;
     double applySnapToItem(double time) const;
     Q_INVOKABLE double applyDetectedSnap(double time) const;
+
     Q_INVOKABLE double findGuideline(double time) const;
+    Q_INVOKABLE bool isGuidelineValid(double guidelineTime) const;
 
     Q_INVOKABLE void updateMousePositionTime(double mouseX);
     Q_INVOKABLE double mousePositionTime() const;

--- a/src/projectscene/view/timeline/timelinecontext.h
+++ b/src/projectscene/view/timeline/timelinecontext.h
@@ -63,6 +63,8 @@ class TimelineContext : public QObject, public muse::async::Asyncable, public mu
     Q_PROPERTY(bool pinnedPlayHeadEnabled READ pinnedPlayHeadEnabled NOTIFY pinnedPlayHeadEnabledChanged FINAL)
     Q_PROPERTY(double lastPlaybackSeekPosition READ lastPlaybackSeekPosition NOTIFY lastPlaybackSeekPositionChanged FINAL)
 
+    Q_PROPERTY(double invalidGuidelineTime READ invalidGuidelineTime CONSTANT FINAL)
+
     muse::GlobalInject<IProjectSceneConfiguration> configuration;
 
     muse::ContextInject<muse::actions::IActionsDispatcher> dispatcher{ this };
@@ -78,6 +80,8 @@ public:
     static constexpr double INVALID_GUIDELINE_TIME = -1.0;
 
     TimelineContext(QObject* parent = nullptr);
+
+    double invalidGuidelineTime() const { return INVALID_GUIDELINE_TIME; }
 
     double frameStartTime() const;
     void setFrameStartTime(double newFrameStartTime);

--- a/src/projectscene/view/timeline/timelinecontext.h
+++ b/src/projectscene/view/timeline/timelinecontext.h
@@ -247,6 +247,8 @@ private:
 
     context::IPlaybackStatePtr playbackState() const;
 
+    friend struct SnapTestAccess;
+
     double m_frameWidth = 0.0;
     double m_frameHeight = 0.0;
     double m_frameContentHeight = 0.0;

--- a/src/projectscene/view/tracksitemsview/selectionviewcontroller.cpp
+++ b/src/projectscene/view/tracksitemsview/selectionviewcontroller.cpp
@@ -102,7 +102,7 @@ void SelectionViewController::onPressed(double x, double y, spectrogram::Spectro
     }
     emit pressedSpectrogramChanged();
 
-    viewState()->updateItemsBoundaries(true);
+    viewState()->updateItemsBoundaries(false);
 
     m_autoScrollConnection = connect(m_context, &TimelineContext::frameTimeChanged, [this]() {
         doOnPositionChanged(m_lastPoint.x(), m_lastPoint.y());

--- a/src/projectscene/view/tracksitemsview/splittoolcontroller.cpp
+++ b/src/projectscene/view/tracksitemsview/splittoolcontroller.cpp
@@ -174,7 +174,7 @@ void SplitToolController::updateGuideline(double pos)
     const bool snapEnabled = true;
     double guideline = context()->findGuideline(context()->positionToTime(pos, snapEnabled));
 
-    if (!muse::RealIsEqualOrMore(guideline, 0)) {
+    if (!context()->isGuidelineValid(guideline)) {
         guideline = context()->positionToTime(pos);
     }
 

--- a/src/projectscene/view/tracksitemsview/trackitemslistmodel.cpp
+++ b/src/projectscene/view/tracksitemsview/trackitemslistmodel.cpp
@@ -635,6 +635,7 @@ void TrackItemsListModel::endEditItem(const TrackItemKey& key)
     vs->setItemEditEndTimeOffset(-1.0);
     vs->setMoveInitiated(false);
     vs->setEditedItem(trackedit::TrackItemKey {});
+    vs->updateItemsBoundaries(false);
 
     disconnectAutoScroll();
 
@@ -663,7 +664,7 @@ bool TrackItemsListModel::cancelItemDragEdit(const TrackItemKey& key)
     trackeditInteraction()->cancelItemDragEdit();
 
     vs->setEditedItem(trackedit::TrackItemKey {});
-    vs->updateItemsBoundaries(true);
+    vs->updateItemsBoundaries(false);
 
     constexpr auto modifyState = false;
     projectHistory()->endUserInteraction(modifyState);

--- a/src/projectscene/view/tracksitemsview/trackitemslistmodel.cpp
+++ b/src/projectscene/view/tracksitemsview/trackitemslistmodel.cpp
@@ -197,19 +197,19 @@ QVariant TrackItemsListModel::findGuideline(const TrackItemKey& key, DirectionTy
     if (direction != DirectionType::Direction::Right) {
         double itemStartTime = item->time().startTime;
         double guidelineTime = m_context->findGuideline(itemStartTime);
-        if (!muse::RealIsEqual(guidelineTime, -1.0)) {
+        if (m_context->isGuidelineValid(guidelineTime)) {
             return QVariant(guidelineTime);
         }
     }
     if (direction != DirectionType::Direction::Left) {
         double itemEndTime = item->time().endTime;
         double guidelineTime = m_context->findGuideline(itemEndTime);
-        if (!muse::RealIsEqual(guidelineTime, -1.0)) {
+        if (m_context->isGuidelineValid(guidelineTime)) {
             return QVariant(guidelineTime);
         }
     }
 
-    return QVariant(-1.0);
+    return QVariant(TimelineContext::INVALID_GUIDELINE_TIME);
 }
 
 void TrackItemsListModel::setFocusedItem(const TrackItemKey& key)

--- a/src/projectscene/view/tracksitemsview/trackitemslistmodel.cpp
+++ b/src/projectscene/view/tracksitemsview/trackitemslistmodel.cpp
@@ -182,34 +182,32 @@ QVariant TrackItemsListModel::prev(const TrackItemKey& key) const
     return neighbor(key, -1);
 }
 
-QVariant TrackItemsListModel::findGuideline(const TrackItemKey& key, DirectionType::Direction direction) const
+bool TrackItemsListModel::containsItem(const TrackItemKey& key) const
 {
-    auto vs = globalContext()->currentProject()->viewState();
-    if (!vs) {
-        return QVariant();
-    }
+    return itemByKey(key.key) != nullptr;
+}
 
+double TrackItemsListModel::findGuideline(const TrackItemKey& key, DirectionType::Direction direction) const
+{
     ViewTrackItem* item = itemByKey(key.key);
     if (!item) {
-        return QVariant();
+        return TimelineContext::INVALID_GUIDELINE_TIME;
     }
 
     if (direction != DirectionType::Direction::Right) {
-        double itemStartTime = item->time().startTime;
-        double guidelineTime = m_context->findGuideline(itemStartTime);
+        double guidelineTime = m_context->findGuideline(item->time().startTime);
         if (m_context->isGuidelineValid(guidelineTime)) {
-            return QVariant(guidelineTime);
+            return guidelineTime;
         }
     }
     if (direction != DirectionType::Direction::Left) {
-        double itemEndTime = item->time().endTime;
-        double guidelineTime = m_context->findGuideline(itemEndTime);
+        double guidelineTime = m_context->findGuideline(item->time().endTime);
         if (m_context->isGuidelineValid(guidelineTime)) {
-            return QVariant(guidelineTime);
+            return guidelineTime;
         }
     }
 
-    return QVariant(TimelineContext::INVALID_GUIDELINE_TIME);
+    return TimelineContext::INVALID_GUIDELINE_TIME;
 }
 
 void TrackItemsListModel::setFocusedItem(const TrackItemKey& key)

--- a/src/projectscene/view/tracksitemsview/trackitemslistmodel.cpp
+++ b/src/projectscene/view/tracksitemsview/trackitemslistmodel.cpp
@@ -612,6 +612,7 @@ void TrackItemsListModel::startEditItem(const TrackItemKey& key)
     vs->setItemEditEndTimeOffset(item->time().endTime - mousePositionTime);
 
     if (vs) {
+        vs->setEditedItem(key.key);
         vs->updateItemsBoundaries(true, key.key);
     }
 
@@ -633,6 +634,7 @@ void TrackItemsListModel::endEditItem(const TrackItemKey& key)
     vs->setItemEditStartTimeOffset(-1.0);
     vs->setItemEditEndTimeOffset(-1.0);
     vs->setMoveInitiated(false);
+    vs->setEditedItem(trackedit::TrackItemKey {});
 
     disconnectAutoScroll();
 
@@ -660,6 +662,7 @@ bool TrackItemsListModel::cancelItemDragEdit(const TrackItemKey& key)
 
     trackeditInteraction()->cancelItemDragEdit();
 
+    vs->setEditedItem(trackedit::TrackItemKey {});
     vs->updateItemsBoundaries(true);
 
     constexpr auto modifyState = false;

--- a/src/projectscene/view/tracksitemsview/trackitemslistmodel.cpp
+++ b/src/projectscene/view/tracksitemsview/trackitemslistmodel.cpp
@@ -243,7 +243,8 @@ QVariant TrackItemsListModel::neighbor(const TrackItemKey& key, int offset) cons
 TrackItemsListModel::MoveOffset TrackItemsListModel::calculateMoveOffset(const ViewTrackItem* item,
                                                                          const TrackItemKey& key,
                                                                          const std::vector<trackedit::TrackType>& trackTypesAllowedToMove,
-                                                                         bool completed) const
+                                                                         bool completed,
+                                                                         bool applySnap) const
 {
     project::IAudacityProjectPtr prj = globalContext()->currentProject();
     if (!prj) {
@@ -253,7 +254,7 @@ TrackItemsListModel::MoveOffset TrackItemsListModel::calculateMoveOffset(const V
     auto vs = prj->viewState();
 
     MoveOffset moveOffset {
-        calculateTimePositionOffset(item),
+        calculateTimePositionOffset(item, applySnap),
         completed ? 0 : calculateTrackPositionOffset(key, trackTypesAllowedToMove)
     };
 
@@ -368,7 +369,7 @@ bool TrackItemsListModel::isAllowedToMoveToTracks(const std::vector<trackedit::T
     return track.has_value() ? muse::contains(allowedTrackTypes, track->type) : false;
 }
 
-secs_t TrackItemsListModel::calculateTimePositionOffset(const ViewTrackItem* item) const
+secs_t TrackItemsListModel::calculateTimePositionOffset(const ViewTrackItem* item, bool applySnap) const
 {
     auto vs = globalContext()->currentProject()->viewState();
     if (!vs) {
@@ -376,25 +377,28 @@ secs_t TrackItemsListModel::calculateTimePositionOffset(const ViewTrackItem* ite
     }
 
     double newStartTime = m_context->mousePositionTime() - vs->itemEditStartTimeOffset();
-    double duration = item->time().endTime - item->time().startTime;
-    double newEndTime = newStartTime + duration;
 
-    double snappedEndTime = newEndTime;
-    double snappedStartTime = newStartTime;
-    if (vs->isSnapEnabled()) {
-        snappedStartTime = m_context->applySnapToTime(newStartTime);
-    } else {
-        snappedEndTime = m_context->applySnapToItem(newEndTime);
-        snappedStartTime = m_context->applySnapToItem(newStartTime);
-    }
-    if (muse::RealIsEqual(snappedEndTime, newEndTime)) {
-        newStartTime = snappedStartTime;
-    } else if (muse::RealIsEqual(snappedStartTime, newStartTime)) {
-        newStartTime = snappedEndTime - duration;
-    } else {
-        newStartTime
-            = (!muse::RealIsEqualOrMore(std::abs(snappedStartTime - newStartTime), std::abs(snappedEndTime - newEndTime))
-               ? snappedStartTime : snappedEndTime - duration);
+    if (applySnap) {
+        double duration = item->time().endTime - item->time().startTime;
+        double newEndTime = newStartTime + duration;
+
+        double snappedEndTime = newEndTime;
+        double snappedStartTime = newStartTime;
+        if (vs->isSnapEnabled()) {
+            snappedStartTime = m_context->applySnapToTime(newStartTime);
+        } else {
+            snappedEndTime = m_context->applySnapToItem(newEndTime);
+            snappedStartTime = m_context->applySnapToItem(newStartTime);
+        }
+        if (muse::RealIsEqual(snappedEndTime, newEndTime)) {
+            newStartTime = snappedStartTime;
+        } else if (muse::RealIsEqual(snappedStartTime, newStartTime)) {
+            newStartTime = snappedEndTime - duration;
+        } else {
+            newStartTime
+                = (!muse::RealIsEqualOrMore(std::abs(snappedStartTime - newStartTime), std::abs(snappedEndTime - newEndTime))
+                   ? snappedStartTime : snappedEndTime - duration);
+        }
     }
 
     secs_t timePositionOffset = newStartTime - item->time().startTime;

--- a/src/projectscene/view/tracksitemsview/trackitemslistmodel.h
+++ b/src/projectscene/view/tracksitemsview/trackitemslistmodel.h
@@ -66,7 +66,8 @@ public:
     Q_INVOKABLE QVariant next(const TrackItemKey& key) const;
     Q_INVOKABLE QVariant prev(const TrackItemKey& key) const;
 
-    Q_INVOKABLE QVariant findGuideline(const TrackItemKey& key, DirectionType::Direction direction) const;
+    Q_INVOKABLE bool containsItem(const TrackItemKey& key) const;
+    Q_INVOKABLE double findGuideline(const TrackItemKey& key, DirectionType::Direction direction) const;
 
     Q_INVOKABLE void setFocusedItem(const TrackItemKey& key);
     Q_INVOKABLE void resetFocusedItem();

--- a/src/projectscene/view/tracksitemsview/trackitemslistmodel.h
+++ b/src/projectscene/view/tracksitemsview/trackitemslistmodel.h
@@ -120,8 +120,9 @@ protected:
         int trackOffset = 0;
     };
     MoveOffset calculateMoveOffset(const ViewTrackItem* item, const TrackItemKey& key,
-                                   const std::vector<trackedit::TrackType>& trackTypesAllowedToMove, bool completed) const;
-    trackedit::secs_t calculateTimePositionOffset(const ViewTrackItem* item) const;
+                                   const std::vector<trackedit::TrackType>& trackTypesAllowedToMove, bool completed,
+                                   bool applySnap = true) const;
+    trackedit::secs_t calculateTimePositionOffset(const ViewTrackItem* item, bool applySnap = true) const;
 
     int calculateTrackPositionOffset(const TrackItemKey& key, const std::vector<trackedit::TrackType>& trackTypesAllowedToMove) const;
     bool isAllowedToMoveToTracks(const std::vector<trackedit::TrackType>& allowedTrackTypes, const trackedit::TrackId& movedTrackId) const;

--- a/src/projectscene/view/tracksitemsview/trackitemslistmodel.h
+++ b/src/projectscene/view/tracksitemsview/trackitemslistmodel.h
@@ -132,6 +132,7 @@ protected:
 
     friend class TrackClipsSelectionTests;
     friend class TrackLabelsSelectionTests;
+    friend class TrackItemsFindGuidelineTests;
 
     TimelineContext* m_context = nullptr;
     trackedit::TrackId m_trackId = -1;

--- a/src/projectscene/view/tracksitemsview/tracklabelslistmodel.cpp
+++ b/src/projectscene/view/tracksitemsview/tracklabelslistmodel.cpp
@@ -316,8 +316,9 @@ bool TrackLabelsListModel::moveSelectedLabels(const LabelKey& key, bool complete
 
     bool ok = false;
 
-    // Labels can only be moved to label tracks
-    TrackItemsListModel::MoveOffset moveOffset = calculateMoveOffset(item, key, { trackedit::TrackType::Label }, completed);
+    // Labels can only be moved to label tracks. Labels don't snap while being dragged.
+    TrackItemsListModel::MoveOffset moveOffset
+        = calculateMoveOffset(item, key, { trackedit::TrackType::Label }, completed, /*applySnap*/ false);
     if (vs->moveInitiated()) {
         if (!selectionController()->timeSelectionIsEmpty()) {
             ok = trackeditInteraction()->moveRangeSelection(moveOffset.timeOffset, completed);

--- a/src/projectscene/view/tracksitemsview/tracklabelslistmodel.cpp
+++ b/src/projectscene/view/tracksitemsview/tracklabelslistmodel.cpp
@@ -316,9 +316,9 @@ bool TrackLabelsListModel::moveSelectedLabels(const LabelKey& key, bool complete
 
     bool ok = false;
 
-    // Labels can only be moved to label tracks. Labels don't snap while being dragged.
+    // Labels can only be moved to label tracks.
     TrackItemsListModel::MoveOffset moveOffset
-        = calculateMoveOffset(item, key, { trackedit::TrackType::Label }, completed, /*applySnap*/ false);
+        = calculateMoveOffset(item, key, { trackedit::TrackType::Label }, completed);
     if (vs->moveInitiated()) {
         if (!selectionController()->timeSelectionIsEmpty()) {
             ok = trackeditInteraction()->moveRangeSelection(moveOffset.timeOffset, completed);


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/11051
Resolves: https://github.com/audacity/audacity/issues/11028
Resolves: https://github.com/audacity/audacity/issues/9921
Resolves: https://github.com/audacity/audacity/issues/8865
Resolves: https://github.com/audacity/audacity/issues/9354
Resolves: https://github.com/audacity/audacity/issues/8928
Resolves: https://github.com/audacity/audacity/issues/9661
Resolves: https://github.com/audacity/audacity/issues/8926

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run

- [x] Hover the mouse over a clip/label → yellow guideline shows at the nearest edge.
- [x] Move the cursor out of the clip → guideline disappears once far enough out.
- [x] Hover the mouse over an empty track area but below a clip edge → yellow guideline shows at the edge. 
- [x] No guideline blink/flicker at the track↔clip boundary on entry or exit.
- [x] Grab a clip's left grab handle and drag → guideline/snap considers clip start only (mouse position ignored)
- [x] Place a label; drag/trim a clip edge near the label boundary. Clip snaps to the label and shows the yellow guideline.
- [x] Drag a point label. It snaps to clip/label boundaries. (range label edge trimming also snaps)
- [x] Cursor snaps to the clip/label boundary.

