### PR TITLE
Stop moving playhead on clip/label select

### DIFF
--- a/src/playback/internal/playbackcontroller.cpp
+++ b/src/playback/internal/playbackcontroller.cpp
@@ -86,39 +86,6 @@ void PlaybackController::init()
     recordController()->isRecordingChanged().onNotify(this, [this]() {
         m_isPlayAllowedChanged.notify();
     });
-
-    selectionController()->clipsSelected().onReceive(this, [this](const trackedit::ClipKeyList& clipKeyList) {
-        if (clipKeyList.empty()) {
-            return;
-        }
-        if (!isPlaying()) {
-            player()->stop();
-            PlaybackRegion selectionRegion = selectionPlaybackRegion();
-            if (selectionRegion.isValid()) {
-                doChangePlaybackRegion(selectionRegion);
-            }
-            doSeek(lastPlaybackSeekTime(), false);
-        }
-    });
-
-    selectionController()->labelsSelected().onReceive(this, [this](const trackedit::LabelKeyList& labelKeyList) {
-        if (labelKeyList.empty()) {
-            return;
-        }
-        if (!isPlaying()) {
-            player()->stop();
-            PlaybackRegion selectionRegion = selectionPlaybackRegion();
-            if (selectionRegion.isValid()) {
-                doChangePlaybackRegion(selectionRegion);
-            }
-            auto labelStartTime = selectionController()->selectedLabelStartTime();
-            auto labelEndTime = selectionController()->selectedLabelEndTime();
-            if (labelStartTime.has_value()) {
-                doSeek(labelStartTime.value(), false);
-                m_lastPlaybackRegion = { labelStartTime.value_or(0.0), labelEndTime.value_or(0.0) };
-            }
-        }
-    });
 }
 
 void PlaybackController::deinit()
