### PR TITLE
fixed #10585: The first time you right-click a clip after launching Audacity, the context menu becomes trimmed

### DIFF
--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/ClipItem.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/ClipItem.qml
@@ -822,7 +822,9 @@ Rectangle {
                         Qt.callLater(menuModel.handleMenuItem, itemId)
                     }
 
-                    onClicked: function (mouse) {
+                    //! NOTE: Override doClicked function from FlatButton to run clip selection logic before the base
+                    //! menu button emits clicked
+                    function doClicked(mouse) {
                         if (root.multiClipsSelected || root.isGrouped) {
                             prv.ensureMultiMenuLoaded()
                         } else {
@@ -835,6 +837,8 @@ Rectangle {
                             }
                             root.requestSelected()
                         }
+
+                        Qt.callLater(menuBtn.clicked, mouse)
                     }
                 }
             }


### PR DESCRIPTION
FlatButton calls doClicked from its internal MouseArea, which then emits clicked. When both the MenuButton component definition (MenuButton.qml) and the instantiation site (ClipItem.qml) declare onClicked, both handlers fire - the component's first, the instance's second - with no control over ordering or the parent container's reaction.

Override doClicked at the instance level instead of using onClicked. This runs clip selection logic synchronously before the menu opens, then defers the clicked signal via Qt.callLater. The deferral ensures selection state is fully committed before clicked propagates and any parent handlers react to it.

Resolves: #10585