### PR TITLE
fix: Use MUSE_COMPILE_ASAN in ASAN preset for cross-platform support

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -34,11 +34,7 @@
       "description": "Debug profile with AddressSanitizer enabled.",
       "inherits": "audacity-debug",
       "cacheVariables": {
-        "CMAKE_CXX_FLAGS": "-fsanitize=address -fno-omit-frame-pointer",
-        "CMAKE_LINK_FLAGS": "-fsanitize=address -fno-omit-frame-pointer",
-        "CMAKE_EXE_LINKER_FLAGS": "-fsanitize=address",
-        "CMAKE_MODULE_LINKER_FLAGS": "-fsanitize=address",
-        "CMAKE_SHARED_LINKER_FLAGS": "-fsanitize=address"
+        "MUSE_COMPILE_ASAN": "ON"
       }
     },
     {


### PR DESCRIPTION
Resolves: fix: Use MUSE_COMPILE_ASAN in ASAN preset for cross-platform support

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
