### PR TITLE
7669 Generator should use playhead position if no time selection

### DIFF
--- a/src/effects/effects_base/internal/effectexecutionscenario.cpp
+++ b/src/effects/effects_base/internal/effectexecutionscenario.cpp
@@ -177,6 +177,25 @@ muse::Ret EffectExecutionScenario::doPerformEffect(au3::Au3Project& project, con
             isTrackSelection = !selectionController()->selectedTracks().empty();
         }
 
+        if (effect->GetType() == EffectTypeGenerate && !isTimeSelection) {
+            // Generate at the current playhead position.
+            t0 = t1 = playback()->player()->playbackPosition();
+
+            const auto selectedTracks = selectionController()->selectedTracks();
+            const bool hasSelectedWaveTrack = std::any_of(selectedTracks.begin(), selectedTracks.end(),
+                                                          [&](const trackedit::TrackId& id) {
+                return au3::DomAccessor::findWaveTrack(project, ::TrackId(id)) != nullptr;
+            });
+
+            if (!hasSelectedWaveTrack) {
+                const trackedit::TrackId focused = trackNavigationController()->focusedTrack();
+                if (focused != trackedit::INVALID_TRACK && au3::DomAccessor::findWaveTrack(project, ::TrackId(focused))) {
+                    // No selected wave track, use focused track
+                    selectionController()->setSelectedTracks({ focused });
+                }
+            }
+        }
+
         if ((!isTimeSelection || !isTrackSelection) && (effect->GetType() != EffectTypeGenerate
                                                         && effect->GetType() != EffectTypeTool)
             && !isNyquistPrompt(*effect)) {


### PR DESCRIPTION
Resolves: #7669 

For generator without a time selection we should use the current playhead position

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [ ] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
- [x] Multiple and single track time selections
- [x] Multiple and single track selections
- [x] Mixed track time selection (labels + wave)
- [x] Mixed track selection (labels + wave)