### PR TITLE
Fix number format example display in Light theme

### DIFF
--- a/src/preferences/qml/Audacity/Preferences/internal/NumberFormatSection.qml
+++ b/src/preferences/qml/Audacity/Preferences/internal/NumberFormatSection.qml
@@ -67,7 +67,7 @@ BaseSection {
 
         StyledTextLabel {
             text: qsTrc("preferences", "Example: 1,000,000.99")
-            color: ui.theme.fontSecondaryColor
+            opacity: 0.7
         }
     }
 }


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/11324

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [ ] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [ ] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [x] Test legibility in Light/Dark/Hi-contrast themes
Verify these UI elements:
- [x] Preferences → General → Number format section (the one in bug description)
- [x] Preferences → Temporary files section
- [x] Playback toolbar → play-position timecode
- [x] Playback toolbar → BPM / tempo field
- [x] Playback toolbar → Time signature control 
- [x] Timecode format dropdown arrow
- [x] Selection status bar (bottom) → start / end / length timecodes
- [x] Dialogs with timecode fields: Loop region In/Out, Custom Time dialog, Label editor table timecodes
- [x] Effect generator dialogs: Tone, Chirp, Noise, Silence, DTMF
- [x] Track waveform ruler — the time-tick labels
- [x] Spectrogram view → channel ruler — the frequency labels