@@ -169,13 +136,6 @@ bool PlaybackController::isLoopRegionActive() const
 
 PlaybackRegion PlaybackController::selectionPlaybackRegion() const
 {
-    // item selection has priority over time selection
-    auto itemStart = selectionController()->leftMostSelectedItemStartTime();
-    auto itemEnd = selectionController()->rightMostSelectedItemEndTime();
-    if (itemStart.has_value() && itemEnd.has_value()) {
-        return { itemStart.value(), itemEnd.value() };
-    }
-
     if (!selectionController()->timeSelectionIsEmpty()) {
         return { selectionController()->dataSelectedStartTime(),
                  selectionController()->dataSelectedEndTime() };

--- a/src/playback/tests/playbackcontroller_tests.cpp
+++ b/src/playback/tests/playbackcontroller_tests.cpp
@@ -156,12 +156,6 @@ TEST_F(PlaybackControllerTests, TogglePlay_WhenStopped)
     EXPECT_CALL(*m_player, playbackPosition())
     .WillRepeatedly(Return(currentPosition));
 
-    //! [GIVEN] No item selection
-    EXPECT_CALL(*m_selectionController, leftMostSelectedItemStartTime())
-    .WillOnce(Return(std::nullopt));
-    EXPECT_CALL(*m_selectionController, rightMostSelectedItemEndTime())
-    .WillOnce(Return(std::nullopt));
-
     //! [GIVEN] No time selection
     EXPECT_CALL(*m_selectionController, timeSelectionIsEmpty())
     .WillOnce(Return(true));
@@ -247,9 +241,10 @@ TEST_F(PlaybackControllerTests, TogglePlay_WithSelection)
 }
 
 /**
- * @brief Toggle play when there is clips data selection
- * @details User made a selection by double clicking on waveform and clicked play
- *          Playback should be started from clip's start time
+ * @brief Toggle play when there is a clip selection
+ * @details User selected a clip and clicked play
+ *          Clip selection does not affect playback: it should run
+ *          from the seek position to the end of the project
  */
 TEST_F(PlaybackControllerTests, TogglePlay_WithSelection_Clip)
 {
@@ -262,17 +257,21 @@ TEST_F(PlaybackControllerTests, TogglePlay_WithSelection_Clip)
     .WillRepeatedly(Return(secs_t(0.0)));
 
     //! [GIVEN] There is single clip selection from 10 to 20 secs
-    PlaybackRegion selectionRegion = { secs_t(10.0), secs_t(20.0) };
-    EXPECT_CALL(*m_selectionController, leftMostSelectedItemStartTime())
-    .WillOnce(Return(std::optional<secs_t>(selectionRegion.start)));
-    EXPECT_CALL(*m_selectionController, rightMostSelectedItemEndTime())
-    .WillOnce(Return(std::optional<secs_t>(selectionRegion.end)));
+    ON_CALL(*m_selectionController, leftMostSelectedItemStartTime())
+    .WillByDefault(Return(std::optional<secs_t>(secs_t(10.0))));
+    ON_CALL(*m_selectionController, rightMostSelectedItemEndTime())
+    .WillByDefault(Return(std::optional<secs_t>(secs_t(20.0))));
 
-    //! [THEN] Expect that we will take into account the clip's selection region
-    EXPECT_CALL(*m_player, setPlaybackRegion(selectionRegion))
+    //! [GIVEN] No time selection
+    EXPECT_CALL(*m_selectionController, timeSelectionIsEmpty())
+    .WillOnce(Return(true));
+
+    //! [THEN] The clip selection is ignored: playback region falls back to
+    //! {lastPlaybackSeekTime, totalPlayTime}
+    EXPECT_CALL(*m_player, setPlaybackRegion(PlaybackRegion { secs_t(0.0), secs_t(100.0) }))
     .Times(1);
 
-    //! [THEN] No explicit seek (will play from clip start via playback region)
+    //! [THEN] No explicit seek (playback runs from the seek position)
     EXPECT_CALL(*m_player, seek(_, _))
     .Times(0);
 
@@ -756,10 +755,6 @@ TEST_F(PlaybackControllerTests, TogglePlay_AfterRecord_PlaysFromSeekToProjectEnd
     .WillRepeatedly(Return(recordEnd));
 
     //! [GIVEN] No selection
-    EXPECT_CALL(*m_selectionController, leftMostSelectedItemStartTime())
-    .WillOnce(Return(std::nullopt));
-    EXPECT_CALL(*m_selectionController, rightMostSelectedItemEndTime())
-    .WillOnce(Return(std::nullopt));
     EXPECT_CALL(*m_selectionController, timeSelectionIsEmpty())
     .WillOnce(Return(true));
 

--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TracksItemsView.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TracksItemsView.qml
@@ -683,6 +683,7 @@ Rectangle {
 
                 if (root.itemHovered) {
                     selectionViewController.selectItemData(root.hoveredItemKey)
+                    playCursorController.seekToTime(timeline.context.selectedItemStartTime)
                     playCursorController.setPlaybackRegionByTime(timeline.context.selectedItemStartTime, timeline.context.selectedItemEndTime)
                 } else {
                     selectionViewController.selectTrackAudioData(e.y)

--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TracksItemsView.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TracksItemsView.qml
@@ -640,20 +640,23 @@ Rectangle {
                 } else {
                     splitToolController.mouseUp(e.x)
 
-                    let releaseTime = timeline.context.positionToTime(e.x)
-                    if (selectionViewController.isLeftSelection(releaseTime)) {
-                        playCursorController.seekToTime(releaseTime)
-                    }
-                    if (!splitToolController.active) {
-                        selectionViewController.onReleased(releaseTime, e.y)
-                        itemsSelection.visible = false
-                    }
-                    hideGuideline()
-                    if (e.modifiers & (Qt.ControlModifier | Qt.ShiftModifier)) {
-                        playCursorController.seekToTime(timeline.context.selectionStartTime)
+                    if (selectionViewController.selectionInProgress) {
+                        let releaseTime = timeline.context.positionToTime(e.x)
+                        if (selectionViewController.isLeftSelection(releaseTime)) {
+                            playCursorController.seekToTime(releaseTime)
+                        }
+                        if (!splitToolController.active) {
+                            selectionViewController.onReleased(releaseTime, e.y)
+                        }
+                        if (e.modifiers & (Qt.ControlModifier | Qt.ShiftModifier)) {
+                            playCursorController.seekToTime(timeline.context.selectionStartTime)
+                        }
+
+                        playCursorController.setPlaybackRegionByTime(timeline.context.selectionStartTime, timeline.context.selectionEndTime)
                     }
 
-                    playCursorController.setPlaybackRegionByTime(timeline.context.selectionStartTime, timeline.context.selectionEndTime)
+                    itemsSelection.visible = false
+                    hideGuideline()
                 }
             }
 

--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TracksItemsView.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TracksItemsView.qml
@@ -686,11 +686,11 @@ Rectangle {
 
                 if (root.itemHovered) {
                     selectionViewController.selectItemData(root.hoveredItemKey)
-                    playCursorController.seekToTime(timeline.context.selectedItemStartTime)
+                    playCursorController.animatedSeekToTime(timeline.context.selectedItemStartTime)
                     playCursorController.setPlaybackRegionByTime(timeline.context.selectedItemStartTime, timeline.context.selectedItemEndTime)
                 } else {
                     selectionViewController.selectTrackAudioData(e.y)
-                    playCursorController.seekToTime(timeline.context.selectionStartTime)
+                    playCursorController.animatedSeekToTime(timeline.context.selectionStartTime)
                     playCursorController.setPlaybackRegionByTime(timeline.context.selectionStartTime, timeline.context.selectionEndTime)
                 }
                 itemsSelection.visible = false

--- a/src/projectscene/view/playcursor/playcursorcontroller.cpp
+++ b/src/projectscene/view/playcursor/playcursorcontroller.cpp
@@ -74,6 +74,15 @@ void PlayCursorController::seekToTime(double secs, bool triggerPlay)
     }
 }
 
+void PlayCursorController::animatedSeekToTime(double secs)
+{
+    if (!playbackState()->isPlaying()) {
+        m_seekAnimated = true;
+    }
+
+    seekToTime(secs);
+}
+
 void PlayCursorController::setPlaybackRegionByTime(double t1, double t2)
 {
     const double start = std::max(0.0, t1);
@@ -97,6 +106,8 @@ au::context::IPlaybackStatePtr PlayCursorController::playbackState() const
 
 void PlayCursorController::updatePositionX(muse::secs_t secs)
 {
+    const bool seekAnimated = std::exchange(m_seekAnimated, false);
+
     if (m_positionX == m_context->timeToPosition(secs)) {
         return;
     }
@@ -134,7 +145,14 @@ void PlayCursorController::updatePositionX(muse::secs_t secs)
             }
         }
     } else {
-        m_context->insureVisible(secs);
+        const double halfFrameDuration = (m_context->frameEndTime() - m_context->frameStartTime()) * 0.5;
+        const bool zoomTooClose = halfFrameDuration < ANIMATION_DURATION_SEC;
+
+        if (seekAnimated && !zoomTooClose) {
+            m_context->animatedInsureVisible(secs);
+        } else {
+            m_context->insureVisible(secs);
+        }
     }
 
     m_positionX = m_context->timeToPosition(secs);

--- a/src/projectscene/view/playcursor/playcursorcontroller.h
+++ b/src/projectscene/view/playcursor/playcursorcontroller.h
@@ -55,6 +55,7 @@ public:
 
     Q_INVOKABLE void init();
     Q_INVOKABLE void seekToTime(double secs, bool triggerPlay = false);
+    Q_INVOKABLE void animatedSeekToTime(double secs);
     Q_INVOKABLE void setPlaybackRegionByTime(double time1, double time2);
 
 signals:
@@ -80,6 +81,7 @@ private:
 
     QTimer m_scrollSuppressionTimer;
     bool m_viewUpdatesSuppressed = false;
+    bool m_seekAnimated = false;
 
     friend struct SnapTestAccess;
 };

--- a/src/projectscene/view/tracksitemsview/selectionviewcontroller.cpp
+++ b/src/projectscene/view/tracksitemsview/selectionviewcontroller.cpp
@@ -326,6 +326,18 @@ void SelectionViewController::cancelSpectrogramEdit()
     emit pressedSpectrogramChanged();
 }
 
+void SelectionViewController::cancelSelectionGesture()
+{
+    if (!m_selectionStarted) {
+        return;
+    }
+
+    m_selectionStarted = false;
+    m_context->stopAutoScroll();
+    disconnect(m_autoScrollConnection);
+    emit selectionInProgressChanged();
+}
+
 void SelectionViewController::selectTrackAudioData(double y)
 {
     if (!isProjectOpened()) {
@@ -342,12 +354,7 @@ void SelectionViewController::selectTrackAudioData(double y)
         return;
     }
 
-    if (m_selectionStarted) {
-        m_selectionStarted = false;
-        m_context->stopAutoScroll();
-        disconnect(m_autoScrollConnection);
-        emit selectionInProgressChanged();
-    }
+    cancelSelectionGesture();
 
     selectionController()->setSelectedTrackAudioData(tracks.at(0));
 }
@@ -364,6 +371,8 @@ void SelectionViewController::selectItemData(const TrackItemKey& key)
         LOGW() << "Track not found: " << key.key.trackId;
         return;
     }
