### PR TITLE
Fix clip color track icon

### DIFF
--- a/src/au3wrap/internal/domconverter.cpp
+++ b/src/au3wrap/internal/domconverter.cpp
@@ -96,9 +96,9 @@ au::trackedit::Clip DomConverter::clip(const Au3WaveTrack* waveTrack, const Au3W
     clip.title = wxToString(au3clip->GetName());
     clip.startTime = au3clip->GetPlayStartTime();
     clip.endTime = au3clip->GetPlayEndTime();
-    int clipIdx = au3clip->GetColorIndex();
-    clip.isAutoColor = (clipIdx == 0);
-    clip.colorIndex = clip.isAutoColor ? TrackColor::Get(waveTrack).GetColorIndex() : clipIdx;
+    int clipColorIdx = au3clip->GetColorIndex();
+    clip.isAutoColor = (clipColorIdx == trackedit::CLIP_COLOR_INDEX_NONE);
+    clip.colorIndex = clip.isAutoColor ? TrackColor::Get(waveTrack).GetColorIndex() : clipColorIdx;
     clip.groupId = au3clip->GetGroupId();
     clip.stereo = au3clip->NChannels() > 1;
 

--- a/src/au3wrap/internal/domconverter.cpp
+++ b/src/au3wrap/internal/domconverter.cpp
@@ -97,7 +97,8 @@ au::trackedit::Clip DomConverter::clip(const Au3WaveTrack* waveTrack, const Au3W
     clip.startTime = au3clip->GetPlayStartTime();
     clip.endTime = au3clip->GetPlayEndTime();
     int clipIdx = au3clip->GetColorIndex();
-    clip.colorIndex = (clipIdx != 0) ? clipIdx : TrackColor::Get(waveTrack).GetColorIndex();
+    clip.isAutoColor = (clipIdx == 0);
+    clip.colorIndex = clip.isAutoColor ? TrackColor::Get(waveTrack).GetColorIndex() : clipIdx;
     clip.groupId = au3clip->GetGroupId();
     clip.stereo = au3clip->NChannels() > 1;
 

--- a/src/projectscene/view/tracksitemsview/clipcontextmenumodel.cpp
+++ b/src/projectscene/view/tracksitemsview/clipcontextmenumodel.cpp
@@ -7,6 +7,7 @@
 #include "trackedit/dom/track.h"
 #include "framework/global/translation.h"
 #include "global/realfn.h"
+#include "ui/view/iconcodes.h"
 
 using namespace au::projectscene;
 using namespace muse::uicomponents;
@@ -211,6 +212,16 @@ void ClipContextMenuModel::updateColorCheckedState()
     auto clip = project->trackeditProject()->clip(m_clipKey.key);
     if (!clip.isValid()) {
         return;
+    }
+
+    auto trackOpt = project->trackeditProject()->track(m_clipKey.trackId());
+    if (trackOpt) {
+        muse::Color trackColor = projectSceneConfiguration()->clipColor(trackOpt->colorIndex);
+        MenuItem& autoColorItem = findItem(muse::actions::ActionCode("action://trackedit/clip/change-color-auto"));
+        muse::ui::UiAction action = autoColorItem.action();
+        action.iconCode = muse::ui::IconCode::Code::FRETBOARD_MARKER_CIRCLE_FILLED;
+        action.iconColor = QString::fromStdString(trackColor.toString());
+        autoColorItem.setAction(action);
     }
 
     for (const auto& action : m_colorChangeActionCodeList) {

--- a/src/projectscene/view/tracksitemsview/clipcontextmenumodel.cpp
+++ b/src/projectscene/view/tracksitemsview/clipcontextmenumodel.cpp
@@ -229,9 +229,9 @@ void ClipContextMenuModel::updateColorCheckedState()
         ActionQuery query(action);
 
         bool checked = false;
-        if (clip.colorIndex == trackedit::CLIP_COLOR_INDEX_NONE && action == m_colorChangeActionCodeList.at(0)) {
+        if (clip.isAutoColor && action == m_colorChangeActionCodeList.at(0)) {
             checked = true;
-        } else if (query.contains("colorindex") && query.param("colorindex").toInt() == clip.colorIndex) {
+        } else if (!clip.isAutoColor && query.contains("colorindex") && query.param("colorindex").toInt() == clip.colorIndex) {
             checked = true;
         }
 

--- a/src/projectscene/view/tracksitemsview/clipcontextmenumodel.cpp
+++ b/src/projectscene/view/tracksitemsview/clipcontextmenumodel.cpp
@@ -111,6 +111,12 @@ void ClipContextMenuModel::load()
                 load();
             }
         }, muse::async::Asyncable::Mode::SetReplace);
+
+        prj->trackChanged().onReceive(this, [this](const trackedit::Track& track) {
+            if (track.id == m_clipKey.trackId()) {
+                updateColorCheckedState();
+            }
+        }, muse::async::Asyncable::Mode::SetReplace);
     }
 
     setItems(items);

