### PR TITLE
Fix plugin validation app CI test

### DIFF
--- a/.github/workflows/au4_build_linux.yml
+++ b/.github/workflows/au4_build_linux.yml
@@ -241,6 +241,10 @@ jobs:
     steps:
     - name: Clone repository
       uses: actions/checkout@v6
+      with:
+        repository: ${{ inputs.app_repo || job.workflow_repository }}
+        ref: ${{ inputs.app_ref || job.workflow_sha }}
+        persist-credentials: false
 
     - name: Setup environment
       run: |


### PR DESCRIPTION
fixes: https://github.com/musescore/muse_framework/actions/runs/28433589437/job/84260240550?pr=97

The plugin-registration-self-test job actions/checkout@v6 under workflow_call, github.repository is the caller (muse_framework), so it cloned the wrong repo and ran the wrong buildscripts/ci/linux/setup.sh


<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
