### PR TITLE
Fix assert in ~RealtimeEffectListItemModel on project close

### DIFF
--- a/src/effects/effects_base/internal/realtimeeffectservice.cpp
+++ b/src/effects/effects_base/internal/realtimeeffectservice.cpp
@@ -218,8 +218,6 @@ std::optional<std::string> RealtimeEffectService::effectTrackName(const Realtime
 
 std::optional<std::vector<RealtimeEffectStatePtr> > RealtimeEffectService::effectStack(TrackId trackId) const
 {
-    // TrackList::Clear() publishes DELETION while tracks are still in the list; report
-    // unregistered tracks as gone so UI models drop their items while states are alive.
     if (m_rtEffectSubscriptions.count(trackId) == 0) {
         return {};
     }

--- a/src/effects/effects_base/internal/realtimeeffectservice.cpp
+++ b/src/effects/effects_base/internal/realtimeeffectservice.cpp
@@ -218,6 +218,12 @@ std::optional<std::string> RealtimeEffectService::effectTrackName(const Realtime
 
 std::optional<std::vector<RealtimeEffectStatePtr> > RealtimeEffectService::effectStack(TrackId trackId) const
 {
+    // TrackList::Clear() publishes DELETION while tracks are still in the list; report
+    // unregistered tracks as gone so UI models drop their items while states are alive.
+    if (m_rtEffectSubscriptions.count(trackId) == 0) {
+        return {};
+    }
+
     const auto data = utils::utilData(globalContext()->currentProject(), trackId);
     if (!data) {
         return {};

--- a/src/effects/effects_base/tests/CMakeLists.txt
+++ b/src/effects/effects_base/tests/CMakeLists.txt
@@ -9,6 +9,7 @@ set(MODULE_TEST_SRC
     ${CMAKE_CURRENT_LIST_DIR}/config_tests.cpp
     ${CMAKE_CURRENT_LIST_DIR}/effectsutils_tests.cpp
     ${CMAKE_CURRENT_LIST_DIR}/pluginmigration_tests.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/realtimeeffectservice_tests.cpp
 )
 
 set(MODULE_TEST_LINK
@@ -20,7 +21,10 @@ set(MODULE_TEST_LINK
 # AU3 - needed because test files include AU3 headers
 include(${PROJECT_SOURCE_DIR}/src/au3wrap/au3wrapDefs.cmake)
 
-set(MODULE_TEST_INCLUDE ${AU3_INCLUDE})
+set(MODULE_TEST_INCLUDE
+    ${AU3_INCLUDE}
+    ${PROJECT_SOURCE_DIR}/src/effects/effects_base # for internal headers included relatively (e.g. realtimeeffectservice.h)
+)
 set(MODULE_TEST_DEF ${AU3_DEF})
 set(MODULE_TEST_DATA_ROOT ${CMAKE_CURRENT_LIST_DIR})
 

--- a/src/effects/effects_base/tests/environment.cpp
+++ b/src/effects/effects_base/tests/environment.cpp
@@ -4,10 +4,23 @@
 
 #include "testing/environment.h"
 
-static muse::testing::SuiteEnvironment effects_base_se(
-{
-},
-    nullptr,
-    []() {
-}
-    );
+#include "au3wrap/au3wrapmodule.h"
+
+#include "project/tests/mocks/projectconfigurationmock.h"
+
+static muse::testing::SuiteEnvironment effects_base_se
+    = muse::testing::SuiteEnvironment()
+      .setDependencyModules({ new au::au3::Au3WrapModule() })
+      .setPreInit([]() {
+    // Au3WrapModule::onInit needs a project configuration (temporary dir).
+    std::shared_ptr<au::project::ProjectConfigurationMock> projectConfigurator(
+        new au::project::ProjectConfigurationMock(), [](au::project::ProjectConfigurationMock*) {});
+
+    ON_CALL(*projectConfigurator, temporaryDir())
+    .WillByDefault(::testing::Return(""));
+
+    // Intentionally immortal (owned by the global IoC with a no-op deleter).
+    ::testing::Mock::AllowLeak(projectConfigurator.get());
+
+    muse::modularity::globalIoc()->registerExport<au::project::IProjectConfiguration>("utests", projectConfigurator);
+});

--- a/src/effects/effects_base/tests/realtimeeffectservice_tests.cpp
+++ b/src/effects/effects_base/tests/realtimeeffectservice_tests.cpp
@@ -1,0 +1,123 @@
+/*
+* Audacity: A Digital Audio Editor
+*/
+
+// Regression test for the ~RealtimeEffectListItemModel() assert on project close.
+//
+// On close, TrackList::Clear() publishes per-track DELETION events while the tracks
+// are still in the list, and destroys the tracks (and the effect states they own)
+// right after. UI models react to the resulting realtimeEffectStackChanged
+// notification by re-reading effectStack(): it must already report "no stack" for
+// the unregistered track, so that the models drop their references while the
+// states are still alive.
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include "effects/effects_base/internal/realtimeeffectservice.h"
+
+#include "context/tests/mocks/globalcontextmock.h"
+#include "project/tests/mocks/audacityprojectmock.h"
+#include "project/tests/mocks/dummyeffectinstancefactory.h"
+
+#include "testing/testcontext.h"
+
+#include "au3-project/Project.h"
+#include "au3-track/Track.h"
+#include "au3-wave-track/WaveTrack.h"
+#include "au3-realtime-effects/RealtimeEffectList.h"
+#include "au3-realtime-effects/RealtimeEffectState.h"
+
+using namespace ::testing;
+
+namespace au::effects {
+class Effects_RealtimeEffectServiceTests : public ::testing::Test, public muse::async::Asyncable
+{
+protected:
+    void SetUp() override
+    {
+        m_ctx = testutils::makeTestContext();
+
+        m_globalContext = std::make_shared<NiceMock<context::GlobalContextMock> >();
+        muse::modularity::ioc(m_ctx)->registerExport<context::IGlobalContext>("utests", m_globalContext);
+
+        m_au3Project = ::AudacityProject::Create();
+        m_project = std::make_shared<NiceMock<project::AudacityProjectMock> >();
+
+        ON_CALL(*m_project, au3ProjectPtr())
+        .WillByDefault(Return(reinterpret_cast<uintptr_t>(m_au3Project.get())));
+        ON_CALL(*m_globalContext, currentProject())
+        .WillByDefault(Return(m_project));
+        ON_CALL(*m_globalContext, currentProjectChanged())
+        .WillByDefault(Return(m_currentProjectChanged));
+
+        m_service = std::make_shared<RealtimeEffectService>(m_ctx);
+    }
+
+    void TearDown() override
+    {
+        m_service.reset();
+        muse::modularity::ioc(m_ctx)->unregister<context::IGlobalContext>("utests");
+    }
+
+    muse::modularity::ContextPtr m_ctx;
+    std::shared_ptr<NiceMock<context::GlobalContextMock> > m_globalContext;
+    std::shared_ptr<NiceMock<project::AudacityProjectMock> > m_project;
+    std::shared_ptr<::AudacityProject> m_au3Project;
+    muse::async::Notification m_currentProjectChanged;
+    std::shared_ptr<RealtimeEffectService> m_service;
+};
+
+TEST_F(Effects_RealtimeEffectServiceTests, EffectStackGoneOnTrackDeletionWhileStatesStillAlive)
+{
+    RealtimeEffectState::EffectFactory::Scope factoryScope {
+        [](const PluginID&) -> const EffectInstanceFactory* { return &project::dummyFactory(); }
+    };
+
+    // A track with one realtime effect, as after loading a project.
+    auto& trackList = ::TrackList::Get(*m_au3Project);
+    auto waveTrack = ::WaveTrackFactory::Get(*m_au3Project).Create();
+    trackList.Add(waveTrack);
+    const TrackId trackId = waveTrack->GetId();
+
+    auto state = RealtimeEffectState::make_shared(wxString::FromUTF8("au-test:fake-effect"));
+    const std::weak_ptr<RealtimeEffectState> weakState = state;
+    ASSERT_TRUE(RealtimeEffectList::Get(*waveTrack).AddState(state));
+
+    // The track (via its effect list) must be the sole owner of the state.
+    state.reset();
+    waveTrack.reset();
+
+    m_service->init();
+
+    ASSERT_TRUE(m_service->effectStack(trackId).has_value());
+    EXPECT_EQ(m_service->effectStack(trackId)->size(), 1u);
+    ASSERT_TRUE(m_service->effectStack(IRealtimeEffectService::masterTrackId).has_value());
+
+    // UI models re-read the stack from within the stack-changed notification.
+    bool notified = false;
+    bool stackGoneDuringNotification = false;
+    bool stateAliveDuringNotification = false;
+    m_service->realtimeEffectStackChanged().onReceive(this, [&](TrackId id) {
+        if (id != trackId) {
+            return;
+        }
+        notified = true;
+        stackGoneDuringNotification = !m_service->effectStack(id).has_value();
+        stateAliveDuringNotification = !weakState.expired();
+    });
+
+    trackList.Clear();
+
+    EXPECT_TRUE(notified);
+    EXPECT_TRUE(stackGoneDuringNotification);
+    EXPECT_TRUE(stateAliveDuringNotification);
+
+    // After the clear the states are destroyed, and the track's stack stays gone.
+    EXPECT_TRUE(weakState.expired());
+    EXPECT_FALSE(m_service->effectStack(trackId).has_value());
+
+    // The master list belongs to the project and remains registered.
+    EXPECT_TRUE(m_service->effectStack(IRealtimeEffectService::masterTrackId).has_value());
+}
+}

--- a/src/effects/effects_base/tests/realtimeeffectservice_tests.cpp
+++ b/src/effects/effects_base/tests/realtimeeffectservice_tests.cpp
@@ -2,15 +2,6 @@
 * Audacity: A Digital Audio Editor
 */
 
-// Regression test for the ~RealtimeEffectListItemModel() assert on project close.
-//
-// On close, TrackList::Clear() publishes per-track DELETION events while the tracks
-// are still in the list, and destroys the tracks (and the effect states they own)
-// right after. UI models react to the resulting realtimeEffectStackChanged
-// notification by re-reading effectStack(): it must already report "no stack" for
-// the unregistered track, so that the models drop their references while the
-// states are still alive.
-
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 
@@ -91,7 +82,7 @@ TEST_F(Effects_RealtimeEffectServiceTests, EffectStackGoneOnTrackDeletionWhileSt
     m_service->init();
 
     ASSERT_TRUE(m_service->effectStack(trackId).has_value());
-    EXPECT_EQ(m_service->effectStack(trackId)->size(), 1u);
+    ASSERT_EQ(m_service->effectStack(trackId)->size(), 1u);
     ASSERT_TRUE(m_service->effectStack(IRealtimeEffectService::masterTrackId).has_value());
 
     // UI models re-read the stack from within the stack-changed notification.


### PR DESCRIPTION
On close, TrackList::Clear() publishes its per-track DELETION events while the tracks are still in the list, and destroys the tracks (and the effect states they own) right after. RealtimeEffectListModel::onChanged() therefore re-read a still-present effect stack and kept its item models, which were left holding expired weak_ptrs until the final model reset, where ~RealtimeEffectListItemModel() asserted.

Make RealtimeEffectService::effectStack() treat unregistered tracks as having no stack, so UI models drop their items from within the DELETION notification, while the states are still alive.

Add a service-level regression test; the effects_base test environment now brings up Au3WrapModule so real Au3 track lists can be used.


<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
