### PR TITLE
Zoom step prefs

### DIFF
--- a/src/preferences/qml/Audacity/Preferences/EditPreferencesPage.qml
+++ b/src/preferences/qml/Audacity/Preferences/EditPreferencesPage.qml
@@ -116,6 +116,27 @@ PreferencesPage {
 
         SeparatorLine {}
 
+        ZoomSection {
+            id: zoomSection
+
+            mouseZoomPrecision: editPreferencesModel.mouseZoomPrecision
+
+            navigation.section: root.navigationSection
+            navigation.order: monoStereoConversionSection.navigationOrderEnd + 1
+
+            onMouseZoomPrecisionChangeRequested: function(zoomPrecision) {
+                editPreferencesModel.setMouseZoomPrecision(zoomPrecision)
+            }
+
+            onFocusChanged: {
+                if (activeFocus) {
+                    root.ensureContentVisibleRequested(Qt.rect(x, y, width, height))
+                }
+            }
+        }
+
+        SeparatorLine {}
+
         ZoomToggleSection {
             id: zoomToggleSection
 
@@ -124,7 +145,7 @@ PreferencesPage {
             zoomPreset2: editPreferencesModel.zoomPreset2
 
             navigation.section: root.navigationSection
-            navigation.order: monoStereoConversionSection.navigationOrderEnd + 1
+            navigation.order: zoomSection.navigationOrderEnd + 1
 
             onZoomPreset1ChangeRequested: function (preset) {
                 editPreferencesModel.setZoomPreset1(preset)

--- a/src/preferences/qml/Audacity/Preferences/EditPreferencesPage.qml
+++ b/src/preferences/qml/Audacity/Preferences/EditPreferencesPage.qml
@@ -124,7 +124,7 @@ PreferencesPage {
             navigation.section: root.navigationSection
             navigation.order: monoStereoConversionSection.navigationOrderEnd + 1
 
-            onMouseZoomPrecisionChangeRequested: function(zoomPrecision) {
+            onMouseZoomPrecisionChangeRequested: function (zoomPrecision) {
                 editPreferencesModel.setMouseZoomPrecision(zoomPrecision)
             }
 

--- a/src/preferences/qml/Audacity/Preferences/editpreferencesmodel.cpp
+++ b/src/preferences/qml/Audacity/Preferences/editpreferencesmodel.cpp
@@ -260,4 +260,18 @@ QVariantList EditPreferencesModel::zoomPresetList() const
     list << QVariantMap{ { "title", muse::qtrc("appshell/preferences", "Max Zoom") }, { "value", 14 } };
     return list;
 }
+
+int EditPreferencesModel::mouseZoomPrecision() const
+{
+    return projectsceneConfiguration()->mouseZoomPrecision();
+}
+
+void EditPreferencesModel::setMouseZoomPrecision(int precision)
+{
+    if (mouseZoomPrecision() == precision) {
+        return;
+    }
+    projectsceneConfiguration()->setMouseZoomPrecision(precision);
+    emit mouseZoomPrecisionChanged();
+}
 }

--- a/src/preferences/qml/Audacity/Preferences/editpreferencesmodel.h
+++ b/src/preferences/qml/Audacity/Preferences/editpreferencesmodel.h
@@ -40,6 +40,7 @@ class EditPreferencesModel : public QObject, public muse::async::Asyncable, publ
     Q_PROPERTY(int zoomPreset1 READ zoomPreset1 NOTIFY zoomPreset1Changed)
     Q_PROPERTY(int zoomPreset2 READ zoomPreset2 NOTIFY zoomPreset2Changed)
     Q_PROPERTY(QVariantList zoomPresetList READ zoomPresetList CONSTANT)
+    Q_PROPERTY(int mouseZoomPrecision READ mouseZoomPrecision NOTIFY mouseZoomPrecisionChanged)
 
 public:
     explicit EditPreferencesModel(QObject* parent = nullptr);
@@ -79,6 +80,8 @@ public:
     int zoomPreset2() const;
     Q_INVOKABLE void setZoomPreset2(int preset);
     QVariantList zoomPresetList() const;
+    int mouseZoomPrecision() const;
+    Q_INVOKABLE void setMouseZoomPrecision(int precision);
 
     void asymmetricStereoHeightWorkspacesCleanUp();
 
@@ -94,5 +97,6 @@ signals:
     void askBeforeConvertingToMonoOrStereoChanged();
     void zoomPreset1Changed();
     void zoomPreset2Changed();
+    void mouseZoomPrecisionChanged();
 };
 }

--- a/src/preferences/qml/Audacity/Preferences/internal/ZoomSection.qml
+++ b/src/preferences/qml/Audacity/Preferences/internal/ZoomSection.qml
@@ -42,6 +42,8 @@ BaseSection {
     signal mouseZoomPrecisionChangeRequested(int zoomPrecision)
 
     Row {
+        visible: root.defaultZoom !== null
+
         spacing: root.columnSpacing
 
         ComboBoxWithTitle {
@@ -53,7 +55,7 @@ BaseSection {
             control.textRole: "title"
             control.valueRole: "value"
 
-            currentIndex: control.indexOfValue(root.defaultZoom.type)
+            currentIndex: root.defaultZoom ? control.indexOfValue(root.defaultZoom.type) : -1
 
             navigation.name: "DefaultZoomBox"
             navigation.panel: root.navigation
@@ -76,8 +78,8 @@ BaseSection {
 
             measureUnitsSymbol: "%"
 
-            currentValue: root.defaultZoom.level
-            enabled: root.defaultZoom.isPercentage
+            currentValue: root.defaultZoom ? root.defaultZoom.level : 100
+            enabled: root.defaultZoom ? root.defaultZoom.isPercentage : false
 
             navigation.name: "DefaultZoomControl"
             navigation.panel: root.navigation

--- a/src/preferences/qml/Audacity/Preferences/internal/ZoomSection.qml
+++ b/src/preferences/qml/Audacity/Preferences/internal/ZoomSection.qml
@@ -20,6 +20,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 import QtQuick 2.15
+import QtQuick.Controls 2.15
 
 import Muse.Ui 1.0
 import Muse.UiComponents
@@ -35,7 +36,7 @@ BaseSection {
 
     property var defaultZoom: null
     property alias zoomTypes: defaultZoomTypesBox.model
-    property alias mouseZoomPrecision: mouseZoomPrecisionControl.currentValue
+    property alias mouseZoomPrecision: precisionSlider.value
 
     signal defaultZoomTypeChangeRequested(int zoomType)
     signal defaultZoomLevelChangeRequested(int zoomLevel)
@@ -92,24 +93,53 @@ BaseSection {
         }
     }
 
-    IncrementalPropertyControlWithTitle {
+    Column {
         id: mouseZoomPrecisionControl
 
-        title: qsTrc("appshell/preferences", "Mouse zoom precision:")
+        spacing: 6
 
-        columnWidth: root.columnWidth
-        control.width: 60
+        StyledTextLabel {
+            text: qsTrc("appshell/preferences", "Mouse zoom precision")
+            width: root.columnWidth
+            horizontalAlignment: Qt.AlignLeft
+            wrapMode: Text.WordWrap
+            maximumLineCount: 2
+        }
 
-        minValue: 1
-        maxValue: 16
+        Row {
+            spacing: 8
 
-        navigation.name: "MouseZoomPrecisionControl"
-        navigation.panel: root.navigation
-        navigation.row: 1
-        navigation.column: 0
+            StyledTextLabel {
+                text: qsTrc("appshell/preferences", "Fast")
+                width: 40
+                horizontalAlignment: Qt.AlignLeft
+            }
 
-        onValueEdited: function (newValue) {
-            root.mouseZoomPrecisionChangeRequested(newValue)
+            StyledSlider {
+                id: precisionSlider
+
+                width: 220
+                from: 1
+                to: 16
+                stepSize: 1
+                snapMode: Slider.SnapAlways
+
+                navigation.name: "MouseZoomPrecisionControl"
+                navigation.panel: root.navigation
+                navigation.row: 1
+                navigation.column: 0
+                navigation.accessible.name: qsTrc("appshell/preferences", "Mouse zoom precision")
+
+                onMoved: {
+                    root.mouseZoomPrecisionChangeRequested(Math.round(value))
+                }
+            }
+
+            StyledTextLabel {
+                text: qsTrc("appshell/preferences", "Slow")
+                width: 40
+                horizontalAlignment: Qt.AlignRight
+            }
         }
     }
 }

--- a/src/projectscene/internal/projectsceneconfiguration.cpp
+++ b/src/projectscene/internal/projectsceneconfiguration.cpp
@@ -72,7 +72,7 @@ void ProjectSceneConfiguration::init()
         m_effectsPanelVisible.notify();
     });
 
-    muse::settings()->setDefaultValue(MOUSE_ZOOM_PRECISION, muse::Val(6));
+    muse::settings()->setDefaultValue(MOUSE_ZOOM_PRECISION, muse::Val(2));
 
     muse::settings()->setDefaultValue(CLIP_STYLE, muse::Val(ClipStyles::Style::COLORFUL));
     muse::settings()->valueChanged(CLIP_STYLE).onReceive(nullptr, [this](const muse::Val& val) {


### PR DESCRIPTION
Resolves:  #6143

Also makes the existing pref page visible.

Also sets the sensitivity to 2 (ie, each wheel click halves/doubles), from currently 6, so zooming in and out is much faster (as fast as it was in early versions of Audacity 3). The reason it got changed previously was because on some devices in Audacity 3, you'd zoom way too quickly into the "timeline = 1 week of audio" view, making it unusable there. This now makes it a pref. 

@teetow I have attached the pref to the other zoom thing in editing, though it feels borderline belonging into the "Advanced settings" rumblebin of unimportant things to expose. Wdyt

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
