### PR TITLE
10966 Buffer early QFileOpenEvents so Audio.com projects sync on startup

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -9,6 +9,7 @@
 #include <csignal>
 
 #include "appfactory.h"
+#include "appshell/internal/fileopeneventbuffer.h"
 #include "commandlineparser.h"
 #include "log.h"
 
@@ -203,6 +204,7 @@ int main(int argc, char** argv)
 
         QApplication* guiApp = new QApplication(argcFinal, argvFinal);
         guiApp->setQuitOnLastWindowClosed(false);
+        au::appshell::FileOpenEventBuffer::install(guiApp);
         qApplication = guiApp;
     }
 

--- a/src/appshell/CMakeLists.txt
+++ b/src/appshell/CMakeLists.txt
@@ -33,6 +33,8 @@ target_sources(appshell PRIVATE
     internal/appshellconfiguration.h
     internal/applicationactioncontroller.cpp
     internal/applicationactioncontroller.h
+    internal/fileopeneventbuffer.cpp
+    internal/fileopeneventbuffer.h
     internal/framelesswindowcontroller.cpp
     internal/framelesswindowcontroller.h
     internal/startupscenario.cpp

--- a/src/appshell/internal/applicationactioncontroller.cpp
+++ b/src/appshell/internal/applicationactioncontroller.cpp
@@ -36,6 +36,7 @@
 #include "framework/global/translation.h"
 
 #include "project/types/projecttypes.h"
+#include "fileopeneventbuffer.h"
 
 using namespace au::appshell;
 using namespace muse::actions;
@@ -45,6 +46,10 @@ static const QString TRACK_VIEW_SECTION_NAME("TrackViewSection");
 void ApplicationActionController::preInit()
 {
     qApp->installEventFilter(this);
+
+    for (const QUrl& url : FileOpenEventBuffer::takePendingUrls()) {
+        onFileOpenUrl(url);
+    }
 
 #ifdef Q_OS_MAC
     // Re-open window when user clicks the dock icon while all windows are closed
@@ -237,43 +242,45 @@ bool ApplicationActionController::eventFilter(QObject* watched, QEvent* event)
     //! on macOS custom URL opened from browser are also passed as QEvent::FileOpen
     if (event->type() == QEvent::FileOpen && watched == qApp) {
         const QFileOpenEvent* openEvent = static_cast<const QFileOpenEvent*>(event);
-        const QUrl url = openEvent->url();
+        onFileOpenUrl(openEvent->url());
+        return true;
+    }
 
-        // TODO: isUrlSupported - is misleading, as it does not handle audio.com urls
-        if (projectFilesController()->isUrlSupported(url)) {
-            if (startupScenario()->startupCompleted()) {
-                // On macos the main window may be hidden, show and raise it
-                // before loading the project
-                if (auto mw = mainWindow()) {
-                    if (QWindow* window = mw->qWindow(); window && !window->isVisible()) {
-                        window->setVisible(true);
-                    }
-                    mw->requestShowOnFront();
-                }
-                dispatcher()->dispatch("file-open", ActionData::make_arg1<QUrl>(url));
-            } else {
-                startupScenario()->setStartupProjectFile(project::ProjectFile { url });
-            }
+    return QObject::eventFilter(watched, event);
+}
 
-            return true;
-        }
-
-        const QString urlStr = url.toString(QUrl::FullyEncoded);
+void ApplicationActionController::onFileOpenUrl(const QUrl& url)
+{
+    if (projectFilesController()->isUrlSupported(url)) {
         if (startupScenario()->startupCompleted()) {
+            // On macos the main window may be hidden, show and raise it
+            // before loading the project
             if (auto mw = mainWindow()) {
                 if (QWindow* window = mw->qWindow(); window && !window->isVisible()) {
                     window->setVisible(true);
                 }
                 mw->requestShowOnFront();
             }
-            dispatcher()->dispatch("open-url", ActionData::make_arg1<QString>(urlStr));
+            dispatcher()->dispatch("file-open", ActionData::make_arg1<QUrl>(url));
         } else {
-            startupScenario()->setStartupUrl(urlStr);
+            startupScenario()->setStartupProjectFile(project::ProjectFile { url });
         }
-        return true;
+
+        return;
     }
 
-    return QObject::eventFilter(watched, event);
+    const QString urlStr = url.toString(QUrl::FullyEncoded);
+    if (startupScenario()->startupCompleted()) {
+        if (auto mw = mainWindow()) {
+            if (QWindow* window = mw->qWindow(); window && !window->isVisible()) {
+                window->setVisible(true);
+            }
+            mw->requestShowOnFront();
+        }
+        dispatcher()->dispatch("open-url", ActionData::make_arg1<QString>(urlStr));
+    } else {
+        startupScenario()->setStartupUrl(urlStr);
+    }
 }
 
 bool ApplicationActionController::quit(const muse::io::path_t& installerPath)

--- a/src/appshell/internal/applicationactioncontroller.h
+++ b/src/appshell/internal/applicationactioncontroller.h
@@ -92,6 +92,8 @@ public:
 private:
     bool eventFilter(QObject* watched, QEvent* event) override;
 
+    void onFileOpenUrl(const QUrl& url);
+
     void setupConnections();
 
     bool quit(const muse::io::path_t& installerPath = "");

--- a/src/appshell/internal/fileopeneventbuffer.cpp
+++ b/src/appshell/internal/fileopeneventbuffer.cpp
@@ -1,0 +1,48 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+#include "fileopeneventbuffer.h"
+
+#include <utility>
+
+#include <QCoreApplication>
+#include <QFileOpenEvent>
+
+using namespace au::appshell;
+
+FileOpenEventBuffer* FileOpenEventBuffer::s_instance = nullptr;
+
+FileOpenEventBuffer::FileOpenEventBuffer(QObject* parent)
+    : QObject(parent)
+{
+}
+
+void FileOpenEventBuffer::install(QCoreApplication* app)
+{
+    if (s_instance) {
+        return;
+    }
+
+    s_instance = new FileOpenEventBuffer(app);
+    app->installEventFilter(s_instance);
+}
+
+QList<QUrl> FileOpenEventBuffer::takePendingUrls()
+{
+    if (!s_instance) {
+        return {};
+    }
+
+    return std::exchange(s_instance->m_pendingUrls, {});
+}
+
+bool FileOpenEventBuffer::eventFilter(QObject* watched, QEvent* event)
+{
+    if (event->type() == QEvent::FileOpen && watched == qApp) {
+        const QUrl url = static_cast<const QFileOpenEvent*>(event)->url();
+        m_pendingUrls << url;
+        return true;
+    }
+
+    return QObject::eventFilter(watched, event);
+}

--- a/src/appshell/internal/fileopeneventbuffer.h
+++ b/src/appshell/internal/fileopeneventbuffer.h
@@ -1,0 +1,30 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+#pragma once
+
+#include <QList>
+#include <QObject>
+#include <QUrl>
+
+class QCoreApplication;
+
+namespace au::appshell {
+//! Buffers QFileOpenEvent urls delivered before ApplicationActionController installs
+//! its event filter. On macOS the launch url can arrive during an early event pump
+//! (splash screen, module init), where an unfiltered QFileOpenEvent is silently lost.
+class FileOpenEventBuffer : public QObject
+{
+public:
+    static void install(QCoreApplication* app);
+    static QList<QUrl> takePendingUrls();
+
+private:
+    explicit FileOpenEventBuffer(QObject* parent);
+
+    bool eventFilter(QObject* watched, QEvent* event) override;
+
+    static FileOpenEventBuffer* s_instance;
+    QList<QUrl> m_pendingUrls;
+};
+}

--- a/src/appshell/internal/startupscenario.cpp
+++ b/src/appshell/internal/startupscenario.cpp
@@ -26,6 +26,7 @@
 #include <QJsonDocument>
 #include <QJsonObject>
 
+#include "framework/global/defer.h"
 #include "framework/global/log.h"
 #include "framework/global/types/uri.h"
 
@@ -136,7 +137,7 @@ void StartupScenario::runAfterSplashScreen()
 {
     TRACEFUNC;
 
-    if (m_startupCompleted) {
+    if (m_startupCompleted || m_startupProcessing) {
         return;
     }
 
@@ -152,18 +153,34 @@ void StartupScenario::runAfterSplashScreen()
 
     muse::async::Channel<muse::Uri> opened = interactive()->opened();
     opened.onReceive(this, [this, opened, modeType](const muse::Uri&) {
-        if (m_startupCompleted) {
+        if (m_startupCompleted || m_startupProcessing) {
             return;
         }
 
-        m_startupCompleted = true;
+        m_startupProcessing = true;
+        DEFER {
+            m_startupProcessing = false;
+            m_startupCompleted = true;
+        };
 
         muse::async::Channel<muse::Uri> mut = opened;
         mut.disconnect(this);
 
         effectsProviderInitializer()->callAfterSplashScreen();
 
-        onStartupPageOpened(modeType);
+        showStartupDialogsIfNeed(modeType);
+
+        if (!m_startupMediaFiles.empty()) {
+            importStartupMediaFiles();
+            return;
+        }
+
+        if (!m_startupUrl.isEmpty()) {
+            openStartupUrl();
+            return;
+        }
+
+        runStartupMode(modeType);
     });
 
     interactive()->open(startupUri);
@@ -191,28 +208,32 @@ StartupModeType StartupScenario::resolveStartupModeType() const
     return configuration()->startupModeType();
 }
 
-void StartupScenario::onStartupPageOpened(StartupModeType modeType)
+void StartupScenario::importStartupMediaFiles()
 {
-    TRACEFUNC;
-
-    showStartupDialogsIfNeed(modeType);
-
-    if (!m_startupMediaFiles.empty()) {
-        QStringList files;
-        for (const auto& file : m_startupMediaFiles) {
-            files << file.toQString();
-        }
-
-        dispatcher()->dispatch("project-import-startup-media",
-                               ActionData::make_arg2<QStringList, bool>(files, m_removeMediaFilesAfterImport));
-        return;
+    QStringList files;
+    for (const auto& file : m_startupMediaFiles) {
+        files << file.toQString();
     }
 
-    if (!m_startupUrl.isEmpty()) {
-        dispatcher()->dispatch("open-url", ActionData::make_arg1<QString>(m_startupUrl));
-        return;
-    }
+    dispatcher()->dispatch("project-import-startup-media",
+                           ActionData::make_arg2<QStringList, bool>(files, m_removeMediaFilesAfterImport));
+}
 
+void StartupScenario::openStartupUrl()
+{
+    const QString url = m_startupUrl;
+    m_startupUrl.clear();
+
+    //! NOTE Deferred so the dispatch runs outside of async queue processing,
+    //! otherwise dialogs opened synchronously by the handler (e.g. sign-in)
+    //! would not receive async messages
+    QTimer::singleShot(0, [this, url]() {
+        dispatcher()->dispatch("open-url", ActionData::make_arg1<QString>(url));
+    });
+}
+
+void StartupScenario::runStartupMode(StartupModeType modeType)
+{
     switch (modeType) {
     case StartupModeType::StartEmpty:
         break;

--- a/src/appshell/internal/startupscenario.h
+++ b/src/appshell/internal/startupscenario.h
@@ -78,8 +78,10 @@ public:
     bool startupCompleted() const override;
 
 private:
-    void onStartupPageOpened(StartupModeType modeType);
     void showStartupDialogsIfNeed(StartupModeType modeType);
+    void importStartupMediaFiles();
+    void runStartupMode(StartupModeType modeType);
+    void openStartupUrl();
 
     StartupModeType resolveStartupModeType() const;
     muse::Uri startupPageUri(StartupModeType modeType) const;
@@ -98,6 +100,7 @@ private:
     bool m_removeMediaFilesAfterImport = false;
     QString m_startupUrl;
     bool m_startupCompleted = false;
+    bool m_startupProcessing = false;
     QTimer m_updateCheckTimer;
 };
 }


### PR DESCRIPTION
Resolves: #10966 

Dispatch startup open-url outside of async queue processing and buffer early QFileOpenEvents so the startup URL is not lost.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
