### PR TITLE
fixed #10441: Split tool should work when in Spectrogram view

### DIFF
--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/ClipItem.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/ClipItem.qml
@@ -65,6 +65,7 @@ Rectangle {
     required property real selectionEndFrequency
     required property bool spectralSelectionEnabled
     required property var pressedSpectrogram
+    required property bool splitToolActive
 
     property real distanceToLeftNeighbor: -1
     property real distanceToRightNeighbor: -1
@@ -1049,6 +1050,8 @@ Rectangle {
                     selectionStartFrequency: root.selectionStartFrequency
                     selectionEndFrequency: root.selectionEndFrequency
                     clipSelected: root.clipSelected
+
+                    enabled: !root.splitToolActive
 
                     ChannelSplitter {
                         anchors.fill: parent

--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TrackClipsContainer.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TrackClipsContainer.qml
@@ -28,6 +28,7 @@ TrackItemsContainer {
     required property var pressedSpectrogram
     required property double sampleRate
     required property var selectionController
+    required property bool splitToolActive
 
     signal movePreviewClip(int x, int width, string title)
     signal clearPreviewClip
@@ -386,6 +387,7 @@ TrackItemsContainer {
                                 selectionEndFrequency: root.selectionEndFrequency
                                 pressedSpectrogram: root.pressedSpectrogram
                                 spectralSelectionEnabled: root.spectralSelectionEnabled
+                                splitToolActive: root.splitToolActive
 
                                 leftVisibleMargin: itemData.leftVisibleMargin
                                 rightVisibleMargin: itemData.rightVisibleMargin
@@ -668,6 +670,7 @@ TrackItemsContainer {
                 id: spectralSelectionContainer
 
                 visible: root.isSpectrogramViewVisible
+                enabled: !root.splitToolActive
 
                 y: root.headerHeight + (root.isWaveformViewVisible ? prv.viewHeight : 0)
                 height: prv.viewHeight

--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TracksItemsView.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TracksItemsView.qml
@@ -186,6 +186,13 @@ Rectangle {
 
         clipHovered: root.itemHovered && !root.itemHeaderHovered
         hoveredTrack: root.hoveredTrackId
+
+        onActiveChanged: {
+            if (active) {
+                selectionViewController.cancelSpectrogramEdit()
+                itemsSelection.visible = false
+            }
+        }
     }
 
     SelectionViewController {

--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TracksItemsView.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TracksItemsView.qml
@@ -916,6 +916,7 @@ Rectangle {
                             pressedSpectrogram: selectionViewController.pressedSpectrogram
                             spectralSelectionEnabled: selectionViewController.spectralSelectionEnabled
                             selectionController: selectionViewController
+                            splitToolActive: splitToolController.active
 
                             navigationPanel: navPanels && navPanels[index] ? navPanels[index] : null
 

--- a/src/projectscene/view/tracksitemsview/selectionviewcontroller.cpp
+++ b/src/projectscene/view/tracksitemsview/selectionviewcontroller.cpp
@@ -295,6 +295,21 @@ void SelectionViewController::updateSelectionVerticalResize(double y, bool compl
     frequencySelectionController()->setHandleFrequency(frequency, completed, m_frequencyEdgeHandle);
 }
 
+void SelectionViewController::cancelSpectrogramEdit()
+{
+    frequencySelectionController()->resetFrequencySelection();
+
+    if (!m_verticalSelectionEditInProgress) {
+        return;
+    }
+
+    m_verticalSelectionEditInProgress = false;
+    m_frequencyEdgeHandle = 0;
+    m_spectrogramHit.reset();
+    emit verticalSelectionEditInProgressChanged();
+    emit pressedSpectrogramChanged();
+}
+
 void SelectionViewController::selectTrackAudioData(double y)
 {
     if (!isProjectOpened()) {

--- a/src/projectscene/view/tracksitemsview/selectionviewcontroller.h
+++ b/src/projectscene/view/tracksitemsview/selectionviewcontroller.h
@@ -65,6 +65,7 @@ public:
     Q_INVOKABLE void onSelectionHorizontalResize(double x, double x2, bool completed);
     Q_INVOKABLE void startSelectionVerticalResize(spectrogram::SpectrogramHit hit, bool isTop);
     Q_INVOKABLE void updateSelectionVerticalResize(double y, bool completed);
+    Q_INVOKABLE void cancelSpectrogramEdit();
 
     Q_INVOKABLE void selectTrackAudioData(double y);
     Q_INVOKABLE void selectItemData(const TrackItemKey& key);

--- a/src/spectrogram/qml/Audacity/Spectrogram/ChannelSpectralSelectionContainer.qml
+++ b/src/spectrogram/qml/Audacity/Spectrogram/ChannelSpectralSelectionContainer.qml
@@ -98,12 +98,14 @@ Item {
     }
 
     MouseArea {
+        property var draggedEdges: []
+
         anchors.fill: parent
 
         hoverEnabled: true
         acceptedButtons: Qt.LeftButton
 
-        property var draggedEdges: []
+        enabled: root.visible && root.enabled
 
         onPressed: function (mouse) {
             switch (marquee.hitHandle(mouse.x - marquee.x, mouse.y - marquee.y, marquee)) {

--- a/src/spectrogram/qml/Audacity/Spectrogram/ChannelSpectralSelectionContainer.qml
+++ b/src/spectrogram/qml/Audacity/Spectrogram/ChannelSpectralSelectionContainer.qml
@@ -80,6 +80,12 @@ Item {
         }
     }
 
+    onEnabledChanged: {
+        if (!enabled && selectionModel.verticalDragActive) {
+            selectionModel.endCenterFrequencyDrag()
+        }
+    }
+
     ChannelSpectralSelectionModel {
         id: selectionModel
 

--- a/src/spectrogram/qml/Audacity/Spectrogram/ClipSpectrogramView.qml
+++ b/src/spectrogram/qml/Audacity/Spectrogram/ClipSpectrogramView.qml
@@ -100,6 +100,8 @@ Item {
 
                     cursorShape: Qt.CrossCursor
                     acceptedButtons: Qt.NoButton // Don't consume mouse events
+
+                    enabled: root.visible && root.enabled
                 }
             }
         }

--- a/src/spectrogram/qml/Audacity/Spectrogram/TrackSpectralSelectionContainer.qml
+++ b/src/spectrogram/qml/Audacity/Spectrogram/TrackSpectralSelectionContainer.qml
@@ -52,6 +52,9 @@ Item {
         visible: selectionStartFrequency < selectionEndFrequency
         hoverEnabled: true
         acceptedButtons: Qt.RightButton
+
+        enabled: root.visible && root.enabled
+
         onClicked: function (mouse) {
             contextMenuLoader.show(Qt.point(mouse.x, mouse.y), contextMenuModel.items)
         }
@@ -78,6 +81,8 @@ Item {
         selectionEndTime: root.selectionEndTime
         selectionController: root.selectionController
 
+        enabled: root.visible && root.enabled
+
         onSelectionHorizontalResize: function (x1, x2, completed) {
             root.selectionHorizontalResize(x1, x2, completed)
         }
@@ -90,8 +95,6 @@ Item {
 
     ChannelSpectralSelectionContainer {
         id: rightContainer
-
-        visible: root.isStereo
 
         anchors.top: leftOrMonoContainer.bottom
         anchors.left: parent.left
@@ -110,6 +113,9 @@ Item {
         selectionStartTime: root.selectionStartTime
         selectionEndTime: root.selectionEndTime
         selectionController: root.selectionController
+
+        visible: root.isStereo
+        enabled: root.visible && root.enabled
 
         onSelectionHorizontalResize: function (x1, x2, completed) {
             root.selectionHorizontalResize(x1, x2, completed)


### PR DESCRIPTION
Resolves: #10441 

Two fixes:
- disable spectrogram edit if split is enabled
- cancel spectrogram edit if split is enabled