### PR TITLE
Restore 'Silence audio' item in Edit menu

### DIFF
--- a/src/app/configs/data/shortcuts.xml
+++ b/src/app/configs/data/shortcuts.xml
@@ -338,7 +338,7 @@
         <seq>Ctrl+D</seq>
     </SC>
     <SC>
-        <key>silence</key>
+        <key>silence-audio-selection</key>
         <seq>Ctrl+L</seq>
     </SC>
     <SC>

--- a/src/appshell/qml/Audacity/AppShell/appmenumodel.cpp
+++ b/src/appshell/qml/Audacity/AppShell/appmenumodel.cpp
@@ -240,6 +240,7 @@ MenuItem* AppMenuModel::makeEditMenu()
         makeSeparator(),
         makeMenu(TranslatableString("appshell-menu-clip", "Clip"), makeClipItems(), "menu-clip"),
         makeMenu(TranslatableString("appshell-menu-label", "Label"), makeLabelItems(), "menu-label"),
+        makeMenuItem("silence-audio-selection", TranslatableString("action", "Silence audio")),
         makeSeparator(),
         makeMenuItem("open-metadata-editor", TranslatableString("action", "Metadata editor")),
 #ifndef Q_OS_MAC

--- a/src/trackedit/internal/au3/au3tracksinteraction.cpp
+++ b/src/trackedit/internal/au3/au3tracksinteraction.cpp
@@ -9,6 +9,7 @@
 #include "au3-track/Track.h"
 #include "au3-track/TimeWarper.h"
 #include "au3-track/PendingTracks.h"
+#include "au3-wave-track/WaveChannelUtilities.h"
 #include "au3-wave-track/WaveTrackUtilities.h"
 #include "au3-wave-track/WaveTrack.h"
 #include "au3-wave-track/WaveClip.h"
@@ -92,6 +93,28 @@ bool Au3TracksInteraction::silenceTracksData(const std::vector<trackedit::TrackI
 
         trackedit::ITrackeditProjectPtr prj = globalContext()->currentTrackeditProject();
         prj->notifyAboutTrackChanged(DomConverter::track(waveTrack));
+    }
+
+    return true;
+}
+
+bool Au3TracksInteraction::tracksDataIsSilent(const std::vector<trackedit::TrackId>& tracksIds, secs_t begin, secs_t end) const
+{
+    for (TrackId trackId : tracksIds) {
+        Au3WaveTrack* waveTrack = DomAccessor::findWaveTrack(projectRef(), Au3TrackId(trackId));
+        if (!waveTrack) {
+            continue;
+        }
+
+        for (const auto& channel : waveTrack->Channels()) {
+            const auto [min, max] = WaveChannelUtilities::GetMinMax(*channel, begin, end, false /*mayThrow*/);
+            if (min > max) {
+                continue; // no audio data in the given range
+            }
+            if (min != 0.f || max != 0.f) {
+                return false;
+            }
+        }
     }
 
     return true;

--- a/src/trackedit/internal/au3/au3tracksinteraction.h
+++ b/src/trackedit/internal/au3/au3tracksinteraction.h
@@ -39,6 +39,7 @@ public:
 
     bool trimTracksData(const std::vector<trackedit::TrackId>& tracksIds, secs_t begin, secs_t end) override;
     bool silenceTracksData(const std::vector<trackedit::TrackId>& tracksIds, secs_t begin, secs_t end) override;
+    bool tracksDataIsSilent(const std::vector<trackedit::TrackId>& tracksIds, secs_t begin, secs_t end) const override;
     bool changeTrackTitle(const trackedit::TrackId trackId, const muse::String& title) override;
     bool changeTracksColor(const TrackIdList& tracksIds, ClipColorIndex colorIndex) override;
 

--- a/src/trackedit/internal/trackeditactionscontroller.cpp
+++ b/src/trackedit/internal/trackeditactionscontroller.cpp
@@ -330,6 +330,7 @@ void TrackeditActionsController::init()
     projectHistory()->historyChanged().onReceive(this, [this](auto) {
         notifyActionEnabledChanged(TRACKEDIT_UNDO);
         notifyActionEnabledChanged(TRACKEDIT_REDO);
+        notifyActionEnabledChanged(SILENCE_AUDIO_SELECTION);
         setFocusedItemMoveInProgress(false);
     });
 
@@ -343,10 +344,23 @@ void TrackeditActionsController::init()
         notifyActionEnabledChanged(GROUP_CLIPS_CODE);
         notifyActionEnabledChanged(UNGROUP_CLIPS_CODE);
         notifyActionEnabledChanged(JOIN_CODE);
+        notifyActionEnabledChanged(SILENCE_AUDIO_SELECTION);
     });
 
     selectionController()->clipsIntersectingRangeSelectionChanged().onReceive(this, [this](const trackedit::ClipKeyList&) {
         notifyActionEnabledChanged(JOIN_CODE);
+    });
+
+    selectionController()->selectedTracksChanged().onReceive(this, [this](const trackedit::TrackIdList&) {
+        notifyActionEnabledChanged(SILENCE_AUDIO_SELECTION);
+    });
+
+    selectionController()->dataSelectedStartTimeChanged().onReceive(this, [this](trackedit::secs_t) {
+        notifyActionEnabledChanged(SILENCE_AUDIO_SELECTION);
+    });
+
+    selectionController()->dataSelectedEndTimeChanged().onReceive(this, [this](trackedit::secs_t) {
+        notifyActionEnabledChanged(SILENCE_AUDIO_SELECTION);
     });
 }
 
