### PR TITLE
Change focused track to closest deleted one

### DIFF
--- a/src/trackedit/internal/au3/au3tracksinteraction.cpp
+++ b/src/trackedit/internal/au3/au3tracksinteraction.cpp
@@ -761,8 +761,9 @@ bool Au3TracksInteraction::deleteTracks(const TrackIdList& trackIds)
     auto& tracks = Au3TrackList::Get(project);
 
     TrackId focusedTrack = trackNavigationController()->focusedTrack();
-
     const auto prj = globalContext()->currentTrackeditProject();
+    const auto indexFocusedTrack = muse::indexOf(prj->trackIdList(), focusedTrack);
+
     for (const auto& trackId : trackIds) {
         Au3Track* au3Track = DomAccessor::findTrack(project, Au3TrackId(trackId));
         IF_ASSERT_FAILED(au3Track) {
@@ -778,9 +779,25 @@ bool Au3TracksInteraction::deleteTracks(const TrackIdList& trackIds)
         prj->notifyAboutTrackRemoved(track);
     }
 
-    if (muse::contains(trackIds, focusedTrack)) {
-        const auto notRemovedTracks = prj->trackIdList();
-        trackNavigationController()->setFocusedTrack(notRemovedTracks.empty() ? -1 : notRemovedTracks.front());
+    if (!muse::contains(trackIds, focusedTrack)) {
+        return true;
+    }
+
+    if (indexFocusedTrack == muse::nidx) {
+        return true;
+    }
+
+    const auto notRemovedTracks = prj->trackIdList();
+    if (notRemovedTracks.empty()) {
+        trackNavigationController()->setFocusedTrack(-1);
+        return true;
+    }
+
+    const auto maxIndex = notRemovedTracks.size() - 1;
+    if (maxIndex < indexFocusedTrack) {
+        trackNavigationController()->setFocusedTrack(notRemovedTracks.back());
+    } else {
+        trackNavigationController()->setFocusedTrack(notRemovedTracks[indexFocusedTrack]);
     }
 
     return true;


### PR DESCRIPTION
Resolves: [#11179](https://github.com/audacity/audacity/issues/11179)

At the moment, deleting tracks always changes focus to the first track.
With this pull request, the track chosen after deletion will be on the same index, unless the index is too high, then the last track will be focused.
Change focused track to closest deleted track.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
