### PR TITLE
Remove autofill menu entry

### DIFF
--- a/src/appshell/internal/platform/macos/macosappmenumodelhook.mm
+++ b/src/appshell/internal/platform/macos/macosappmenumodelhook.mm
@@ -24,10 +24,98 @@
 
 #include <Cocoa/Cocoa.h>
 
+@interface AUMenuAutoFillFilter : NSObject <NSMenuDelegate>
+@property (nonatomic, assign) id<NSMenuDelegate> chainedDelegate;
+- (void)stripAutoFillFrom:(NSMenu*)menu;
+@end
+
+@implementation AUMenuAutoFillFilter
+
+- (BOOL)isAutoFillItem:(NSMenuItem*)item
+{
+    // AutoFill is injected by AppKit as a submenu whose children use private
+    // Apple selectors. Qt's own submenus always contain at least one item with
+    // qt_itemFired:, so the absence of that selector identifies an injected
+    // submenu without depending on the locale-sensitive item title.
+    if (!item.hasSubmenu || item.action != @selector(submenuAction:)) {
+        return NO;
+    }
+    SEL qtFired = NSSelectorFromString(@"qt_itemFired:");
+    for (NSMenuItem* child in item.submenu.itemArray) {
+        if (child.action == qtFired) {
+            return NO;
+        }
+    }
+    return item.submenu.numberOfItems > 0;
+}
+
+- (void)stripAutoFillFrom:(NSMenu*)menu
+{
+    for (NSInteger i = menu.numberOfItems - 1; i >= 0; i--) {
+        if (![self isAutoFillItem:[menu itemAtIndex:i]]) {
+            continue;
+        }
+        [menu removeItemAtIndex:i];
+        // Remove only the separator directly adjacent to the removed item so
+        // that unrelated menus with intentional leading/trailing separators are
+        // left intact.
+        if (i < menu.numberOfItems && [[menu itemAtIndex:i] isSeparatorItem]) {
+            [menu removeItemAtIndex:i];
+        } else if (i > 0 && [[menu itemAtIndex:i - 1] isSeparatorItem]) {
+            [menu removeItemAtIndex:i - 1];
+            i--;
+        }
+    }
+}
+
+- (void)menuWillOpen:(NSMenu*)menu
+{
+    [self stripAutoFillFrom:menu];
+    if ([_chainedDelegate respondsToSelector:@selector(menuWillOpen:)]) {
+        [_chainedDelegate menuWillOpen:menu];
+    }
+}
+
+- (BOOL)respondsToSelector:(SEL)sel
+{
+    return [super respondsToSelector:sel] || [_chainedDelegate respondsToSelector:sel];
+}
+
+- (id)forwardingTargetForSelector:(SEL)sel
+{
+    return [_chainedDelegate respondsToSelector:sel] ? _chainedDelegate : [super forwardingTargetForSelector:sel];
+}
+
+@end
+
+// Retained owner for per-menu delegate instances (NSMenu.delegate is weak/assign).
+static NSMutableArray* s_filters = nil;
+
 using namespace au::appshell;
 
 void MacOSAppMenuModelHook::onAppMenuInited()
 {
     [[NSUserDefaults standardUserDefaults] setBool:YES forKey:@"NSDisabledDictationMenuItem"];
     [[NSUserDefaults standardUserDefaults] setBool:YES forKey:@"NSDisabledCharacterPaletteMenuItem"];
+
+    // Qt uses qt_itemFired: for all menu items rather than standard Cocoa selectors,
+    // so the Edit menu cannot be identified by action. Install the delegate on every
+    // top-level submenu instead — stripAutoFillFrom: is a no-op on menus that
+    // contain no injected items.
+    dispatch_async(dispatch_get_main_queue(), ^{
+        if (!s_filters) {
+            s_filters = [[NSMutableArray alloc] init];
+        }
+        for (NSMenuItem* topItem in [NSApp mainMenu].itemArray) {
+            NSMenu* sub = topItem.submenu;
+            if (!sub || [sub.delegate isKindOfClass:[AUMenuAutoFillFilter class]]) {
+                continue;
+            }
+            AUMenuAutoFillFilter* f = [[AUMenuAutoFillFilter alloc] init];
+            f.chainedDelegate = sub.delegate;
+            sub.delegate = f;
+            [s_filters addObject:f];
+            [f release];
+        }
+    });
 }

--- a/src/appshell/qml/Audacity/AppShell/appmenumodel.cpp
+++ b/src/appshell/qml/Audacity/AppShell/appmenumodel.cpp
@@ -242,7 +242,9 @@ MenuItem* AppMenuModel::makeEditMenu()
         makeMenu(TranslatableString("appshell-menu-label", "Label"), makeLabelItems(), "menu-label"),
         makeSeparator(),
         makeMenuItem("open-metadata-editor", TranslatableString("action", "Metadata editor")),
+#ifndef Q_OS_MAC
         makeSeparator(),
+#endif
         makeMenuItem("preference-dialog", MenuItemRole::PreferencesRole)
     };
 


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/11287
Resolves: https://github.com/audacity/audacity/issues/11286

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [ ] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [x]  Edit menu item state updates — Make a change (e.g. move a clip), then open the Edit menu and verify "Undo 'Move clip'" is correctly enabled and named. Repeat for Redo. 
- [x] Hover across all menu bar items and back to Edit — Hover through Edit → Select → View → Tracks → back to Edit, ideally a few times in sequence.
- [x]  Preferences access — Open Audacity (app menu) → Preferences, and verify it opens via `Cmd+,`.