@@ -1653,15 +1667,9 @@ void TrackeditActionsController::doGlobalSilence()
         return;
     }
 
-    ClipKeyList selectedClips = clipsForInteraction();
+    ClipKeyList selectedClips = selectionController()->selectedClips();
     if (!selectedClips.empty()) {
         silenceClips(selectedClips);
-        return;
-    }
-
-    const auto selectedTracks = selectionController()->selectedTracks();
-    if (!selectedTracks.empty()) {
-        silenceTracks();
     }
 }
 
@@ -1692,22 +1700,6 @@ void TrackeditActionsController::silenceAudioSelection()
 void TrackeditActionsController::silenceClips(const ClipKeyList& clipKeys)
 {
     trackeditInteraction()->silenceClips(clipKeys);
-}
-
-void TrackeditActionsController::silenceTracks()
-{
-    const TrackIdList selectedTracks = selectionController()->selectedTracks();
-    if (selectedTracks.empty()) {
-        return;
-    }
-
-    const std::optional<secs_t> selectedStartTime = selectionController()->selectedTracksStartTime();
-    const std::optional<secs_t> selectedEndTime = selectionController()->selectedTracksEndTime();
-    if (!selectedStartTime.has_value() || !selectedEndTime.has_value()) {
-        return;
-    }
-
-    trackeditInteraction()->silenceTracksData(selectedTracks, selectedStartTime.value(), selectedEndTime.value());
 }
 
 void TrackeditActionsController::toggleStretchClipToMatchTempo(const ActionData& args)
@@ -2205,9 +2197,30 @@ bool TrackeditActionsController::canReceiveAction(const ActionCode& actionCode) 
             return rangeSelectionCoversMultipleClips();
         }
         return contiguousSelectedClipsSpan().has_value();
+    } else if (actionCode == SILENCE_AUDIO_SELECTION) {
+        return canSilenceAudio();
     }
 
     return true;
+}
+
+bool TrackeditActionsController::canSilenceAudio() const
+{
+    if (!selectionController()->timeSelectionIsEmpty()) {
+        return !trackeditInteraction()->tracksDataIsSilent(selectionController()->selectedTracks(),
+                                                           selectionController()->dataSelectedStartTime(),
+                                                           selectionController()->dataSelectedEndTime());
+    }
+
+    for (const auto& clipKey : selectionController()->selectedClips()) {
+        const secs_t begin = trackeditInteraction()->clipStartTime(clipKey);
+        const secs_t end = trackeditInteraction()->clipEndTime(clipKey);
+        if (!trackeditInteraction()->tracksDataIsSilent({ clipKey.trackId }, begin, end)) {
+            return true;
+        }
+    }
+
+    return false;
 }
 
 void TrackeditActionsController::moveFocusedItemLeft()

--- a/src/trackedit/internal/trackeditactionscontroller.h
+++ b/src/trackedit/internal/trackeditactionscontroller.h
@@ -66,6 +66,7 @@ private:
 
     bool isFocusedItemClip() const;
     ClipKeyList clipsForInteraction() const;
+    bool canSilenceAudio() const;
 
     struct ContiguousClipsSpan {
         TrackId trackId = INVALID_TRACK;
@@ -148,7 +149,6 @@ private:
     void doGlobalSilence();
     void silenceAudioSelection();
     void silenceClips(const trackedit::ClipKeyList& clipKeys);
-    void silenceTracks();
 
     void toggleStretchClipToMatchTempo(const muse::actions::ActionData& args);
     void openClipPitchAndSpeed();

--- a/src/trackedit/internal/trackeditinteraction.cpp
+++ b/src/trackedit/internal/trackeditinteraction.cpp
@@ -41,6 +41,11 @@ bool TrackeditInteraction::silenceClips(const ClipKeyList& clipKeyList)
     return withPlaybackStop(&ITrackeditInteraction::silenceClips, clipKeyList);
 }
 
