### PR TITLE
fixed #10964: Undo/Redo State Carries into New Instance

### DIFF
--- a/src/appshell/qml/Audacity/AppShell/appmenumodel.cpp
+++ b/src/appshell/qml/Audacity/AppShell/appmenumodel.cpp
@@ -160,13 +160,13 @@ void AppMenuModel::setItemIsChecked(const QString& itemId, bool checked)
 
 void AppMenuModel::updateUndoRedoItems()
 {
-    MenuItem& undoItem = findItem(ActionCode("action://undo"));
+    MenuItem& undoItem = findItem(ActionCode("action://trackedit/undo"));
     const TranslatableString undoActionName = projectHistory()->topMostUndoActionName();
     undoItem.setTitle(undoActionName.isEmpty()
                       ? TranslatableString("action", "Undo")
                       : TranslatableString("action", "Undo ‘%1’").arg(undoActionName));
 
-    MenuItem& redoItem = findItem(ActionCode("action://redo"));
+    MenuItem& redoItem = findItem(ActionCode("action://trackedit/redo"));
     const TranslatableString redoActionName = projectHistory()->topMostRedoActionName();
     redoItem.setTitle(redoActionName.isEmpty()
                       ? TranslatableString("action", "Redo")
@@ -222,8 +222,8 @@ MenuItem* AppMenuModel::makeFileMenu()
 MenuItem* AppMenuModel::makeEditMenu()
 {
     MenuItemList editItems {
-        makeMenuItem("action://undo"),
-        makeMenuItem("action://redo"),
+        makeMenuItem("action://trackedit/undo"),
+        makeMenuItem("action://trackedit/redo"),
         makeSeparator(),
         makeMenuItem("action://cut"),
         makeMenuItem("action://copy"),

--- a/src/projectscene/view/toolbars/undoredotoolbarmodel.cpp
+++ b/src/projectscene/view/toolbars/undoredotoolbarmodel.cpp
@@ -9,8 +9,8 @@ using namespace au::projectscene;
 using namespace muse::uicomponents;
 using namespace muse::actions;
 
-static const muse::actions::ActionCode UNDO_ACTION_CODE("action://undo");
-static const muse::actions::ActionCode REDO_ACTION_CODE("action://redo");
+static const muse::actions::ActionCode UNDO_ACTION_CODE("action://trackedit/undo");
+static const muse::actions::ActionCode REDO_ACTION_CODE("action://trackedit/redo");
 
 void UndoRedoToolBarModel::load()
 {

--- a/src/projectscene/view/toolbars/undoredotoolbarmodel.cpp
+++ b/src/projectscene/view/toolbars/undoredotoolbarmodel.cpp
@@ -9,17 +9,18 @@ using namespace au::projectscene;
 using namespace muse::uicomponents;
 using namespace muse::actions;
 
+static const muse::actions::ActionCode UNDO_ACTION_CODE("action://undo");
+static const muse::actions::ActionCode REDO_ACTION_CODE("action://redo");
+
 void UndoRedoToolBarModel::load()
 {
     if (m_loaded) {
         return;
     }
 
-    AbstractToolBarModel::load();
-
     muse::actions::ActionCodeList itemsCodes = {
-        "action://undo",
-        "action://redo",
+        UNDO_ACTION_CODE,
+        REDO_ACTION_CODE,
     };
 
     ToolBarItemList items;
@@ -31,9 +32,59 @@ void UndoRedoToolBarModel::load()
 
     setItems(items);
 
+    AbstractToolBarModel::load();
+
     context()->currentProjectChanged().onNotify(this, [this]() {
-        load();
+        updateItems();
+
+        subscribeOnHistoryChanges();
     });
 
+    subscribeOnHistoryChanges();
+
     m_loaded = true;
+}
+
+void UndoRedoToolBarModel::onActionsStateChanges(const muse::actions::ActionCodeList& codes)
+{
+    auto history = projectHistory();
+
+    for (const muse::actions::ActionCode& code : codes) {
+        if (code == UNDO_ACTION_CODE) {
+            ToolBarItem* undoItem = findItemPtr(UNDO_ACTION_CODE);
+            if (undoItem) {
+                const muse::TranslatableString undoActionName = history ? history->topMostUndoActionName() : muse::TranslatableString();
+                undoItem->setTitle(undoActionName.isEmpty()
+                                   ? muse::TranslatableString("action", "Undo")
+                                   : muse::TranslatableString("action", "Undo ‘%1’").arg(undoActionName));
+            }
+        } else if (code == REDO_ACTION_CODE) {
+            ToolBarItem* redoItem = findItemPtr(REDO_ACTION_CODE);
+            if (redoItem) {
+                const muse::TranslatableString redoActionName = history ? history->topMostRedoActionName() : muse::TranslatableString();
+                redoItem->setTitle(redoActionName.isEmpty()
+                                   ? muse::TranslatableString("action", "Redo")
+                                   : muse::TranslatableString("action", "Redo ‘%1’").arg(redoActionName));
+            }
+        }
+    }
+
+    AbstractToolBarModel::onActionsStateChanges(codes);
+}
+
+void UndoRedoToolBarModel::updateItems()
+{
+    onActionsStateChanges({ UNDO_ACTION_CODE, REDO_ACTION_CODE });
+}
+
+void UndoRedoToolBarModel::subscribeOnHistoryChanges()
+{
+    auto history = projectHistory();
+    if (!history) {
+        return;
+    }
+
+    history->historyChanged().onReceive(this, [this](const trackedit::HistoryEvent&) {
+        updateItems();
+    }, Asyncable::Mode::SetReplace);
 }

--- a/src/projectscene/view/toolbars/undoredotoolbarmodel.h
+++ b/src/projectscene/view/toolbars/undoredotoolbarmodel.h
@@ -7,19 +7,25 @@
 
 #include "modularity/ioc.h"
 #include "context/iglobalcontext.h"
+#include "trackedit/iprojecthistory.h"
 
 namespace au::projectscene {
 class UndoRedoToolBarModel : public muse::uicomponents::AbstractToolBarModel
 {
     Q_OBJECT
 
-    muse::ContextInject<au::context::IGlobalContext> context { this };
+    muse::ContextInject<context::IGlobalContext> context { this };
+    muse::ContextInject<trackedit::IProjectHistory> projectHistory { this };
 
 public:
 
     Q_INVOKABLE void load() override;
 
 private:
+    void onActionsStateChanges(const muse::actions::ActionCodeList& codes) override;
+
+    void updateItems();
+    void subscribeOnHistoryChanges();
 
     bool m_loaded = false;
 };

--- a/src/trackedit/internal/au3/au3projecthistory.cpp
+++ b/src/trackedit/internal/au3/au3projecthistory.cpp
@@ -15,10 +15,16 @@ void au::trackedit::Au3ProjectHistory::init()
 {
     auto& project = projectRef();
     ::ProjectHistory::Get(project).InitialState();
+
+    m_historyChanged.send(HistoryEvent::RestoredState);
 }
 
 bool au::trackedit::Au3ProjectHistory::undoAvailable() const
 {
+    if (!globalContext()->currentProject()) {
+        return false;
+    }
+
     auto& project = projectRef();
     return ::ProjectHistory::Get(project).UndoAvailable();
 }
@@ -33,6 +39,10 @@ void au::trackedit::Au3ProjectHistory::undo()
 
 bool au::trackedit::Au3ProjectHistory::redoAvailable() const
 {
+    if (!globalContext()->currentProject()) {
+        return false;
+    }
+
     auto& project = projectRef();
     return ::ProjectHistory::Get(project).RedoAvailable();
 }


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/10964

As a bonus, I added a description of actions for undo/redo items and turning off the state of items if there is nothing to apply