### PR TITLE
AppMenuBar. Updated app menu bar

### DIFF
--- a/src/appshell/qml/Audacity/AppShell/platform/PlatformMenuBar.qml
+++ b/src/appshell/qml/Audacity/AppShell/platform/PlatformMenuBar.qml
@@ -19,12 +19,17 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-import QtQuick 2.15
-import Qt.labs.platform 1.1 as PLATFORM
+
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import Qt.labs.platform as PLATFORM
 
 import Audacity.AppShell
 
 Item {
+    id: root
+
     readonly property bool available: menuModel.isGlobalMenuAvailable()
 
     PLATFORM.MenuBar {
@@ -80,6 +85,13 @@ Item {
         menu.title = menuInfo.title
         menu.enabled = menuInfo.enabled
         menu.subitems = menuInfo.subitems
+
+        menuInfo.subitemsChanged.connect(function (subitems, menuId) {
+            if (menu.id === menuId) {
+                menu.subitems = subitems
+                menu.load()
+            }
+        })
     }
 
     function makeMenuItem(parentMenu, itemInfo) {
@@ -119,11 +131,11 @@ Item {
                     var isMenu = Boolean(item.subitems) && item.subitems.length > 0
 
                     if (isMenu) {
-                        let menu = makeMenu(item)
+                        let menu = root.makeMenu(item)
                         addMenu(menu)
                         menu.load()
                     } else {
-                        let menuItem = makeMenuItem(this, item)
+                        let menuItem = root.makeMenuItem(this, item)
                         addItem(menuItem)
                     }
                 }
@@ -139,15 +151,15 @@ Item {
                     let isMenu = Boolean(item.subitems) && item.subitems.length > 0
 
                     if (isMenu) {
-                        setUpMenu(items[i].subMenu, item)
+                        root.setUpMenu(items[i].subMenu, item)
                     } else {
-                        setUpMenuItem(items[i], item)
+                        root.setUpMenuItem(items[i], item)
                     }
                 }
             }
 
             onAboutToShow: {
-                load()
+                update()
             }
         }
     }


### PR DESCRIPTION
Copy-paste of current app menu bar from MuseScore

Actually fixed a problem with the positioning of system items on macOS: call update instead of load in onAboutToShow

Before: 
<img width="311" height="407" alt="Screenshot 2026-07-28 at 3 41 31 PM" src="https://github.com/user-attachments/assets/7dde4993-ea58-4b67-9773-574fa188cc1e" />


After:
<img width="329" height="412" alt="Screenshot 2026-07-28 at 3 41 05 PM" src="https://github.com/user-attachments/assets/726830fb-1423-436c-8435-f7604419baac" />