+bool TrackeditInteraction::tracksDataIsSilent(const std::vector<trackedit::TrackId>& tracksIds, secs_t begin, secs_t end) const
+{
+    return m_interaction->tracksDataIsSilent(tracksIds, begin, end);
+}
+
 bool TrackeditInteraction::changeTrackTitle(const trackedit::TrackId trackId, const muse::String& title)
 {
     return m_interaction->changeTrackTitle(trackId, title);

--- a/src/trackedit/internal/trackeditinteraction.h
+++ b/src/trackedit/internal/trackeditinteraction.h
@@ -27,6 +27,7 @@ private:
     bool trimTracksData(const std::vector<trackedit::TrackId>& tracksIds, secs_t begin, secs_t end) override;
     bool silenceTracksData(const std::vector<trackedit::TrackId>& tracksIds, secs_t begin, secs_t end) override;
     bool silenceClips(const ClipKeyList& clipKeyList) override;
+    bool tracksDataIsSilent(const std::vector<trackedit::TrackId>& tracksIds, secs_t begin, secs_t end) const override;
     bool changeTrackTitle(const trackedit::TrackId trackId, const muse::String& title) override;
     bool changeClipTitle(const trackedit::ClipKey& clipKey, const muse::String& newTitle) override;
     bool changeClipPitch(const ClipKey& clipKey, int pitch) override;

--- a/src/trackedit/internal/trackeditoperationcontroller.cpp
+++ b/src/trackedit/internal/trackeditoperationcontroller.cpp
@@ -70,6 +70,11 @@ bool TrackeditOperationController::silenceClips(const ClipKeyList& clipKeyList)
     return anySilenced;
 }
 
+bool TrackeditOperationController::tracksDataIsSilent(const std::vector<trackedit::TrackId>& tracksIds, secs_t begin, secs_t end) const
+{
+    return tracksInteraction()->tracksDataIsSilent(tracksIds, begin, end);
+}
+
 bool TrackeditOperationController::changeTrackTitle(const trackedit::TrackId trackId, const muse::String& title)
 {
     if (tracksInteraction()->changeTrackTitle(trackId, title)) {

--- a/src/trackedit/internal/trackeditoperationcontroller.h
+++ b/src/trackedit/internal/trackeditoperationcontroller.h
@@ -45,6 +45,7 @@ public:
     bool trimTracksData(const std::vector<trackedit::TrackId>& tracksIds, secs_t begin, secs_t end) override;
     bool silenceTracksData(const std::vector<trackedit::TrackId>& tracksIds, secs_t begin, secs_t end) override;
     bool silenceClips(const ClipKeyList& clipKeyList) override;
+    bool tracksDataIsSilent(const std::vector<trackedit::TrackId>& tracksIds, secs_t begin, secs_t end) const override;
     bool changeTrackTitle(const trackedit::TrackId trackId, const muse::String& title) override;
 
     bool changeClipTitle(const ClipKey& clipKey, const muse::String& newTitle) override;

--- a/src/trackedit/itrackeditinteraction.h
+++ b/src/trackedit/itrackeditinteraction.h
@@ -33,6 +33,7 @@ public:
     virtual bool trimTracksData(const std::vector<trackedit::TrackId>& tracksIds, secs_t begin, secs_t end) = 0;
     virtual bool silenceTracksData(const std::vector<trackedit::TrackId>& tracksIds, secs_t begin, secs_t end) = 0;
     virtual bool silenceClips(const ClipKeyList& clipKeyList) = 0;
+    virtual bool tracksDataIsSilent(const std::vector<trackedit::TrackId>& tracksIds, secs_t begin, secs_t end) const = 0;
     virtual bool changeTrackTitle(const trackedit::TrackId trackId, const muse::String& title) = 0;
 
     virtual bool changeClipTitle(const ClipKey& clipKey, const muse::String& newTitle) = 0;

--- a/src/trackedit/itracksinteraction.h
+++ b/src/trackedit/itracksinteraction.h
@@ -24,6 +24,7 @@ public:
 
     virtual bool trimTracksData(const std::vector<trackedit::TrackId>& tracksIds, secs_t begin, secs_t end) = 0;
     virtual bool silenceTracksData(const std::vector<trackedit::TrackId>& tracksIds, secs_t begin, secs_t end) = 0;
+    virtual bool tracksDataIsSilent(const std::vector<trackedit::TrackId>& tracksIds, secs_t begin, secs_t end) const = 0;
     virtual bool changeTrackTitle(const trackedit::TrackId trackId, const muse::String& title) = 0;
 
     virtual bool changeTracksColor(const TrackIdList& trackId, ClipColorIndex colorIndex) = 0;

--- a/src/trackedit/tests/mocks/trackeditinteractionmock.h
+++ b/src/trackedit/tests/mocks/trackeditinteractionmock.h
@@ -20,6 +20,7 @@ public:
     MOCK_METHOD(bool, trimTracksData, (const std::vector<trackedit::TrackId>&, secs_t, secs_t), (override));
     MOCK_METHOD(bool, silenceTracksData, (const std::vector<trackedit::TrackId>&, secs_t, secs_t), (override));
     MOCK_METHOD(bool, silenceClips, (const ClipKeyList&), (override));
+    MOCK_METHOD(bool, tracksDataIsSilent, (const std::vector<trackedit::TrackId>&, secs_t, secs_t), (const, override));
     MOCK_METHOD(bool, changeTrackTitle, (const trackedit::TrackId, const muse::String&), (override));
 
     MOCK_METHOD(bool, changeClipTitle, (const ClipKey&, const muse::String&), (override));


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/10855

Reuses the existing silence-audio-selection action (same as the toolbar Silence button). The item is enabled only when non-silent audio is selected and is bound to Ctrl+L, matching AU3.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [ ] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [x] Basic silencing via the menu
- [x] It's disabled when there's nothing to silence
- [x] Already-silent audio doesn't re-enable it 