### PR TITLE
11196 login in the browser after app login

### DIFF
--- a/au3/libraries/au3-cloud-audiocom/ServiceConfig.cpp
+++ b/au3/libraries/au3-cloud-audiocom/ServiceConfig.cpp
@@ -448,6 +448,18 @@ std::string ServiceConfig::GetProjectsPagePath(
         });
 }
 
+std::string ServiceConfig::GetProfilePagePath(
+    std::string_view userSlug, AudiocomTrace trace) const
+{
+    return Substitute(
+        "/{user_slug}?" MTM_CAMPAIGN,
+        {
+            { "user_slug", userSlug },
+            { "version_number", audacity::ToUTF8(AUDACITY_VERSION_STRING) },
+            { "button_name", GetButtonName(trace) },
+        });
+}
+
 std::string ServiceConfig::GetTaskPollUrl() const
 {
     return Substitute(

--- a/au3/libraries/au3-cloud-audiocom/ServiceConfig.h
+++ b/au3/libraries/au3-cloud-audiocom/ServiceConfig.h
@@ -77,6 +77,8 @@ public:
     std::string GetProjectPagePath(std::string_view userSlug, std::string_view projectId, AudiocomTrace) const;
     std::string
     GetProjectsPagePath(std::string_view userSlug, AudiocomTrace) const;
+    std::string
+    GetProfilePagePath(std::string_view userSlug, AudiocomTrace) const;
 
     std::string GetTaskPollUrl() const;
     std::string GetTaskAckUrl(std::string_view taskId) const;

--- a/src/appshell/qml/Audacity/AppShell/HomePage/AccountPage.qml
+++ b/src/appshell/qml/Audacity/AppShell/HomePage/AccountPage.qml
@@ -83,6 +83,10 @@ FocusScope {
             model.openSignInDialog()
         }
 
+        onMyProfileRequested: {
+            model.openProfile()
+        }
+
         onSignOutRequested: {
             model.signOut()
         }

--- a/src/appshell/qml/Audacity/AppShell/HomePage/CloudItem.qml
+++ b/src/appshell/qml/Audacity/AppShell/HomePage/CloudItem.qml
@@ -13,7 +13,6 @@ Item {
     property string cloudTitle: ""
     property bool userIsAuthorized: false
     property string userName: ""
-    property url userProfileUrl
     property url userAvatarUrl
     property url userCollectionUrl
 
@@ -37,6 +36,7 @@ Item {
     signal signInRequested
     signal signOutRequested
     signal createAccountRequested
+    signal myProfileRequested
 
     AccessibleItem {
         id: accessibleInfo
@@ -149,7 +149,7 @@ Item {
 
                     onClicked: {
                         if (Boolean(root.userIsAuthorized)) {
-                            api.launcher.openUrl(root.userProfileUrl)
+                            root.myProfileRequested()
                         } else {
                             root.signInRequested()
                         }

--- a/src/au3cloud/iau3audiocomservice.h
+++ b/src/au3cloud/iau3audiocomservice.h
@@ -63,6 +63,7 @@ public:
     virtual std::string getCloudProjectPage(const std::string& projectId) const = 0;
     virtual std::string getCloudProjectPage(const muse::io::path_t& projectPath) const = 0;
     virtual std::string getCloudAudioPage(const std::string& slug) const = 0;
+    virtual std::string getCloudProfilePage() const = 0;
 
     virtual void deinit() = 0;
 };

--- a/src/au3cloud/internal/au3audiocomservice.cpp
+++ b/src/au3cloud/internal/au3audiocomservice.cpp
@@ -494,6 +494,17 @@ std::string Au3AudioComService::getCloudAudioPage(const std::string& slug) const
     return oauthService.MakeAudioComAuthorizeURL(userId, audioPage);
 }
 
+std::string Au3AudioComService::getCloudProfilePage() const
+{
+    auto& oauthService = GetOAuthService();
+    const auto& serviceConfig = GetServiceConfig();
+
+    const auto userId = GetUserService().GetUserId().ToStdString();
+    const auto userSlug = GetUserService().GetUserSlug().ToStdString();
+    const auto profilePage = serviceConfig.GetProfilePagePath(userSlug, AudiocomTrace::OpenFromCloudMenu);
+    return oauthService.MakeAudioComAuthorizeURL(userId, profilePage);
+}
+
 muse::RetVal<muse::ProgressPtr> Au3AudioComService::downloadAudioFile(const std::string& audioId)
 {
     if (audioId.empty()) {

--- a/src/au3cloud/internal/au3audiocomservice.h
+++ b/src/au3cloud/internal/au3audiocomservice.h
@@ -76,6 +76,7 @@ public:
     std::string getCloudProjectPage(const std::string& projectId) const override;
     std::string getCloudProjectPage(const muse::io::path_t& projectPath) const override;
     std::string getCloudAudioPage(const std::string& slug) const override;
+    std::string getCloudProfilePage() const override;
 
     void deinit() override;
 

--- a/src/au3cloud/internal/au3cloudactionscontroller.cpp
+++ b/src/au3cloud/internal/au3cloudactionscontroller.cpp
@@ -19,6 +19,7 @@ const muse::actions::ActionQuery OPEN_SIGNIN_DIALOG_ACTION("audacity://cloud/ope
 const muse::actions::ActionQuery OPEN_CREATE_ACCOUNT_DIALOG_ACTION("audacity://cloud/open-create-account-dialog");
 const muse::actions::ActionQuery OPEN_CLOUD_PROJECT_PAGE_ACTION("audacity://cloud/open-project-page");
 const muse::actions::ActionQuery OPEN_CLOUD_AUDIO_PAGE_ACTION("audacity://cloud/open-audio-page");
+const muse::actions::ActionQuery OPEN_CLOUD_PROFILE_PAGE_ACTION("audacity://cloud/open-profile-page");
 
 constexpr const char* createAccountModeParam = "isCreateAccountMode";
 }
@@ -39,6 +40,7 @@ void Au3CloudActionsController::init()
     dispatcher()->reg(this, OPEN_CREATE_ACCOUNT_DIALOG_ACTION, this, &Au3CloudActionsController::openCreateAccountDialog);
     dispatcher()->reg(this, OPEN_CLOUD_PROJECT_PAGE_ACTION, this, &Au3CloudActionsController::openCloudProjectPage);
     dispatcher()->reg(this, OPEN_CLOUD_AUDIO_PAGE_ACTION, this, &Au3CloudActionsController::openCloudAudioPage);
+    dispatcher()->reg(this, OPEN_CLOUD_PROFILE_PAGE_ACTION, this, &Au3CloudActionsController::openCloudProfilePage);
     dispatcher()->reg(this, "open-url", this, &Au3CloudActionsController::openUrl);
 }
 
@@ -138,6 +140,22 @@ void Au3CloudActionsController::openCloudAudioPage(const muse::actions::ActionQu
     const auto url = audioComService()->getCloudAudioPage(slug);
     if (url.empty()) {
         LOGE() << "Cannot open cloud audio page: empty URL";
+        return;
+    }
+
+    platformInteractive()->openUrl(url);
+}
+
+void Au3CloudActionsController::openCloudProfilePage()
+{
+    if (!authorization()->isAuthorized()) {
+        LOGE() << "Cannot open cloud profile page: not signed in";
+        return;
+    }
+
+    const auto url = audioComService()->getCloudProfilePage();
+    if (url.empty()) {
+        LOGE() << "Cannot open cloud profile page: empty URL";
         return;
     }
 

--- a/src/au3cloud/internal/au3cloudactionscontroller.h
+++ b/src/au3cloud/internal/au3cloudactionscontroller.h
@@ -40,6 +40,7 @@ private:
     void openCreateAccountDialog(const muse::actions::ActionQuery& query);
     void openCloudProjectPage(const muse::actions::ActionQuery& query);
     void openCloudAudioPage(const muse::actions::ActionQuery& query);
+    void openCloudProfilePage();
     void openUrl(const muse::actions::ActionData& args);
 
     std::unique_ptr<CloudUrlHandler> m_urlHandler;

--- a/src/au3cloud/internal/au3cloudservice.cpp
+++ b/src/au3cloud/internal/au3cloudservice.cpp
@@ -38,6 +38,7 @@ void Au3CloudService::init()
 
         if (code.empty() || !error.empty()) {
             m_authState.set(NotAuthorized(error));
+            m_replyHandler->sendError();
             return;
         }
 
@@ -51,6 +52,8 @@ void Au3CloudService::init()
             const auto AUTHORIZATION_FAILED = muse::qtrc("appshell/gettingstarted", "Authorization failed");
             if (token.empty()) {
                 m_authState.set(NotAuthorized(AUTHORIZATION_FAILED.toStdString()));
+                m_replyHandler->sendError();
+                return;
             }
         });
     });
@@ -75,6 +78,7 @@ void Au3CloudService::init()
 
         auto& service = audacity::cloud::audiocom::GetUserService();
         if (message.authorised) {
+            m_silent = message.silent;
             service.UpdateUserData();
         } else {
             service.ClearUserData();
@@ -96,8 +100,14 @@ void Au3CloudService::init()
             m_accountInfo.displayName = userService.GetDisplayName().ToStdString();
             m_accountInfo.avatarPath = userService.GetAvatarPath().ToStdString();
 
-            //Only set to authorized if we have user data
-            m_authState.set(AuthState(Authorized()));
+            if (!std::holds_alternative<Authorized>(m_authState.val)) {
+                //Only set to authorized if we have user data
+                m_authState.set(AuthState(Authorized()));
+
+                if (!m_silent) {
+                    openBrowserSession();
+                }
+            }
         } else {
             m_accountInfo = AccountInfo();
 
@@ -190,6 +200,23 @@ void Au3CloudService::syncUsageInfoPrefs()
     SendAnonymousUsageInfo->Write(usageInfo()->getSendAnonymousUsageInfo());
     InstanceId->Write(wxString::FromUTF8(usageInfo()->instanceId()));
     gPrefs->Flush();
+}
+
+void Au3CloudService::openBrowserSession()
+{
+    auto& serviceConfig = audacity::cloud::audiocom::GetServiceConfig();
+    auto& authService = audacity::cloud::audiocom::GetOAuthService();
+
+    const auto landingPage = m_accountInfo.userSlug.empty()
+                             ? serviceConfig.GetTourPage()
+                             : serviceConfig.GetProfilePagePath(m_accountInfo.userSlug, AudiocomTrace::ignore);
+    const auto url = authService.MakeAudioComAuthorizeURL(m_accountInfo.id, landingPage);
+
+    if (m_replyHandler->hasPendingSocket()) {
+        m_replyHandler->sendRedirect(QUrl(QString::fromStdString(url)));
+    } else {
+        platformInteractive()->openUrl(url);
+    }
 }
 
 std::string Au3CloudService::buildOAuthRequestURL(const std::string& provider)

--- a/src/au3cloud/internal/au3cloudservice.h
+++ b/src/au3cloud/internal/au3cloudservice.h
@@ -43,6 +43,7 @@ public:
 private:
     std::string buildOAuthRequestURL(const std::string& provider);
     void syncUsageInfoPrefs();
+    void openBrowserSession();
 
     Observer::Subscription m_authSubscription;
     Observer::Subscription m_urlRegisterSubscription;
@@ -54,5 +55,7 @@ private:
 
     AccountInfo m_accountInfo;
     muse::async::Notification m_accountInfoChanged;
+
+    bool m_silent { true };
 };
 }

--- a/src/au3cloud/internal/oauthhttpserverreplyhandler.cpp
+++ b/src/au3cloud/internal/oauthhttpserverreplyhandler.cpp
@@ -5,6 +5,7 @@
 
 #include <QCoreApplication>
 #include <QNetworkReply>
+#include <QPointer>
 #include <QTcpServer>
 #include <QTcpSocket>
 #include <QUrl>
@@ -27,10 +28,16 @@ public:
 
     QUrl m_redirectUrl;
 
+    bool hasPendingSocket();
+    void sendRedirect(const QUrl& url);
+    void sendError();
+
 private:
     void onClientConnected();
     void readData(QTcpSocket* socket);
     void answerClient(QTcpSocket* socket, const QUrl& url);
+    void answerPendingClient(const QByteArray& response);
+    QByteArray makeResponse(const QByteArray& status, const QUrl& location, const QString& text) const;
 
     struct HttpRequest {
         quint16 port = 0;
@@ -66,6 +73,7 @@ private:
     };
 
     QMap<QTcpSocket*, HttpRequest> m_clients;
+    QPointer<QTcpSocket> m_pendingSocket;
 
     OAuthHttpServerReplyHandler* m_public = nullptr;
 };
