### PR TITLE
Non consecutive selection

### DIFF
--- a/src/app/configs/data/shortcuts.xml
+++ b/src/app/configs/data/shortcuts.xml
@@ -168,9 +168,14 @@
     </SC>
 
     <SC>
-        <key>track-view-toggle-selection</key>
+        <key>track-view-replace-selection</key>
         <seq>Return</seq>
         <seq>Enter</seq>
+    </SC>
+    <SC>
+        <key>track-view-toggle-selection</key>
+        <seq>Ctrl+Enter</seq>
+        <seq>Ctrl+Return</seq>
     </SC>
     <SC>
         <key>track-view-range-selection</key>

--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/ClipItem.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/ClipItem.qml
@@ -390,7 +390,7 @@ Rectangle {
         onClicked: function (e) {
             if (root.multiClipsSelected) {
                 prv.ensureMultiMenuLoaded()
-                if (e.modifiers & Qt.ShiftModifier) {
+                if (e.modifiers & (Qt.ShiftModifier | Qt.ControlModifier)) {
                     if (!root.clipSelected) {
                         root.requestSelectionReset()
                     }
@@ -630,7 +630,7 @@ Rectangle {
                         root.editTitle()
                     } else {
                         //! NOTE Handle singleClick logic
-                        if ((!root.multiClipsSelected || (e.modifiers & Qt.ShiftModifier)) && !(root.isDataSelected && isWithinRange(e.x, headerSelectionRectangle.x, headerSelectionRectangle.width))) {
+                        if ((!root.multiClipsSelected || (e.modifiers & (Qt.ShiftModifier | Qt.ControlModifier))) && !(root.isDataSelected && isWithinRange(e.x, headerSelectionRectangle.x, headerSelectionRectangle.width))) {
                             root.requestSelected()
                         }
 
@@ -829,7 +829,7 @@ Rectangle {
                             prv.ensureSingleMenuLoaded()
                         }
 
-                        if (!root.multiClipsSelected || (mouse.modifiers & Qt.ShiftModifier)) {
+                        if (!root.multiClipsSelected || (mouse.modifiers & (Qt.ShiftModifier | Qt.ControlModifier))) {
                             if (!root.clipSelected) {
                                 root.requestSelectionReset()
                             }

--- a/src/projectscene/qml/Audacity/ProjectScene/trackspanel/TrackItem.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/trackspanel/TrackItem.qml
@@ -227,9 +227,9 @@ ListItemBlank {
                 // Pass the event forward to allow
                 // child elements to handle the input
                 e.accepted = false
-                let toggleModifier = e.modifiers & Qt.ControlModifier
+                let multiSelectionModifier = e.modifiers & (Qt.ControlModifier | Qt.ShiftModifier)
 
-                if (!toggleModifier) {
+                if (!multiSelectionModifier) {
                     root.selectionRequested(true)
                     root.dataSelectionRequested()
                     return

--- a/src/projectscene/view/tracksitemsview/selectionviewcontroller.cpp
+++ b/src/projectscene/view/tracksitemsview/selectionviewcontroller.cpp
@@ -79,6 +79,8 @@ void SelectionViewController::onPressed(double x, double y, spectrogram::Spectro
 
     if (!tracks.empty()) {
         trackNavigationController()->setFocusedTrack(tracks.at(0), false /*highlight*/);
+    } else {
+        trackNavigationController()->setFocusedItem({});
     }
     selectionController()->setSelectedTracks(tracks, true);
 

--- a/src/projectscene/view/tracksitemsview/trackclipslistmodel.cpp
+++ b/src/projectscene/view/tracksitemsview/trackclipslistmodel.cpp
@@ -754,10 +754,28 @@ void TrackClipsListModel::selectClip(const ClipKey& key)
     Qt::KeyboardModifiers modifiers = keyboardModifiers();
 
     constexpr auto complete = true;
+
+    if (modifiers.testFlag(Qt::ShiftModifier)) {
+        const trackedit::TrackItemKey anchor = trackNavigationController()->focusedItem();
+        if (anchor.isValid() && anchor.trackId == key.key.trackId) {
+            const ClipKeyList rangeKeys = itemKeysInRange(anchor, key.key);
+            if (!rangeKeys.empty()) {
+                selectionController()->resetSelectedLabels();
+                selectionController()->setSelectedClips(rangeKeys, complete);
+                return;
+            }
+        }
+
+        selectionController()->resetSelectedLabels();
+        selectionController()->setSelectedClips(ClipKeyList({ key.key }), complete);
+        setFocusedItem(key);
+        return;
+    }
+
     const auto clipGroupId = trackeditInteraction()->clipGroupId(key.key);
     if (clipGroupId != -1) {
         //! NOTE: clip belongs to a group, select the whole group
-        if (modifiers.testFlag(Qt::ShiftModifier)) {
+        if (modifiers.testFlag(Qt::ControlModifier)) {
             const auto groupedClips = trackeditInteraction()->clipsInGroup(clipGroupId);
             const auto selectedClips = selectionController()->selectedClips();
             const bool allGroupClipsSelected = std::all_of(groupedClips.cbegin(), groupedClips.cend(), [&](const auto& groupClipKey) {
@@ -777,7 +795,7 @@ void TrackClipsListModel::selectClip(const ClipKey& key)
             trackNavigationController()->setFocusedTrack(key.key.trackId);
         }
     } else {
-        if (modifiers.testFlag(Qt::ShiftModifier)) {
+        if (modifiers.testFlag(Qt::ControlModifier)) {
             if (muse::contains(selectionController()->selectedClips(), key.key)) {
                 m_pendingShiftDeselect = { key.key };
             } else {

--- a/src/projectscene/view/tracksitemsview/trackclipslistmodel.cpp
+++ b/src/projectscene/view/tracksitemsview/trackclipslistmodel.cpp
@@ -751,11 +751,11 @@ bool TrackClipsListModel::stretchRightClip(const ClipKey& key, bool completed, C
 
 void TrackClipsListModel::selectClip(const ClipKey& key)
 {
-    Qt::KeyboardModifiers modifiers = keyboardModifiers();
-
     constexpr auto complete = true;
 
-    if (modifiers.testFlag(Qt::ShiftModifier)) {
+    const SelectionMode mode = selectionMode();
+
+    if (mode == SelectionMode::Range) {
         const trackedit::TrackItemKey anchor = trackNavigationController()->focusedItem();
         if (anchor.isValid() && anchor.trackId == key.key.trackId) {
             const ClipKeyList rangeKeys = itemKeysInRange(anchor, key.key);
@@ -775,7 +775,7 @@ void TrackClipsListModel::selectClip(const ClipKey& key)
     const auto clipGroupId = trackeditInteraction()->clipGroupId(key.key);
     if (clipGroupId != -1) {
         //! NOTE: clip belongs to a group, select the whole group
-        if (modifiers.testFlag(Qt::ControlModifier)) {
+        if (mode == SelectionMode::Toggle) {
             const auto groupedClips = trackeditInteraction()->clipsInGroup(clipGroupId);
             const auto selectedClips = selectionController()->selectedClips();
             const bool allGroupClipsSelected = std::all_of(groupedClips.cbegin(), groupedClips.cend(), [&](const auto& groupClipKey) {
@@ -795,7 +795,7 @@ void TrackClipsListModel::selectClip(const ClipKey& key)
             trackNavigationController()->setFocusedTrack(key.key.trackId);
         }
     } else {
-        if (modifiers.testFlag(Qt::ControlModifier)) {
+        if (mode == SelectionMode::Toggle) {
             if (muse::contains(selectionController()->selectedClips(), key.key)) {
                 m_pendingShiftDeselect = { key.key };
             } else {

--- a/src/projectscene/view/tracksitemsview/trackclipslistmodel.cpp
+++ b/src/projectscene/view/tracksitemsview/trackclipslistmodel.cpp
@@ -756,14 +756,11 @@ void TrackClipsListModel::selectClip(const ClipKey& key)
     const SelectionMode mode = selectionMode();
 
     if (mode == SelectionMode::Range) {
-        const trackedit::TrackItemKey anchor = trackNavigationController()->focusedItem();
-        if (anchor.isValid() && anchor.trackId == key.key.trackId) {
-            const ClipKeyList rangeKeys = itemKeysInRange(anchor, key.key);
-            if (!rangeKeys.empty()) {
-                selectionController()->resetSelectedLabels();
-                selectionController()->setSelectedClips(rangeKeys, complete);
-                return;
-            }
+        const ClipKeyList rangeKeys = trackNavigationController()->itemKeysInRange(trackNavigationController()->focusedItem(), key.key);
+        if (!rangeKeys.empty()) {
+            selectionController()->resetSelectedLabels();
+            selectionController()->setSelectedClips(rangeKeys, complete);
+            return;
         }
 
         selectionController()->resetSelectedLabels();

--- a/src/projectscene/view/tracksitemsview/trackclipslistmodel.cpp
+++ b/src/projectscene/view/tracksitemsview/trackclipslistmodel.cpp
@@ -394,7 +394,7 @@ bool TrackClipsListModel::moveSelectedClips(const ClipKey& key, bool completed)
         return false;
     }
 
-    m_pendingShiftDeselect.clear();
+    m_pendingToggleDeselect.clear();
 
     auto project = globalContext()->currentProject();
     IF_ASSERT_FAILED(project) {
@@ -783,7 +783,7 @@ void TrackClipsListModel::selectClip(const ClipKey& key)
             });
 
             if (allGroupClipsSelected) {
-                m_pendingShiftDeselect = groupedClips;
+                m_pendingToggleDeselect = groupedClips;
             } else {
                 for (const auto& groupClipKey : groupedClips) {
                     selectionController()->addSelectedClip(groupClipKey);
@@ -797,7 +797,7 @@ void TrackClipsListModel::selectClip(const ClipKey& key)
     } else {
         if (mode == SelectionMode::Toggle) {
             if (muse::contains(selectionController()->selectedClips(), key.key)) {
-                m_pendingShiftDeselect = { key.key };
+                m_pendingToggleDeselect = { key.key };
             } else {
                 selectionController()->addSelectedClip(key.key);
             }
@@ -814,11 +814,11 @@ void TrackClipsListModel::selectClip(const ClipKey& key)
 
 void TrackClipsListModel::handleClipRelease(const ClipKey& key)
 {
-    if (!m_pendingShiftDeselect.empty() && muse::contains(m_pendingShiftDeselect, key.key)) {
-        for (const auto& clipKey : m_pendingShiftDeselect) {
+    if (!m_pendingToggleDeselect.empty() && muse::contains(m_pendingToggleDeselect, key.key)) {
+        for (const auto& clipKey : m_pendingToggleDeselect) {
             selectionController()->removeClipSelection(clipKey);
         }
-        m_pendingShiftDeselect.clear();
+        m_pendingToggleDeselect.clear();
     }
 }
 
@@ -826,7 +826,7 @@ void TrackClipsListModel::endEditItem(const TrackItemKey& key)
 {
     TrackItemsListModel::endEditItem(key);
 
-    m_pendingShiftDeselect.clear();
+    m_pendingToggleDeselect.clear();
 }
 
 void TrackClipsListModel::resetSelectedClips()

--- a/src/projectscene/view/tracksitemsview/trackclipslistmodel.h
+++ b/src/projectscene/view/tracksitemsview/trackclipslistmodel.h
@@ -91,6 +91,6 @@ private:
     ClipStyles::Style m_clipStyle = ClipStyles::Style::COLORFUL;
     bool m_isStereo = false;
 
-    trackedit::ClipKeyList m_pendingShiftDeselect;
+    trackedit::ClipKeyList m_pendingToggleDeselect;
 };
 }

--- a/src/projectscene/view/tracksitemsview/trackitemslistmodel.cpp
+++ b/src/projectscene/view/tracksitemsview/trackitemslistmodel.cpp
@@ -126,41 +126,6 @@ int TrackItemsListModel::indexByKey(const trackedit::TrackItemKey& key) const
     return -1;
 }
 
-au::trackedit::TrackItemKeyList TrackItemsListModel::itemKeysInRange(const trackedit::TrackItemKey& anchor,
-                                                                     const trackedit::TrackItemKey& target) const
-{
-    std::vector<std::pair<double, trackedit::TrackItemKey> > ordered;
-    ordered.reserve(m_items.size());
-    for (const ViewTrackItem* item : m_items) {
-        ordered.emplace_back(item->time().startTime, item->key().key);
-    }
-
-    std::stable_sort(ordered.begin(), ordered.end(), [](const auto& a, const auto& b) {
-        return a.first < b.first;
-    });
-
-    int anchorIndex = -1;
-    int targetIndex = -1;
-    for (int i = 0; i < static_cast<int>(ordered.size()); ++i) {
-        if (ordered.at(i).second == anchor) {
-            anchorIndex = i;
-        }
-        if (ordered.at(i).second == target) {
-            targetIndex = i;
-        }
-    }
-
-    if (anchorIndex < 0 || targetIndex < 0) {
-        return {};
-    }
-
-    trackedit::TrackItemKeyList result;
-    for (int i = std::min(anchorIndex, targetIndex); i <= std::max(anchorIndex, targetIndex); ++i) {
-        result.push_back(ordered.at(i).second);
-    }
-    return result;
-}
-
 void TrackItemsListModel::onSelectedItem(const trackedit::TrackItemKey& k)
 {
     // ignore if item already selected

--- a/src/projectscene/view/tracksitemsview/trackitemslistmodel.cpp
+++ b/src/projectscene/view/tracksitemsview/trackitemslistmodel.cpp
@@ -666,7 +666,9 @@ void TrackItemsListModel::startEditItem(const TrackItemKey& key)
         vs->updateItemsBoundaries(true, key.key);
     }
 
-    setFocusedItem(key);
+    if (selectionMode() != SelectionMode::Range) {
+        setFocusedItem(key);
+    }
 }
 
 void TrackItemsListModel::endEditItem(const TrackItemKey& key)

--- a/src/projectscene/view/tracksitemsview/trackitemslistmodel.cpp
+++ b/src/projectscene/view/tracksitemsview/trackitemslistmodel.cpp
@@ -126,6 +126,41 @@ int TrackItemsListModel::indexByKey(const trackedit::TrackItemKey& key) const
     return -1;
 }
 
+au::trackedit::TrackItemKeyList TrackItemsListModel::itemKeysInRange(const trackedit::TrackItemKey& anchor,
+                                                                     const trackedit::TrackItemKey& target) const
+{
+    std::vector<std::pair<double, trackedit::TrackItemKey> > ordered;
+    ordered.reserve(m_items.size());
+    for (const ViewTrackItem* item : m_items) {
+        ordered.emplace_back(item->time().startTime, item->key().key);
+    }
+
+    std::stable_sort(ordered.begin(), ordered.end(), [](const auto& a, const auto& b) {
+        return a.first < b.first;
+    });
+
+    int anchorIndex = -1;
+    int targetIndex = -1;
+    for (int i = 0; i < static_cast<int>(ordered.size()); ++i) {
+        if (ordered.at(i).second == anchor) {
+            anchorIndex = i;
+        }
+        if (ordered.at(i).second == target) {
+            targetIndex = i;
+        }
+    }
+
+    if (anchorIndex < 0 || targetIndex < 0) {
+        return {};
+    }
+
+    trackedit::TrackItemKeyList result;
+    for (int i = std::min(anchorIndex, targetIndex); i <= std::max(anchorIndex, targetIndex); ++i) {
+        result.push_back(ordered.at(i).second);
+    }
+    return result;
+}
+
 void TrackItemsListModel::onSelectedItem(const trackedit::TrackItemKey& k)
 {
     // ignore if item already selected

--- a/src/projectscene/view/tracksitemsview/trackitemslistmodel.cpp
+++ b/src/projectscene/view/tracksitemsview/trackitemslistmodel.cpp
@@ -541,6 +541,21 @@ Qt::KeyboardModifiers TrackItemsListModel::keyboardModifiers() const
     return modifiers;
 }
 
+au::trackedit::SelectionMode TrackItemsListModel::selectionMode() const
+{
+    const Qt::KeyboardModifiers modifiers = keyboardModifiers();
+
+    if (modifiers.testFlag(Qt::ShiftModifier)) {
+        return SelectionMode::Range;
+    }
+
+    if (modifiers.testFlag(Qt::ControlModifier)) {
+        return SelectionMode::Toggle;
+    }
+
+    return SelectionMode::Replace;
+}
+
 int TrackItemsListModel::cacheBufferPx()
 {
     return CACHE_BUFFER_PX;

--- a/src/projectscene/view/tracksitemsview/trackitemslistmodel.h
+++ b/src/projectscene/view/tracksitemsview/trackitemslistmodel.h
@@ -130,6 +130,8 @@ protected:
     int calculateTrackPositionOffset(const TrackItemKey& key, const std::vector<trackedit::TrackType>& trackTypesAllowedToMove) const;
     bool isAllowedToMoveToTracks(const std::vector<trackedit::TrackType>& allowedTrackTypes, const trackedit::TrackId& movedTrackId) const;
 
+    trackedit::SelectionMode selectionMode() const;
+
     Qt::KeyboardModifiers keyboardModifiers() const;
 
     friend class TrackClipsSelectionTests;

--- a/src/projectscene/view/tracksitemsview/trackitemslistmodel.h
+++ b/src/projectscene/view/tracksitemsview/trackitemslistmodel.h
@@ -102,8 +102,6 @@ protected:
     ViewTrackItem* itemByKey(const trackedit::TrackItemKey& key) const;
     int indexByKey(const trackedit::TrackItemKey& key) const;
 
-    trackedit::TrackItemKeyList itemKeysInRange(const trackedit::TrackItemKey& anchor, const trackedit::TrackItemKey& target) const;
-
     void requestItemTitleChange();
     virtual trackedit::TrackItemKeyList getSelectedItemKeys() const = 0;
 

--- a/src/projectscene/view/tracksitemsview/trackitemslistmodel.h
+++ b/src/projectscene/view/tracksitemsview/trackitemslistmodel.h
@@ -102,6 +102,8 @@ protected:
     ViewTrackItem* itemByKey(const trackedit::TrackItemKey& key) const;
     int indexByKey(const trackedit::TrackItemKey& key) const;
 
+    trackedit::TrackItemKeyList itemKeysInRange(const trackedit::TrackItemKey& anchor, const trackedit::TrackItemKey& target) const;
+
     void requestItemTitleChange();
     virtual trackedit::TrackItemKeyList getSelectedItemKeys() const = 0;
 

--- a/src/projectscene/view/tracksitemsview/tracklabelslistmodel.cpp
+++ b/src/projectscene/view/tracksitemsview/tracklabelslistmodel.cpp
@@ -236,9 +236,9 @@ void TrackLabelsListModel::selectLabel(const LabelKey& key)
         return;
     }
 
-    Qt::KeyboardModifiers modifiers = keyboardModifiers();
+    const SelectionMode mode = selectionMode();
 
-    if (modifiers.testFlag(Qt::ShiftModifier)) {
+    if (mode == SelectionMode::Range) {
         const trackedit::TrackItemKey anchor = trackNavigationController()->focusedItem();
         if (anchor.isValid() && anchor.trackId == key.key.trackId) {
             const LabelKeyList rangeKeys = itemKeysInRange(anchor, key.key);
@@ -259,7 +259,7 @@ void TrackLabelsListModel::selectLabel(const LabelKey& key)
         return;
     }
 
-    if (modifiers.testFlag(Qt::ControlModifier)) {
+    if (mode == SelectionMode::Toggle) {
         if (muse::contains(selectionController()->selectedLabels(), key.key)) {
             m_pendingShiftDeselect = key.key;
         } else {

--- a/src/projectscene/view/tracksitemsview/tracklabelslistmodel.cpp
+++ b/src/projectscene/view/tracksitemsview/tracklabelslistmodel.cpp
@@ -239,16 +239,13 @@ void TrackLabelsListModel::selectLabel(const LabelKey& key)
     const SelectionMode mode = selectionMode();
 
     if (mode == SelectionMode::Range) {
-        const trackedit::TrackItemKey anchor = trackNavigationController()->focusedItem();
-        if (anchor.isValid() && anchor.trackId == key.key.trackId) {
-            const LabelKeyList rangeKeys = itemKeysInRange(anchor, key.key);
-            if (!rangeKeys.empty()) {
-                selectionController()->resetDataSelection();
-                selectionController()->resetSelectedClips();
-                selectionController()->setSelectedLabels(rangeKeys, true);
-                m_needToSelectTracksData = false;
-                return;
-            }
+        const LabelKeyList rangeKeys = trackNavigationController()->itemKeysInRange(trackNavigationController()->focusedItem(), key.key);
+        if (!rangeKeys.empty()) {
+            selectionController()->resetDataSelection();
+            selectionController()->resetSelectedClips();
+            selectionController()->setSelectedLabels(rangeKeys, true);
+            m_needToSelectTracksData = false;
+            return;
         }
 
         selectionController()->resetDataSelection();

--- a/src/projectscene/view/tracksitemsview/tracklabelslistmodel.cpp
+++ b/src/projectscene/view/tracksitemsview/tracklabelslistmodel.cpp
@@ -239,6 +239,27 @@ void TrackLabelsListModel::selectLabel(const LabelKey& key)
     Qt::KeyboardModifiers modifiers = keyboardModifiers();
 
     if (modifiers.testFlag(Qt::ShiftModifier)) {
+        const trackedit::TrackItemKey anchor = trackNavigationController()->focusedItem();
+        if (anchor.isValid() && anchor.trackId == key.key.trackId) {
+            const LabelKeyList rangeKeys = itemKeysInRange(anchor, key.key);
+            if (!rangeKeys.empty()) {
+                selectionController()->resetDataSelection();
+                selectionController()->resetSelectedClips();
+                selectionController()->setSelectedLabels(rangeKeys, true);
+                m_needToSelectTracksData = false;
+                return;
+            }
+        }
+
+        selectionController()->resetDataSelection();
+        selectionController()->resetSelectedClips();
+        selectionController()->setSelectedLabels(LabelKeyList({ key.key }), true);
+        setFocusedItem(key);
+        m_needToSelectTracksData = false;
+        return;
+    }
+
+    if (modifiers.testFlag(Qt::ControlModifier)) {
         if (muse::contains(selectionController()->selectedLabels(), key.key)) {
             m_pendingShiftDeselect = key.key;
         } else {

--- a/src/projectscene/view/tracksitemsview/tracklabelslistmodel.cpp
+++ b/src/projectscene/view/tracksitemsview/tracklabelslistmodel.cpp
@@ -261,7 +261,7 @@ void TrackLabelsListModel::selectLabel(const LabelKey& key)
 
     if (mode == SelectionMode::Toggle) {
         if (muse::contains(selectionController()->selectedLabels(), key.key)) {
-            m_pendingShiftDeselect = key.key;
+            m_pendingToggleDeselect = key.key;
         } else {
             selectionController()->addSelectedLabel(key.key);
         }
@@ -339,9 +339,9 @@ void TrackLabelsListModel::toggleTracksDataSelectionByLabel(const LabelKey& key)
         return;
     }
 
-    if (m_pendingShiftDeselect.isValid() && m_pendingShiftDeselect == key.key) {
+    if (m_pendingToggleDeselect.isValid() && m_pendingToggleDeselect == key.key) {
         selectionController()->removeLabelSelection(key.key);
-        m_pendingShiftDeselect = {};
+        m_pendingToggleDeselect = {};
         return;
     }
 
@@ -372,7 +372,7 @@ bool TrackLabelsListModel::moveSelectedLabels(const LabelKey& key, bool complete
         return false;
     }
 
-    m_pendingShiftDeselect = {};
+    m_pendingToggleDeselect = {};
 
     auto project = globalContext()->currentProject();
     IF_ASSERT_FAILED(project) {
@@ -509,7 +509,7 @@ void TrackLabelsListModel::endEditItem(const TrackItemKey& key)
 
     trackeditInteraction()->resetLabelStretchState();
 
-    m_pendingShiftDeselect = {};
+    m_pendingToggleDeselect = {};
 }
 
 TrackLabelItem* TrackLabelsListModel::labelItemByKey(const trackedit::LabelKey& k) const

--- a/src/projectscene/view/tracksitemsview/tracklabelslistmodel.h
+++ b/src/projectscene/view/tracksitemsview/tracklabelslistmodel.h
@@ -49,7 +49,7 @@ private:
     muse::async::NotifyList<au::trackedit::Label> m_allLabelList;
     bool m_needToSelectTracksData = false;
 
-    trackedit::TrackItemKey m_pendingShiftDeselect;
+    trackedit::TrackItemKey m_pendingToggleDeselect;
 
     double m_editedLabelStartTime = 0.0;
     double m_editedLabelEndTime = 0.0;

--- a/src/trackedit/internal/itracknavigationcontroller.h
+++ b/src/trackedit/internal/itracknavigationcontroller.h
@@ -29,6 +29,8 @@ public:
     virtual void setFocusedItem(const TrackItemKey& key, bool highlight = false) = 0;
     virtual muse::async::Channel<TrackItemKey, bool /*highlight*/> focusedItemChanged() const = 0;
 
+    virtual TrackItemKeyList itemKeysInRange(const TrackItemKey& anchor, const TrackItemKey& target) const = 0;
+
     virtual muse::async::Channel<TrackItemKey> openContextMenuRequested() const = 0;
 };
 }

--- a/src/trackedit/internal/trackedituiactions.cpp
+++ b/src/trackedit/internal/trackedituiactions.cpp
@@ -489,8 +489,8 @@ UiActionList STATIC_ACTIONS = {
     UiAction("track-view-toggle-selection",
              au::context::UiCtxProjectFocused,
              au::context::CTX_PROJECT_FOCUSED,
-             TranslatableString("action", "Add track item to selection"),
-             TranslatableString("action", "Add track item to selection")
+             TranslatableString("action", "Add track or track item to selection"),
+             TranslatableString("action", "Add track or track item to selection")
              ),
     UiAction("track-view-range-selection",
              au::context::UiCtxProjectFocused,

--- a/src/trackedit/internal/trackedituiactions.cpp
+++ b/src/trackedit/internal/trackedituiactions.cpp
@@ -480,11 +480,17 @@ UiActionList STATIC_ACTIONS = {
              TranslatableString("action", "Last track")
              ),
 
-    UiAction("track-view-toggle-selection",
+    UiAction("track-view-replace-selection",
              au::context::UiCtxProjectFocused,
              au::context::CTX_PROJECT_FOCUSED,
              TranslatableString("action", "Select track/track item"),
              TranslatableString("action", "Select track/track item")
+             ),
+    UiAction("track-view-toggle-selection",
+             au::context::UiCtxProjectFocused,
+             au::context::CTX_PROJECT_FOCUSED,
+             TranslatableString("action", "Add track item to selection"),
+             TranslatableString("action", "Add track item to selection")
              ),
     UiAction("track-view-range-selection",
              au::context::UiCtxProjectFocused,

--- a/src/trackedit/internal/tracknavigationcontroller.cpp
+++ b/src/trackedit/internal/tracknavigationcontroller.cpp
@@ -22,8 +22,9 @@ static const muse::actions::ActionCode TRACK_VIEW_PREV_PANEL_CODE("track-view-pr
 static const muse::actions::ActionCode TRACK_VIEW_FIRST_TRACK_CODE("track-view-first-track");
 static const muse::actions::ActionCode TRACK_VIEW_LAST_TRACK_CODE("track-view-last-track");
 
+static const muse::actions::ActionCode TRACK_VIEW_REPLACE_SELECTION_CODE("track-view-replace-selection");
 static const muse::actions::ActionCode TRACK_VIEW_TOGGLE_SELECTION_CODE("track-view-toggle-selection");
-static const muse::actions::ActionCode TRACK_RANGE_SELECTION_CODE("track-view-range-selection");
+static const muse::actions::ActionCode TRACK_VIEW_RANGE_SELECTION_CODE("track-view-range-selection");
 static const muse::actions::ActionCode TRACK_VIEW_TRACK_SELECTION_PREV_CODE("track-view-extend-track-selection-prev");
 static const muse::actions::ActionCode TRACK_VIEW_TRACK_SELECTION_NEXT_CODE("track-view-extend-track-selection-next");
 
@@ -49,8 +50,9 @@ void TrackNavigationController::init()
     dispatcher()->reg(this, TRACK_VIEW_ABOVE_ITEM_CODE, this, &TrackNavigationController::navigateToAboveItem);
     dispatcher()->reg(this, TRACK_VIEW_BELOW_ITEM_CODE, this, &TrackNavigationController::navigateToBelowItem);
 
+    dispatcher()->reg(this, TRACK_VIEW_REPLACE_SELECTION_CODE, this, &TrackNavigationController::replaceSelection);
     dispatcher()->reg(this, TRACK_VIEW_TOGGLE_SELECTION_CODE, this, &TrackNavigationController::toggleSelection);
-    dispatcher()->reg(this, TRACK_RANGE_SELECTION_CODE, this, &TrackNavigationController::trackRangeSelection);
+    dispatcher()->reg(this, TRACK_VIEW_RANGE_SELECTION_CODE, this, &TrackNavigationController::rangeSelection);
 
     dispatcher()->reg(this, TRACK_VIEW_TRACK_SELECTION_PREV_CODE, this, &TrackNavigationController::multiSelectionUp);
     dispatcher()->reg(this, TRACK_VIEW_TRACK_SELECTION_NEXT_CODE, this, &TrackNavigationController::multiSelectionDown);
@@ -237,6 +239,37 @@ TrackItemKeyList TrackNavigationController::sortedItemsKeys(const TrackId& track
     }
 
     return result;
+}
+
+TrackItemKeyList TrackNavigationController::itemKeysInRange(const TrackItemKey& anchor, const TrackItemKey& target) const
+{
+    if (!anchor.isValid() || !target.isValid() || anchor.trackId != target.trackId) {
+        return {};
+    }
+
+    const TrackItemKeyList ordered = sortedItemsKeys(target.trackId);
+
+    int anchorIndex = -1;
+    int targetIndex = -1;
+    for (int i = 0; i < static_cast<int>(ordered.size()); ++i) {
+        if (ordered.at(i) == anchor) {
+            anchorIndex = i;
+        }
+        if (ordered.at(i) == target) {
+            targetIndex = i;
+        }
+    }
+
+    if (anchorIndex < 0 || targetIndex < 0) {
+        return {};
+    }
+
+    TrackItemKeyList range;
+    for (int i = std::min(anchorIndex, targetIndex); i <= std::max(anchorIndex, targetIndex); ++i) {
+        range.push_back(ordered.at(i));
+    }
+
+    return range;
 }
 
 bool TrackNavigationController::isTrackItemsEmpty(const TrackId& trackId) const
@@ -589,7 +622,7 @@ void TrackNavigationController::navigateToLastItem()
     setFocusedItem(itemsKeys.back(), true /*highlight*/);
 }
 
-void TrackNavigationController::toggleSelection()
+void TrackNavigationController::replaceSelection()
 {
     bool isTrackPanel = m_focusedItemKey.itemId == INVALID_TRACK_ITEM;
 
@@ -618,34 +651,66 @@ void TrackNavigationController::toggleSelection()
     }
 
     m_lastSelectedTrack = isSelect ? std::optional<TrackId>(m_focusedItemKey.trackId) : std::nullopt;
+    m_lastSelectedItem = (isSelect && !isTrackPanel) ? m_focusedItemKey : TrackItemKey {};
 }
 
-void TrackNavigationController::trackRangeSelection()
+void TrackNavigationController::toggleSelection()
+{
+    bool isTrackPanel = m_focusedItemKey.itemId == INVALID_TRACK_ITEM;
+
+    if (!isTrackPanel) {
+        if (isFocusedItemLabel()) {
+            LabelKeyList selectedLabels = selectionController()->selectedLabels();
+            if (muse::contains(selectedLabels, m_focusedItemKey)) {
+                selectionController()->removeLabelSelection(m_focusedItemKey);
+            } else {
+                selectionController()->addSelectedLabel(m_focusedItemKey);
+            }
+        } else {
+            ClipKeyList selectedClips = selectionController()->selectedClips();
+            if (muse::contains(selectedClips, m_focusedItemKey)) {
+                selectionController()->removeClipSelection(m_focusedItemKey);
+            } else {
+                selectionController()->addSelectedClip(m_focusedItemKey);
+            }
+        }
+
+        m_lastSelectedItem = m_focusedItemKey;
+    } else {
+        TrackIdList selectedTracks = selectionController()->selectedTracks();
+        const TrackId focusedTrack = m_focusedItemKey.trackId;
+        if (muse::contains(selectedTracks, focusedTrack)) {
+            selectedTracks.erase(std::remove(selectedTracks.begin(), selectedTracks.end(), focusedTrack), selectedTracks.end());
+        } else {
+            selectedTracks.push_back(focusedTrack);
+        }
+        selectionController()->setSelectedTracks(selectedTracks);
+        m_lastSelectedTrack = focusedTrack;
+    }
+}
+
+void TrackNavigationController::rangeSelection()
 {
     bool isTrackPanel = m_focusedItemKey.itemId == INVALID_TRACK_ITEM;
 
     bool isSelect = false;
 
     if (!isTrackPanel) {
-        if (isFocusedItemLabel()) {
-            LabelKeyList selectedLabels = selectionController()->selectedLabels();
-            isSelect = !muse::contains(selectedLabels, m_focusedItemKey);
-
-            if (isSelect) {
-                selectionController()->addSelectedLabel(m_focusedItemKey);
-            } else {
-                selectionController()->removeLabelSelection(m_focusedItemKey);
-            }
-        } else {
-            ClipKeyList selectedClips = selectionController()->selectedClips();
-            isSelect = !muse::contains(selectedClips, m_focusedItemKey);
-
-            if (isSelect) {
-                selectionController()->addSelectedClip(m_focusedItemKey);
-            } else {
-                selectionController()->removeClipSelection(m_focusedItemKey);
-            }
+        TrackItemKeyList range = itemKeysInRange(m_lastSelectedItem, m_focusedItemKey);
+        if (range.empty()) {
+            m_lastSelectedItem = m_focusedItemKey;
+            range.push_back(m_focusedItemKey);
         }
+
+        if (isFocusedItemLabel()) {
+            selectionController()->setSelectedLabels(range);
+            selectionController()->setSelectedClips({});
+        } else {
+            selectionController()->setSelectedClips(range);
+            selectionController()->setSelectedLabels({});
+        }
+
+        return;
     } else {
         const auto orderedTracks = selectionController()->orderedTrackList();
         if (orderedTracks.empty()) {

--- a/src/trackedit/internal/tracknavigationcontroller.h
+++ b/src/trackedit/internal/tracknavigationcontroller.h
@@ -49,6 +49,8 @@ public:
     void setFocusedItem(const TrackItemKey& key, bool highlight = false) override;
     muse::async::Channel<TrackItemKey, bool /*highlight*/> focusedItemChanged() const override;
 
+    TrackItemKeyList itemKeysInRange(const TrackItemKey& anchor, const TrackItemKey& target) const override;
+
     muse::async::Channel<TrackItemKey> openContextMenuRequested() const override;
 
 private:
@@ -82,8 +84,9 @@ private:
     TrackItemKey findClosestItemOnTrack(const TrackId& trackId, double referenceStartTime) const;
     double itemStartTime(const TrackItemKey& key) const;
 
+    void replaceSelection();
     void toggleSelection();
-    void trackRangeSelection();
+    void rangeSelection();
 
     void multiSelectionUp();
     void multiSelectionDown();
@@ -102,6 +105,7 @@ private:
 
     std::optional<TrackId> m_selectionStart;
     std::optional<TrackId> m_lastSelectedTrack;
+    TrackItemKey m_lastSelectedItem;
 
     std::optional<double> m_savedItemStartTime;
 

--- a/src/trackedit/tests/mocks/tracknavigationcontrollermock.h
+++ b/src/trackedit/tests/mocks/tracknavigationcontrollermock.h
@@ -23,6 +23,8 @@ public:
     MOCK_METHOD(void, setFocusedItem, (const TrackItemKey& key, bool), (override));
     MOCK_METHOD((muse::async::Channel<TrackItemKey, bool>), focusedItemChanged, (), (const, override));
 
+    MOCK_METHOD(TrackItemKeyList, itemKeysInRange, (const TrackItemKey& anchor, const TrackItemKey& target), (const, override));
+
     MOCK_METHOD(muse::async::Channel<TrackItemKey>, openContextMenuRequested, (), (const, override));
 };
 }

--- a/src/trackedit/trackedittypes.h
+++ b/src/trackedit/trackedittypes.h
@@ -100,6 +100,12 @@ enum class HistoryEvent {
     NewState,
 };
 
+enum class SelectionMode {
+    Replace,
+    Toggle,
+    Range,
+};
+
 // 1-based index into theme clip_color_N / clip_selected_color_N slots.
 // 0 means "no custom color" (clip inherits from track).
 using ClipColorIndex = int;


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/11166

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
- [x] IMPORTANT: please remove your shortcuts.xml first
- [x] Current master's behavior was changed: old shift+select behavior is now ctrl+select (toggle individual clips/labels)
- [x] shift+select now selects a range of clips/labels on the same track
- [x] test keynav: basic selection with enter, non-consecutive selection with ctrl(cmd)+enter, consecutive selection with shift+enter
