### PR TITLE
fixed #11321: Opening the effect stack via 'Effects' button selects all audio data on the track

### DIFF
--- a/src/projectscene/internal/realtimeeffectpaneltrackselection.cpp
+++ b/src/projectscene/internal/realtimeeffectpaneltrackselection.cpp
@@ -3,13 +3,13 @@
 namespace au::projectscene {
 void RealtimeEffectPanelTrackSelection::init()
 {
-    selectionController()->tracksSelected().onReceive(this, [this](const au::trackedit::TrackIdList& tracks) {
-        if (!tracks.empty()) {
-            setTrackId(tracks.back());
+    trackNavigationController()->focusedTrackChanged().onReceive(this, [this](const au::trackedit::TrackId& trackId, bool) {
+        if (trackId != au::trackedit::INVALID_TRACK) {
+            setTrackId(trackId);
         }
     });
     globalContext()->currentTrackeditProjectChanged().onNotify(this, [this] {
-        // Show effects of top-most track if there isn't one selected already and the project isn't empty.
+        // Show effects of top-most track if there isn't one focused already and the project isn't empty.
         const trackedit::ITrackeditProjectPtr project = globalContext()->currentTrackeditProject();
         std::optional<trackedit::TrackId> trackId;
         if (project) {

--- a/src/projectscene/internal/realtimeeffectpaneltrackselection.h
+++ b/src/projectscene/internal/realtimeeffectpaneltrackselection.h
@@ -4,7 +4,7 @@
 #pragma once
 
 #include "irealtimeeffectpaneltrackselection.h"
-#include "trackedit/iselectioncontroller.h"
+#include "trackedit/internal/itracknavigationcontroller.h"
 #include "context/iglobalcontext.h"
 #include "modularity/ioc.h"
 #include "async/asyncable.h"
@@ -12,7 +12,7 @@
 namespace au::projectscene {
 class RealtimeEffectPanelTrackSelection : public IRealtimeEffectPanelTrackSelection, muse::async::Asyncable, public muse::Contextable
 {
-    muse::ContextInject<trackedit::ISelectionController> selectionController{ this };
+    muse::ContextInject<trackedit::ITrackNavigationController> trackNavigationController{ this };
     muse::ContextInject<context::IGlobalContext> globalContext{ this };
 
 public:

--- a/src/projectscene/qml/Audacity/ProjectScene/trackspanel/TracksPanel.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/trackspanel/TracksPanel.qml
@@ -258,6 +258,7 @@ Item {
                             }
 
                             onOpenEffectsRequested: {
+                                tracksModel.focusTrack(index)
                                 effectSectionModel.showEffectsSection = true
                                 root.openEffectsRequested()
                             }

--- a/src/projectscene/qml/Audacity/ProjectScene/trackspanel/WaveTrackItem.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/trackspanel/WaveTrackItem.qml
@@ -113,7 +113,6 @@ TrackItem {
                 navigation.enabled: topRow.visible
 
                 onClicked: {
-                    root.selectionRequested(true)
                     root.openEffectsRequested()
                 }
             }

--- a/src/projectscene/view/trackspanel/paneltrackslistmodel.cpp
+++ b/src/projectscene/view/trackspanel/paneltrackslistmodel.cpp
@@ -192,6 +192,17 @@ void PanelTracksListModel::selectAudioData(int row)
     }
 }
 
+void PanelTracksListModel::focusTrack(int row)
+{
+    if (row < 0 || row >= rowCount()) {
+        return;
+    }
+
+    if (TrackItem* item = modelIndexToItem(index(row))) {
+        trackNavigationController()->setFocusedTrack(item->trackId());
+    }
+}
+
 void PanelTracksListModel::clearSelection()
 {
     m_selectionModel->clear();

--- a/src/projectscene/view/trackspanel/paneltrackslistmodel.h
+++ b/src/projectscene/view/trackspanel/paneltrackslistmodel.h
@@ -57,6 +57,7 @@ public:
     Q_INVOKABLE QItemSelectionModel* selectionModel() const;
     Q_INVOKABLE void selectRow(int row, bool exclusive = false);
     Q_INVOKABLE void selectAudioData(int row);
+    Q_INVOKABLE void focusTrack(int row);
     Q_INVOKABLE void clearSelection();
     Q_INVOKABLE void moveSelectedRowsUp();
     Q_INVOKABLE void moveSelectedRowsDown();


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/11321