### PR TITLE
Master effects don't stick  #9790

### DIFF
--- a/src/au3wrap/internal/au3project.cpp
+++ b/src/au3wrap/internal/au3project.cpp
@@ -187,6 +187,15 @@ bool Au3ProjectAccessor::save(const muse::io::path_t& filePath)
     auto& project = m_data->projectRef();
 
     auto& projectFileIO = ProjectFileIO::Get(project);
+
+    // WriteXML serializes the master realtime-effect list from a snapshot
+    // (SavedMasterEffectList), not the live list, so that closing without saving
+    // discards unsaved master-effect changes. Refresh the snapshot here so an
+    // explicit save persists the *current* master effects. The track snapshot in
+    // updateSavedState() is intentionally refreshed only AFTER the save to keep
+    // "Save As" correct (see commit 86c2f8f7).
+    SavedMasterEffectList::Get(project).UpdateCopy();
+
     auto result = projectFileIO.SaveProject(wxFromString(filePath.toString()), m_lastSavedTracks.get());
     if (result) {
         UndoManager::Get(project).StateSaved();

--- a/src/au3wrap/internal/au3project.cpp
+++ b/src/au3wrap/internal/au3project.cpp
@@ -188,12 +188,9 @@ bool Au3ProjectAccessor::save(const muse::io::path_t& filePath)
 
     auto& projectFileIO = ProjectFileIO::Get(project);
 
-    // WriteXML serializes the master realtime-effect list from a snapshot
-    // (SavedMasterEffectList), not the live list, so that closing without saving
-    // discards unsaved master-effect changes. Refresh the snapshot here so an
-    // explicit save persists the *current* master effects. The track snapshot in
-    // updateSavedState() is intentionally refreshed only AFTER the save to keep
-    // "Save As" correct (see commit 86c2f8f7).
+    // Refresh the saved master-effect snapshot before serializing so this save persists
+    // the current master effects. (updateSavedState() refreshes it only AFTER the save,
+    // intentionally, to keep "Save As" correct — see commit 86c2f8f7.)
     SavedMasterEffectList::Get(project).UpdateCopy();
 
     auto result = projectFileIO.SaveProject(wxFromString(filePath.toString()), m_lastSavedTracks.get());

--- a/src/project/internal/audacityproject.h
+++ b/src/project/internal/audacityproject.h
@@ -100,6 +100,7 @@ public:
 
 private:
     friend class Project_Audacity4ProjectTests;
+    friend class Project_RealtimeEffectsPersistenceTests;
 
     void setupProjectNotifications();
     void setPath(const muse::io::path_t& path);

--- a/src/project/tests/CMakeLists.txt
+++ b/src/project/tests/CMakeLists.txt
@@ -10,6 +10,7 @@ set(MODULE_TEST_SRC
     ${CMAKE_CURRENT_LIST_DIR}/mocks/audacityprojectmock.h
     ${CMAKE_CURRENT_LIST_DIR}/mocks/projectconfigurationmock.h
     ${CMAKE_CURRENT_LIST_DIR}/mocks/trackeditprojectcreatormock.h
+    ${CMAKE_CURRENT_LIST_DIR}/mocks/dummyeffectinstancefactory.h
     ${CMAKE_CURRENT_LIST_DIR}/audacityproject_tests.cpp
     ${CMAKE_CURRENT_LIST_DIR}/realtimeeffectspersistence_tests.cpp
 )

--- a/src/project/tests/CMakeLists.txt
+++ b/src/project/tests/CMakeLists.txt
@@ -11,6 +11,7 @@ set(MODULE_TEST_SRC
     ${CMAKE_CURRENT_LIST_DIR}/mocks/projectconfigurationmock.h
     ${CMAKE_CURRENT_LIST_DIR}/mocks/trackeditprojectcreatormock.h
     ${CMAKE_CURRENT_LIST_DIR}/audacityproject_tests.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/realtimeeffectspersistence_tests.cpp
 )
 
 set(MODULE_TEST_LINK

--- a/src/project/tests/mocks/dummyeffectinstancefactory.h
+++ b/src/project/tests/mocks/dummyeffectinstancefactory.h
@@ -1,0 +1,50 @@
+/*
+* Audacity: A Digital Audio Editor
+*/
+#pragma once
+
+#include "au3-components/EffectInterface.h"
+
+namespace au::project {
+// Minimal EffectInstanceFactory so that RealtimeEffectList::AddState succeeds
+// (it requires state->GetEffect() != nullptr). No real plugin / PluginManager is
+// needed: serialization only writes the plugin id, and the state is retained on
+// reload regardless. All methods return trivial/empty values; MakeInstance() is
+// never called in this no-playback test.
+class DummyEffectInstanceFactory final : public EffectInstanceFactory
+{
+public:
+    // ComponentInterface
+    PluginPath GetPath() const override { return {}; }
+    ComponentInterfaceSymbol GetSymbol() const override { return {}; }
+    VendorSymbol GetVendor() const override { return {}; }
+    wxString GetVersion() const override { return {}; }
+    TranslatableString GetDescription() const override { return {}; }
+
+    // EffectDefinitionInterface
+    EffectType GetType() const override { return EffectTypeProcess; }
+    EffectFamilySymbol GetFamily() const override { return {}; }
+    bool IsInteractive() const override { return false; }
+    bool IsDefault() const override { return false; }
+    RealtimeSince RealtimeSupport() const override { return RealtimeSince::Always; }
+    bool SupportsAutomation() const override { return false; }
+
+    // EffectSettingsManager
+    bool SaveSettings(const EffectSettings&, CommandParameters&) const override { return true; }
+    bool LoadSettings(const CommandParameters&, EffectSettings&) const override { return true; }
+    RegistryPaths GetFactoryPresets() const override { return {}; }
+    OptionalMessage LoadUserPreset(const RegistryPath&, EffectSettings&) const override { return {}; }
+    bool SaveUserPreset(const RegistryPath&, const EffectSettings&) const override { return true; }
+    OptionalMessage LoadFactoryPreset(int, EffectSettings&) const override { return {}; }
+    OptionalMessage LoadFactoryDefaults(EffectSettings&) const override { return {}; }
+
+    // EffectInstanceFactory
+    std::shared_ptr<EffectInstance> MakeInstance() const override { return nullptr; }
+};
+
+inline const EffectInstanceFactory& dummyFactory()
+{
+    static DummyEffectInstanceFactory instance;
+    return instance;
+}
+}

--- a/src/project/tests/realtimeeffectspersistence_tests.cpp
+++ b/src/project/tests/realtimeeffectspersistence_tests.cpp
@@ -1,24 +1,6 @@
 /*
-* SPDX-License-Identifier: GPL-3.0-only
- * Audacity-CLA-applies
- *
- * Audacity
- * A Digital Audio Editor
- *
- * Copyright (C) 2025 Audacity Limited
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License version 3 as
- * published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
- */
+* Audacity: A Digital Audio Editor
+*/
 
 // Regression test for: master-track realtime effects lost on save/reload.
 //
@@ -39,6 +21,7 @@
 
 #include "project/tests/mocks/trackeditprojectcreatormock.h"
 #include "project/tests/mocks/projectviewstatecreatormock.h"
+#include "project/tests/mocks/dummyeffectinstancefactory.h"
 #include "trackedit/tests/mocks/clipboardmock.h"
 
 #include "testtools.h"
@@ -49,53 +32,8 @@
 #include "au3-project/Project.h"
 #include "au3-realtime-effects/RealtimeEffectList.h"
 #include "au3-realtime-effects/RealtimeEffectState.h"
-#include "au3-components/EffectInterface.h"
 
 namespace au::project {
-namespace {
-// Minimal EffectInstanceFactory so that RealtimeEffectList::AddState succeeds
-// (it requires state->GetEffect() != nullptr). No real plugin / PluginManager is
-// needed: serialization only writes the plugin id, and the state is retained on
-// reload regardless. All methods return trivial/empty values; MakeInstance() is
-// never called in this no-playback test.
-class DummyEffectInstanceFactory final : public EffectInstanceFactory
-{
-public:
-    // ComponentInterface
-    PluginPath GetPath() const override { return {}; }
-    ComponentInterfaceSymbol GetSymbol() const override { return {}; }
-    VendorSymbol GetVendor() const override { return {}; }
-    wxString GetVersion() const override { return {}; }
-    TranslatableString GetDescription() const override { return {}; }
-
-    // EffectDefinitionInterface
-    EffectType GetType() const override { return EffectTypeProcess; }
-    EffectFamilySymbol GetFamily() const override { return {}; }
-    bool IsInteractive() const override { return false; }
-    bool IsDefault() const override { return false; }
-    RealtimeSince RealtimeSupport() const override { return RealtimeSince::Always; }
-    bool SupportsAutomation() const override { return false; }
-
-    // EffectSettingsManager
-    bool SaveSettings(const EffectSettings&, CommandParameters&) const override { return true; }
-    bool LoadSettings(const CommandParameters&, EffectSettings&) const override { return true; }
-    RegistryPaths GetFactoryPresets() const override { return {}; }
-    OptionalMessage LoadUserPreset(const RegistryPath&, EffectSettings&) const override { return {}; }
-    bool SaveUserPreset(const RegistryPath&, const EffectSettings&) const override { return true; }
-    OptionalMessage LoadFactoryPreset(int, EffectSettings&) const override { return {}; }
-    OptionalMessage LoadFactoryDefaults(EffectSettings&) const override { return {}; }
-
-    // EffectInstanceFactory
-    std::shared_ptr<EffectInstance> MakeInstance() const override { return nullptr; }
-};
-
-const EffectInstanceFactory& dummyFactory()
-{
-    static DummyEffectInstanceFactory instance;
-    return instance;
-}
-}
-
 class Project_RealtimeEffectsPersistenceTests : public ::testing::Test
 {
 protected:
@@ -150,7 +88,7 @@ TEST_F(Project_RealtimeEffectsPersistenceTests, MasterEffectList_SurvivesSaveRel
         = (muse::String::fromUtf8(au_project_tests_DATA_ROOT) + "/data/master_effect_roundtrip.aup3").toStdString();
 
     // Writable working copy of the (empty) project.
-    testtools::removeIfExists(dstPath);
+    testtools::removeProjectIfExists(dstPath);
     ASSERT_TRUE(testtools::copyFile(srcPath, dstPath));
 
     const muse::io::path_t projectPath(dstPath);
@@ -175,8 +113,9 @@ TEST_F(Project_RealtimeEffectsPersistenceTests, MasterEffectList_SurvivesSaveRel
         ASSERT_EQ(live.GetStatesCount(), 1u);
     }
 
-    // 3) Save through the same path that had the bug (Au3ProjectAccessor::save ->
-    //    SaveProject -> WriteXML), bypassing the facade's thumbnail creation.
+    // 3) Save through the path that had the #9790 bug (Au3ProjectAccessor::save ->
+    //    SaveProject -> WriteXML serializing a stale master-effect snapshot),
+    //    bypassing the facade's thumbnail creation.
     ASSERT_TRUE(saveDirect(m_currentProject, projectPath));
 
     // 4) Close and reload into a fresh project instance.
@@ -193,8 +132,6 @@ TEST_F(Project_RealtimeEffectsPersistenceTests, MasterEffectList_SurvivesSaveRel
 
     m_currentProject->close();
 
-    testtools::removeIfExists(dstPath);
-    testtools::removeIfExists(dstPath + "-wal");
-    testtools::removeIfExists(dstPath + "-shm");
+    testtools::removeProjectIfExists(dstPath);
 }
 }

--- a/src/project/tests/realtimeeffectspersistence_tests.cpp
+++ b/src/project/tests/realtimeeffectspersistence_tests.cpp
@@ -1,0 +1,200 @@
+/*
+* SPDX-License-Identifier: GPL-3.0-only
+ * Audacity-CLA-applies
+ *
+ * Audacity
+ * A Digital Audio Editor
+ *
+ * Copyright (C) 2025 Audacity Limited
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+// Regression test for: master-track realtime effects lost on save/reload.
+//
+// The master (project-wide) realtime-effect list is serialized in
+// ProjectFileIO::WriteXML from a snapshot (SavedMasterEffectList), not the live
+// list. Au3ProjectAccessor::load() takes that snapshot (empty) right after load;
+// if the snapshot is not refreshed before SaveProject, master effects added since
+// load are never written, and reopening loses them. This test reproduces the
+// load -> add -> save -> reload round trip and asserts the effect survives.
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include "global/io/fileinfo.h"
+#include "global/types/ret.h"
+
+#include "project/internal/audacityproject.h"
+
+#include "project/tests/mocks/trackeditprojectcreatormock.h"
+#include "project/tests/mocks/projectviewstatecreatormock.h"
+#include "trackedit/tests/mocks/clipboardmock.h"
+
+#include "testtools.h"
+#include "testing/testcontext.h"
+
+// au3 realtime-effects (symbols come transitively from au3wrap's public link of
+// au3-realtime-effects / au3-components).
+#include "au3-project/Project.h"
+#include "au3-realtime-effects/RealtimeEffectList.h"
+#include "au3-realtime-effects/RealtimeEffectState.h"
+#include "au3-components/EffectInterface.h"
+
+namespace au::project {
+namespace {
+// Minimal EffectInstanceFactory so that RealtimeEffectList::AddState succeeds
+// (it requires state->GetEffect() != nullptr). No real plugin / PluginManager is
+// needed: serialization only writes the plugin id, and the state is retained on
+// reload regardless. All methods return trivial/empty values; MakeInstance() is
+// never called in this no-playback test.
+class DummyEffectInstanceFactory final : public EffectInstanceFactory
+{
+public:
+    // ComponentInterface
+    PluginPath GetPath() const override { return {}; }
+    ComponentInterfaceSymbol GetSymbol() const override { return {}; }
+    VendorSymbol GetVendor() const override { return {}; }
+    wxString GetVersion() const override { return {}; }
+    TranslatableString GetDescription() const override { return {}; }
+
+    // EffectDefinitionInterface
+    EffectType GetType() const override { return EffectTypeProcess; }
+    EffectFamilySymbol GetFamily() const override { return {}; }
+    bool IsInteractive() const override { return false; }
+    bool IsDefault() const override { return false; }
+    RealtimeSince RealtimeSupport() const override { return RealtimeSince::Always; }
+    bool SupportsAutomation() const override { return false; }
+
+    // EffectSettingsManager
+    bool SaveSettings(const EffectSettings&, CommandParameters&) const override { return true; }
+    bool LoadSettings(const CommandParameters&, EffectSettings&) const override { return true; }
+    RegistryPaths GetFactoryPresets() const override { return {}; }
+    OptionalMessage LoadUserPreset(const RegistryPath&, EffectSettings&) const override { return {}; }
+    bool SaveUserPreset(const RegistryPath&, const EffectSettings&) const override { return true; }
+    OptionalMessage LoadFactoryPreset(int, EffectSettings&) const override { return {}; }
+    OptionalMessage LoadFactoryDefaults(EffectSettings&) const override { return {}; }
+
+    // EffectInstanceFactory
+    std::shared_ptr<EffectInstance> MakeInstance() const override { return nullptr; }
+};
+
+const EffectInstanceFactory& dummyFactory()
+{
+    static DummyEffectInstanceFactory instance;
+    return instance;
+}
+}
+
+class Project_RealtimeEffectsPersistenceTests : public ::testing::Test
+{
+protected:
+    muse::modularity::ContextPtr m_testCtx;
+    std::unique_ptr<Audacity4Project> m_currentProject;
+    std::shared_ptr<au::project::TrackeditProjectCreatorMock> m_trackeditProjectCreator;
+    std::shared_ptr<au::projectscene::ProjectViewStateCreatorMock> m_projectViewStateCreator;
+    std::shared_ptr<au::trackedit::ClipboardMock> m_clipboard;
+
+    void SetUp() override
+    {
+        m_testCtx = au::testutils::makeTestContext();
+        m_clipboard = std::make_shared<::testing::NiceMock<au::trackedit::ClipboardMock> >();
+        m_currentProject = makeProject();
+    }
+
+    void TearDown() override
+    {
+        if (m_currentProject) {
+            m_currentProject.reset();
+        }
+    }
+
+    std::unique_ptr<Audacity4Project> makeProject()
+    {
+        auto project = std::make_unique<Audacity4Project>(m_testCtx);
+        project->trackeditProjectCreator.set(m_trackeditProjectCreator);
+        project->viewStateCreator.set(m_projectViewStateCreator);
+        project->clipboard.set(m_clipboard);
+        return project;
+    }
+
+    static ::AudacityProject& au3Project(const std::unique_ptr<Audacity4Project>& project)
+    {
+        return *reinterpret_cast<::AudacityProject*>(project->m_au3Project->au3ProjectPtr());
+    }
+
+    // Save through Au3ProjectAccessor::save() directly (the method under test),
+    // bypassing the facade's thumbnail creation. Friendship is granted to this
+    // fixture, not to the TEST_F-generated subclass, so the access must live here.
+    static bool saveDirect(const std::unique_ptr<Audacity4Project>& project, const muse::io::path_t& path)
+    {
+        return project->m_au3Project->save(path);
+    }
+};
+
+TEST_F(Project_RealtimeEffectsPersistenceTests, MasterEffectList_SurvivesSaveReload)
+{
+    const std::string srcPath
+        = (muse::String::fromUtf8(au_project_tests_DATA_ROOT) + "/data/empty.aup3").toStdString();
+    const std::string dstPath
+        = (muse::String::fromUtf8(au_project_tests_DATA_ROOT) + "/data/master_effect_roundtrip.aup3").toStdString();
+
+    // Writable working copy of the (empty) project.
+    testtools::removeIfExists(dstPath);
+    ASSERT_TRUE(testtools::copyFile(srcPath, dstPath));
+
+    const muse::io::path_t projectPath(dstPath);
+    const PluginID kFakeId = wxString::FromUTF8("au-test:fake-master-effect");
+
+    // Resolve the fake plugin id for the whole test, so AddState succeeds and the
+    // state survives reload's SetID() -> GetEffect() re-resolution.
+    RealtimeEffectState::EffectFactory::Scope effectFactoryScope {
+        [](const PluginID&) -> const EffectInstanceFactory* { return &dummyFactory(); }
+    };
+
+    // 1) Load the project. Au3ProjectAccessor::load() takes the (empty) master snapshot.
+    ASSERT_TRUE(m_currentProject->load(projectPath, false, "").success());
+
+    // 2) Add a master realtime effect to the LIVE list (the snapshot is now stale).
+    {
+        auto& live = RealtimeEffectList::Get(au3Project(m_currentProject));
+        ASSERT_EQ(live.GetStatesCount(), 0u);
+
+        auto state = RealtimeEffectState::make_shared(kFakeId);
+        ASSERT_TRUE(live.AddState(state));
+        ASSERT_EQ(live.GetStatesCount(), 1u);
+    }
+
+    // 3) Save through the same path that had the bug (Au3ProjectAccessor::save ->
+    //    SaveProject -> WriteXML), bypassing the facade's thumbnail creation.
+    ASSERT_TRUE(saveDirect(m_currentProject, projectPath));
+
+    // 4) Close and reload into a fresh project instance.
+    m_currentProject->close();
+    m_currentProject = makeProject();
+    ASSERT_TRUE(m_currentProject->load(projectPath, false, "").success());
+
+    // 5) The master effect must have round-tripped.
+    auto& reloaded = RealtimeEffectList::Get(au3Project(m_currentProject));
+    EXPECT_EQ(reloaded.GetStatesCount(), 1u);
+    if (reloaded.GetStatesCount() == 1u) {
+        EXPECT_EQ(reloaded.GetStateAt(0)->GetID().ToStdString(), kFakeId.ToStdString());
+    }
+
+    m_currentProject->close();
+
+    testtools::removeIfExists(dstPath);
+    testtools::removeIfExists(dstPath + "-wal");
+    testtools::removeIfExists(dstPath + "-shm");
+}
+}

--- a/src/project/tests/testtools.h
+++ b/src/project/tests/testtools.h
@@ -122,6 +122,15 @@ inline bool removeIfExists(const std::string& path)
     return true;
 }
 
+//! Remove an .aup3 project file along with its SQLite WAL/SHM sidecar files, if present.
+inline bool removeProjectIfExists(const std::string& path)
+{
+    bool ok = removeIfExists(path);
+    ok = removeIfExists(path + "-wal") && ok;
+    ok = removeIfExists(path + "-shm") && ok;
+    return ok;
+}
+
 inline bool prepareDestinationFile(const std::string& from, const std::string& to)
 {
     return (from == to) || removeIfExists(to);

--- a/src/projectscene/view/trackspanel/realtimeeffectlistmodel.cpp
+++ b/src/projectscene/view/trackspanel/realtimeeffectlistmodel.cpp
@@ -28,11 +28,19 @@ void RealtimeEffectListModel::onProjectChanged()
                 emit trackNameChanged();
             }
         });
-        const std::vector<au::trackedit::TrackId> trackIds = project->trackIdList();
-        for (const auto& trackId : trackIds) {
-            if (belongsWithMe(trackId)) {
-                // Project was just opened, we can use brute-force `onChanged`, it won't have an impact on scrollbar position or alike.
-                onChanged(trackId);
+        // Project was just opened, we can use brute-force `onChanged`, it won't have an impact on scrollbar position or alike.
+        if (m_isMasterTrack) {
+            // The master track is not part of `trackIdList()`, so populate it explicitly.
+            // Otherwise persisted master effects would not be shown on project open, and
+            // `m_trackEffectLists` would have no master entry when a `realtimeEffectAdded`
+            // event later arrives (causing an assert in `onAdded`).
+            onChanged(IRealtimeEffectService::masterTrackId);
+        } else {
+            const std::vector<au::trackedit::TrackId> trackIds = project->trackIdList();
+            for (const auto& trackId : trackIds) {
+                if (belongsWithMe(trackId)) {
+                    onChanged(trackId);
+                }
             }
         }
     } else {

--- a/src/projectscene/view/trackspanel/realtimeeffectlistmodel.cpp
+++ b/src/projectscene/view/trackspanel/realtimeeffectlistmodel.cpp
@@ -31,9 +31,6 @@ void RealtimeEffectListModel::onProjectChanged()
         // Project was just opened, we can use brute-force `onChanged`, it won't have an impact on scrollbar position or alike.
         if (m_isMasterTrack) {
             // The master track is not part of `trackIdList()`, so populate it explicitly.
-            // Otherwise persisted master effects would not be shown on project open, and
-            // `m_trackEffectLists` would have no master entry when a `realtimeEffectAdded`
-            // event later arrives (causing an assert in `onAdded`).
             onChanged(IRealtimeEffectService::masterTrackId);
         } else {
             const std::vector<au::trackedit::TrackId> trackIds = project->trackIdList();


### PR DESCRIPTION
Resolves: Master effects don't stick #9790

- Fix master-track realtime effects lost on save/reload
- Show persisted master-track effects on project open


<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
