### PR TITLE
Mono/stereo history entries fixed

### DIFF
--- a/src/trackedit/internal/au3/au3tracksinteraction.cpp
+++ b/src/trackedit/internal/au3/au3tracksinteraction.cpp
@@ -804,8 +804,7 @@ bool Au3TracksInteraction::deleteTracks(const TrackIdList& trackIds)
 bool Au3TracksInteraction::duplicateTracks(const TrackIdList& trackIds)
 {
     if (trackIds.empty()) {
-        projectHistory()->pushHistoryState("Duplicated tracks", "Duplicate Tracks");
-        return true;
+        return false;
     }
 
     auto& project = projectRef();

--- a/src/trackedit/internal/au3/au3tracksinteraction.cpp
+++ b/src/trackedit/internal/au3/au3tracksinteraction.cpp
@@ -727,7 +727,6 @@ bool Au3TracksInteraction::newMonoTrack()
     selectionController()->setSelectedTracks({ trackId });
     trackNavigationController()->setFocusedTrack(trackId);
 
-    projectHistory()->pushHistoryState("Created new mono track", "New Mono Track");
     return true;
 }
 
@@ -737,7 +736,6 @@ bool Au3TracksInteraction::newStereoTrack()
     selectionController()->setSelectedTracks({ trackId });
     trackNavigationController()->setFocusedTrack(trackId);
 
-    projectHistory()->pushHistoryState("Created new stereo track", "New Stereo Track");
     return true;
 }
 

--- a/src/trackedit/tests/au3tracksinteraction_tests.cpp
+++ b/src/trackedit/tests/au3tracksinteraction_tests.cpp
@@ -720,7 +720,7 @@ TEST_F(Au3TracksInteractionTests, DuplicateTracksOnEmptyList)
     EXPECT_CALL(*m_trackEditProject, notifyAboutTrackInserted(_, _)).Times(0);
 
     //! [WHEN] Duplicate the tracks with an empty list
-    EXPECT_EQ(m_tracksInteraction->duplicateTracks({}), true);
+    EXPECT_EQ(m_tracksInteraction->duplicateTracks({}), false);
 
     //! [THEN] The number of tracks is still 0
     ASSERT_EQ(projectTracks.Size(), 0) << "The number of tracks after the duplicate operation is not 0";


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/10027
Resolves: https://github.com/audacity/audacity/issues/9664

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
