### PR TITLE
Use audacity-actions v7

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,13 +135,13 @@ jobs:
           postfix: '-22.04'
     steps:
     - name: Setup Dependencies
-      uses: audacity/audacity-actions/dependencies@v5
+      uses: audacity/audacity-actions/dependencies@v7
       with:
         force_gcc11: ${{ matrix.config.force_gcc11 }}
     - name: Checkout Audacity
       uses: actions/checkout@v4
     - name: Configure
-      uses: audacity/audacity-actions/configure@v4
+      uses: audacity/audacity-actions/configure@v7
       with:
         generator: Unix Makefiles
         build_type: ${{ env.BUILD_TYPE }}
@@ -149,14 +149,14 @@ jobs:
         build_level: ${{ env.BUILD_LEVEL }}
         cmake_options: ${{ env.CONFIGURE_CMAKE_OPTIONS }}
     - name: Build
-      uses: audacity/audacity-actions/build@v4
+      uses: audacity/audacity-actions/build@v7
     - name: Test
       uses: GabrielBB/xvfb-action@v1
       with:
         run: ctest -C ${{ env.BUILD_TYPE }} --verbose
         working-directory: ./.build.x64/
     - name: Package
-      uses: audacity/audacity-actions/package@v6
+      uses: audacity/audacity-actions/package@v7
       with:
         postfix: ${{ matrix.config.postfix }}
 
@@ -189,11 +189,11 @@ jobs:
     - name: Checkout Audacity
       uses: actions/checkout@v4
     - name: Setup Dependencies
-      uses: audacity/audacity-actions/dependencies@v4
+      uses: audacity/audacity-actions/dependencies@v7
       with:
         force_gcc11: ${{ matrix.config.force_gcc11 }}
     - name: Configure
-      uses: audacity/audacity-actions/configure@v4
+      uses: audacity/audacity-actions/configure@v7
       with:
         generator: ${{ matrix.config.generator }}
         arch: ${{ matrix.config.arch }}
@@ -207,7 +207,7 @@ jobs:
         windows_code_signing_access_key_id: ${{ secrets.WINDOWS_CODE_SIGNING_ACCESS_KEY_ID }}
         windows_code_signing_secret_access_key: ${{ secrets.WINDOWS_CODE_SIGNING_SECRET_ACCESS_KEY }}
     - name: Build
-      uses: audacity/audacity-actions/build@v4
+      uses: audacity/audacity-actions/build@v7
     - name: Test
       shell: pwsh
       run: |
@@ -215,7 +215,7 @@ jobs:
         ctest -C ${{ env.BUILD_TYPE }} --verbose
         popd
     - name: Package
-      uses: audacity/audacity-actions/package@v6
+      uses: audacity/audacity-actions/package@v7
       with:
         postfix: ${{ matrix.config.postfix }}
   build_macos_intel:
@@ -225,11 +225,11 @@ jobs:
     - name: Checkout Audacity
       uses: actions/checkout@v4
     - name: Setup Dependencies
-      uses: audacity/audacity-actions/dependencies@v4
+      uses: audacity/audacity-actions/dependencies@v7
       with:
         force_gcc11: ${{ matrix.config.force_gcc11 }}
     - name: Configure x86_64
-      uses: audacity/audacity-actions/configure@v4
+      uses: audacity/audacity-actions/configure@v7
       with:
         generator: Xcode
         build_type: ${{ env.BUILD_TYPE }}
@@ -238,7 +238,7 @@ jobs:
         cmake_options: ${{ env.CONFIGURE_CMAKE_OPTIONS }}
         arch: x64
     - name: Build x86_64
-      uses: audacity/audacity-actions/build@v4
+      uses: audacity/audacity-actions/build@v7
     - name: Test
       shell: bash
       run: |
@@ -259,11 +259,11 @@ jobs:
     - name: Checkout Audacity
       uses: actions/checkout@v4
     - name: Setup Dependencies
-      uses: audacity/audacity-actions/dependencies@v4
+      uses: audacity/audacity-actions/dependencies@v7
       with:
         force_gcc11: ${{ matrix.config.force_gcc11 }}
     - name: Configure x86_64
-      uses: audacity/audacity-actions/configure@v4
+      uses: audacity/audacity-actions/configure@v7
       with:
         generator: Xcode
         build_type: ${{ env.BUILD_TYPE }}
@@ -272,11 +272,11 @@ jobs:
         cmake_options: ${{ env.CONFIGURE_CMAKE_OPTIONS }}
         arch: x64
     - name: Build x86_64
-      uses: audacity/audacity-actions/build@v4
+      uses: audacity/audacity-actions/build@v7
       with:
         target: image-compiler
     - name: Configure arm64
-      uses: audacity/audacity-actions/configure@v4
+      uses: audacity/audacity-actions/configure@v7
       with:
         generator: Xcode
         build_type: ${{ env.BUILD_TYPE }}
@@ -286,7 +286,7 @@ jobs:
         arch: arm64
         image_compiler: "${{ github.workspace }}/.build.x64/RelWithDebInfo/Audacity.app/Contents/image-compiler/image-compiler"
     - name: Build arm64
-      uses: audacity/audacity-actions/build@v4
+      uses: audacity/audacity-actions/build@v7
     - name: 'Tar files'
       shell: bash
       run: tar cf macos_arm64.tar .build.arm64
@@ -327,7 +327,7 @@ jobs:
         p12-file-base64: ${{ secrets.APPLE_CERTIFICATE }}
         p12-password: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
     - name: Package
-      uses: audacity/audacity-actions/package@v6
+      uses: audacity/audacity-actions/package@v7
       env:
         AUDACITY_BUILD_DIR: "${{ github.workspace }}/.build.x64"
         AUDACITY_BUILD_TYPE: ${{ env.BUILD_TYPE }}
@@ -346,13 +346,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Setup Dependencies
-      uses: audacity/audacity-actions/dependencies@v4
+      uses: audacity/audacity-actions/dependencies@v7
       with:
         force_gcc11: ${{ matrix.config.force_gcc11 }}
     - name: Checkout Audacity
       uses: actions/checkout@v4
     - name: Configure
-      uses: audacity/audacity-actions/configure@v4
+      uses: audacity/audacity-actions/configure@v7
       with:
         generator: Unix Makefiles
         build_type: ${{ env.BUILD_TYPE }}

--- a/.github/workflows/package_linux.yml
+++ b/.github/workflows/package_linux.yml
@@ -57,9 +57,9 @@ jobs:
     - name: Checkout Audacity
       uses: actions/checkout@v2
     - name: Setup Dependencies
-      uses: audacity/audacity-actions/dependencies@v2
+      uses: audacity/audacity-actions/dependencies@v7
     - name: Configure
-      uses: audacity/audacity-actions/configure@v2
+      uses: audacity/audacity-actions/configure@v7
       with:
         generator: Unix Makefiles
         build_type: ${{ env.BUILD_TYPE }}


### PR DESCRIPTION
Updates all audacity-actions references to v7, which runs on Node 24 ahead of GitHub's forced runner migration on June 16 and includes a volume.node rebuilt for the Node 24 ABI (the old blob would fail to load, breaking macOS packaging).