### PR TITLE
Fix metadata not clearing on project reset

### DIFF
--- a/src/ProjectManager.cpp
+++ b/src/ProjectManager.cpp
@@ -29,6 +29,7 @@ Paul Licameli split from AudacityProject.cpp
 #include "ProjectWindow.h"
 #include "ProjectWindows.h"
 #include "SelectUtilities.h"
+#include "Tags.h"
 #include "TrackPanel.h"
 #include "TrackUtilities.h"
 #include "UndoManager.h"
@@ -741,6 +742,8 @@ void ProjectManager::ResetProjectToEmpty() {
 
    SelectUtilities::DoSelectAll( project );
    TrackUtilities::DoRemoveTracks( project );
+
+   Tags::Set( project, std::make_shared<Tags>() );
 
    WaveTrackFactory::Reset( project );
 


### PR DESCRIPTION
Resolves: https://forum.audacityteam.org/t/how-do-i-turn-off-meta-data-editor/152816/4

Metadata was not cleared on project reset.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
- [ ] test case is described in: https://forum.audacityteam.org/t/how-do-i-turn-off-meta-data-editor/152816/7
