### PR TITLE
11243 Fix opening a cloud project when its local copy was removed

### DIFF
--- a/src/au3cloud/internal/au3audiocomservice.cpp
+++ b/src/au3cloud/internal/au3audiocomservice.cpp
@@ -622,15 +622,16 @@ muse::RetVal<muse::ProgressPtr> Au3AudioComService::openCloudProject(const muse:
             return;
         }
 
-        //! When an explicit snapshot is requested, skip the local fast-path:
-        //! the local copy reflects whichever snapshot was last synced, which
-        //! may not be the one the URL is asking for.
+        //! Reuse the local copy only when the project file is present on disk and
+        //! no explicit snapshot is requested; otherwise fall through to OpenFromCloud.
         auto cancelCheck = [progress](double) -> bool { return !progress->isCanceled(); };
-        if (!forceOverwrite && snapshotId.empty()
-            && self->isSnapshotUpToDate(dbProjectData, cancelCheck, cancellationContext)) {
+        if (!forceOverwrite && snapshotId.empty() && dbProjectData.has_value()) {
             const auto normalizedLocalPath = muse::io::Dir::fromNativeSeparators(muse::io::path_t(dbProjectData->LocalPath));
-            progress->finish(muse::RetVal<muse::Val>::make_ok(muse::Val(muse::io::path_t(normalizedLocalPath))));
-            return;
+            if (self->filesystem()->exists(normalizedLocalPath)
+                && self->isSnapshotUpToDate(dbProjectData, cancelCheck, cancellationContext)) {
+                progress->finish(muse::RetVal<muse::Val>::make_ok(muse::Val(normalizedLocalPath)));
+                return;
+            }
         }
 
         const auto syncMode = forceOverwrite


### PR DESCRIPTION
Resolves: #11243 

The "open cloud project" reused the local file whenever the cloud database still had a matching record and the snapshot was up to date, without checking that the file actually existed on disk. If the user deleted the project directory, this returned a non-existent path and opening failed with a read error.

Only take the local path when the project file is present on disk, otherwise go through to OpenFromCloud, which recreates the directory and re-downloads the snapshot.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [ ] I signed [CLA](https://www.audacityteam.org/cla/)
- [ ] The title of the pull request describes an issue it addresses
- [ ] If changes are extensive, then there is a sequence of easily reviewable commits
- [ ] Each commit's message describes its purpose and effects
- [ ] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [ ] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