+
+    cancelSelectionGesture();
 
     if (track->type == trackedit::TrackType::Label) {
         selectionController()->setSelectedLabels(trackedit::LabelKeyList({ key.key }));

--- a/src/projectscene/view/tracksitemsview/selectionviewcontroller.h
+++ b/src/projectscene/view/tracksitemsview/selectionviewcontroller.h
@@ -66,6 +66,7 @@ public:
     Q_INVOKABLE void updateSelectionVerticalResize(double y, bool completed);
     Q_INVOKABLE void cancelSpectrogramEdit();
 
+    Q_INVOKABLE void cancelSelectionGesture();
     Q_INVOKABLE void selectTrackAudioData(double y);
     Q_INVOKABLE void selectItemData(const TrackItemKey& key);
 


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/11391

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
- [x] Clip/label header click doesn't move the playhead
- [x] When zoomed it enough so beginning of clip/label is not visible on the screen, moving such item doesn't scroll the view
- [x] Double-click on waveform moves the playcursor to the clip beginning (with animation)
- [x] No UI selection glitch in such case:
1. Zoom in so only the right half of the clip is visible
2. Double-click on the waveform so playcursor moves and frame is shifted
3. No glitch as in the screenshot below:
<img width="580" height="131" alt="Zrzut ekranu 2026-07-10 o 12 21 19" src="https://github.com/user-attachments/assets/a8fbc62b-b86b-4ab1-bca6-f62440ae6dc2" />

