### PR TITLE
Don't replace the user's selection with split leftovers after applying an effect

### DIFF
--- a/src/effects/effects_base/internal/effectexecutionscenario.cpp
+++ b/src/effects/effects_base/internal/effectexecutionscenario.cpp
@@ -434,14 +434,17 @@ muse::Ret EffectExecutionScenario::performGenerator(au3::Au3Project& project, Ef
         const auto clipsAfter = getAllClips(*prj);
         const std::vector<const au::trackedit::Clip*> newClips = trackedit::utils::clipSetDifference(clipsAfter, clipsBefore);
         if (!newClips.empty()) {
-            trackedit::ClipKeyList newClipsKeys;
-            std::transform(newClips.begin(), newClips.end(), std::back_inserter(newClipsKeys),
-                           [](const auto clip) { return clip->key; });
             for (const auto* clip : newClips) {
                 prj->notifyAboutClipAdded(*clip);
             }
-            selectionController()->resetDataSelection();
-            selectionController()->setSelectedClips(newClipsKeys, true);
+
+            if (effect.GetType() == EffectTypeGenerate) {
+                trackedit::ClipKeyList newClipsKeys;
+                std::transform(newClips.begin(), newClips.end(), std::back_inserter(newClipsKeys),
+                               [](const auto clip) { return clip->key; });
+                selectionController()->resetDataSelection();
+                selectionController()->setSelectedClips(newClipsKeys, true);
+            }
         }
     }
 


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/11138

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
