### PR TITLE
Fix audacity build on latest framework version

### DIFF
--- a/src/appshell/qml/Audacity/AppShell/CMakeLists.txt
+++ b/src/appshell/qml/Audacity/AppShell/CMakeLists.txt
@@ -145,6 +145,8 @@ if (NOT OS_IS_MAC)
     target_link_libraries(appshell_qml PRIVATE Qt6::GuiPrivate)
 endif(NOT OS_IS_MAC)
 
+target_link_libraries(appshell_qml PRIVATE Qt::Widgets)
+
 fixup_qml_module_dependencies(appshell_qml)
 
 # Necessary for the auto-generated sources

--- a/src/appshell/tests/CMakeLists.txt
+++ b/src/appshell/tests/CMakeLists.txt
@@ -13,6 +13,8 @@ set(MODULE_TEST_SRC
 set(MODULE_TEST_LINK
     appshell
     project
+
+    muse::ui
 )
 
 set(MODULE_TEST_INCLUDE

--- a/src/au3cloud/internal/au3cloudservice.cpp
+++ b/src/au3cloud/internal/au3cloudservice.cpp
@@ -3,7 +3,6 @@
 */
 #include "au3cloudservice.h"
 
-#include <QApplication>
 #include <QTimer>
 
 #include <string>

--- a/src/effects/effects_base/tests/CMakeLists.txt
+++ b/src/effects/effects_base/tests/CMakeLists.txt
@@ -16,6 +16,8 @@ set(MODULE_TEST_LINK
     effects_base
     muse_audioplugins
     au3-preferences
+
+    Qt::Qml
 )
 
 # AU3 - needed because test files include AU3 headers

--- a/src/playback/internal/au3/au3trackplaybackcontrol.cpp
+++ b/src/playback/internal/au3/au3trackplaybackcontrol.cpp
@@ -1,5 +1,3 @@
-#include <QApplication>
-
 #include "framework/global/log.h"
 #include "global/types/translatablestring.h"
 
@@ -87,7 +85,7 @@ void Au3TrackPlaybackControl::setMuteOrSolo(long trackId, bool value, MuteOrSolo
         which == MuteOrSolo::Solo ? t->SetSolo(v) : t->SetMute(v);
     };
 
-    const bool exclusiveSet = QApplication::keyboardModifiers().testFlag(Qt::ShiftModifier);
+    const bool exclusiveSet = application()->keyboardModifiers().testFlag(Qt::ShiftModifier);
 
     bool changed = false;
     if (exclusiveSet) {

--- a/src/playback/internal/au3/au3trackplaybackcontrol.h
+++ b/src/playback/internal/au3/au3trackplaybackcontrol.h
@@ -3,6 +3,7 @@
 */
 #pragma once
 
+#include "framework/global/iapplication.h"
 #include "framework/global/modularity/ioc.h"
 
 #include "context/iglobalcontext.h"
@@ -18,6 +19,8 @@ using au::audio::pan_t;
 
 class Au3TrackPlaybackControl : public ITrackPlaybackControl, public muse::Contextable
 {
+    muse::GlobalInject<muse::IApplication> application;
+
     muse::ContextInject<au::context::IGlobalContext> globalContext { this };
     muse::ContextInject<au::trackedit::IProjectHistory> projectHistory { this };
 

--- a/src/preferences/qml/Audacity/Preferences/preferencesmodel.cpp
+++ b/src/preferences/qml/Audacity/Preferences/preferencesmodel.cpp
@@ -19,7 +19,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-#include <QApplication>
+#include <QGuiApplication>
 
 #include "preferencesmodel.h"
 
@@ -198,11 +198,11 @@ void PreferencesModel::load(const QString& currentPageId)
 void PreferencesModel::resetFactorySettings()
 {
     static constexpr bool KEEP_DEFAULT_SETTINGS = true;
-    QApplication::setOverrideCursor(Qt::WaitCursor);
-    QApplication::processEvents();
+    QGuiApplication::setOverrideCursor(Qt::WaitCursor);
+    QCoreApplication::processEvents();
     configuration()->revertToFactorySettings(KEEP_DEFAULT_SETTINGS);
     configuration()->startEditSettings();
-    QApplication::restoreOverrideCursor();
+    QGuiApplication::restoreOverrideCursor();
 }
 
 void PreferencesModel::apply()

--- a/src/project/CMakeLists.txt
+++ b/src/project/CMakeLists.txt
@@ -141,7 +141,7 @@ include(${CMAKE_CURRENT_LIST_DIR}/../au3wrap/au3wrapDefs.cmake)
 
 set(MODULE_INCLUDE ${AU3_INCLUDE})
 set(MODULE_DEF ${AU3_DEF})
-set(MODULE_LINK au3wrap)
+set(MODULE_LINK au3wrap Qt::Widgets)
 if (QT_ADD_CONCURRENT)
     list(APPEND MODULE_LINK Qt::Concurrent)
 endif()

--- a/src/projectscene/internal/projectviewstate.cpp
+++ b/src/projectscene/internal/projectviewstate.cpp
@@ -4,7 +4,6 @@
 
 #include <memory>
 
-#include <QApplication>
 #include <QEvent>
 #include <QKeyEvent>
 

--- a/src/projectscene/view/timeline/playregioncontroller.cpp
+++ b/src/projectscene/view/timeline/playregioncontroller.cpp
@@ -5,7 +5,7 @@
 
 #include <cmath>
 
-#include <QApplication>
+#include <QGuiApplication>
 
 #include "framework/global/log.h"
 
@@ -21,7 +21,7 @@ void PlayRegionController::init()
         updateIsActive();
     });
 
-    connect(qApp, &QApplication::applicationStateChanged, this, [this](Qt::ApplicationState state){
+    connect(qApp, &QGuiApplication::applicationStateChanged, this, [this](Qt::ApplicationState state){
         if (state != Qt::ApplicationActive) {
             finishInteraction(m_dragStartPos);
         }

--- a/src/projectscene/view/timeline/timelinecontext.cpp
+++ b/src/projectscene/view/timeline/timelinecontext.cpp
@@ -1,6 +1,5 @@
 #include "timelinecontext.h"
 
-#include <QApplication>
 #include <QWheelEvent>
 #include <cmath>
 
@@ -216,7 +215,7 @@ void TimelineContext::onWheel(double mouseX, const QPoint& pixelDelta, const QPo
         stepsY = static_cast<qreal>(stepsScrolled.y()) / static_cast<qreal>(QWheelEvent::DefaultDeltasPerStep);
     }
 
-    Qt::KeyboardModifiers modifiers = QApplication::keyboardModifiers();
+    Qt::KeyboardModifiers modifiers = application()->keyboardModifiers();
 
     if (modifiers.testFlag(Qt::ControlModifier)) {
         double zoomSpeed = qPow(2.0, 1.0 / configuration()->mouseZoomPrecision());

--- a/src/projectscene/view/timeline/timelinecontext.h
+++ b/src/projectscene/view/timeline/timelinecontext.h
@@ -5,6 +5,7 @@
 #include <QVariantAnimation>
 
 #include "modularity/ioc.h"
+#include "global/iapplication.h"
 #include "context/iglobalcontext.h"
 #include "global/async/asyncable.h"
 #include "actions/actionable.h"
@@ -66,6 +67,7 @@ class TimelineContext : public QObject, public muse::async::Asyncable, public mu
     Q_PROPERTY(double invalidGuidelineTime READ invalidGuidelineTime CONSTANT FINAL)
 
     muse::GlobalInject<IProjectSceneConfiguration> configuration;
+    muse::GlobalInject<muse::IApplication> application;
 
     muse::ContextInject<muse::actions::IActionsDispatcher> dispatcher{ this };
     muse::ContextInject<context::IGlobalContext> globalContext{ this };

--- a/src/projectscene/view/tracksitemsview/selectionviewcontroller.cpp
+++ b/src/projectscene/view/tracksitemsview/selectionviewcontroller.cpp
@@ -1,7 +1,7 @@
 /*
 * Audacity: A Digital Audio Editor
 */
-#include <QApplication>
+#include <QGuiApplication>
 
 #include <cmath>
 
@@ -25,7 +25,7 @@ SelectionViewController::SelectionViewController(QObject* parent)
 
 void SelectionViewController::load()
 {
-    connect(qApp, &QApplication::applicationStateChanged, this, [this](Qt::ApplicationState state){
+    connect(qApp, &QGuiApplication::applicationStateChanged, this, [this](Qt::ApplicationState state){
         if (state != Qt::ApplicationActive) {
             //Application lost focus, end any selection in progress
             onReleased(m_selectionStartTime, m_startY);
@@ -462,7 +462,7 @@ TrackIdList SelectionViewController::trackIdList() const
 
 Qt::KeyboardModifiers SelectionViewController::keyboardModifiers() const
 {
-    Qt::KeyboardModifiers modifiers = QApplication::keyboardModifiers();
+    Qt::KeyboardModifiers modifiers = application()->keyboardModifiers();
 
     //! NOTE: always treat simultaneously pressed Ctrl and Shift as Ctrl
     if (modifiers.testFlag(Qt::ShiftModifier) && modifiers.testFlag(Qt::ControlModifier)) {

--- a/src/projectscene/view/tracksitemsview/selectionviewcontroller.h
+++ b/src/projectscene/view/tracksitemsview/selectionviewcontroller.h
@@ -6,6 +6,7 @@
 #include <QObject>
 
 #include "framework/global/async/async.h"
+#include "framework/global/iapplication.h"
 #include "framework/global/modularity/ioc.h"
 
 #include "context/iglobalcontext.h"
@@ -35,6 +36,7 @@ class SelectionViewController : public QObject, public muse::async::Asyncable, p
     Q_PROPERTY(QVariantMap pressedSpectrogram READ pressedSpectrogram NOTIFY pressedSpectrogramChanged FINAL)
 
     muse::GlobalInject<spectrogram::IGlobalSpectrogramConfiguration> spectrogramConfiguration;
+    muse::GlobalInject<muse::IApplication> application;
 
     muse::ContextInject<context::IGlobalContext> globalContext { this };
     muse::ContextInject<trackedit::ISelectionController> selectionController { this };

--- a/src/projectscene/view/tracksitemsview/splittoolcontroller.cpp
+++ b/src/projectscene/view/tracksitemsview/splittoolcontroller.cpp
@@ -6,7 +6,7 @@
 
 #include <cmath>
 
-#include <QApplication>
+#include <QGuiApplication>
 
 #include "view/common/customcursor.h"
 
@@ -51,7 +51,7 @@ void SplitToolController::init(QObject* root)
 
     qApp->installEventFilter(this);
 
-    connect(qApp, &QApplication::applicationStateChanged, this, [this](Qt::ApplicationState state){
+    connect(qApp, &QGuiApplication::applicationStateChanged, this, [this](Qt::ApplicationState state){
         if (state != Qt::ApplicationActive) {
             setActive(false);
             setSingleTrack(true);

--- a/src/projectscene/view/tracksitemsview/trackitemslistmodel.cpp
+++ b/src/projectscene/view/tracksitemsview/trackitemslistmodel.cpp
@@ -3,8 +3,6 @@
 */
 #include "trackitemslistmodel.h"
 
-#include <QApplication>
-
 #include "global/realfn.h"
 
 using namespace au::projectscene;
@@ -496,7 +494,7 @@ void TrackItemsListModel::disconnectAutoScroll()
 
 Qt::KeyboardModifiers TrackItemsListModel::keyboardModifiers() const
 {
-    Qt::KeyboardModifiers modifiers = QApplication::keyboardModifiers();
+    Qt::KeyboardModifiers modifiers = application()->keyboardModifiers();
 
     //! NOTE: always treat simultaneously pressed Ctrl and Shift as Ctrl
     if (modifiers.testFlag(Qt::ShiftModifier) && modifiers.testFlag(Qt::ControlModifier)) {

--- a/src/projectscene/view/tracksitemsview/trackitemslistmodel.h
+++ b/src/projectscene/view/tracksitemsview/trackitemslistmodel.h
@@ -8,6 +8,7 @@
 #include <QAbstractListModel>
 
 #include "framework/global/async/asyncable.h"
+#include "framework/global/iapplication.h"
 #include "framework/global/modularity/ioc.h"
 
 #include "framework/actions/actionable.h"
@@ -37,6 +38,8 @@ class TrackItemsListModel : public QAbstractListModel, public muse::async::Async
     Q_PROPERTY(int cacheBufferPx READ cacheBufferPx CONSTANT)
 
 protected:
+    muse::GlobalInject<muse::IApplication> application;
+
     muse::ContextInject<muse::actions::IActionsDispatcher> dispatcher{ this };
     muse::ContextInject<context::IGlobalContext> globalContext{ this };
     muse::ContextInject<muse::IInteractive> interactive{ this };

--- a/src/trackedit/tests/CMakeLists.txt
+++ b/src/trackedit/tests/CMakeLists.txt
@@ -28,6 +28,8 @@ set(MODULE_TEST_SRC
 set(MODULE_TEST_LINK
     trackedit
     au3wrap
+
+    muse::ui
     )
 
 set(MODULE_TEST_DATA_ROOT ${CMAKE_CURRENT_LIST_DIR})


### PR DESCRIPTION
The framework changed QtWidgets link from PUBLIC to PRIVATE. 
It has some effects on audacity code.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
