### PR TITLE
Fix the loading of presets for the Distortion effect

### DIFF
--- a/src/effects/Distortion.cpp
+++ b/src/effects/Distortion.cpp
@@ -345,6 +345,9 @@ void EffectDistortion::Editor::PopulateOrExchange(ShuttleGui& S)
 
 bool EffectDistortion::Editor::UpdateUI()
 {
+   // get the settings from the MessageBuffer and write them to our local copy
+   mSettings = GetSettings(mAccess.Get());
+
    const auto& ms = mSettings;
 
    if (!mUIParent->TransferDataToWindow())


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/4326

Problem:
Loading the Distortion's presets has no effect.

Fix:
I only have limited understanding of the code, but by comparing the Reverb effect (which doesn't have this issue) with the Distortion effect, there's a corresponding line missing from EffectDistortion::Editor::UpdateUI(). Inserting this line appears to fix the problem.


<!-- Use "x" to fill the checkboxes below like [x] -->

- [x ] I signed [CLA](https://www.audacityteam.org/cla/)
- [x ] The title of the pull request describes an issue it addresses
- [ x] If changes are extensive, then there is a sequence of easily reviewable commits
- [ x] Each commit's message describes its purpose and effects
- [x ] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x ] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
