### PR TITLE
11269 Fix welcome screen sign in flow

### DIFF
--- a/src/appshell/qml/Audacity/AppShell/welcomedialogmodel.cpp
+++ b/src/appshell/qml/Audacity/AppShell/welcomedialogmodel.cpp
@@ -59,9 +59,7 @@ std::vector<WelcomeDialogModel::Item> WelcomeDialogModel::buildItems()
                        "This integration allows you to save and access your Audacity projects on any device"),
             muse::qtrc("appshell/welcome", "Continue"),
             [this]() {
-                muse::actions::ActionQuery query("audacity://cloud/open-signin-dialog");
-                query.addParam("showTourPage", muse::Val(true));
-
+                muse::actions::ActionQuery query("audacity://cloud/show-tour-page");
                 dispatcher()->dispatch(query);
             }
         },

--- a/src/au3cloud/internal/au3cloudactionscontroller.cpp
+++ b/src/au3cloud/internal/au3cloudactionscontroller.cpp
@@ -14,6 +14,7 @@ namespace {
 const muse::Uri SIGNIN_URI("audacity://signin/audiocom");
 const char* TOUR_PAGE_URL { "https://audio.com/tour?mtm_campaign=audacitydesktop&mtm_content=app_launch_reg" };
 
+const muse::actions::ActionQuery SHOW_TOUR_PAGE_ACTION("audacity://cloud/show-tour-page");
 const muse::actions::ActionQuery OPEN_SIGNIN_DIALOG_ACTION("audacity://cloud/open-signin-dialog");
 const muse::actions::ActionQuery OPEN_CREATE_ACCOUNT_DIALOG_ACTION("audacity://cloud/open-create-account-dialog");
 const muse::actions::ActionQuery OPEN_CLOUD_PROJECT_PAGE_ACTION("audacity://cloud/open-project-page");
@@ -33,6 +34,7 @@ void Au3CloudActionsController::init()
 {
     m_urlHandler = std::make_unique<CloudUrlHandler>(iocContext());
 
+    dispatcher()->reg(this, SHOW_TOUR_PAGE_ACTION, this, &Au3CloudActionsController::showTourPage);
     dispatcher()->reg(this, OPEN_SIGNIN_DIALOG_ACTION, this, &Au3CloudActionsController::openSignInDialog);
     dispatcher()->reg(this, OPEN_CREATE_ACCOUNT_DIALOG_ACTION, this, &Au3CloudActionsController::openCreateAccountDialog);
     dispatcher()->reg(this, OPEN_CLOUD_PROJECT_PAGE_ACTION, this, &Au3CloudActionsController::openCloudProjectPage);
@@ -61,13 +63,25 @@ void Au3CloudActionsController::openCreateAccountDialog(const muse::actions::Act
     openSignInDialog(newQuery);
 }
 
+void Au3CloudActionsController::showTourPage()
+{
+    if (!authorization()->isAuthorized()) {
+        const muse::UriQuery uri(SIGNIN_URI);
+        const muse::RetVal<muse::Val> rv = interactive()->openSync(uri);
+        if (!rv.ret) {
+            return;
+        }
+    }
+
+    platformInteractive()->openUrl(TOUR_PAGE_URL);
+}
+
 void Au3CloudActionsController::openSignInDialog(const muse::actions::ActionQuery& query)
 {
     if (authorization()->isAuthorized()) {
         return;
     }
 
-    const bool showTourPage = query.param("showTourPage").toBool();
     const bool sync = query.param("sync").toBool();
     const bool isCreateAccountMode = query.param(createAccountModeParam, muse::Val(false)).toBool();
 
@@ -75,16 +89,12 @@ void Au3CloudActionsController::openSignInDialog(const muse::actions::ActionQuer
     uri.addParam(createAccountModeParam, muse::Val(isCreateAccountMode));
 
     if (sync) {
-        muse::RetVal<muse::Val> rv = interactive()->openSync(uri);
+        const muse::RetVal<muse::Val> rv = interactive()->openSync(uri);
         if (!rv.ret) {
             return;
         }
     } else {
         interactive()->open(uri);
-    }
-
-    if (showTourPage) {
-        platformInteractive()->openUrl(TOUR_PAGE_URL);
     }
 }
 

--- a/src/au3cloud/internal/au3cloudactionscontroller.h
+++ b/src/au3cloud/internal/au3cloudactionscontroller.h
@@ -35,6 +35,7 @@ public:
     bool canReceiveAction(const muse::actions::ActionCode& code) const override;
 
 private:
+    void showTourPage();
     void openSignInDialog(const muse::actions::ActionQuery& query);
     void openCreateAccountDialog(const muse::actions::ActionQuery& query);
     void openCloudProjectPage(const muse::actions::ActionQuery& query);

--- a/src/au3cloud/view/accountmodel.cpp
+++ b/src/au3cloud/view/accountmodel.cpp
@@ -59,7 +59,6 @@ void AccountModel::openSignInDialog() const
 {
     muse::actions::ActionQuery query("audacity://cloud/open-signin-dialog");
     query.addParam("sync", muse::Val(true));
-    query.addParam("showTourPage", muse::Val(false));
 
     dispatcher()->dispatch(query);
 }
@@ -68,7 +67,6 @@ void AccountModel::openCreateAccountDialog() const
 {
     muse::actions::ActionQuery query("audacity://cloud/open-create-account-dialog");
     query.addParam("sync", muse::Val(true));
-    query.addParam("showTourPage", muse::Val(false));
 
     dispatcher()->dispatch(query);
 }

--- a/src/project/internal/projectactionscontroller.cpp
+++ b/src/project/internal/projectactionscontroller.cpp
@@ -1342,7 +1342,6 @@ muse::Ret ProjectActionsController::ensureAuthorization()
 
     muse::actions::ActionQuery query("audacity://cloud/open-signin-dialog");
     query.addParam("sync", muse::Val(true));
-    query.addParam("showTourPage", muse::Val(false));
 
     dispatcher()->dispatch(query);
 


### PR DESCRIPTION
Resolves: #11269

Fix cloud signing and welcome screen flow.

If the user is not signed in the sign in dialog will be show otherwise the tour page.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
