### PR TITLE
Update selection toolbar when moving cursor with arrow keys

### DIFF
--- a/src/projectscene/view/playcursor/playpositionactioncontroller.cpp
+++ b/src/projectscene/view/playcursor/playpositionactioncontroller.cpp
@@ -105,6 +105,11 @@ void PlayPositionActionController::applySingleStep(Direction direction)
         q.addParam("triggerPlay", muse::Val(false));
         dispatcher()->dispatch(q);
 
+        if (!playbackState()->isPlaying()) {
+            selectionController()->setDataSelectedStartTime(secs, true);
+            selectionController()->setDataSelectedEndTime(secs, true);
+        }
+
         m_context->animatedInsureVisible(secs);
     }
 }


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/10856

Fixed the Selection toolbar not updating when moving the cursor with arrow keys by updating the selection controller's start/end time in PlayPositionActionController::applySingleStep() when not playing.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [ ] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Selection toolbar (from/to) updates correctly regardless of the chosen time display format
