### PR TITLE
accessibility: add screen reader labels across UI

### DIFF
--- a/src/appshell/qml/Audacity/AppShell/MainToolBar.qml
+++ b/src/appshell/qml/Audacity/AppShell/MainToolBar.qml
@@ -61,7 +61,7 @@ Item {
         id: navPanel
         name: "MainToolBar"
         enabled: root.enabled && root.visible
-        accessible.name: qsTrc("appshell", "Main toolbar") + " " + navPanel.directionInfo
+        accessible.name: qsTrc("appshell", "Main toolbar")
     }
 
     RadioButtonGroup {

--- a/src/appshell/qml/Audacity/AppShell/ProjectPage/ProjectStatusBar.qml
+++ b/src/appshell/qml/Audacity/AppShell/ProjectPage/ProjectStatusBar.qml
@@ -40,6 +40,7 @@ Item {
         id: navPanel
         name: "ProjectStatusBar"
         enabled: root.enabled && root.visible
+        accessible.name: qsTrc("appshell", "Selection status")
         order: 0
         direction: NavigationPanel.Horizontal
         section: navSec

--- a/src/effects/builtin_collection/graphiceq/GraphicEqBoard.qml
+++ b/src/effects/builtin_collection/graphiceq/GraphicEqBoard.qml
@@ -163,6 +163,7 @@ Item {
 
                     navigation.panel: root.navigationPanel
                     navigation.order: root.navigationOrderStart + index
+                    navigation.accessible.name: qsTrc("effects/graphiceq", "%1 Hz").arg(model.centerFreq)
 
                     value: model.dbGain
 

--- a/src/effects/builtin_collection/noisereduction/NoiseReductionSlider.qml
+++ b/src/effects/builtin_collection/noisereduction/NoiseReductionSlider.qml
@@ -11,6 +11,7 @@ Row {
     property alias from: slider.from
     property alias to: slider.to
     property alias measureUnitsSymbol: textControl.measureUnitsSymbol
+    property string accessibleName: ""
 
     property var navigationPanel: null
     property int navigationOrderStart: 0
@@ -34,6 +35,7 @@ Row {
 
         navigation.panel: root.navigationPanel
         navigation.order: root.navigationOrderStart
+        navigation.accessible.name: root.accessibleName
 
         value: root.value
         onMoved: {
@@ -51,6 +53,7 @@ Row {
 
         navigation.panel: root.navigationPanel
         navigation.order: slider.navigation.order + 1
+        navigation.accessible.name: root.accessibleName + " " + currentValue + " " + measureUnitsSymbol
 
         decimals: root.isInt ? 0 : 2
         minValue: root.from

--- a/src/effects/builtin_collection/noisereduction/NoiseReductionView.qml
+++ b/src/effects/builtin_collection/noisereduction/NoiseReductionView.qml
@@ -152,6 +152,7 @@ BuiltinEffectBase {
 
                         navigationPanel: root.slidersNavigationPanel
                         navigationOrderStart: 0
+                        accessibleName: qsTrc("effects/noisereduction", "Noise reduction")
 
                         value: noiseReduction.reduction
                         onNewValueRequested: function (newValue) {
@@ -182,6 +183,7 @@ BuiltinEffectBase {
 
                         navigationPanel: root.slidersNavigationPanel
                         navigationOrderStart: reductionSlider.navigationOrderStart + 2
+                        accessibleName: qsTrc("effects/noisereduction", "Sensitivity")
 
                         value: noiseReduction.sensitivity
                         onNewValueRequested: function (newValue) {
@@ -211,6 +213,7 @@ BuiltinEffectBase {
 
                         navigationPanel: root.slidersNavigationPanel
                         navigationOrderStart: sensitivitySlider.navigationOrderStart + 2
+                        accessibleName: qsTrc("effects/noisereduction", "Frequency smoothing")
 
                         value: noiseReduction.frequencySmoothingBands
                         onNewValueRequested: function (newValue) {

--- a/src/effects/builtin_collection/qml/Audacity/BuiltinEffectsCollection/BigParameterKnob.qml
+++ b/src/effects/builtin_collection/qml/Audacity/BuiltinEffectsCollection/BigParameterKnob.qml
@@ -98,6 +98,8 @@ Item {
         KnobControl {
             id: knob
 
+            navigation.accessible.name: root.parameter["title"]
+
             value: warper.warpedValue
 
             anchors.horizontalCenter: parent.horizontalCenter
@@ -139,6 +141,8 @@ Item {
 
         IncrementalPropertyControl {
             id: textEdit
+
+            navigation.accessible.name: root.parameter["title"] + " " + currentValue
 
             anchors.horizontalCenter: parent.horizontalCenter
 

--- a/src/effects/builtin_collection/qml/Audacity/BuiltinEffectsCollection/ParameterKnob.qml
+++ b/src/effects/builtin_collection/qml/Audacity/BuiltinEffectsCollection/ParameterKnob.qml
@@ -56,6 +56,8 @@ Item {
             KnobControl {
                 id: knob
 
+                navigation.accessible.name: root.parameter["title"]
+
                 onNewValueRequested: function (value) {
                     root.newValueRequested(root.parameter["key"], value)
                 }
@@ -84,6 +86,8 @@ Item {
 
             IncrementalPropertyControl {
                 id: textEdit
+
+                navigation.accessible.name: root.parameter["title"] + " " + currentValue
 
                 width: 80
 

--- a/src/effects/builtin_collection/qml/Audacity/BuiltinEffectsCollection/SliderWithTextInput.qml
+++ b/src/effects/builtin_collection/qml/Audacity/BuiltinEffectsCollection/SliderWithTextInput.qml
@@ -42,6 +42,7 @@ Column {
 
             navigation.panel: root.navigationPanel
             navigation.order: root.navigationOrderStart
+            navigation.accessible.name: root.text
 
             anchors.verticalCenter: parent.verticalCenter
 
@@ -62,6 +63,7 @@ Column {
 
             navigation.panel: root.navigationPanel
             navigation.order: slider.navigation.order + 1
+            navigation.accessible.name: root.text + " " + currentValue + " " + measureUnitsSymbol
 
             width: parent.width * .35
 

--- a/src/effects/effects_base/qml/Audacity/Effects/BypassEffectButton.qml
+++ b/src/effects/effects_base/qml/Audacity/Effects/BypassEffectButton.qml
@@ -15,4 +15,5 @@ FlatButton {
     iconColor: accentButton ? ui.theme.extra["white_color"] : ui.theme.fontPrimaryColor
     iconFont: ui.theme.toolbarIconsFont
     accentColor: isMasterEffect ? ui.theme.extra["black_color"] : ui.theme.accentColor
+    toolTipTitle: qsTrc("effects", "Bypass effect")
 }

--- a/src/effects/effects_base/qml/Audacity/Effects/EffectPresetsBar.qml
+++ b/src/effects/effects_base/qml/Audacity/Effects/EffectPresetsBar.qml
@@ -86,6 +86,7 @@ RowLayout {
         navigation.panel: root.navigationPanel
         navigation.order: root.navigationOrder
         navigation.name: "preset dropdown"
+        navigation.accessible.name: qsTrc("effects", "Select preset")
 
         Layout.fillWidth: true
         background.color: ui.theme.backgroundPrimaryColor
@@ -158,6 +159,7 @@ RowLayout {
         navigation.panel: root.navigationPanel
         navigation.order: presetSelector.navigation.order + 1
         navigation.name: "save preset btn"
+        toolTipTitle: qsTrc("effects", "Save preset")
 
         Layout.alignment: Qt.AlignVCenter
         icon: IconCode.SAVE
@@ -173,6 +175,7 @@ RowLayout {
         navigation.panel: root.navigationPanel
         navigation.order: saveBtn.navigation.order + 1
         navigation.name: "reset preset btn"
+        toolTipTitle: qsTrc("effects", "Reset preset")
 
         Layout.alignment: Qt.AlignVCenter
 
@@ -190,6 +193,7 @@ RowLayout {
         navigation.panel: root.navigationPanel
         navigation.order: resetBtn.navigation.order + 1
         navigation.name: "delete preset btn"
+        toolTipTitle: qsTrc("effects", "Delete preset")
 
         Layout.alignment: Qt.AlignVCenter
 
@@ -207,6 +211,7 @@ RowLayout {
         navigation.panel: root.navigationPanel
         navigation.order: deleteBtn.navigation.order + 1
         navigation.name: "manage preset btn"
+        toolTipTitle: qsTrc("effects", "Preset options")
 
         Layout.alignment: Qt.AlignVCenter
 

--- a/src/effects/effects_base/qml/Audacity/Effects/RealtimeEffectViewerDialog.qml
+++ b/src/effects/effects_base/qml/Audacity/Effects/RealtimeEffectViewerDialog.qml
@@ -167,6 +167,7 @@ EffectStyledDialogView {
                         navigation.panel: root.navigationPanel
                         navigation.order: 0
                         navigation.name: "Bypass effect"
+                        toolTipTitle: qsTrc("effects", "Bypass effect")
                         size: presetsBar.implicitHeight
                         isMasterEffect: viewerModel.isMasterEffect
                         accentButton: viewerModel.isActive

--- a/src/importexport/export/qml/Export/CustomMappingDialog.qml
+++ b/src/importexport/export/qml/Export/CustomMappingDialog.qml
@@ -61,6 +61,9 @@ StyledDialogView {
                 minValue: 1
                 maxValue: 32
                 currentValue: customMappingModel.exportChannels
+
+                navigation.accessible.name: qsTrc("export", "Channel count %1").arg(currentValue)
+
                 onValueEdited: function (newValue) {
                     customMappingModel.exportChannels = newValue
                 }

--- a/src/importexport/export/qml/Export/ExportDialog.qml
+++ b/src/importexport/export/qml/Export/ExportDialog.qml
@@ -529,6 +529,7 @@ StyledDialogView {
                             property var option: ({
                                     index: model.index,
                                     type: model.type,
+                                    title: model.title,
                                     value: model.value,
                                     values: model.values,
                                     names: model.names,
@@ -697,6 +698,7 @@ StyledDialogView {
 
             navigation.panel: audioSection.navigation
             navigation.order: sampleRateDropdown.navigation.order + 1 + option.index
+            navigation.accessible.name: option.title + " " + currentText
 
             onActivated: function (index, value) {
                 dynamicOptionsModel.setData(dynamicOptionsModel.index(option.index, 0), option.values[index], ExportOptionType.ValueRole)
@@ -713,6 +715,7 @@ StyledDialogView {
 
             navigation.panel: audioSection.navigation
             navigation.order: sampleRateDropdown.navigation.order + 1 + option.index
+            navigation.accessible.name: option.title
 
             onClicked: dynamicOptionsModel.setData(dynamicOptionsModel.index(option.index, 0), checked, ExportOptionType.ValueRole)
         }
@@ -744,6 +747,8 @@ StyledDialogView {
             value: Number(dynamicOptionsModel.data(dynamicOptionsModel.index(option.index, 0), ExportOptionType.ValueRole))
             onValueChanged: dynamicOptionsModel.setData(dynamicOptionsModel.index(option.index, 0), Math.round(option.value), ExportOptionType.ValueRole)
             Layout.minimumWidth: 180
+
+            navigation.accessible.name: option.title
         }
     }
 
@@ -761,6 +766,7 @@ StyledDialogView {
 
             navigation.panel: audioSection.navigation
             navigation.order: sampleRateDropdown.navigation.order + 1 + option.index
+            navigation.accessible.name: option.title + " " + currentValue
 
             onValueEdited: function (newValue) {
                 dynamicOptionsModel.setData(dynamicOptionsModel.index(option.index, 0), newValue, ExportOptionType.ValueRole)

--- a/src/importexport/export/qml/Export/internal/FLACOptionsSection.qml
+++ b/src/importexport/export/qml/Export/internal/FLACOptionsSection.qml
@@ -50,6 +50,8 @@ ColumnLayout {
 
                     currentValue: ffmpegPrefModel.compression
 
+                    navigation.accessible.name: qsTrc("export", "Compression %1").arg(currentValue)
+
                     onValueEdited: function (newValue) {
                         ffmpegPrefModel.setCompression(newValue)
                     }
@@ -77,6 +79,8 @@ ColumnLayout {
                     step: 1
 
                     currentValue: ffmpegPrefModel.lpc
+
+                    navigation.accessible.name: qsTrc("export", "LPC %1").arg(currentValue)
 
                     onValueEdited: function (newValue) {
                         ffmpegPrefModel.setLpc(newValue)
@@ -106,6 +110,8 @@ ColumnLayout {
 
                     currentValue: ffmpegPrefModel.minPdO
 
+                    navigation.accessible.name: qsTrc("export", "Min. PdO %1").arg(currentValue)
+
                     onValueEdited: function (newValue) {
                         ffmpegPrefModel.setMinPdO(newValue)
                     }
@@ -133,6 +139,8 @@ ColumnLayout {
                     step: 1
 
                     currentValue: ffmpegPrefModel.minPtO
+
+                    navigation.accessible.name: qsTrc("export", "Min. PtO %1").arg(currentValue)
 
                     onValueEdited: function (newValue) {
                         ffmpegPrefModel.setMinPtO(newValue)
@@ -173,6 +181,8 @@ ColumnLayout {
 
                     currentValue: ffmpegPrefModel.frameSize
 
+                    navigation.accessible.name: qsTrc("export", "Frame %1").arg(currentValue)
+
                     onValueEdited: function (newValue) {
                         ffmpegPrefModel.setFrameSize(newValue)
                     }
@@ -194,6 +204,8 @@ ColumnLayout {
                     model: ffmpegPrefModel.pdOMethodList
 
                     currentIndex: indexOfValue(ffmpegPrefModel.pdOMethod)
+
+                    navigation.accessible.name: qsTrc("export", "PdO method %1").arg(currentText)
 
                     onActivated: function (index, value) {
                         ffmpegPrefModel.setPdOMethod(index)
@@ -220,6 +232,8 @@ ColumnLayout {
 
                     currentValue: ffmpegPrefModel.maxPdO
 
+                    navigation.accessible.name: qsTrc("export", "Max. PdO %1").arg(currentValue)
+
                     onValueEdited: function (newValue) {
                         ffmpegPrefModel.setMaxPdO(newValue)
                     }
@@ -244,6 +258,8 @@ ColumnLayout {
                     step: 1
 
                     currentValue: ffmpegPrefModel.maxPtO
+
+                    navigation.accessible.name: qsTrc("export", "Max. PtO %1").arg(currentValue)
 
                     onValueEdited: function (newValue) {
                         ffmpegPrefModel.setMaxPtO(newValue)

--- a/src/importexport/export/qml/Export/internal/GeneralOptionsSection.qml
+++ b/src/importexport/export/qml/Export/internal/GeneralOptionsSection.qml
@@ -48,6 +48,8 @@ ColumnLayout {
 
                     currentText: ffmpegPrefModel.language
 
+                    navigation.accessible.name: qsTrc("export", "Language")
+
                     onTextChanged: function (newTextValue) {
                         ffmpegPrefModel.setLanguage(newTextValue)
                     }
@@ -70,6 +72,8 @@ ColumnLayout {
                     implicitWidth: root.controlWidth
 
                     currentText: ffmpegPrefModel.tag
+
+                    navigation.accessible.name: qsTrc("export", "Tag")
 
                     onTextChanged: function (newTextValue) {
                         ffmpegPrefModel.setTag(newTextValue)
@@ -98,6 +102,8 @@ ColumnLayout {
 
                     currentValue: ffmpegPrefModel.quality
 
+                    navigation.accessible.name: qsTrc("export", "Quality %1").arg(currentValue)
+
                     onValueEdited: function (newValue) {
                         ffmpegPrefModel.setQuality(newValue)
                     }
@@ -125,6 +131,8 @@ ColumnLayout {
                     step: 1
 
                     currentValue: ffmpegPrefModel.cutoff
+
+                    navigation.accessible.name: qsTrc("export", "Cutoff %1").arg(currentValue)
 
                     onValueEdited: function (newValue) {
                         ffmpegPrefModel.setCutoff(newValue)
@@ -165,6 +173,8 @@ ColumnLayout {
 
                     currentValue: ffmpegPrefModel.bitrate
 
+                    navigation.accessible.name: qsTrc("export", "Bit rate %1").arg(currentValue)
+
                     onValueEdited: function (newValue) {
                         ffmpegPrefModel.setBitrate(newValue)
                     }
@@ -197,6 +207,8 @@ ColumnLayout {
 
                     currentValue: ffmpegPrefModel.sampleRate
 
+                    navigation.accessible.name: qsTrc("export", "Sample rate %1").arg(currentValue)
+
                     onValueEdited: function (newValue) {
                         ffmpegPrefModel.setSampleRate(newValue)
                     }
@@ -218,6 +230,8 @@ ColumnLayout {
                     model: ffmpegPrefModel.profileList
 
                     currentIndex: indexOfValue(ffmpegPrefModel.profile)
+
+                    navigation.accessible.name: qsTrc("export", "Profile %1").arg(currentText)
 
                     onActivated: function (index, value) {
                         ffmpegPrefModel.setProfile(value)

--- a/src/importexport/export/qml/Export/internal/MPEGOptionsSection.qml
+++ b/src/importexport/export/qml/Export/internal/MPEGOptionsSection.qml
@@ -50,6 +50,8 @@ ColumnLayout {
 
                     currentValue: ffmpegPrefModel.muxRate
 
+                    navigation.accessible.name: qsTrc("export", "Mux rate %1").arg(currentValue)
+
                     onValueEdited: function (newValue) {
                         ffmpegPrefModel.setMuxRate(newValue)
                     }
@@ -87,6 +89,8 @@ ColumnLayout {
                     step: 1
 
                     currentValue: ffmpegPrefModel.packetSize
+
+                    navigation.accessible.name: qsTrc("export", "Packet size %1").arg(currentValue)
 
                     onValueEdited: function (newValue) {
                         ffmpegPrefModel.setPacketSize(newValue)

--- a/src/playback/qml/Audacity/Playback/components/VerticalVolumeSlider.qml
+++ b/src/playback/qml/Audacity/Playback/components/VerticalVolumeSlider.qml
@@ -75,6 +75,7 @@ Slider {
         enabled: root.enabled && root.visible
 
         accessible.role: MUAccessible.Range
+        accessible.name: qsTrc("playback", "Playback volume")
         accessible.visualItem: root
 
         accessible.value: root.readableVolumeLevel

--- a/src/playback/qml/Audacity/Playback/components/VolumeSlider.qml
+++ b/src/playback/qml/Audacity/Playback/components/VolumeSlider.qml
@@ -84,6 +84,7 @@ Slider {
         enabled: root.enabled && root.visible
 
         accessible.role: MUAccessible.Range
+        accessible.name: qsTrc("playback", "Volume")
         accessible.visualItem: root
 
         accessible.value: root.readableVolumeLevel

--- a/src/playback/qml/Audacity/Playback/toolbars/PlaybackLevel.qml
+++ b/src/playback/qml/Audacity/Playback/toolbars/PlaybackLevel.qml
@@ -58,6 +58,7 @@ Item {
             Layout.rightMargin: 6
 
             icon: IconCode.AUDIO
+            toolTipTitle: qsTrc("playback", "Playback meter settings")
             accentButton: popup.isOpened
 
             onClicked: {
@@ -131,6 +132,7 @@ Item {
                 navigation.panel: root.navigation.panel
                 navigation.row: root.navigation.row
                 navigation.column: root.navigation.column + 1
+                navigation.accessible.name: qsTrc("playback", "Playback volume")
 
                 onVolumeLevelMoved: function (level) {
                     leftVolumePressure.reset()

--- a/src/preferences/qml/Audacity/Preferences/internal/AutoSaveSection.qml
+++ b/src/preferences/qml/Audacity/Preferences/internal/AutoSaveSection.qml
@@ -75,6 +75,7 @@ BaseSection {
             measureUnitsSymbol: qsTrc("global", "min" /*disambiguation*/ , "abbreviation of minutes")
 
             navigation.name: "AutoSavePeriodControl"
+            navigation.accessible.name: qsTrc("appshell/preferences", "Auto save every %1 %2").arg(currentValue).arg(measureUnitsSymbol)
             navigation.panel: root.navigation
             navigation.column: 2
 

--- a/src/preferences/qml/Audacity/Preferences/internal/FFmpegLibrarySection.qml
+++ b/src/preferences/qml/Audacity/Preferences/internal/FFmpegLibrarySection.qml
@@ -41,6 +41,8 @@ BaseSection {
 
                 currentText: ffmpegPrefModel.ffmpegLibraryPath ?? qsTrc("preferences", "FFmpeg library not found")
 
+                navigation.accessible.name: qsTrc("preferences", "FFmpeg library path")
+
                 property var newLibPath
 
                 onTextEditingFinished: function (newTextValue) {

--- a/src/preferences/qml/Audacity/Preferences/internal/KeyboardLayoutsSection.qml
+++ b/src/preferences/qml/Audacity/Preferences/internal/KeyboardLayoutsSection.qml
@@ -46,6 +46,7 @@ BaseSection {
         currentIndex: dropdown.indexOfValue(root.currentKeyboardLayout)
 
         navigation.name: "LanguagesBox"
+        navigation.accessible.name: qsTrc("appshell/preferences", "Keyboard layout %1").arg(currentText)
         navigation.panel: root.navigation
         navigation.order: 1
 

--- a/src/preferences/qml/Audacity/Preferences/internal/LanguagesSection.qml
+++ b/src/preferences/qml/Audacity/Preferences/internal/LanguagesSection.qml
@@ -64,6 +64,7 @@ BaseSection {
             currentIndex: dropdown.indexOfValue(root.currentLanguageCode)
 
             navigation.name: "LanguagesBox"
+            navigation.accessible.name: qsTrc("preferences", "Language %1").arg(currentText)
             navigation.panel: root.navigation
             navigation.column: 1
 

--- a/src/preferences/qml/Audacity/Preferences/internal/NumberFormatSection.qml
+++ b/src/preferences/qml/Audacity/Preferences/internal/NumberFormatSection.qml
@@ -55,6 +55,7 @@ BaseSection {
             currentIndex: dropdown.indexOfValue(root.currentNumberFormatCode)
 
             navigation.name: "NumberFormatBox"
+            navigation.accessible.name: qsTrc("preferences", "Number format %1").arg(currentText)
             navigation.panel: root.navigation
             navigation.column: 1
 

--- a/src/projectscene/qml/Audacity/ProjectScene/toolbars/PlaybackToolBar.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/toolbars/PlaybackToolBar.qml
@@ -161,6 +161,8 @@ Item {
             Timecode {
                 property var itemData: null
 
+                accessibleName: qsTrc("projectscene", "Playback position: ")
+
                 value: Boolean(itemData) ? itemData.currentValue : 0
 
                 mode: TimecodeModeSelector.TimePoint
@@ -307,6 +309,8 @@ Item {
                 height: 28
 
                 title: qsTrc("projectscene", "Snap")
+                toggleAccessibleName: qsTrc("projectscene", "Snapping")
+                dropdownAccessibleName: qsTrc("projectscene", "Snap to")
 
                 current: Boolean(itemData) ? itemData.currentValue : ""
                 model: Boolean(itemData) ? itemData.availableSnapTypes : null

--- a/src/projectscene/qml/Audacity/ProjectScene/toolbars/ProjectToolBar.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/toolbars/ProjectToolBar.qml
@@ -13,7 +13,7 @@ StyledToolBarView {
     property alias isCompactMode: toolBarModel.isCompactMode
 
     navigationPanel.name: "ProjectToolBar"
-    navigationPanel.accessible.name: qsTrc("projectscene", "Project toolbar")
+    navigationPanel.accessible.name: qsTrc("projectscene", "Audio setup and sharing")
 
     spacing: 2
     rowHeight: 28

--- a/src/projectscene/qml/Audacity/ProjectScene/toolbars/UndoRedoToolBar.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/toolbars/UndoRedoToolBar.qml
@@ -11,7 +11,7 @@ StyledToolBarView {
     id: root
 
     navigationPanel.name: "UndoRedoToolBar"
-    navigationPanel.accessible.name: qsTrc("projectscene", "Undo/redo toolbar")
+    navigationPanel.accessible.name: qsTrc("projectscene", "Undo and redo")
 
     spacing: 0
     rowHeight: 28

--- a/src/projectscene/qml/Audacity/ProjectScene/toolbars/WorkspacesToolBar.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/toolbars/WorkspacesToolBar.qml
@@ -18,7 +18,7 @@ StyledToolBarView {
     property bool isCompactMode: false
 
     navigationPanel.name: "WorkspacesToolBar"
-    navigationPanel.accessible.name: qsTrc("projectscene", "Workspaces toolbar")
+    navigationPanel.accessible.name: qsTrc("projectscene", "Workspace selection")
 
     spacing: 0
     rowHeight: 28

--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/ClipItem.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/ClipItem.qml
@@ -156,7 +156,7 @@ Rectangle {
         enabled: root.enabled && root.visible
 
         accessible.role: MUAccessible.Button
-        accessible.name: root.name
+        accessible.name: qsTrc("projectscene", "Clip: %1").arg(root.title)
 
         onActiveChanged: function (active) {
             // Make sure the focus navigation border is visible on top of other clips
@@ -679,6 +679,8 @@ Rectangle {
                     panel: root.clipNavigationPanel
                     column: 3
 
+                    accessible.role: MUAccessible.EditableText
+                    accessible.name: qsTrc("projectscene", "Clip name: %1").arg(root.title)
                     accessible.enabled: titleEditNavCtrl.enabled
 
                     onTriggered: {
@@ -817,6 +819,7 @@ Rectangle {
                     navigation.name: "ClipMenuBtn"
                     navigation.panel: root.clipNavigationPanel
                     navigation.column: 4
+                    navigation.accessible.name: qsTrc("projectscene", "Clip menu")
 
                     onHandleMenuItem: function (itemId) {
                         Qt.callLater(menuModel.handleMenuItem, itemId)

--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/LabelItem.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/LabelItem.qml
@@ -100,7 +100,7 @@ Item {
         enabled: root.enabled && root.visible
 
         accessible.role: MUAccessible.Button
-        accessible.name: root.title
+        accessible.name: qsTrc("projectscene", "Label: %1").arg(root.title)
 
         onActiveChanged: function (active) {
             if (active) {

--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TrackClipsContainer.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TrackClipsContainer.qml
@@ -398,7 +398,6 @@ TrackItemsContainer {
                                 navigation.name: Boolean(itemData) ? itemData.key.itemId() : ""
                                 navigation.panel: root.navigationPanel
                                 navigation.column: itemData ? Math.floor(itemData.x) : 0
-                                navigation.accessible.name: Boolean(itemData) ? itemData.title : ""
                                 navigation.onActiveChanged: {
                                     if (navigation.highlight) {
                                         root.context.animatedInsureVisible(itemData.time.startTime)

--- a/src/projectscene/qml/Audacity/ProjectScene/trackspanel/EditableLabel.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/trackspanel/EditableLabel.qml
@@ -26,8 +26,8 @@ FocusScope {
         name: root.objectName !== "" ? root.objectName : "EditableLabel"
         enabled: root.enabled && root.visible && !loader.isEditState
 
-        accessible.role: MUAccessible.Information
-        accessible.name: root.text
+        accessible.role: MUAccessible.EditableText
+        accessible.name: qsTrc("projectscene", "Track name: %1").arg(root.text)
         accessible.visualItem: root
 
         onTriggered: {

--- a/src/projectscene/qml/Audacity/ProjectScene/trackspanel/RealtimeEffectListItem.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/trackspanel/RealtimeEffectListItem.qml
@@ -249,9 +249,12 @@ ListItemBlank {
             accentButton: root.innerGripReorderActive
             accentColor: ui.theme.accentColor
             iconColor: root.innerGripReorderActive ? ui.theme.extra["white_color"] : ui.theme.fontPrimaryColor
+            toolTipTitle: qsTrc("projectscene", "Reorder effect")
+
             mouseArea.cursorShape: Qt.SizeAllCursor
             navigation.panel: root.innerNavigationPanel
             navigation.order: 0
+            navigation.name: "grip handle - " + prv.title
 
             mouseArea.drag.target: content
             mouseArea.drag.axis: Drag.YAxis
@@ -295,6 +298,7 @@ ListItemBlank {
             navigation.panel: root.innerNavigationPanel
             navigation.order: gripButton.navigation.order + 1
             navigation.name: "panel bypass btn - " + prv.title
+            toolTipTitle: qsTrc("projectscene", "Bypass %1").arg(prv.title)
 
             isMasterEffect: item && item.isMasterEffect
             accentButton: item && item.isActive
@@ -313,6 +317,7 @@ ListItemBlank {
             navigation.panel: root.innerNavigationPanel
             navigation.order: bypassButton.navigation.order + 1
             navigation.name: "show ui btn - " + prv.title
+            toolTipTitle: qsTrc("projectscene", "Open %1").arg(prv.title)
 
             Layout.fillWidth: true
             Layout.fillHeight: true
@@ -353,6 +358,7 @@ ListItemBlank {
             navigation.panel: root.innerNavigationPanel
             navigation.order: effectNameButton.navigation.order + 1
             navigation.name: "replace btn - " + prv.title
+            toolTipTitle: qsTrc("projectscene", "Replace %1").arg(prv.title)
 
             Layout.fillHeight: true
             Layout.preferredWidth: height

--- a/src/projectscene/qml/Audacity/ProjectScene/trackspanel/TrackEffectsSection.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/trackspanel/TrackEffectsSection.qml
@@ -57,6 +57,9 @@ Rectangle {
                 id: trackEffectsPowerButton
                 navigation.panel: root.navigationPanel
                 navigation.order: root.navigationOrderStart
+                navigation.name: "Toggle all track effects"
+                navigation.accessible.name: root.isMasterTrack ? qsTrc("projectscene", "Toggle all master effects") : qsTrc("projectscene", "Toggle all effects")
+                toolTipTitle: root.isMasterTrack ? qsTrc("projectscene", "Toggle all master effects") : qsTrc("projectscene", "Toggle all effects")
 
                 Layout.alignment: Qt.AlignVCenter | Qt.AlignLeft
                 Layout.margins: 8
@@ -123,6 +126,8 @@ Rectangle {
 
             navigation.panel: root.navigationPanel
             navigation.order: root.navigationOrderEnd
+            navigation.name: "Add effect"
+            navigation.accessible.name: root.isMasterTrack ? qsTrc("projectscene", "Add master effect") : qsTrc("projectscene", "Add effect")
 
             text: qsTrc("projectscene", "Add effect")
 

--- a/src/projectscene/qml/Audacity/ProjectScene/trackspanel/TrackItem.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/trackspanel/TrackItem.qml
@@ -201,6 +201,7 @@ ListItemBlank {
 
                     navigation.panel: root.navigation.panel
                     navigation.order: root.collapsed ? root.headerTrailingControlsNavigationEnd + 1 : title.navigation.order + 1
+                    navigation.accessible.name: qsTrc("projectscene", "Track menu")
 
                     onClicked: {
                         root.selectionRequested(true)

--- a/src/projectscene/qml/Audacity/ProjectScene/trackspanel/TracksPanel.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/trackspanel/TracksPanel.qml
@@ -232,7 +232,9 @@ Item {
                             navigation.name: Boolean(item) ? item.title + item.index : ""
                             navigation.panel: root.navPanels && root.navPanels[index] ? root.navPanels[index] : null
                             navigation.order: 0
-                            navigation.accessible.name: Boolean(item) ? item.title : ""
+                            navigation.accessible.name: Boolean(item) ? (isSelected ? qsTrc("projectscene", "Track %1: %2, audio track, selected").arg(index + 1).arg(item.title) : qsTrc("projectscene", "Track %1: %2, audio track").arg(index + 1).arg(item.title)) : ""
+                            navigation.accessible.description: qsTrc("projectscene", "Press Enter to select or deselect")
+                            navigation.accessible.role: MUAccessible.Group
                             navigation.onActiveChanged: {
                                 if (navigation.active) {
                                     prv.currentItemNavigationName = navigation.name
@@ -293,7 +295,9 @@ Item {
                             navigation.name: Boolean(item) ? item.title + item.index : ""
                             navigation.panel: root.navPanels && root.navPanels[index] ? root.navPanels[index] : null
                             navigation.order: 0
-                            navigation.accessible.name: Boolean(item) ? item.title : ""
+                            navigation.accessible.name: Boolean(item) ? (isSelected ? qsTrc("projectscene", "Track %1: %2, label track, selected").arg(index + 1).arg(item.title) : qsTrc("projectscene", "Track %1: %2, label track").arg(index + 1).arg(item.title)) : ""
+                            navigation.accessible.description: qsTrc("projectscene", "Press Enter to select or deselect")
+                            navigation.accessible.role: MUAccessible.Group
                             navigation.onActiveChanged: {
                                 if (navigation.active) {
                                     prv.currentItemNavigationName = navigation.name

--- a/src/projectscene/qml/Audacity/ProjectScene/trackspanel/TracksTitleBar.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/trackspanel/TracksTitleBar.qml
@@ -54,7 +54,7 @@ Item {
                 direction: NavigationPanel.Vertical
                 order: 0
 
-                accessible.name: qsTrc("projectscene", "Realtime effects")
+                accessible.name: qsTrc("projectscene", "Real-time effects panel")
             }
 
             Layout.preferredWidth: root.effectsSectionWidth
@@ -95,6 +95,8 @@ Item {
                     navigation.name: "CloseEffectsSection"
                     navigation.panel: effectsTitleBar.navigation
                     navigation.order: 0
+
+                    toolTipTitle: qsTrc("projectscene", "Close real-time effects panel")
 
                     normalColor: ui.theme.backgroundPrimaryColor
                     hoverHitColor: ui.theme.buttonColor

--- a/src/projectscene/qml/Audacity/ProjectScene/trackspanel/WaveTrackItem.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/trackspanel/WaveTrackItem.qml
@@ -59,6 +59,7 @@ TrackItem {
                     navigation.panel: root.navigation.panel
                     navigation.order: root.extraControlsNavigationStart
                     navigation.enabled: !root.collapsed
+                    navigation.accessible.name: qsTrc("projectscene", "Pan")
 
                     onNewPanRequested: function (newValue, completed) {
                         if (Boolean(root.item)) {
@@ -75,6 +76,7 @@ TrackItem {
                     navigation.panel: root.navigation.panel
                     navigation.order: panKnob.navigation.order + 1
                     navigation.enabled: !root.collapsed
+                    navigation.accessible.name: qsTrc("projectscene", "Track volume")
 
                     onNewVolumeRequested: function (newValue, completed) {
                         if (Boolean(root.item)) {
@@ -99,6 +101,7 @@ TrackItem {
                 Layout.preferredHeight: 24
 
                 text: qsTrc("projectscene", "Effects")
+                toolTipDescription: qsTrc("projectscene", "Opens effects panel")
 
                 opacity: topRow.visible && root.height > root.mapFromItem(this, 0, height + bottomSeparatorHeight).y ? 1 : 0
                 visible: opacity !== 0
@@ -244,6 +247,8 @@ TrackItem {
 
                 navigation.panel: root.navigation.panel
                 navigation.order: root.headerTrailingControlsNavigationStart
+                navigation.accessible.name: qsTrc("projectscene", "Mute")
+                navigation.accessible.role: MUAccessible.CheckBox
 
                 onToggled: {
                     if (Boolean(root.item)) {
@@ -263,6 +268,8 @@ TrackItem {
 
                 navigation.panel: root.navigation.panel
                 navigation.order: muteButton.navigation.order + 1
+                navigation.accessible.name: qsTrc("projectscene", "Solo")
+                navigation.accessible.role: MUAccessible.CheckBox
 
                 onToggled: {
                     if (Boolean(root.item)) {

--- a/src/record/qml/Audacity/Record/internal/RecordLevelPopup.qml
+++ b/src/record/qml/Audacity/Record/internal/RecordLevelPopup.qml
@@ -153,6 +153,7 @@ StyledPopupView {
 
                     navigation.panel: navPanel
                     navigation.order: 1
+                    navigation.accessible.name: qsTrc("record", "Recording level")
 
                     onVolumeLevelMoved: function (level) {
                         root.volumeLevelChangeRequested(Math.round(level * 100) / 100)

--- a/src/uicomponents/qml/Audacity/UiComponents/components/BPM.qml
+++ b/src/uicomponents/qml/Audacity/UiComponents/components/BPM.qml
@@ -44,7 +44,7 @@ NumericView {
             navigation.panel: root.navigation.panel
             navigation.row: root.navigation.row
             navigation.column: root.navigationColumnEnd + 1
-            navigation.accessible.name: qsTrc("au/uicomponents", "Up")
+            navigation.accessible.name: qsTrc("au/uicomponents", "Increase BPM")
 
             onClicked: function (mouse) {
                 bpmModel.upValue()
@@ -63,7 +63,7 @@ NumericView {
             navigation.panel: root.navigation.panel
             navigation.row: root.navigation.row
             navigation.column: upButton.navigation.column + 1
-            navigation.accessible.name: qsTrc("au/uicomponents", "Down")
+            navigation.accessible.name: qsTrc("au/uicomponents", "Decrease BPM")
 
             onClicked: function (mouse) {
                 bpmModel.downValue()

--- a/src/uicomponents/qml/Audacity/UiComponents/components/DropdownWithTitle.qml
+++ b/src/uicomponents/qml/Audacity/UiComponents/components/DropdownWithTitle.qml
@@ -12,6 +12,8 @@ RowLayout {
 
     property string title: ""
     property string current: ""
+    property string toggleAccessibleName: title
+    property string dropdownAccessibleName: title
     property var model: null
 
     property bool isOptionEnabled: false
@@ -41,6 +43,7 @@ RowLayout {
 
         checked: root.isOptionEnabled
         visible: root.allowOptionToggle
+        navigation.accessible.name: root.toggleAccessibleName
 
         onClicked: function () {
             root.isOptionEnableChangeRequested(!optionCheckBox.checked)
@@ -64,8 +67,8 @@ RowLayout {
 
             name: "DropdownWithTitleItem"
             enabled: dropdown.enabled && dropdown.visible
-            accessible.role: MUAccessible.ListItem
-            accessible.name: labelItem.text
+            accessible.role: MUAccessible.Button
+            accessible.name: root.dropdownAccessibleName ? root.dropdownAccessibleName + ": " + root.current : root.current
 
             panel: optionCheckBox.navigation.panel
             row: optionCheckBox.navigation.row


### PR DESCRIPTION
Adds accessible.name, accessible.description, and accessible.role declarations to toolbars, track items, clips, effects controls, volume sliders, BPM, and navigation panels so the assistive tech layer can announce them clearly.

Resolves: https://github.com/audacity/audacity/issues/6531

Plug accessibility screen reader gaps across the UI.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
