### PR TITLE
Allow to de-select tracks via Cmd/Ctrl+click

### DIFF
--- a/src/projectscene/qml/Audacity/ProjectScene/trackspanel/TrackItem.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/trackspanel/TrackItem.qml
@@ -222,7 +222,8 @@ ListItemBlank {
                 // Pass the event forward to allow
                 // child elements to handle the input
                 e.accepted = false
-                if(!root.isSelected) {
+                let toggleModifier = e.modifiers & Qt.ControlModifier
+                if (!root.isSelected || toggleModifier) {
                     root.selectionRequested(false)
                 }
             }

--- a/src/projectscene/view/tracksitemsview/selectionviewcontroller.cpp
+++ b/src/projectscene/view/tracksitemsview/selectionviewcontroller.cpp
@@ -65,8 +65,12 @@ void SelectionViewController::onPressed(double x, double y, spectrogram::Spectro
         tracks = selectionController()->selectedTracks();
         TrackIdList newTracks = vs->tracksInRange(y, y);
         if (!newTracks.empty()) {
-            if (!muse::contains(tracks, newTracks.at(0))) {
-                tracks.push_back(newTracks.at(0));
+            const TrackId clickedTrack = newTracks.at(0);
+            auto it = std::find(tracks.begin(), tracks.end(), clickedTrack);
+            if (it == tracks.end()) {
+                tracks.push_back(clickedTrack);
+            } else {
+                tracks.erase(it);
             }
         }
     } else {


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/9171

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