--- a/src/projectscene/view/tracksitemsview/clipcontextmenumodel.cpp
+++ b/src/projectscene/view/tracksitemsview/clipcontextmenumodel.cpp
@@ -220,9 +220,9 @@ void ClipContextMenuModel::updateColorCheckedState()
         return;
     }
 
-    auto trackOpt = project->trackeditProject()->track(m_clipKey.trackId());
+    const auto trackOpt = project->trackeditProject()->track(m_clipKey.trackId());
     if (trackOpt) {
-        muse::Color trackColor = projectSceneConfiguration()->clipColor(trackOpt->colorIndex);
+        const muse::Color trackColor = projectSceneConfiguration()->clipColor(trackOpt->colorIndex);
         MenuItem& autoColorItem = findItem(muse::actions::ActionCode("action://trackedit/clip/change-color-auto"));
         muse::ui::UiAction action = autoColorItem.action();
         action.iconCode = muse::ui::IconCode::Code::FRETBOARD_MARKER_CIRCLE_FILLED;

--- a/src/trackedit/dom/clip.h
+++ b/src/trackedit/dom/clip.h
@@ -17,6 +17,7 @@ struct Clip {
 
     muse::String title;
     ClipColorIndex colorIndex = CLIP_COLOR_INDEX_NONE;
+    bool isAutoColor = true;
     int groupId = -1;
     double startTime = 0.0;
     double endTime = 0.0;

--- a/src/trackedit/internal/au3/au3tracksinteraction.cpp
+++ b/src/trackedit/internal/au3/au3tracksinteraction.cpp
@@ -129,9 +129,9 @@ bool Au3TracksInteraction::changeTracksColor(const TrackIdList& tracksIds, ClipC
 
         if (Au3WaveTrack* waveTrack = dynamic_cast<Au3WaveTrack*>(track)) {
             for (auto& clips: DomAccessor::waveClipsAsList(waveTrack)) {
-                //Set it back to auto (inherit from track)
-                clips->SetColorIndex(CLIP_COLOR_INDEX_NONE);
-                prj->notifyAboutClipChanged(DomConverter::clip(waveTrack, clips.get()));
+                if (clips->GetColorIndex() == CLIP_COLOR_INDEX_NONE) {
+                    prj->notifyAboutClipChanged(DomConverter::clip(waveTrack, clips.get()));
+                }
             }
         } else if (Au3LabelTrack* labelTrack = dynamic_cast<Au3LabelTrack*>(track)) {
             const auto& au3labels = labelTrack->GetLabels();

--- a/src/trackedit/internal/au3/au3tracksinteraction.cpp
+++ b/src/trackedit/internal/au3/au3tracksinteraction.cpp
@@ -128,9 +128,9 @@ bool Au3TracksInteraction::changeTracksColor(const TrackIdList& tracksIds, ClipC
         prj->notifyAboutTrackChanged(DomConverter::track(track));
 
         if (Au3WaveTrack* waveTrack = dynamic_cast<Au3WaveTrack*>(track)) {
-            for (auto& clips: DomAccessor::waveClipsAsList(waveTrack)) {
-                if (clips->GetColorIndex() == CLIP_COLOR_INDEX_NONE) {
-                    prj->notifyAboutClipChanged(DomConverter::clip(waveTrack, clips.get()));
+            for (auto& clip: DomAccessor::waveClipsAsList(waveTrack)) {
+                if (clip->GetColorIndex() == CLIP_COLOR_INDEX_NONE) {
+                    prj->notifyAboutClipChanged(DomConverter::clip(waveTrack, clip.get()));
                 }
             }
         } else if (Au3LabelTrack* labelTrack = dynamic_cast<Au3LabelTrack*>(track)) {

--- a/src/trackedit/tests/au3tracksinteraction_tests.cpp
+++ b/src/trackedit/tests/au3tracksinteraction_tests.cpp
@@ -91,7 +91,7 @@ TEST_F(Au3TracksInteractionTests, ChangeTrackColor)
     //! [WHEN] Change the color of the track
     m_tracksInteraction->changeTracksColor({ trackMinSilenceId }, 9);
 
-    //! [THEN] Clip color index is cleared to follow the track color
+    //! [THEN] Auto-color clip (index 0) is unaffected; explicit-color clips keep their color
     const std::shared_ptr<Au3WaveClip> au3UpdatedClip = DomAccessor::findWaveClip(project, trackMinSilenceId, 0);
     EXPECT_EQ(au3UpdatedClip->GetColorIndex(), 0);
 


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/8203

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [ ] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [x] Set track color to any named color; check that the menu updates accordingly.
- [x] Set a clip to an explicit color (e.g. green), open the menu: verify "Green" is checked and "Same as track color" is not.
- [x] Set clip color, then change the track color. Right-click the clip, verify the clip color is still checked and "Same as track color" shows a correct color circle.
- [x] Change the track color. Verify the "Same as track color" circle updates to the new track color.
