### PR TITLE
Frequency parameter in some of the Nyquist effects is broken  #10478

### DIFF
--- a/src/effects/effects_base/effectstypes.h
+++ b/src/effects/effects_base/effectstypes.h
@@ -124,6 +124,10 @@ struct ParameterInfo {
     // for cases where display precision and stepSize differ (e.g. sliding-stretch).
     int numDecimalsOverride = -1;
 
+    //! Upper bound on displayed fractional digits, applied by the auto-derive
+    //! path in numDecimals(). Overrides set elsewhere should clamp to this too.
+    static constexpr int maxNumDecimals = 6;
+
     bool isValid() const { return !id.empty(); }
 
     //! Number of decimals to display for numeric input.
@@ -141,7 +145,7 @@ struct ParameterInfo {
         }
         int n = 0;
         double s = stepSize;
-        while (n < 6 && std::abs(s - std::round(s)) > 1e-9 * std::max(1.0, std::abs(s))) {
+        while (n < maxNumDecimals && std::abs(s - std::round(s)) > 1e-9 * std::max(1.0, std::abs(s))) {
             s *= 10.0;
             ++n;
         }

--- a/src/effects/nyquist/internal/nyquistparameterextractorservice.cpp
+++ b/src/effects/nyquist/internal/nyquistparameterextractorservice.cpp
@@ -61,11 +61,12 @@ int fractionalDigits(const wxString& str)
 }
 
 //! Display precision for a float control: the most precise of its declared
-//! default/min/max values, clamped to match ParameterInfo::numDecimals()'s cap.
+//! default/min/max values, clamped to ParameterInfo::maxNumDecimals so a
+//! numDecimalsOverride set from here never exceeds the auto-derive path's cap.
 int maxFractionalDigits(const wxString& a, const wxString& b, const wxString& c)
 {
     const int n = std::max({ fractionalDigits(a), fractionalDigits(b), fractionalDigits(c) });
-    return std::min(n, 6);
+    return std::min(n, ParameterInfo::maxNumDecimals);
 }
 
 //! Convert NyqControlType to AU4 ParameterType

--- a/src/effects/nyquist/internal/nyquistparameterextractorservice.cpp
+++ b/src/effects/nyquist/internal/nyquistparameterextractorservice.cpp
@@ -19,14 +19,14 @@ namespace {
 ParameterType convertControlType(int nyqType)
 {
     switch (nyqType) {
-    case NYQ_CTRL_INT:
     case NYQ_CTRL_INT_TEXT:
     case NYQ_CTRL_FLOAT_TEXT:
-        // `float-text` renders as a plain numeric input (no slider) to match
-        // legacy AU3 semantics (au3/src/effects/nyquist/Nyquist.cpp:487-522)
+        // `int-text` and `float-text` renders as a plain numeric input (no slider)
+        // to match legacy AU3 semantics (au3/src/effects/nyquist/Nyquist.cpp:487-522)
         // and to avoid creating an unusable slider when the high bound is
         // `nil` (parsed as FLT_MAX in NyquistBase.cpp).
         return ParameterType::Numeric;
+    case NYQ_CTRL_INT:
     case NYQ_CTRL_FLOAT:
         return ParameterType::Slider;
     case NYQ_CTRL_CHOICE:

--- a/src/effects/nyquist/internal/nyquistparameterextractorservice.cpp
+++ b/src/effects/nyquist/internal/nyquistparameterextractorservice.cpp
@@ -3,6 +3,7 @@
  */
 #include "nyquistparameterextractorservice.h"
 
+#include <algorithm>
 #include <cmath>
 
 #include "au3wrap/internal/wxtypes_convert.h"
@@ -15,16 +16,69 @@ using namespace au::effects;
 using namespace muse;
 
 namespace {
+//! Round a raw step to the nearest "nice" 1/2/5 x power-of-ten value.
+//!
+//! `range / ticks` often lands on an ugly value (e.g. 999.999/1000 = 0.999999),
+//! which then drives both the spinbox increment and the derived decimal count.
+//! Snapping it to a nice number makes the arrows step by +1, +0.5, +2, etc.
+double niceStep(double raw)
+{
+    if (!(raw > 0.0) || !std::isfinite(raw)) {
+        return 1.0;
+    }
+    const double exponent = std::floor(std::log10(raw));
+    const double mag = std::pow(10.0, exponent);
+    const double frac = raw / mag; // in [1, 10)
+    double niceFrac;
+    if (frac < 1.5) {
+        niceFrac = 1.0;
+    } else if (frac < 3.0) {
+        niceFrac = 2.0;
+    } else if (frac < 7.0) {
+        niceFrac = 5.0;
+    } else {
+        niceFrac = 10.0;
+    }
+    return niceFrac * mag;
+}
+
+//! Number of digits after the decimal point in a numeric token (0 for integers
+//! or non-numeric tokens such as "nil").
+int fractionalDigits(const wxString& str)
+{
+    const int dot = str.Find(wxT('.'));
+    if (dot == wxNOT_FOUND) {
+        return 0;
+    }
+    int digits = 0;
+    for (size_t i = dot + 1; i < str.length(); ++i) {
+        if (!wxIsdigit(str[i])) {
+            break;
+        }
+        ++digits;
+    }
+    return digits;
+}
+
+//! Display precision for a float control: the most precise of its declared
+//! default/min/max values, clamped to match ParameterInfo::numDecimals()'s cap.
+int maxFractionalDigits(const wxString& a, const wxString& b, const wxString& c)
+{
+    const int n = std::max({ fractionalDigits(a), fractionalDigits(b), fractionalDigits(c) });
+    return std::min(n, 6);
+}
+
 //! Convert NyqControlType to AU4 ParameterType
 ParameterType convertControlType(int nyqType)
 {
     switch (nyqType) {
     case NYQ_CTRL_INT_TEXT:
     case NYQ_CTRL_FLOAT_TEXT:
-        // `int-text` and `float-text` renders as a plain numeric input (no slider)
-        // to match legacy AU3 semantics (au3/src/effects/nyquist/Nyquist.cpp:487-522)
-        // and to avoid creating an unusable slider when the high bound is
-        // `nil` (parsed as FLT_MAX in NyquistBase.cpp).
+        // `int-text` and `float-text` render as a plain numeric input (no slider)
+        // to match legacy AU3 semantics (au3/src/effects/nyquist/Nyquist.cpp:487-522):
+        // authors pick the `-text` variants when a slider is unwanted (e.g.
+        // open-ended ranges, where a `nil` bound is parsed as +/-FLT_MAX in
+        // NyquistBase.cpp).
         return ParameterType::Numeric;
     case NYQ_CTRL_INT:
     case NYQ_CTRL_FLOAT:
@@ -68,18 +122,22 @@ ParameterInfo convertControl(const NyqControl& ctrl)
     if (ctrl.type == NYQ_CTRL_INT || ctrl.type == NYQ_CTRL_INT_TEXT) {
         info.isInteger = true;
         info.stepSize = 1.0;
-    } else if (ctrl.ticks > 0) {
-        // Calculate step size from ticks.
-        // Nyquist `float-text` / `time` controls with a `nil` bound are parsed
-        // as ±FLT_MAX in NyquistBase.cpp, and ticks is hard-coded to 1000
-        // there. Refuse to synthesise a stepSize from a non-finite or
-        // absurdly wide range: leave stepSize=0 so the QML fallback
-        // (step=0.01 in GeneratedIncrementalPropertyControl.qml) kicks in.
+    } else if (ctrl.type == NYQ_CTRL_FLOAT || ctrl.type == NYQ_CTRL_FLOAT_TEXT) {
+        // Derive a step from the range (ticks is hard-coded to 1000 in
+        // NyquistBase.cpp), snapped to a nice 1/2/5 value so the spinbox arrows
+        // step by e.g. +1 instead of +0.999999. A `nil` bound is parsed as
+        // ±FLT_MAX there, leaving no usable range: fall back to a step of 1.
         const double range = ctrl.high - ctrl.low;
-        if (std::isfinite(range) && range > 0 && range < 1e15) {
-            info.stepSize = range / ctrl.ticks;
+        if (ctrl.ticks > 0 && std::isfinite(range) && range > 0 && range < 1e15) {
+            info.stepSize = niceStep(range / ctrl.ticks);
             info.stepCount = ctrl.ticks;
+        } else {
+            info.stepSize = 1.0;
         }
+        // Keep the precision declared in the .ny values, decoupled from the
+        // rounded step, so e.g. Frequency still accepts 4.5 even though the
+        // arrows move by 1.
+        info.numDecimalsOverride = maxFractionalDigits(ctrl.valStr, ctrl.lowStr, ctrl.highStr);
     }
 
     // For choice controls, extract enum values
@@ -142,11 +200,10 @@ ParameterInfo convertControl(const NyqControl& ctrl)
     }
 
     // For float/slider controls, format the current value as string
-    // This is needed for the formattedValue display next to the slider in the UI
+    // This is needed for the formattedValue display next to the slider in the UI.
+    // Match the precision derived above so the display agrees with the text box.
     if (ctrl.type == NYQ_CTRL_FLOAT || ctrl.type == NYQ_CTRL_FLOAT_TEXT) {
-        // Use reasonable precision: 2 decimal places for most cases
-        // Could be made more sophisticated based on the range/stepSize in the future
-        info.currentValueString = String::number(ctrl.val, 2);
+        info.currentValueString = String::number(ctrl.val, info.numDecimalsOverride);
     }
 
     return info;


### PR DESCRIPTION
Resolves: Frequency parameter in some of the Nyquist effects is broken #10478
- fixed some int controller not displayed as sliders 
- fixed incremental step not using nice values

affect only Nyquist effects, if we want same behaviour for plugin fallback UI we can if needed

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
