### PR TITLE
fixed #9394: Typing a negative value into the "cents" text box of the Pitch and Speed dialog resets to 0 once the focus is away

### DIFF
--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/pitchandspeed/PitchSection.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/pitchandspeed/PitchSection.qml
@@ -109,7 +109,7 @@ Column {
             title: qsTrc("projectscene", "Cents")
 
             currentValue: root.pitch % 100
-            minValue: 0
+            minValue: -99
             maxValue: 100
             decimals: 0
 


### PR DESCRIPTION
Resolves: #9394