### PR TITLE
encode effectId to safely pass via muse::URI

### DIFF
--- a/src/effects/effects_base/effectstypes.h
+++ b/src/effects/effects_base/effectstypes.h
@@ -8,6 +8,8 @@
 #include <vector>
 #include <string>
 
+#include <QUrl>
+
 #include "framework/global/types/string.h"
 #include "framework/global/types/ratio.h"
 #include "framework/actions/actiontypes.h"
@@ -260,14 +262,24 @@ const std::string REALTIME_EFFECT_REPLACE_ACTION = "action://effects/realtime-re
 
 const std::string DESTRUCTIVE_EFFECT_VIEWER_URI = "audacity://effects/destructive_viewer?instanceId=%1&effectFamily=%2";
 
+inline std::string encodeEffectId(const EffectId& id)
+{
+    return QUrl::toPercentEncoding(id.toQString()).toStdString();
+}
+
+inline EffectId decodeEffectId(const std::string& encoded)
+{
+    return EffectId::fromQString(QUrl::fromPercentEncoding(QByteArray::fromStdString(encoded)));
+}
+
 inline std::string makeEffectAction(const std::string& action, const EffectId& id)
 {
-    return QString::fromStdString(action).arg(id).toStdString();
+    return QString::fromStdString(action).arg(QString::fromStdString(encodeEffectId(id))).toStdString();
 }
 
 inline EffectId effectIdFromAction(const muse::actions::ActionQuery& action)
 {
-    return EffectId::fromStdString(action.param("effectId").toString());
+    return decodeEffectId(action.param("effectId").toString());
 }
 
 inline EffectId effectIdFromAction(const QString& action)

--- a/src/effects/effects_base/internal/effectsactionscontroller.cpp
+++ b/src/effects/effects_base/internal/effectsactionscontroller.cpp
@@ -79,7 +79,7 @@ void EffectsActionsController::registerActions()
 
 void EffectsActionsController::onEffectTriggered(const muse::actions::ActionQuery& q)
 {
-    muse::String effectId = muse::String::fromStdString(q.param("effectId").toString());
+    const EffectId effectId = effectIdFromAction(q);
     IF_ASSERT_FAILED(!effectId.empty()) {
         return;
     }
@@ -159,7 +159,7 @@ void EffectsActionsController::deletePreset(const ActionQuery& q)
         return;
     }
 
-    EffectId effectId = EffectId::fromStdString(q.param("effectId").toString());
+    EffectId effectId = effectIdFromAction(q);
     PresetId presetId = q.param("presetId").toString();
     presetsScenario()->deletePreset(effectId, presetId);
 }
@@ -190,7 +190,7 @@ void EffectsActionsController::toggleVendorUI(const ActionQuery& q)
         return;
     }
 
-    const EffectId effectId = EffectId::fromStdString(q.param("effectId").toString());
+    const EffectId effectId = effectIdFromAction(q);
     const EffectUIMode currentMode = configuration()->effectUIMode(effectId);
     const EffectUIMode newMode = (currentMode == EffectUIMode::VendorUI) ? EffectUIMode::FallbackUI : EffectUIMode::VendorUI;
     configuration()->setEffectUIMode(effectId, newMode);

--- a/src/effects/effects_base/view/effectpresetsbarmodel.cpp
+++ b/src/effects/effects_base/view/effectpresetsbarmodel.cpp
@@ -342,7 +342,7 @@ void EffectPresetsBarModel::deletePreset()
     }
 
     ActionQuery q("action://effects/presets/delete");
-    q.addParam("effectId", Val(effectId.toStdString()));
+    q.addParam("effectId", Val(encodeEffectId(effectId)));
     q.addParam("presetId", Val(m_currentPreset.toStdString()));
     dispatcher()->dispatch(q);
 }

--- a/src/effects/effects_base/view/presetscontextmenumodel.cpp
+++ b/src/effects/effects_base/view/presetscontextmenumodel.cpp
@@ -80,7 +80,7 @@ void PresetsContextMenuModel::reload()
         items << makeSeparator();
 
         ActionQuery q("action://effects/toggle_vendor_ui");
-        q.addParam("effectId", Val(effectId.toStdString()));
+        q.addParam("effectId", Val(encodeEffectId(effectId)));
         MenuItem* item = makeMenuItem(q.toString());
 
         if (item) {


### PR DESCRIPTION
Fixes: #10883

Some effects may contain special characters in their id, and it breaks URL params parsing.

Before

`action://effects/open?effectId=Effect_LV2_Robin Gareus_LV2 Convolution Mono=>Stereo_http://gareus.org/oss/lv2/convoLV2#MonoToStereo@file:///usr/lib/lv2/convo.lv2/`

After

`action://effects/open?effectId=Effect_LV2_Robin%20Gareus_LV2%20Convolution%20Mono%3D%3EStereo_http%3A%2F%2Fgareus.org%2Foss%2Flv2%2FconvoLV2%23MonoToStereo%40file%3A%2F%2F%2Fusr%2Flib%2Flv2%2Fconvo.lv2%2F`

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