@@ -149,27 +157,75 @@ void OAuthHttpServerReplyHandler::Impl::answerClient(QTcpSocket* socket, const Q
         receivedData.insert(it->first, it->second);
     }
 
+    if (!receivedData.contains(QStringLiteral("code")) && !receivedData.contains(QStringLiteral("error"))) {
+        // Not an OAuth callback (e.g. a favicon request); don't touch the pending socket
+        socket->write(QByteArrayLiteral("HTTP/1.0 404 Not Found\r\nContent-Length: 0\r\n\r\n"));
+        socket->disconnectFromHost();
+        return;
+    }
+
+    if (m_pendingSocket) {
+        m_pendingSocket->disconnectFromHost();
+    }
+
+    m_pendingSocket = socket;
+
     Q_EMIT m_public->callbackReceived(receivedData);
+}
 
-    // Fallback text, shown while redirecting
+bool OAuthHttpServerReplyHandler::Impl::hasPendingSocket()
+{
+    return m_pendingSocket;
+}
+
+void OAuthHttpServerReplyHandler::Impl::sendRedirect(const QUrl& url)
+{
+    if (!m_pendingSocket) {
+        return;
+    }
+
+    const QUrl target = url.isEmpty() ? m_redirectUrl : url;
     const QString text = muse::qtrc("cloud", "Sign in successful! You’re good to go back to Audacity.");
+    const QByteArray status = target.isEmpty() ? QByteArrayLiteral("200 OK") : QByteArrayLiteral("302 Found");
 
+    answerPendingClient(makeResponse(status, target, text));
+}
+
+void OAuthHttpServerReplyHandler::Impl::sendError()
+{
+    if (!m_pendingSocket) {
+        return;
+    }
+
+    const QString text = muse::qtrc("cloud", "Sign in failed. Please return to Audacity and try again.");
+    answerPendingClient(makeResponse(QByteArrayLiteral("200 OK"), QUrl(), text));
+}
+
+QByteArray OAuthHttpServerReplyHandler::Impl::makeResponse(const QByteArray& status, const QUrl& location, const QString& text) const
+{
     const QByteArray html = QByteArrayLiteral("<html><head><title>")
                             + qApp->applicationName().toUtf8()
                             + QByteArrayLiteral("</title></head><body>")
                             + text.toUtf8()
-                            + ("</body></html>");
+                            + QByteArrayLiteral("</body></html>");
 
-    const QByteArray htmlSize = QByteArray::number(html.size());
-    const QByteArray replyMessage = QByteArrayLiteral("HTTP/1.0 301 Moved Permanently \r\n"
-                                                      "Location: ") + m_redirectUrl.toString().toUtf8()
-                                    + QByteArrayLiteral("\r\nContent-Type: text/html; "
-                                                        "charset=\"utf-8\"\r\n"
-                                                        "Content-Length: ") + htmlSize
-                                    + QByteArrayLiteral("\r\n\r\n")
-                                    + html;
+    QByteArray response = QByteArrayLiteral("HTTP/1.0 ") + status + QByteArrayLiteral("\r\n");
+    if (!location.isEmpty()) {
+        response += QByteArrayLiteral("Location: ") + location.toString().toUtf8() + QByteArrayLiteral("\r\n");
+    }
+    response += QByteArrayLiteral("Content-Type: text/html; charset=\"utf-8\"\r\n"
+                                  "Content-Length: ") + QByteArray::number(html.size())
+                + QByteArrayLiteral("\r\n\r\n")
+                + html;
 
-    socket->write(replyMessage);
+    return response;
+}
+
+void OAuthHttpServerReplyHandler::Impl::answerPendingClient(const QByteArray& response)
+{
+    m_pendingSocket->write(response);
+    m_pendingSocket->disconnectFromHost();
+    m_pendingSocket.clear();
 }
 
 bool OAuthHttpServerReplyHandler::Impl::HttpRequest::readMethod(QTcpSocket* socket)
