### PR TITLE
Fade in out toolbar

### DIFF
--- a/src/effects/effects_base/internal/effectsactionscontroller.cpp
+++ b/src/effects/effects_base/internal/effectsactionscontroller.cpp
@@ -56,6 +56,13 @@ void EffectsActionsController::registerActions()
         dispatcher()->reg(this, ActionQuery(makeEffectAction(EFFECT_OPEN_ACTION, e.id)), [this](const ActionQuery& q) {
             onEffectTriggered(q);
         });
+
+        const ActionCode toolbarActionCode = utils::toolbarEffectActionCode(e.id);
+        if (!toolbarActionCode.empty()) {
+            dispatcher()->reg(this, ActionQuery(toolbarActionCode), [this, effectId = e.id](const ActionQuery&) {
+                triggerEffect(effectId);
+            });
+        }
     }
 
     dispatcher()->reg(this, "repeat-last-effect", this, &EffectsActionsController::repeatLastEffect);
@@ -83,6 +90,12 @@ void EffectsActionsController::onEffectTriggered(const muse::actions::ActionQuer
     IF_ASSERT_FAILED(!effectId.empty()) {
         return;
     }
+
+    triggerEffect(effectId);
+}
+
+void EffectsActionsController::triggerEffect(const EffectId& effectId)
+{
     playbackController()->stop();
 
     effectExecutionScenario()->performEffect(effectId);

--- a/src/effects/effects_base/internal/effectsactionscontroller.h
+++ b/src/effects/effects_base/internal/effectsactionscontroller.h
@@ -52,6 +52,7 @@ private:
     void notifyAboutSpectralEffectsAvailability();
 
     void onEffectTriggered(const muse::actions::ActionQuery& q);
+    void triggerEffect(const EffectId& effectId);
     void applyEffect(const muse::actions::ActionQuery& q);
     void repeatLastEffect();
 

--- a/src/effects/effects_base/internal/effectsuiactions.cpp
+++ b/src/effects/effects_base/internal/effectsuiactions.cpp
@@ -6,8 +6,9 @@
 #include "context/uicontext.h"
 #include "context/shortcutcontext.h"
 #include "types/translatablestring.h"
-#include "log.h"
+#include "ui/view/iconcodes.h"
 #include "effects/effects_base/internal/effectsutils.h"
+#include "log.h"
 
 using namespace au::effects;
 using namespace muse;
@@ -16,6 +17,8 @@ using namespace muse::actions;
 
 static const TranslatableString REPEAT_LAST_EFFECT_DEF_TITLE("action", "Repeat last effect");
 static const TranslatableString REPEAT_LAST_EFFECT_TITLE("action", "Repeat %1");
+static const ActionCode FADE_IN_EFFECT_ACTION("action://effects/open?effectId=FadeIn");
+static const ActionCode FADE_OUT_EFFECT_ACTION("action://effects/open?effectId=FadeOut");
 
 static UiActionList STATIC_ACTIONS = {
     UiAction("repeat-last-effect",
@@ -101,6 +104,12 @@ UiAction makeUiAction(const std::string& uri, const EffectMeta& meta)
     action.scCtx = au::context::CTX_PROJECT_FOCUSED;
     action.description = TranslatableString::untranslatable(meta.description);
     action.title = TranslatableString::untranslatable(meta.title);
+    const ActionCode toolbarActionCode = utils::toolbarEffectActionCode(meta.id);
+    if (toolbarActionCode == FADE_IN_EFFECT_ACTION) {
+        action.iconCode = IconCode::Code::CHEVRON_LEFT;
+    } else if (toolbarActionCode == FADE_OUT_EFFECT_ACTION) {
+        action.iconCode = IconCode::Code::CHEVRON_RIGHT;
+    }
     return action;
 }
 

--- a/src/effects/effects_base/internal/effectsuiactions.cpp
+++ b/src/effects/effects_base/internal/effectsuiactions.cpp
@@ -7,6 +7,7 @@
 #include "context/shortcutcontext.h"
 #include "types/translatablestring.h"
 #include "log.h"
+#include "effects/effects_base/internal/effectsutils.h"
 
 using namespace au::effects;
 using namespace muse;
@@ -138,6 +139,13 @@ void EffectsUiActions::makeActions(EffectMetaList effects)
 
     for (const EffectMeta& e : effects) {
         m_actions.push_back(makeUiAction(EFFECT_OPEN_ACTION, e));
+        const ActionCode toolbarActionCode = utils::toolbarEffectActionCode(e.id);
+        if (!toolbarActionCode.empty()) {
+            UiAction action = makeUiAction(EFFECT_OPEN_ACTION, e);
+            action.code = toolbarActionCode;
+            m_actions.push_back(std::move(action));
+        }
+
         if (e.isRealtimeCapable) {
             for (const auto& uri : { REALTIME_EFFECT_ADD_ACTION, REALTIME_EFFECT_REPLACE_ACTION }) {
                 UiAction action = makeUiAction(uri, e);

--- a/src/effects/effects_base/internal/effectsutils.cpp
+++ b/src/effects/effects_base/internal/effectsutils.cpp
@@ -125,6 +125,36 @@ std::string utils::parseEffectPath(const EffectId& effectId)
     return parseEffectIdPart(effectId, 4);
 }
 
+namespace {
+static const std::string EFFECT_NAME_FADE_IN("FadeIn");
+static const std::string EFFECT_NAME_FADE_OUT("FadeOut");
+
+std::string normalizedEffectName(std::string name)
+{
+    name.erase(std::remove_if(name.begin(), name.end(), [](char c) {
+        return c == ' ' || c == '-' || c == '_';
+    }), name.end());
+    return name;
+}
+
+bool effectIdMatchesName(const effects::EffectId& effectId, const std::string& name)
+{
+    return normalizedEffectName(utils::parseEffectName(effectId)) == normalizedEffectName(name);
+}
+}
+
+muse::actions::ActionCode utils::toolbarEffectActionCode(const EffectId& effectId)
+{
+    if (effectIdMatchesName(effectId, EFFECT_NAME_FADE_IN)) {
+        return makeEffectAction(EFFECT_OPEN_ACTION, EffectId::fromStdString(EFFECT_NAME_FADE_IN));
+    }
+    if (effectIdMatchesName(effectId, EFFECT_NAME_FADE_OUT)) {
+        return makeEffectAction(EFFECT_OPEN_ACTION, EffectId::fromStdString(EFFECT_NAME_FADE_OUT));
+    }
+
+    return {};
+}
+
 muse::String utils::effectCategoryToString(EffectCategory category)
 {
     switch (category) {

--- a/src/effects/effects_base/internal/effectsutils.h
+++ b/src/effects/effects_base/internal/effectsutils.h
@@ -30,6 +30,8 @@ std::string parseEffectVendor(const EffectId& effectId);
 std::string parseEffectFamily(const EffectId& effectId);
 std::string parseEffectPath(const EffectId& effectId);
 
+muse::actions::ActionCode toolbarEffectActionCode(const EffectId& effectId);
+
 muse::String effectTypeToString(EffectType type);
 EffectType effectTypeFromString(const muse::String& type);
 

--- a/src/projectscene/internal/projectsceneuiactions.cpp
+++ b/src/projectscene/internal/projectsceneuiactions.cpp
@@ -15,6 +15,9 @@ using namespace muse;
 using namespace muse::ui;
 using namespace muse::actions;
 
+static const ActionCode FADE_IN_EFFECT_ACTION("action://effects/open?effectId=FadeIn");
+static const ActionCode FADE_OUT_EFFECT_ACTION("action://effects/open?effectId=FadeOut");
+
 static UiActionList STATIC_ACTIONS = {
     UiAction("clip-gain",
              au::context::UiCtxProjectOpened,

--- a/src/projectscene/internal/projectsceneuiactions.cpp
+++ b/src/projectscene/internal/projectsceneuiactions.cpp
@@ -379,6 +379,8 @@ const ToolConfig& ProjectSceneUiActions::defaultPlaybackToolBarConfig()
             { "", true },
             { "trim-audio-outside-selection", true },
             { "silence-audio-selection", true },
+            { FADE_IN_EFFECT_ACTION, true },
+            { FADE_OUT_EFFECT_ACTION, true },
             { "", true },
             // { "metronome", false },
             // { "", true },

--- a/src/projectscene/view/toolbars/playbacktoolbarcustomisemodel.cpp
+++ b/src/projectscene/view/toolbars/playbacktoolbarcustomisemodel.cpp
@@ -41,7 +41,20 @@ void PlaybackToolBarCustomiseModel::load()
 
     bool lastWasSeparator = false;
     for (const auto& configItem : toolConfig.items) {
+        if (configItem.action.empty()) {
+            if (lastWasSeparator) {
+                continue;
+            }
+            lastWasSeparator = true;
+
+            items << makeSeparatorItem();
+            continue;
+        }
+
         UiAction action = actionsRegister()->action(configItem.action);
+        if (action.code.empty()) {
+            continue;
+        }
 
         if (isSeparator(action) && lastWasSeparator) {
             continue;

--- a/src/projectscene/view/toolbars/playbacktoolbarmodel.cpp
+++ b/src/projectscene/view/toolbars/playbacktoolbarmodel.cpp
@@ -86,6 +86,10 @@ void PlaybackToolBarModel::load()
             reload();
         });
 
+        uiActionsRegister()->actionsChanged().onReceive(this, [this](const UiActionList&) {
+            reload();
+        });
+
         uiConfiguration()->currentThemeChanged().onNotify(this, [this]() {
             reload();
         });
@@ -349,16 +353,20 @@ void PlaybackToolBarModel::updateActions()
             continue;
         }
 
+        if (citem.action.empty()) {
+            items << AbstractToolBarModel::makeSeparator();
+            continue;
+        }
+
+        if (uiActionsRegister()->action(citem.action).code.empty()) {
+            continue;
+        }
+
         if (citem.action == PLAYBACK_LEVEL_QUERY.toString()) {
             if (configuration()->playbackMeterPosition() == playback::PlaybackMeterPosition::MeterPosition::SideBar) {
                 // Skip playback meter item if it is set to be displayed in the sidebar
                 continue;
             }
-        }
-
-        if (citem.action == AbstractToolBarModel::SEPARATOR_ID) {
-            items << AbstractToolBarModel::makeSeparator();
-            continue;
         }
 
         ToolBarItem* item = makeLocalItem(citem.action);
@@ -388,6 +396,9 @@ ToolBarItem* PlaybackToolBarModel::makeLocalItem(const ActionCode& actionCode)
 
     if (type == PlaybackToolBarModel::PROJECT_CONTROL) {
         ToolBarItem* item = AbstractToolBarModel::makeItem(actionCode);
+        if (!item) {
+            return nullptr;
+        }
         item->setType(static_cast<ToolBarItemType::Type>(type));
         return item;
     }


### PR DESCRIPTION
Same thing as https://github.com/audacity/audacity/pull/11186 but this time only the fade in/out part to make it less bulky (and also because adding fading buttons is way less contentious than adding big fileIO buttons which need more design thought)