### PR TITLE
Split tool on clip header

### DIFF
--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/ClipItem.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/ClipItem.qml
@@ -613,7 +613,7 @@ Rectangle {
 
                 acceptedButtons: Qt.LeftButton
                 hoverEnabled: true
-                cursorShape: Qt.OpenHandCursor
+                cursorShape: root.splitToolActive ? Qt.ArrowCursor : Qt.OpenHandCursor
 
                 property var lastClickTime: 0
                 property point doubleClickStartPosition
@@ -624,6 +624,12 @@ Rectangle {
                 // hence we need to let simple events pass (e.accepted = false). Unfortunately this breaks
                 // detecting composed events like doubleClick so we need to take care of it manually.
                 onPressed: function (e) {
+                    if (root.splitToolActive) {
+                        //! NOTE Let the press through so the split tool handles it
+                        e.accepted = false
+                        return
+                    }
+
                     var currentTime = Date.now()
                     if (currentTime - lastClickTime < prv.doubleClickInterval) {
                         //! NOTE Handle doubleClick logic

--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TracksItemsView.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TracksItemsView.qml
@@ -559,14 +559,16 @@ Rectangle {
                 }
 
                 if (e.button === Qt.LeftButton) {
-                    if (root.itemHeaderHovered && !splitToolController.active) {
+                    if (root.itemHeaderHovered && !(splitToolController.active && splitToolController.hoveredTrackSplittable)) {
                         tracksItemsView.itemStartEditRequested(hoveredItemKey)
                         root.interactionState = TracksItemsView.State.DraggingItem
                         lastItemClickKey = root.hoveredItemKey
                     } else {
                         content.forceActiveFocus()
 
-                        if (!((e.modifiers & (Qt.ControlModifier | Qt.ShiftModifier)) || root.isSplitMode)) {
+                        const pressBelongsToSplitTool = splitToolController.active && splitToolController.trackSplittable(tracksViewState.trackAtPosition(e.x, e.y))
+
+                        if (!((e.modifiers & (Qt.ControlModifier | Qt.ShiftModifier)) || pressBelongsToSplitTool)) {
                             let time = timeline.context.positionToTime(e.x)
                             if (playbackState.isPlaying) {
                                 playbackState.setLastPlaybackSeekTime(time)
@@ -574,7 +576,7 @@ Rectangle {
                             playCursorController.seekToTime(time)
                         }
 
-                        if (!splitToolController.active) {
+                        if (!pressBelongsToSplitTool) {
                             const spectrogramHit = tracksItemsView.getSpectrogramHit(e.y)
                             selectionViewController.onPressed(timeline.context.positionToTime(e.x), e.y, spectrogramHit)
                             selectionViewController.resetSelectedItems()
@@ -645,9 +647,7 @@ Rectangle {
                         if (selectionViewController.isLeftSelection(releaseTime)) {
                             playCursorController.seekToTime(releaseTime)
                         }
-                        if (!splitToolController.active) {
-                            selectionViewController.onReleased(releaseTime, e.y)
-                        }
+                        selectionViewController.onReleased(releaseTime, e.y)
                         if (e.modifiers & (Qt.ControlModifier | Qt.ShiftModifier)) {
                             playCursorController.seekToTime(timeline.context.selectionStartTime)
                         }
@@ -680,7 +680,7 @@ Rectangle {
                     return
                 }
 
-                if (root.isSplitMode) {
+                if (root.isSplitMode && splitToolController.trackSplittable(tracksViewState.trackAtPosition(e.x, e.y))) {
                     return
                 }
 

--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TracksItemsView.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TracksItemsView.qml
@@ -184,7 +184,7 @@ Rectangle {
         id: splitToolController
         context: timeline.context
 
-        clipHovered: root.itemHovered && !root.itemHeaderHovered
+        clipHovered: root.itemHovered
         hoveredTrack: root.hoveredTrackId
 
         onActiveChanged: {
@@ -559,7 +559,7 @@ Rectangle {
                 }
 
                 if (e.button === Qt.LeftButton) {
-                    if (root.itemHeaderHovered) {
+                    if (root.itemHeaderHovered && !splitToolController.active) {
                         tracksItemsView.itemStartEditRequested(hoveredItemKey)
                         root.interactionState = TracksItemsView.State.DraggingItem
                         lastItemClickKey = root.hoveredItemKey

--- a/src/projectscene/view/tracksitemsview/splittoolcontroller.cpp
+++ b/src/projectscene/view/tracksitemsview/splittoolcontroller.cpp
@@ -69,7 +69,7 @@ SplitToolController::~SplitToolController() = default;
 
 void au::projectscene::SplitToolController::doSplit()
 {
-    if (!m_clipHovered) {
+    if (!m_clipHovered || !hoveredTrackSplittable()) {
         return;
     }
 
@@ -78,9 +78,29 @@ void au::projectscene::SplitToolController::doSplit()
     if (mods & Qt::ShiftModifier) {
         auto allTracks = globalContext()->currentProject()->trackeditProject()->trackIdList();
         splitTracksAt(allTracks, context()->positionToTime(m_guidelinePos));
-    } else if (m_hoveredTrack >= 0) {
+    } else {
         splitTracksAt({ m_hoveredTrack }, context()->positionToTime(m_guidelinePos));
     }
+}
+
+bool SplitToolController::hoveredTrackSplittable() const
+{
+    return trackSplittable(m_hoveredTrack);
+}
+
+bool SplitToolController::trackSplittable(int trackId) const
+{
+    if (trackId < 0) {
+        return false;
+    }
+
+    const auto prj = globalContext()->currentProject();
+    if (!prj) {
+        return false;
+    }
+
+    const std::optional<trackedit::Track> track = prj->trackeditProject()->track(trackId);
+    return track.has_value() && track->type != trackedit::TrackType::Label;
 }
 
 void SplitToolController::mouseDown(double pos)
@@ -121,7 +141,7 @@ double SplitToolController::guidelinePosition() const
 
 bool SplitToolController::guidelineVisible() const
 {
-    return m_active && m_clipHovered && muse::RealIsEqualOrMore(m_guidelinePos, 0);
+    return m_active && m_clipHovered && hoveredTrackSplittable() && muse::RealIsEqualOrMore(m_guidelinePos, 0);
 }
 
 TimelineContext* SplitToolController::context() const
@@ -194,7 +214,7 @@ void SplitToolController::updateGuideline(double pos)
 
 void SplitToolController::updateCursor()
 {
-    if (active() && clipHovered()) {
+    if (active() && clipHovered() && hoveredTrackSplittable()) {
         overrideCursor();
     } else {
         restoreCursor();
@@ -259,7 +279,11 @@ void SplitToolController::setHoveredTrack(int newHoveredTrack)
         return;
     }
     m_hoveredTrack = newHoveredTrack;
+
+    updateCursor();
+
     emit hoveredTrackChanged();
+    emit guidelineVisibleChanged();
 }
 
 bool SplitToolController::eventFilter(QObject* obj, QEvent* event)

--- a/src/projectscene/view/tracksitemsview/splittoolcontroller.h
+++ b/src/projectscene/view/tracksitemsview/splittoolcontroller.h
@@ -22,6 +22,7 @@ class SplitToolController : public QObject, public muse::actions::Actionable, pu
     Q_PROPERTY(bool active READ active NOTIFY activeChanged FINAL)
     Q_PROPERTY(bool singleTrack READ singleTrack NOTIFY singleTrackChanged FINAL)
     Q_PROPERTY(int hoveredTrack READ hoveredTrack WRITE setHoveredTrack NOTIFY hoveredTrackChanged FINAL)
+    Q_PROPERTY(bool hoveredTrackSplittable READ hoveredTrackSplittable NOTIFY hoveredTrackChanged FINAL)
     Q_PROPERTY(bool clipHovered READ clipHovered WRITE setClipHovered NOTIFY clipHoveredChanged FINAL)
     Q_PROPERTY(double guidelinePosition READ guidelinePosition NOTIFY guidelinePositionChanged FINAL)
     Q_PROPERTY(bool guidelineVisible READ guidelineVisible NOTIFY guidelineVisibleChanged FINAL)
@@ -40,6 +41,8 @@ public:
     Q_INVOKABLE void mouseUp(double pos);
     Q_INVOKABLE void mouseMove(double pos);
 
+    Q_INVOKABLE bool trackSplittable(int trackId) const;
+
     TimelineContext* context() const;
     void setContext(TimelineContext* newContext);
 
@@ -56,6 +59,8 @@ public:
 
     int hoveredTrack() const;
     void setHoveredTrack(int newHoveredTrack);
+
+    bool hoveredTrackSplittable() const;
 
     bool singleTrack() const;
     void setSingleTrack(bool enabled);

--- a/src/trackedit/internal/trackeditactionscontroller.cpp
+++ b/src/trackedit/internal/trackeditactionscontroller.cpp
@@ -1206,6 +1206,16 @@ void TrackeditActionsController::tracksSplitAt(const ActionData& args)
 
     TrackIdList tracksIds = args.arg<TrackIdList>(0);
 
+    const auto prj = globalContext()->currentTrackeditProject();
+    if (!prj) {
+        return;
+    }
+
+    muse::remove_if(tracksIds, [&prj](const TrackId& trackId) {
+        const std::optional<Track> track = prj->track(trackId);
+        return !track.has_value() || track->type == TrackType::Label;
+    });
+
     if (tracksIds.empty()) {
         return;
     }


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/10740

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
- [ ] Test possibility of using split tool on clip header
- [ ] Split tool nor Cmd+I shortcut shouldn't work on label track at all (previously it crashed entire app)
- [ ] Check this scenario: have a clip on a track, have a range label covering same range below, put a playcursor in the middle of a clip, cmd+click on label track header (so both tracks are selected), split tracks using Cmd+I -> only audio track should be splitted
- [ ] You should be able to drag labels and make range selections on labels track when split tool is enabled