@@ -352,7 +408,26 @@ bool OAuthHttpServerReplyHandler::isListening() const
     return m_impl->m_httpServer.isListening();
 }
 
+bool OAuthHttpServerReplyHandler::hasPendingSocket()
+{
+    return m_impl->hasPendingSocket();
+}
+
 void OAuthHttpServerReplyHandler::setRedirectUrl(const QUrl& url)
 {
     m_impl->m_redirectUrl = url;
+}
+
+void OAuthHttpServerReplyHandler::sendRedirect(const QUrl& url)
+{
+    QMetaObject::invokeMethod(this, [this, url]() {
+        m_impl->sendRedirect(url);
+    }, Qt::QueuedConnection);
+}
+
+void OAuthHttpServerReplyHandler::sendError()
+{
+    QMetaObject::invokeMethod(this, [this]() {
+        m_impl->sendError();
+    }, Qt::QueuedConnection);
 }

--- a/src/au3cloud/internal/oauthhttpserverreplyhandler.h
+++ b/src/au3cloud/internal/oauthhttpserverreplyhandler.h
@@ -25,7 +25,10 @@ public:
     void close();
     bool isListening() const;
 
+    bool hasPendingSocket();
     void setRedirectUrl(const QUrl& url);
+    void sendRedirect(const QUrl& url);
+    void sendError();
 
 signals:
     void callbackReceived(const QVariantMap& data);

