### PR TITLE
Fixed pasting audio files from clipboard

### DIFF
--- a/src/importexport/import/internal/au3/au3importer.cpp
+++ b/src/importexport/import/internal/au3/au3importer.cpp
@@ -351,6 +351,7 @@ bool au::importexport::Au3Importer::importFromSystemClipboard(
         files.append(path.toQString());
     }
 
+    dc.startImportSession();
     dc.probeAudioFiles(files);
     int requiredTracksCount = dc.requiredTracksCount();
     dc.prepareConditionalTracks(startingTrack, requiredTracksCount);
@@ -361,6 +362,7 @@ bool au::importexport::Au3Importer::importFromSystemClipboard(
     }
 
     dc.handleDroppedFiles(dstTrackIds, startTime);
+    dc.endImportSession();
 
     return true;
 }

--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/ImportDropArea.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/ImportDropArea.qml
@@ -49,7 +49,7 @@ DropArea {
         onTriggered: {
             tracksItemsView.clearPreviewImportClip([])
             prv.lastProbedUrls = null
-            dropController.endImportDrag()
+            dropController.endImportSession()
             root.setGuidelineRequested(-1, false)
         }
     }
@@ -76,7 +76,7 @@ DropArea {
         clearPreviewClipsTimer.stop()
 
         let urls = drop.urls
-        dropController.startImportDrag()
+        dropController.startImportSession()
         if (!prv.lastProbedUrls) {
             // NOTE: working with urls list from DropArea
             // is expensive so avoid it otherwise the preview clip
@@ -121,7 +121,7 @@ DropArea {
         // by this time, url list is already inside dropController
         dropController.handleDroppedFiles(tracksIds, timeline.context.positionToTime(dropX))
 
-        dropController.endImportDrag()
+        dropController.endImportSession()
         drop.acceptProposedAction()
 
         root.setGuidelineRequested(-1, false)

--- a/src/projectscene/view/tracksitemsview/dropcontroller.cpp
+++ b/src/projectscene/view/tracksitemsview/dropcontroller.cpp
@@ -75,9 +75,9 @@ QVariantList DropController::lastProbedFileNames() const
     return out;
 }
 
-void DropController::startImportDrag()
+void DropController::startImportSession()
 {
-    if (m_tracksCountWhenDragStarted != -1) {
+    if (m_trackCountBeforeImport != -1) {
         return;
     }
 
@@ -86,14 +86,14 @@ void DropController::startImportDrag()
         return;
     }
 
-    m_tracksCountWhenDragStarted = prj->trackList().size();
+    m_trackCountBeforeImport = prj->trackList().size();
 }
 
-void DropController::endImportDrag()
+void DropController::endImportSession()
 {
-    tracksInteraction()->removeDragAddedTracks(m_tracksCountWhenDragStarted, true /* emptyOnly */);
+    tracksInteraction()->removeDragAddedTracks(m_trackCountBeforeImport, true /* emptyOnly */);
 
-    m_tracksCountWhenDragStarted = -1;
+    m_trackCountBeforeImport = -1;
     m_lastDraggedFilesInfo.clear();
     m_lastDraggedUrls.clear();
 }
@@ -124,8 +124,8 @@ void DropController::prepareConditionalTracks(int currentTrackId, int draggedFil
     const int totalTracks = static_cast<int>(trackList.size());
 
     const int tracksCreated
-        =(m_tracksCountWhenDragStarted >= 0)
-          ? std::max(0, totalTracks - m_tracksCountWhenDragStarted)
+        =(m_trackCountBeforeImport >= 0)
+          ? std::max(0, totalTracks - m_trackCountBeforeImport)
           : 0;
 
     if (tracksCreated >= draggedFilesCount) {
@@ -211,7 +211,7 @@ QVariantList DropController::draggedTracksIds(int currentTrackId, int draggedFil
         thresholdRow = currentRow;
     } else {
         // cursor is below tracks, start from newly created track
-        thresholdRow = std::max(0, m_tracksCountWhenDragStarted);
+        thresholdRow = std::max(0, m_trackCountBeforeImport);
     }
 
     int startAudioPos = 0;
@@ -245,7 +245,7 @@ QVariantList DropController::draggedTracksIds(int currentTrackId, int draggedFil
 
 void DropController::removeDragAddedTracks(int currentTrackId, int draggedFilesCount)
 {
-    if (draggedFilesCount <= 0 || m_tracksCountWhenDragStarted < 0) {
+    if (draggedFilesCount <= 0 || m_trackCountBeforeImport < 0) {
         return;
     }
 
@@ -257,7 +257,7 @@ void DropController::removeDragAddedTracks(int currentTrackId, int draggedFilesC
     std::vector<trackedit::Track> trackList = prj->trackList();
 
     const int total = static_cast<int>(trackList.size());
-    if (total <= m_tracksCountWhenDragStarted) {
+    if (total <= m_trackCountBeforeImport) {
         return;
     }
 
@@ -273,17 +273,17 @@ void DropController::removeDragAddedTracks(int currentTrackId, int draggedFilesC
     if (currentIndex >= 0) {
         // cursor is over some existing track (label or audio)
         startIndex = currentIndex;
-    } else if (m_tracksCountWhenDragStarted >= 0
-               && m_tracksCountWhenDragStarted < total) {
+    } else if (m_trackCountBeforeImport >= 0
+               && m_trackCountBeforeImport < total) {
         // cursor is below the last track
-        startIndex = m_tracksCountWhenDragStarted;
+        startIndex = m_trackCountBeforeImport;
     } else {
         // fallback
         startIndex = 0;
     }
 
     int remaining = draggedFilesCount;
-    int highestUsedIndex = m_tracksCountWhenDragStarted - 1;
+    int highestUsedIndex = m_trackCountBeforeImport - 1;
 
     // detect where dragged files will land: walk from startIndex downwards,
     // counting only audio tracks.
@@ -296,7 +296,7 @@ void DropController::removeDragAddedTracks(int currentTrackId, int draggedFilesC
         --remaining;
     }
 
-    int neededTracksCount = m_tracksCountWhenDragStarted;
+    int neededTracksCount = m_trackCountBeforeImport;
     if (highestUsedIndex >= 0) {
         neededTracksCount = std::max(neededTracksCount, highestUsedIndex + 1);
     }

--- a/src/projectscene/view/tracksitemsview/dropcontroller.h
+++ b/src/projectscene/view/tracksitemsview/dropcontroller.h
@@ -24,8 +24,8 @@ public:
     Q_INVOKABLE void probeAudioFiles(const QStringList& fileUrls);
     Q_INVOKABLE QVariantList lastProbedDurations() const;
     Q_INVOKABLE QVariantList lastProbedFileNames() const;
-    Q_INVOKABLE void startImportDrag();
-    Q_INVOKABLE void endImportDrag();
+    Q_INVOKABLE void startImportSession();
+    Q_INVOKABLE void endImportSession();
     Q_INVOKABLE int requiredTracksCount() const;
     Q_INVOKABLE void prepareConditionalTracks(int currentTrackId, int draggedFileCount);
     Q_INVOKABLE QVariantList draggedTracksIds(int currentTrackId, int draggedFilesCount);
@@ -35,6 +35,6 @@ public:
 private:
     std::vector<au::importexport::FileInfo> m_lastDraggedFilesInfo;
     QStringList m_lastDraggedUrls;
-    int m_tracksCountWhenDragStarted = -1;
+    int m_trackCountBeforeImport = -1;
 };
 }

--- a/src/trackedit/internal/trackeditoperationcontroller.cpp
+++ b/src/trackedit/internal/trackeditoperationcontroller.cpp
@@ -173,11 +173,12 @@ muse::Ret TrackeditOperationController::pasteFromClipboard(secs_t begin, bool mo
     auto modifiedState = false;
     muse::Ret ret;
     const auto paths = clipboard()->systemClipboardFilePaths();
+    const bool pastingFromSystemClipboard = !paths.empty();
 
     bool recreateRangeSelection = false;
     secs_t pastedDataEndTime = 0.0;
 
-    if (!paths.empty()) {
+    if (pastingFromSystemClipboard) {
         ret = importer()->importFromSystemClipboard(paths, begin);
         dispatcher()->dispatch("center-view-on-playhead", muse::actions::ActionData::make_arg1<bool>(
                                    true /* center only if playhead is not visible */));
@@ -193,7 +194,10 @@ muse::Ret TrackeditOperationController::pasteFromClipboard(secs_t begin, bool mo
     }
 
     if (ret) {
-        projectHistory()->pushHistoryState("Pasted from the clipboard", "Paste");
+        //! NOTE Importing files pushes its own "Import" history state
+        if (!pastingFromSystemClipboard) {
+            projectHistory()->pushHistoryState("Pasted from the clipboard", "Paste");
+        }
 
         if (recreateRangeSelection) {
             selectionController()->setDataSelectedStartTime(begin, true);


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/10780

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
- [x] Test pasting audio files from clipboard into "empty space" below existing tracks -> audio should be imported into newly created track
- [x] Verify that only one history entry was added during import (single Undo undoes the import)
