### PR TITLE
8676 effects list deepcopy on cloning

### DIFF
--- a/au3/libraries/au3-realtime-effects/RealtimeEffectList.cpp
+++ b/au3/libraries/au3-realtime-effects/RealtimeEffectList.cpp
@@ -28,7 +28,12 @@ RealtimeEffectList::~RealtimeEffectList()
 
 std::unique_ptr<ClientData::Cloneable<> > RealtimeEffectList::Clone() const
 {
-    return std::make_unique<RealtimeEffectList>(*this);
+    auto result = std::make_unique<RealtimeEffectList>();
+    for (auto& pState : mStates) {
+        result->mStates.push_back(pState->Clone());
+    }
+    result->SetActive(this->IsActive());
+    return result;
 }
 
 RealtimeEffectList& RealtimeEffectList::operator=(const RealtimeEffectList& other)

--- a/au3/libraries/au3-realtime-effects/RealtimeEffectState.cpp
+++ b/au3/libraries/au3-realtime-effects/RealtimeEffectState.cpp
@@ -377,6 +377,14 @@ RealtimeEffectState::~RealtimeEffectState()
 {
 }
 
+std::shared_ptr<RealtimeEffectState> RealtimeEffectState::Clone() const
+{
+    auto pNewState{ RealtimeEffectState::make_shared(GetID()) };
+    pNewState->mPlugin = mPlugin;
+    pNewState->mMainSettings.Set(mMainSettings);
+    return pNewState;
+}
+
 void RealtimeEffectState::SetID(const PluginID& id)
 {
     bool empty = id.empty();

--- a/au3/libraries/au3-realtime-effects/RealtimeEffectState.h
+++ b/au3/libraries/au3-realtime-effects/RealtimeEffectState.h
@@ -50,6 +50,9 @@ public:
 public:
     ~RealtimeEffectState();
 
+    //! Create a deep copy of the effect state
+    std::shared_ptr<RealtimeEffectState> Clone() const;
+
     //! May be called with nonempty id at most once in the lifetime of a state
     /*!
      Call with empty id is ignored.


### PR DESCRIPTION
Resolves: #8676 

When cloning the effect list do a deep copy instead of a shallow copy.
This was cherry-picked from au3 without the history part https://github.com/audacity/audacity/issues/4169

Adding the effect parameter change to the history will be implemented on: https://github.com/audacity/audacity/issues/11322

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
