### PR TITLE
fixed #10016: Shift + click when the playhead is off-screen is broken

### DIFF
--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TracksItemsView.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TracksItemsView.qml
@@ -311,8 +311,9 @@ Rectangle {
             onClicked: function (e) {
                 let position = convertToTimelinePosition(e)
                 if (!playRegionActivated) {
-                    playCursorController.seekToX(position.x, playbackState.isPlaying || timeline.context.playbackOnRulerClickEnabled)
-                    playCursorController.setPlaybackRegion(position.x, position.x)
+                    let time = timeline.context.positionToTime(position.x)
+                    playCursorController.seekToTime(time, playbackState.isPlaying || timeline.context.playbackOnRulerClickEnabled)
+                    playCursorController.setPlaybackRegionByTime(time, time)
                 }
                 playRegionActivated = false
             }
@@ -417,17 +418,18 @@ Rectangle {
                         if (pressed) {
                             head.dragPositionX = ix
                             timeline.displayedPlayCursorX = ix
-                            playCursorController.seekToX(ix)
+                            playCursorController.seekToTime(timeline.context.positionToTime(ix))
                         }
                         timeline.updateCursorPosition(ix, 0)
                     }
 
                     onReleased: function (e) {
                         var ix = mapToItem(timeline, e.x, e.y).x
-                        playCursorController.seekToX(ix)
+                        let ixTime = timeline.context.positionToTime(ix)
+                        playCursorController.seekToTime(ixTime)
                         if (!timelineMouseArea.playRegionActivated) {
-                            playCursorController.seekToX(ix, playbackState.isPlaying || timeline.context.playbackOnRulerClickEnabled)
-                            playCursorController.setPlaybackRegion(ix, ix)
+                            playCursorController.seekToTime(ixTime, playbackState.isPlaying || timeline.context.playbackOnRulerClickEnabled)
+                            playCursorController.setPlaybackRegionByTime(ixTime, ixTime)
                         }
                         playCursorReleaseTimer.restart()
                     }
@@ -565,15 +567,16 @@ Rectangle {
                         content.forceActiveFocus()
 
                         if (!((e.modifiers & (Qt.ControlModifier | Qt.ShiftModifier)) || root.isSplitMode)) {
+                            let time = timeline.context.positionToTime(e.x)
                             if (playbackState.isPlaying) {
-                                playbackState.setLastPlaybackSeekTime(timeline.context.positionToTime(e.x))
+                                playbackState.setLastPlaybackSeekTime(time)
                             }
-                            playCursorController.seekToX(e.x)
+                            playCursorController.seekToTime(time)
                         }
 
                         if (!splitToolController.active) {
                             const spectrogramHit = tracksItemsView.getSpectrogramHit(e.y)
-                            selectionViewController.onPressed(e.x, e.y, spectrogramHit)
+                            selectionViewController.onPressed(timeline.context.positionToTime(e.x), e.y, spectrogramHit)
                             selectionViewController.resetSelectedItems()
                             itemsSelection.visible = true
                         }
@@ -610,7 +613,7 @@ Rectangle {
                     tracksItemsView.itemMoveRequested(hoveredItemKey, false)
                     tracksItemsView.startAutoScroll()
                 } else {
-                    selectionViewController.onPositionChanged(e.x, e.y)
+                    selectionViewController.onPositionChanged(timeline.context.positionToTime(e.x), e.y)
                     let trackId = tracksViewState.trackAtPosition(e.x, e.y)
 
                     snapGuidelineToPosition(e.x)
@@ -637,19 +640,20 @@ Rectangle {
                 } else {
                     splitToolController.mouseUp(e.x)
 
-                    if (selectionViewController.isLeftSelection(e.x)) {
-                        playCursorController.seekToX(e.x)
+                    let releaseTime = timeline.context.positionToTime(e.x)
+                    if (selectionViewController.isLeftSelection(releaseTime)) {
+                        playCursorController.seekToTime(releaseTime)
                     }
                     if (!splitToolController.active) {
-                        selectionViewController.onReleased(e.x, e.y)
+                        selectionViewController.onReleased(releaseTime, e.y)
                         itemsSelection.visible = false
                     }
                     hideGuideline()
                     if (e.modifiers & (Qt.ControlModifier | Qt.ShiftModifier)) {
-                        playCursorController.seekToX(timeline.context.selectionStartPosition)
+                        playCursorController.seekToTime(timeline.context.selectionStartTime)
                     }
 
-                    playCursorController.setPlaybackRegion(timeline.context.selectionStartPosition, timeline.context.selectionEndPosition)
+                    playCursorController.setPlaybackRegionByTime(timeline.context.selectionStartTime, timeline.context.selectionEndTime)
                 }
             }
 
@@ -679,10 +683,10 @@ Rectangle {
 
                 if (root.itemHovered) {
                     selectionViewController.selectItemData(root.hoveredItemKey)
-                    playCursorController.setPlaybackRegion(timeline.context.selectedItemStartPosition, timeline.context.selectedItemEndPosition)
+                    playCursorController.setPlaybackRegionByTime(timeline.context.selectedItemStartTime, timeline.context.selectedItemEndTime)
                 } else {
                     selectionViewController.selectTrackAudioData(e.y)
-                    playCursorController.setPlaybackRegion(timeline.context.selectedItemStartPosition, timeline.context.selectedItemEndPosition)
+                    playCursorController.setPlaybackRegionByTime(timeline.context.selectedItemStartTime, timeline.context.selectedItemEndTime)
                 }
                 itemsSelection.visible = false
             }
@@ -978,11 +982,11 @@ Rectangle {
                             }
 
                             onSelectionResize: function (x1, x2, completed) {
-                                selectionViewController.onSelectionHorizontalResize(x1, x2, completed)
+                                selectionViewController.onSelectionHorizontalResize(timeline.context.positionToTime(x1), timeline.context.positionToTime(x2), completed)
                             }
 
                             onSeekToX: function (x) {
-                                playCursorController.seekToX(x)
+                                playCursorController.seekToTime(timeline.context.positionToTime(x))
                             }
 
                             onInsureVerticallyVisible: function () {
@@ -1152,11 +1156,11 @@ Rectangle {
                             }
 
                             onSeekToX: function (x) {
-                                playCursorController.seekToX(x)
+                                playCursorController.seekToTime(timeline.context.positionToTime(x))
                             }
 
                             onSelectionResize: function (x1, x2, completed) {
-                                selectionViewController.onSelectionHorizontalResize(x1, x2, completed)
+                                selectionViewController.onSelectionHorizontalResize(timeline.context.positionToTime(x1), timeline.context.positionToTime(x2), completed)
                             }
 
                             onRequestSelectionContextMenu: function (x, y) {

--- a/src/projectscene/tests/playcursorcontroller_tests.cpp
+++ b/src/projectscene/tests/playcursorcontroller_tests.cpp
@@ -23,9 +23,9 @@
 using namespace ::testing;
 
 namespace au::projectscene {
-//! Exercises PlayCursorController's seek/play-region dispatch, focusing on the
-//! play-cursor snapping: the controller must ask the
-//! TimelineContext to snap (withSnap = true) before dispatching.
+//! Exercises PlayCursorController's seek/play-region dispatch.
+//! Snap is applied by the caller via TimelineContext::positionToTime(x, true)
+//! before passing the time to seekToTime/setPlaybackRegionByTime.
 //! Default zoom (1.0) / frame start (0.0) make position and time 1:1.
 class PlayCursorControllerTests : public ::testing::Test
 {
@@ -99,23 +99,25 @@ protected:
     PlayCursorController* m_controller = nullptr;
 };
 
-TEST_F(PlayCursorControllerTests, SeekToX_GridSnapOff_SnapsToBoundary)
+TEST_F(PlayCursorControllerTests, SeekToTime_GridSnapOff_SnapsToBoundary)
 {
     //! CASE Seeking near an item boundary dispatches a seek at the snapped boundary.
+    //! Snap is applied by the caller via positionToTime(x, true).
     useGridSnapOff({ 10.0 });
 
     muse::actions::ActionQuery captured;
     EXPECT_CALL(*m_dispatcher, dispatch(A<const muse::actions::ActionQuery&>()))
     .WillOnce(SaveArg<0>(&captured));
 
-    m_controller->seekToX(10.5); // within the 4px(=4s at zoom 1) clip-snap tolerance
+    double time = m_context->positionToTime(10.5, true); // within the 4px(=4s at zoom 1) clip-snap tolerance
+    m_controller->seekToTime(time);
 
     EXPECT_TRUE(captured.contains("seekTime"));
     EXPECT_DOUBLE_EQ(captured.param("seekTime").toDouble(), 10.0);
     EXPECT_FALSE(captured.param("triggerPlay").toBool());
 }
 
-TEST_F(PlayCursorControllerTests, SeekToX_GridSnapOff_FarFromBoundary_UsesRawTime)
+TEST_F(PlayCursorControllerTests, SeekToTime_GridSnapOff_FarFromBoundary_UsesRawTime)
 {
     //! CASE Outside the snap tolerance, the raw time is used.
     useGridSnapOff({ 10.0 });
@@ -124,12 +126,13 @@ TEST_F(PlayCursorControllerTests, SeekToX_GridSnapOff_FarFromBoundary_UsesRawTim
     EXPECT_CALL(*m_dispatcher, dispatch(A<const muse::actions::ActionQuery&>()))
     .WillOnce(SaveArg<0>(&captured));
 
-    m_controller->seekToX(20.0); // 10s away from the only boundary
+    double time = m_context->positionToTime(20.0, true); // 10s away from the only boundary
+    m_controller->seekToTime(time);
 
     EXPECT_DOUBLE_EQ(captured.param("seekTime").toDouble(), 20.0);
 }
 
-TEST_F(PlayCursorControllerTests, SeekToX_GridSnapOn_SnapsToGrid)
+TEST_F(PlayCursorControllerTests, SeekToTime_GridSnapOn_SnapsToGrid)
 {
     //! CASE With grid snap on, the seek lands on the nearest grid line.
     useGridSnapOn(SnapType::Seconds);
@@ -138,14 +141,15 @@ TEST_F(PlayCursorControllerTests, SeekToX_GridSnapOn_SnapsToGrid)
     EXPECT_CALL(*m_dispatcher, dispatch(A<const muse::actions::ActionQuery&>()))
     .WillOnce(SaveArg<0>(&captured));
 
-    m_controller->seekToX(7.4);
+    double time = m_context->positionToTime(7.4, true);
+    m_controller->seekToTime(time);
 
     EXPECT_DOUBLE_EQ(captured.param("seekTime").toDouble(), 7.0);
 }
 
-TEST_F(PlayCursorControllerTests, SeekToX_NegativeTime_ClampsToZero_WhenNotAtStart)
+TEST_F(PlayCursorControllerTests, SeekToTime_NegativeTime_ClampsToZero_WhenNotAtStart)
 {
-    //! CASE A negative resulting time seeks to 0, provided we are not already there.
+    //! CASE A negative time seeks to 0, provided we are not already there.
     useGridSnapOff({});
     ON_CALL(*m_playbackState, playbackPosition())
     .WillByDefault(Return(muse::secs_t(5.0)));
@@ -154,12 +158,12 @@ TEST_F(PlayCursorControllerTests, SeekToX_NegativeTime_ClampsToZero_WhenNotAtSta
     EXPECT_CALL(*m_dispatcher, dispatch(A<const muse::actions::ActionQuery&>()))
     .WillOnce(SaveArg<0>(&captured));
 
-    m_controller->seekToX(-3.0);
+    m_controller->seekToTime(-3.0);
 
     EXPECT_DOUBLE_EQ(captured.param("seekTime").toDouble(), 0.0);
 }
 
-TEST_F(PlayCursorControllerTests, SeekToX_NegativeTime_AlreadyAtStart_DoesNotDispatch)
+TEST_F(PlayCursorControllerTests, SeekToTime_NegativeTime_AlreadyAtStart_DoesNotDispatch)
 {
     //! CASE Negative time while already at 0 is a no-op.
     useGridSnapOff({});
@@ -169,10 +173,10 @@ TEST_F(PlayCursorControllerTests, SeekToX_NegativeTime_AlreadyAtStart_DoesNotDis
     EXPECT_CALL(*m_dispatcher, dispatch(A<const muse::actions::ActionQuery&>()))
     .Times(0);
 
-    m_controller->seekToX(-3.0);
+    m_controller->seekToTime(-3.0);
 }
 
-TEST_F(PlayCursorControllerTests, SetPlaybackRegion_SnapsAndClampsEdges)
+TEST_F(PlayCursorControllerTests, SetPlaybackRegionByTime_SnapsAndClampsEdges)
 {
     //! CASE Region edges snap to boundaries and are clamped to >= 0.
     useGridSnapOff({ 10.0 });
@@ -181,7 +185,9 @@ TEST_F(PlayCursorControllerTests, SetPlaybackRegion_SnapsAndClampsEdges)
     EXPECT_CALL(*m_dispatcher, dispatch(A<const muse::actions::ActionQuery&>()))
     .WillOnce(SaveArg<0>(&captured));
 
-    m_controller->setPlaybackRegion(-3.0, 10.4); // start clamps to 0, end snaps to 10.0
+    double t1 = m_context->positionToTime(-3.0, true); // negative — clamped to 0 by setPlaybackRegionByTime
+    double t2 = m_context->positionToTime(10.4, true); // snaps to 10.0
+    m_controller->setPlaybackRegionByTime(t1, t2);
 
     EXPECT_DOUBLE_EQ(captured.param("start").toDouble(), 0.0);
     EXPECT_DOUBLE_EQ(captured.param("end").toDouble(), 10.0);

--- a/src/projectscene/view/playcursor/playcursorcontroller.cpp
+++ b/src/projectscene/view/playcursor/playcursorcontroller.cpp
@@ -54,14 +54,15 @@ void PlayCursorController::init()
     });
 }
 
-void PlayCursorController::seekToX(double x, bool triggerPlay)
+void PlayCursorController::seekToTime(double secs, bool triggerPlay)
 {
     if (playbackState()->isPlaying() && !triggerPlay) {
         //! NOTE: Ignore all seeks in play mode unless it is an activation of play or resume from a new position
         return;
     }
 
-    const double secs = m_context->positionToTime(x, /*withSnap*/ true);
+    secs = snapTime(secs);
+
     muse::actions::ActionQuery q(PLAYBACK_SEEK_QUERY);
     q.addParam("triggerPlay", muse::Val(triggerPlay));
     if (muse::RealIsEqualOrMore(secs, 0.0)) {
@@ -73,15 +74,20 @@ void PlayCursorController::seekToX(double x, bool triggerPlay)
     }
 }
 
-void PlayCursorController::setPlaybackRegion(double x1, double x2)
+void PlayCursorController::setPlaybackRegionByTime(double t1, double t2)
 {
-    const double start = std::max(0.0, m_context->positionToTime(x1, /*withSnap*/ true));
-    const double end = std::max(0.0, m_context->positionToTime(x2, /*withSnap*/ true));
+    const double start = std::max(0.0, t1);
+    const double end = std::max(0.0, t2);
 
     muse::actions::ActionQuery q(PLAYBACK_CHANGE_PLAY_REGION_QUERY);
     q.addParam("start", muse::Val(start));
     q.addParam("end", muse::Val(end));
     dispatcher()->dispatch(q);
+}
+
+double PlayCursorController::snapTime(double time) const
+{
+    return m_context ? m_context->applyDetectedSnap(time) : time;
 }
 
 au::context::IPlaybackStatePtr PlayCursorController::playbackState() const

--- a/src/projectscene/view/playcursor/playcursorcontroller.h
+++ b/src/projectscene/view/playcursor/playcursorcontroller.h
@@ -54,8 +54,8 @@ public:
     double positionX() const;
 
     Q_INVOKABLE void init();
-    Q_INVOKABLE void seekToX(double x, bool triggerPlay = false);
-    Q_INVOKABLE void setPlaybackRegion(double x1, double x2);
+    Q_INVOKABLE void seekToTime(double secs, bool triggerPlay = false);
+    Q_INVOKABLE void setPlaybackRegionByTime(double time1, double time2);
 
 signals:
     void timelineContextChanged();
@@ -67,6 +67,7 @@ private slots:
 private:
     context::IPlaybackStatePtr playbackState() const;
 
+    double snapTime(double time) const;
     void updatePositionX(muse::secs_t secs);
     void ensureCursorAtCenter(muse::secs_t secs) const;
 

--- a/src/projectscene/view/tracksitemsview/selectionviewcontroller.cpp
+++ b/src/projectscene/view/tracksitemsview/selectionviewcontroller.cpp
@@ -29,7 +29,7 @@ void SelectionViewController::load()
     connect(qApp, &QApplication::applicationStateChanged, this, [this](Qt::ApplicationState state){
         if (state != Qt::ApplicationActive) {
             //Application lost focus, end any selection in progress
-            onReleased(m_startPoint.x(), m_startPoint.y());
+            onReleased(m_selectionStartTime, m_startY);
         }
     });
 
@@ -38,7 +38,7 @@ void SelectionViewController::load()
     });
 }
 
-void SelectionViewController::onPressed(double x, double y, spectrogram::SpectrogramHit spectrogramHit)
+void SelectionViewController::onPressed(double time, double y, spectrogram::SpectrogramHit spectrogramHit)
 {
     if (!isProjectOpened()) {
         return;
@@ -49,7 +49,8 @@ void SelectionViewController::onPressed(double x, double y, spectrogram::Spectro
         return;
     }
 
-    m_lastPoint = QPointF(x, y);
+    m_autoScrollLastX = m_context->timeToPosition(time);
+    m_autoScrollLastY = y;
 
     Qt::KeyboardModifiers modifiers = keyboardModifiers();
 
@@ -59,8 +60,11 @@ void SelectionViewController::onPressed(double x, double y, spectrogram::Spectro
         m_selectionThresholdCrossed = modifierHeld;
         //! NOTE: do not update start point when user holds Shift or Ctrl
         if (!modifierHeld) {
-            m_startPoint = QPointF(x, y);
-            selectionController()->setSelectionStartTime(m_context->positionToTime(m_startPoint.x()));
+            m_selectionStartTime = time;
+            m_startY = y;
+            selectionController()->setSelectionStartTime(m_selectionStartTime);
+        } else {
+            m_selectionStartTime = selectionController()->selectionStartTime();
         }
     }
     emit selectionStarted();
@@ -81,7 +85,7 @@ void SelectionViewController::onPressed(double x, double y, spectrogram::Spectro
             }
         }
     } else {
-        tracks = vs->tracksInRange(m_startPoint.y(), y);
+        tracks = vs->tracksInRange(m_startY, y);
     }
 
     if (!tracks.empty()) {
@@ -92,16 +96,16 @@ void SelectionViewController::onPressed(double x, double y, spectrogram::Spectro
     selectionController()->setSelectedTracks(tracks, true);
 
     if (modifiers.testFlag(Qt::ShiftModifier) || modifiers.testFlag(Qt::ControlModifier)) {
-        double x1 = m_startPoint.x();
-        double x2 = x;
-        if (x1 > x2) {
-            std::swap(x1, x2);
+        double time1 = m_selectionStartTime;
+        double time2 = time;
+        if (time1 > time2) {
+            std::swap(time1, time2);
         }
 
         setSelectionActive(true);
 
-        selectionController()->setDataSelectedStartTime(m_context->positionToTime(x1, true /*withSnap*/), false);
-        selectionController()->setDataSelectedEndTime(m_context->positionToTime(x2, true /*withSnap*/), false);
+        selectionController()->setDataSelectedStartTime(snapTime(time1), false);
+        selectionController()->setDataSelectedEndTime(snapTime(time2), false);
     }
 
     m_spectrogramHit.reset();
@@ -114,7 +118,7 @@ void SelectionViewController::onPressed(double x, double y, spectrogram::Spectro
     viewState()->updateItemsBoundaries(false);
 
     m_autoScrollConnection = connect(m_context, &TimelineContext::frameTimeChanged, [this]() {
-        doOnPositionChanged(m_lastPoint.x(), m_lastPoint.y());
+        doOnPositionChanged(m_context->positionToTime(m_autoScrollLastX), m_autoScrollLastY);
     });
 }
 
@@ -125,21 +129,21 @@ double clampToSpectrogram(const au::spectrogram::SpectrogramHit& hit, double y)
 }
 }
 
-void SelectionViewController::onPositionChanged(double x, double y)
+void SelectionViewController::onPositionChanged(double time, double y)
 {
     if (m_spectrogramHit && isInExtendedSpectrogram(*m_spectrogramHit, y)) {
         y = clampToSpectrogram(*m_spectrogramHit, y);
     }
-    if (doOnPositionChanged(x, y) && m_spectrogramHit) {
+    if (doOnPositionChanged(time, y) && m_spectrogramHit) {
         if (m_frequencyEdgeHandle == 0) {
-            const auto frequency = spectrogramHitFrequency(*m_spectrogramHit, m_startPoint.y());
+            const auto frequency = spectrogramHitFrequency(*m_spectrogramHit, m_startY);
             m_frequencyEdgeHandle = frequencySelectionController()->beginSelection(m_spectrogramHit->trackId, frequency);
         }
         setFrequencySelectionEdge(y, false, m_frequencyEdgeHandle);
     }
 }
 
-bool SelectionViewController::doOnPositionChanged(double x, double y)
+bool SelectionViewController::doOnPositionChanged(double time, double y)
 {
     if (!isProjectOpened()) {
         return false;
@@ -154,49 +158,44 @@ bool SelectionViewController::doOnPositionChanged(double x, double y)
         return false;
     }
 
+    Qt::KeyboardModifiers modifiers = keyboardModifiers();
+
+    time = std::max(time, 0.0);
+    m_autoScrollLastX = m_context->timeToPosition(time);
+    m_autoScrollLastY = y;
+    m_context->startAutoScroll(time);
+
     if (!m_selectionThresholdCrossed) {
-        if (std::abs(x - m_startPoint.x()) < SELECTION_DRAG_THRESHOLD_PX
-            && std::abs(y - m_startPoint.y()) < SELECTION_DRAG_THRESHOLD_PX) {
-            // Micro-drag ; ignore
+        const double startXPx = m_context->timeToPosition(m_selectionStartTime);
+        if (std::abs(m_autoScrollLastX - startXPx) < SELECTION_DRAG_THRESHOLD_PX
+            && std::abs(y - m_startY) < SELECTION_DRAG_THRESHOLD_PX) {
             return false;
         }
         m_selectionThresholdCrossed = true;
     }
-
-    Qt::KeyboardModifiers modifiers = keyboardModifiers();
-
-    x = std::max(x, 0.0);
-    m_lastPoint = QPointF(x, y);
-    m_context->startAutoScroll(m_context->positionToTime(x));
-
-    //! NOTE: update m_startPoint in case frameTime changed
-    m_startPoint.setX(m_context->timeToPosition(selectionController()->selectionStartTime()));
-
-    // point
-    emit selectionChanged(m_startPoint, QPointF(x, y));
 
     // tracks
     TrackIdList tracks;
     if (modifiers.testFlag(Qt::ControlModifier)) {
         tracks = selectionController()->selectedTracks();
     } else {
-        tracks = vs->tracksInRange(m_startPoint.y(), y);
+        tracks = vs->tracksInRange(m_startY, y);
     }
     selectionController()->setSelectedTracks(tracks, false);
 
     // time
-    double x1 = m_startPoint.x();
-    double x2 = x;
-    if (x1 > x2) {
-        std::swap(x1, x2);
+    double time1 = m_selectionStartTime;
+    double time2 = time;
+    if (time1 > time2) {
+        std::swap(time1, time2);
     }
 
-    setSelection(x1, x2, false);
+    setSelectionTimes(time1, time2, false);
 
     return true;
 }
 
-void SelectionViewController::onReleased(double x, double y)
+void SelectionViewController::onReleased(double time, double y)
 {
     if (!isProjectOpened()) {
         return;
@@ -219,48 +218,48 @@ void SelectionViewController::onReleased(double x, double y)
 
     m_selectionStarted = false;
 
-    x = std::max(x, 0.0);
-    m_lastPoint = QPointF(x, y);
+    time = std::max(time, 0.0);
+    m_autoScrollLastX = m_context->timeToPosition(time);
+    m_autoScrollLastY = y;
     m_context->stopAutoScroll();
     disconnect(m_autoScrollConnection);
 
-    // point
-    emit selectionEnded(m_startPoint, QPointF(x, y));
     emit selectionInProgressChanged();
 
-    double x1 = m_startPoint.x();
-    double x2 = x;
-    if (x1 > x2) {
-        std::swap(x1, x2);
+    double time1 = m_selectionStartTime;
+    double time2 = time;
+    if (time1 > time2) {
+        std::swap(time1, time2);
     }
 
     TrackIdList tracks;
     if (modifiers.testFlag(Qt::ControlModifier)) {
         tracks = selectionController()->selectedTracks();
     } else {
-        tracks = vs->tracksInRange(m_startPoint.y(), y);
+        tracks = vs->tracksInRange(m_startY, y);
     }
 
-    if (!m_selectionThresholdCrossed || (x2 - x1) < MIN_SELECTION_PX) {
+    const double minSelectionTime = m_context->positionToTime(MIN_SELECTION_PX) - m_context->positionToTime(0.0);
+    if (!m_selectionThresholdCrossed || (time2 - time1) < minSelectionTime) {
         // Click without drag (or a drag that never crossed the threshold)
         if (!tracks.empty()) {
             selectionController()->setSelectedTracks(tracks);
         } else {
             selectionController()->resetSelectedTracks();
         }
-        setSelection(x1, x1, true);
+        setSelectionTimes(time1, time1, true);
         return;
     }
 
     if (tracks.empty()) {
         selectionController()->resetSelectedTracks();
-        setSelection(x1, x2, true);
+        setSelectionTimes(time1, time2, true);
         return;
     }
 
     setSelectionActive(true);
 
-    if (m_startPoint.y() < y) {
+    if (m_startY < y) {
         trackNavigationController()->setFocusedTrack(tracks.back());
     } else {
         trackNavigationController()->setFocusedTrack(tracks.front());
@@ -268,21 +267,20 @@ void SelectionViewController::onReleased(double x, double y)
     selectionController()->setSelectedTracks(tracks, true);
 
     // time
-    setSelection(x1, x2, true);
+    setSelectionTimes(time1, time2, true);
 }
 
-void SelectionViewController::onSelectionHorizontalResize(double x1, double x2, bool completed)
+void SelectionViewController::onSelectionHorizontalResize(double time1, double time2, bool completed)
 {
     if (!isProjectOpened()) {
         return;
     }
 
-    // time
-    if (x1 > x2) {
-        std::swap(x1, x2);
+    if (time1 > time2) {
+        std::swap(time1, time2);
     }
 
-    setSelection(x1, x2, completed);
+    setSelectionTimes(time1, time2, completed);
     m_selectionEditInProgress = !completed;
     emit selectionEditInProgressChanged();
 }
@@ -339,7 +337,7 @@ void SelectionViewController::selectTrackAudioData(double y)
         return;
     }
 
-    const std::vector<TrackId> tracks = vs->tracksInRange(m_startPoint.y(), y);
+    const std::vector<TrackId> tracks = vs->tracksInRange(m_startY, y);
     if (tracks.empty()) {
         return;
     }
@@ -405,13 +403,13 @@ void SelectionViewController::resetDataSelection()
     frequencySelectionController()->resetFrequencySelection();
 }
 
-bool SelectionViewController::isLeftSelection(double x) const
+bool SelectionViewController::isLeftSelection(double time) const
 {
     if (!isProjectOpened()) {
         return false;
     }
 
-    return m_startPoint.x() > x;
+    return m_selectionStartTime > time;
 }
 
 IProjectViewStatePtr SelectionViewController::viewState() const
@@ -510,10 +508,15 @@ void SelectionViewController::setSelectionActive(bool newSelectionActive)
     emit selectionActiveChanged();
 }
 
-void SelectionViewController::setSelection(double x1, double x2, bool complete)
+void SelectionViewController::setSelectionTimes(double time1, double time2, bool complete)
 {
-    selectionController()->setDataSelectedStartTime(m_context->positionToTime(x1, true /*withSnap*/), complete);
-    selectionController()->setDataSelectedEndTime(m_context->positionToTime(x2, true /*withSnap*/), complete);
+    selectionController()->setDataSelectedStartTime(snapTime(time1), complete);
+    selectionController()->setDataSelectedEndTime(snapTime(time2), complete);
+}
+
+double SelectionViewController::snapTime(double time) const
+{
+    return m_context ? m_context->applyDetectedSnap(time) : time;
 }
 
 double SelectionViewController::spectrogramHitFrequency(const spectrogram::SpectrogramHit& hit, double y) const

--- a/src/projectscene/view/tracksitemsview/selectionviewcontroller.h
+++ b/src/projectscene/view/tracksitemsview/selectionviewcontroller.h
@@ -55,14 +55,13 @@ public:
 
     Q_INVOKABLE void load();
 
-    //! NOTE The x coordinates must match the timeline.
+    //! NOTE The time parameters are in seconds (audio time).
     //! The y coordinates must match the track view
-    //! If this is not the case, then appropriate adjustments must be made.
-    Q_INVOKABLE void onPressed(double x, double y, spectrogram::SpectrogramHit spectrogramHit = {});
-    Q_INVOKABLE void onPositionChanged(double x, double y);
-    Q_INVOKABLE void onReleased(double x, double y);
+    Q_INVOKABLE void onPressed(double time, double y, spectrogram::SpectrogramHit spectrogramHit = {});
+    Q_INVOKABLE void onPositionChanged(double time, double y);
+    Q_INVOKABLE void onReleased(double time, double y);
 
-    Q_INVOKABLE void onSelectionHorizontalResize(double x, double x2, bool completed);
+    Q_INVOKABLE void onSelectionHorizontalResize(double time1, double time2, bool completed);
     Q_INVOKABLE void startSelectionVerticalResize(spectrogram::SpectrogramHit hit, bool isTop);
     Q_INVOKABLE void updateSelectionVerticalResize(double y, bool completed);
     Q_INVOKABLE void cancelSpectrogramEdit();
@@ -74,7 +73,7 @@ public:
     Q_INVOKABLE void resetSelectedClips();
     Q_INVOKABLE void resetSelectedLabel();
     Q_INVOKABLE void resetDataSelection();
-    Q_INVOKABLE bool isLeftSelection(double x) const;
+    Q_INVOKABLE bool isLeftSelection(double time) const;
 
     bool selectionActive() const;
     bool selectionEditInProgress() const;
@@ -95,16 +94,15 @@ signals:
     void pressedSpectrogramChanged();
 
     void selectionStarted();
-    void selectionChanged(QPointF p1, QPointF p2);
-    void selectionEnded(QPointF p1, QPointF p2);
 
 private:
 
     IProjectViewStatePtr viewState() const;
     trackedit::TrackIdList trackIdList() const;
 
-    bool doOnPositionChanged(double x, double y);
-    void setSelection(double x1, double x2, bool complete);
+    bool doOnPositionChanged(double time, double y);
+    void setSelectionTimes(double time1, double time2, bool complete);
+    double snapTime(double time) const;
     void setFrequencySelectionEdge(double y, bool complete = true, uintptr_t handle = 0); // If handle is 0, sets both
 
     Qt::KeyboardModifiers keyboardModifiers() const;
@@ -120,8 +118,11 @@ private:
     bool m_selectionActive = false;
     bool m_selectionEditInProgress = false;
     bool m_verticalSelectionEditInProgress = false;
-    QPointF m_startPoint;
-    QPointF m_lastPoint;
+
+    double m_selectionStartTime = 0.0;
+    double m_startY = 0.0;
+    double m_autoScrollLastX = 0.0;
+    double m_autoScrollLastY = 0.0;
 
     double spectrogramHitFrequency(const spectrogram::SpectrogramHit& hit, double y) const;
     bool isInExtendedSpectrogram(const spectrogram::SpectrogramHit& hit, double y) const;


### PR DESCRIPTION
SelectionViewController and PlayCursorController accepted pixel coordinates instead of time values, making the API dependent on the current zoom level and scroll position. All public methods now take secs/time.

Resolves: #10016

QA:
- [x] Click and drag selection at various zoom levels and scroll positions
- [x] Shift/Ctrl selection extension
- [x] Drag selection handles to resize
- [x] Seek on selection release (leftward drag)
- [x] Auto-scroll while dragging selection to view edge
- [x] Snap to clip boundaries
- [x] Snap to grid lines
- [x] Timeline ruler click and play cursor drag
- [x] Double-click on clip sets playback region
- [x] Drag past timeline start — clamps to 0
- [x] spectral selection
- [x] Check if click on extreme high/low zoom levels does not make a tiny selection
- [x] Check what happens if app loses focus mid selection drag (alt+tab)
- [x] Zoom when selection already exists (if it re-renders at the same time)
- [x] If playback honors drag-selected region