### PR TITLE
fixed #9664: Waveform goes blank when undoing a mono clip pasting on a stereo track

### DIFF
--- a/src/trackedit/internal/au3/au3tracksinteraction.cpp
+++ b/src/trackedit/internal/au3/au3tracksinteraction.cpp
@@ -727,7 +727,6 @@ bool Au3TracksInteraction::newMonoTrack()
     selectionController()->setSelectedTracks({ trackId });
     trackNavigationController()->setFocusedTrack(trackId);
 
-    projectHistory()->pushHistoryState("Created new mono track", "New Mono Track");
     return true;
 }
 
@@ -737,7 +736,6 @@ bool Au3TracksInteraction::newStereoTrack()
     selectionController()->setSelectedTracks({ trackId });
     trackNavigationController()->setFocusedTrack(trackId);
 
-    projectHistory()->pushHistoryState("Created new stereo track", "New Stereo Track");
     return true;
 }
 


### PR DESCRIPTION
Resolves: #9664

The main problem is that we’re adding a track’s adding state to the history twice, as you can see in the screenshot from the issue: New Stereo Track/New Stereo Track. I deleted one of them.