### PR TITLE
10558 Select track data on track panel click

### DIFF
--- a/src/projectscene/qml/Audacity/ProjectScene/trackspanel/TrackItem.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/trackspanel/TrackItem.qml
@@ -35,6 +35,7 @@ ListItemBlank {
     signal interactionStarted
     signal interactionEnded
     signal selectionRequested(bool exclusive)
+    signal dataSelectionRequested
 
     signal mousePressed(var item, double x, double y)
     signal mouseReleased(var item, double x, double y)
@@ -227,9 +228,14 @@ ListItemBlank {
                 // child elements to handle the input
                 e.accepted = false
                 let toggleModifier = e.modifiers & Qt.ControlModifier
-                if (!root.isSelected || toggleModifier) {
-                    root.selectionRequested(false)
+
+                if (!toggleModifier) {
+                    root.selectionRequested(true)
+                    root.dataSelectionRequested()
+                    return
                 }
+
+                root.selectionRequested(false)
             }
         }
 

--- a/src/projectscene/qml/Audacity/ProjectScene/trackspanel/TracksPanel.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/trackspanel/TracksPanel.qml
@@ -253,6 +253,10 @@ Item {
                                 tracksModel.selectRow(index, exclusive)
                             }
 
+                            onDataSelectionRequested: {
+                                tracksModel.selectAudioData(index)
+                            }
+
                             onOpenEffectsRequested: {
                                 effectSectionModel.showEffectsSection = true
                                 root.openEffectsRequested()
@@ -308,6 +312,10 @@ Item {
 
                             onSelectionRequested: function (exclusive) {
                                 tracksModel.selectRow(index, exclusive)
+                            }
+
+                            onDataSelectionRequested: {
+                                tracksModel.selectAudioData(index)
                             }
 
                             onRemoveSelectionRequested: {

--- a/src/projectscene/view/tracksitemsview/viewtrackslistmodel.cpp
+++ b/src/projectscene/view/tracksitemsview/viewtrackslistmodel.cpp
@@ -79,8 +79,7 @@ void ViewTracksListModel::load()
         QModelIndex beginIndex = index(0);
         QModelIndex lastIndex = index(static_cast<int>(m_trackList.size()) - 1);
 
-        emit dataChanged(beginIndex, lastIndex, { IsTrackSelectedRole });
-        emit dataChanged(beginIndex, lastIndex, { IsDataSelectedRole });
+        emit dataChanged(beginIndex, lastIndex, { IsTrackSelectedRole, IsDataSelectedRole });
     }, muse::async::Asyncable::Mode::SetReplace);
 
     trackNavigationController()->focusedTrackChanged().onReceive(this, [this](const trackedit::TrackId& /*trackId*/, bool /*highlight*/) {
@@ -124,7 +123,7 @@ void ViewTracksListModel::load()
 
         // TODO: only dataChanged affected tracks, not the whole thing
         const int lastIndex = static_cast<int>(m_trackList.size()) - 1;
-        emit dataChanged(index(0), index(lastIndex), { IsTrackSelectedRole });
+        emit dataChanged(index(0), index(lastIndex), { IsTrackSelectedRole, IsDataSelectedRole });
     }, muse::async::Asyncable::Mode::SetReplace);
 
     selectionController()->dataSelectedStartTimeChanged().onReceive(this, [this](trackedit::secs_t begin) {

--- a/src/projectscene/view/trackspanel/paneltrackslistmodel.cpp
+++ b/src/projectscene/view/trackspanel/paneltrackslistmodel.cpp
@@ -166,10 +166,30 @@ void PanelTracksListModel::selectRow(int row, bool exclusive)
         m_selectionModel->select(index(row));
     }
 
-    //! NOTE: Selecting a track unselects all clips
+    //! NOTE: Selecting a track unselects all clips and clears any frequency selection
     selectionController()->resetSelectedClips();
+    frequencySelectionController()->resetFrequencySelection();
 
     projectHistory()->modifyState();
+}
+
+void PanelTracksListModel::selectAudioData(int row)
+{
+    if (row < 0 || row >= rowCount()) {
+        return;
+    }
+
+    if (TrackItem* item = modelIndexToItem(index(row))) {
+        const trackedit::TrackType type = item->trackType();
+        if (type == trackedit::TrackType::Mono || type == trackedit::TrackType::Stereo) {
+            selectionController()->setSelectedTrackAudioData(item->trackId());
+
+            muse::actions::ActionQuery seek("action://playback/seek");
+            seek.addParam("seekTime", muse::Val(selectionController()->dataSelectedStartTime()));
+            seek.addParam("triggerPlay", muse::Val(false));
+            dispatcher()->dispatch(seek);
+        }
+    }
 }
 
 void PanelTracksListModel::clearSelection()

--- a/src/projectscene/view/trackspanel/paneltrackslistmodel.h
+++ b/src/projectscene/view/trackspanel/paneltrackslistmodel.h
@@ -15,6 +15,7 @@
 #include "trackedit/iselectioncontroller.h"
 #include "trackedit/iprojecthistory.h"
 #include "trackedit/internal/itracknavigationcontroller.h"
+#include "spectrogram/ifrequencyselectioncontroller.h"
 
 #include "trackitem.h"
 
@@ -42,6 +43,7 @@ class PanelTracksListModel : public QAbstractListModel, public muse::async::Asyn
     muse::ContextInject<trackedit::IProjectHistory> projectHistory{ this };
     muse::ContextInject<muse::actions::IActionsDispatcher> dispatcher{ this };
     muse::ContextInject<trackedit::ITrackNavigationController> trackNavigationController{ this };
+    muse::ContextInject<spectrogram::IFrequencySelectionController> frequencySelectionController{ this };
 
 public:
     explicit PanelTracksListModel(QObject* parent = nullptr);
@@ -54,6 +56,7 @@ public:
 
     Q_INVOKABLE QItemSelectionModel* selectionModel() const;
     Q_INVOKABLE void selectRow(int row, bool exclusive = false);
+    Q_INVOKABLE void selectAudioData(int row);
     Q_INVOKABLE void clearSelection();
     Q_INVOKABLE void moveSelectedRowsUp();
     Q_INVOKABLE void moveSelectedRowsDown();


### PR DESCRIPTION
Resolves: #10558 
Resolves: #10726 

Select track data on the panel, double-click, and clear frequency selection.
Track is selected with a single click.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
