### PR TITLE
Widen the track title when the track isn't collapsed

### DIFF
--- a/src/projectscene/qml/Audacity/ProjectScene/trackspanel/TrackItem.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/trackspanel/TrackItem.qml
@@ -171,6 +171,7 @@ ListItemBlank {
 
                 Loader {
                     id: headerTrailingControls
+                    visible: root.collapsed && item !== null
                 }
 
                 MenuButton {


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/10632

Fixed a track title truncation bug where the mute/solo button Loader was always occupying ~44px of layout space even when invisible, by binding its visibility directly to `root.collapsed` in TrackItem.qml

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [ ] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
