### PR TITLE
11182 fix trim on empty selection

### DIFF
--- a/au3/libraries/au3-wave-track/WaveTrack.cpp
+++ b/au3/libraries/au3-wave-track/WaveTrack.cpp
@@ -1010,6 +1010,10 @@ auto WaveTrack::SplitCut(double t0, double t1) -> Holder
 /*! @excsafety{Weak} */
 void WaveTrack::Trim(double t0, double t1)
 {
+    if (t0 >= t1) {
+        return;
+    }
+
     bool inside0 = false;
     bool inside1 = false;
 

--- a/src/trackedit/internal/trackeditactionscontroller.cpp
+++ b/src/trackedit/internal/trackeditactionscontroller.cpp
@@ -1528,6 +1528,10 @@ void TrackeditActionsController::trimAudioOutsideSelection()
     auto selectedEndTime = selectionController()->dataSelectedEndTime();
     auto tracks = project->trackeditProject()->trackList();
 
+    if (selectedStartTime >= selectedEndTime) {
+        return;
+    }
+
     std::vector<TrackId> tracksIdsToTrim;
     for (const auto& track : tracks) {
         if (std::find(selectedTracks.begin(), selectedTracks.end(), track.id) == selectedTracks.end()) {

--- a/src/trackedit/tests/au3tracksinteraction_tests.cpp
+++ b/src/trackedit/tests/au3tracksinteraction_tests.cpp
@@ -411,6 +411,61 @@ TEST_F(Au3TracksInteractionTests, CutTrackDataMovingClips)
     removeTrack(trackId);
 }
 
+TEST_F(Au3TracksInteractionTests, TrimTracksDataEmptySelectionIsNoOp)
+{
+    //! [GIVEN] There is a project with a track and two clips
+    const TrackId trackTwoClipsId = createTrack(TestTrackID::TRACK_TWO_CLIPS);
+    ASSERT_NE(trackTwoClipsId, INVALID_TRACK) << "Failed to create track";
+    Au3WaveTrack* track = DomAccessor::findWaveTrack(projectRef(), Au3TrackId(trackTwoClipsId));
+
+    //! [THEN] The number of intervals is 2
+    ASSERT_EQ(track->NIntervals(), 2) << "Precondition failed: The number of intervals is not 2";
+
+    //! [WHEN] Trim with an empty selection (begin == end) inside the first clip
+    const double point = TRACK_TWO_CLIPS_CLIP1_START + 4 * SAMPLE_INTERVAL;
+    m_tracksInteraction->trimTracksData({ trackTwoClipsId }, point, point);
+
+    //! [THEN] The number of intervals is unchanged
+    ASSERT_EQ(track->NIntervals(), 2) << "The number of intervals after the trim operation is not 2";
+
+    //! [THEN] Both clips are left untouched
+    const WaveTrack::IntervalConstHolder firstClip = track->GetSortedClipByIndex(0);
+    ValidateClipProperties(firstClip, TRACK_TWO_CLIPS_CLIP1_START, TRACK_TWO_CLIPS_CLIP1_END);
+    const WaveTrack::IntervalConstHolder secondClip = track->GetSortedClipByIndex(1);
+    ValidateClipProperties(secondClip, TRACK_TWO_CLIPS_CLIP2_START, TRACK_TWO_CLIPS_CLIP2_END);
+
+    // Cleanup
+    removeTrack(trackTwoClipsId);
+}
+
+TEST_F(Au3TracksInteractionTests, TrimTracksDataInvertedSelectionIsNoOp)
+{
+    //! [GIVEN] There is a project with a track and two clips
+    const TrackId trackTwoClipsId = createTrack(TestTrackID::TRACK_TWO_CLIPS);
+    ASSERT_NE(trackTwoClipsId, INVALID_TRACK) << "Failed to create track";
+    Au3WaveTrack* track = DomAccessor::findWaveTrack(projectRef(), Au3TrackId(trackTwoClipsId));
+
+    //! [THEN] The number of intervals is 2
+    ASSERT_EQ(track->NIntervals(), 2) << "Precondition failed: The number of intervals is not 2";
+
+    //! [WHEN] Trim with an inverted selection (begin > end)
+    const double begin = TRACK_TWO_CLIPS_CLIP1_START + 4 * SAMPLE_INTERVAL;
+    const double end = TRACK_TWO_CLIPS_CLIP1_START + 2 * SAMPLE_INTERVAL;
+    m_tracksInteraction->trimTracksData({ trackTwoClipsId }, begin, end);
+
+    //! [THEN] The number of intervals is unchanged
+    ASSERT_EQ(track->NIntervals(), 2) << "The number of intervals after the trim operation is not 2";
+
+    //! [THEN] Both clips are left untouched
+    const WaveTrack::IntervalConstHolder firstClip = track->GetSortedClipByIndex(0);
+    ValidateClipProperties(firstClip, TRACK_TWO_CLIPS_CLIP1_START, TRACK_TWO_CLIPS_CLIP1_END);
+    const WaveTrack::IntervalConstHolder secondClip = track->GetSortedClipByIndex(1);
+    ValidateClipProperties(secondClip, TRACK_TWO_CLIPS_CLIP2_START, TRACK_TWO_CLIPS_CLIP2_END);
+
+    // Cleanup
+    removeTrack(trackTwoClipsId);
+}
+
 TEST_F(Au3TracksInteractionTests, SplitDeleteOnRangeSelection)
 {
     //! [GIVEN] There is a project with a track and a two clips


### PR DESCRIPTION
Resolves: #11182 

Trim should be no op on empty track selection

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
