### PR TITLE
Rewind doesn't move the viewport

### DIFF
--- a/src/projectscene/view/playcursor/playcursorcontroller.cpp
+++ b/src/projectscene/view/playcursor/playcursorcontroller.cpp
@@ -139,6 +139,8 @@ void PlayCursorController::updatePositionX(muse::secs_t secs)
                 }
             }
         }
+    } else {
+        m_context->insureVisible(secs);
     }
 
     m_positionX = m_context->timeToPosition(secs);


### PR DESCRIPTION
Resolves: #10438

update the view position if not in playback/record mode. In playback/record mode rewind action is disabled.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [ ] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
