### PR TITLE
Fix clips misbehavior after splitting a stereo track

### DIFF
--- a/au3/libraries/au3-wave-track/WaveClip.cpp
+++ b/au3/libraries/au3-wave-track/WaveClip.cpp
@@ -567,6 +567,10 @@ std::shared_ptr<WaveClip> WaveClip::SplitChannels()
     // This call asserts invariants for this clip
     DiscardRightChannel();
 
+    // Assign new IDs from newly created clips
+    SetId(NewID());
+    result->SetId(NewID());
+
     // Assert postconditions
     assert(NChannels() == 1);
     assert(result->NChannels() == 1);


### PR DESCRIPTION
Resolves: #https://github.com/audacity/audacity/issues/11194

After splitting both mono clips shared the same ID

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
