### PR TITLE
Bump actions to Node 24 versions

### DIFF
--- a/.github/workflows/au4_build_windows.yml
+++ b/.github/workflows/au4_build_windows.yml
@@ -155,7 +155,7 @@ jobs:
 
     - name: Setup x64 Python (WoA)
       if: matrix.runner == 'windows-11-arm'
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.12'
         architecture: x64
@@ -254,7 +254,7 @@ jobs:
     steps:
     - name: Setup x64 Python (WoA)
       if: matrix.runner == 'windows-11-arm'
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.12'
         architecture: x64

--- a/.github/workflows/au4_deps_matrix.yml
+++ b/.github/workflows/au4_deps_matrix.yml
@@ -58,7 +58,7 @@ jobs:
       # Qt's arm64 install needs an x64 python (no arm64 aqtinstall wheels)
       - name: Setup x64 Python (WoA)
         if: matrix.runner == 'windows-11-arm'
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
           architecture: x64


### PR DESCRIPTION
GitHub removes the Node 20 runtime from Actions runners on 2026-09-16.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
