### PR TITLE
Fix realtime effect dialogs not staying on top on macos

### DIFF
--- a/src/effects/effects_base/qml/Audacity/Effects/RealtimeEffectViewerDialog.qml
+++ b/src/effects/effects_base/qml/Audacity/Effects/RealtimeEffectViewerDialog.qml
@@ -21,6 +21,8 @@ EffectStyledDialogView {
     title: viewerModel.title + " - " + viewerModel.trackName
     navigationSection.name: title
 
+    alwaysAboveApp: true
+
     contentWidth: Math.max(viewerLoader.width + prv.viewMargins * 2, prv.minimumWidth)
     contentHeight: {
         let height = 0


### PR DESCRIPTION
Resolves: #10990

#10550 - is not directly solved by this PR, but now it can be retested and seems to be fixed.

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