--- a/src/au3cloud/view/accountmodel.cpp
+++ b/src/au3cloud/view/accountmodel.cpp
@@ -70,3 +70,8 @@ void AccountModel::openCreateAccountDialog() const
 
     dispatcher()->dispatch(query);
 }
+
+void AccountModel::openProfile() const
+{
+    dispatcher()->dispatch(muse::actions::ActionQuery("audacity://cloud/open-profile-page"));
+}

--- a/src/au3cloud/view/accountmodel.h
+++ b/src/au3cloud/view/accountmodel.h
@@ -31,6 +31,7 @@ public:
     Q_INVOKABLE void signOut() const;
     Q_INVOKABLE void openSignInDialog() const;
     Q_INVOKABLE void openCreateAccountDialog() const;
+    Q_INVOKABLE void openProfile() const;
 
     bool isAuthorized() const;
     QUrl avatarPath() const;

--- a/src/stubs/au3cloud/au3audiocomservicestub.cpp
+++ b/src/stubs/au3cloud/au3audiocomservicestub.cpp
@@ -68,6 +68,11 @@ std::string Au3AudioComServiceStub::getCloudAudioPage(const std::string& /*unuse
     return {};
 }
 
+std::string Au3AudioComServiceStub::getCloudProfilePage() const
+{
+    return {};
+}
+
 std::string Au3AudioComServiceStub::getCloudProjectPage(const std::string& /*unused*/) const
 {
     return {};

--- a/src/stubs/au3cloud/au3audiocomservicestub.h
+++ b/src/stubs/au3cloud/au3audiocomservicestub.h
@@ -35,6 +35,7 @@ public:
     std::string getCloudProjectPage(const std::string& projectId) const override;
     std::string getCloudProjectPage(const muse::io::path_t& projectPath) const override;
     std::string getCloudAudioPage(const std::string& audioId) const override;
+    std::string getCloudProfilePage() const override;
 
     void deinit() override;
 };


### PR DESCRIPTION
Resolves: #11196 
Resolves: #11007 

Sign in to the browser after app sign in.
We must differentiate silent sign in and an active user sign in attempting. The browser should be opened just on the later.
Also, there is significant distinction on the flow according to user/password sign in and social network sign in.
In this PR we also fix "My profile" button.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
