### PR TITLE
From Pause state, the current playhead position is ignored if you then try to initiate the (lead-in) recording 11077

### DIFF
--- a/src/record/internal/au3/au3record.cpp
+++ b/src/record/internal/au3/au3record.cpp
@@ -473,8 +473,9 @@ muse::Ret Au3Record::leadInRecording()
 {
     Au3Project& project = projectRef();
 
-    // Get cursor position
-    double t1 = std::max(0.0, selectionController()->selectionStartTime().to_double());
+    // Recording always starts from the current playhead position, regardless
+    // of the playback state or where the last selection was made
+    double t1 = std::max(0.0, playbackState()->playbackPosition().to_double());
 
     // Lead-in recording at t=0 makes no sense — there's no audio to play as lead-in
     if (t1 == 0.0) {
@@ -662,6 +663,10 @@ Ret Au3Record::doRecord(Au3Project& project,
         LOGE() << "Audio IO is busy";
         return make_ret(Ret::Code::InternalError);
     }
+
+    // The engine's pause flag survives stream restarts; clear it so that a
+    // recording initiated from a paused playback state starts immediately
+    audioEngine()->pauseStream(false);
 
     // TODO: what is the meaning of the next line, do we need it?
     // projectAudioManager.SetAppending(!altAppearance);

--- a/src/record/internal/au3/au3record.cpp
+++ b/src/record/internal/au3/au3record.cpp
@@ -444,7 +444,7 @@ muse::Ret Au3Record::pause()
 muse::Ret Au3Record::resume()
 {
     if (!canStopAudioStream()) {
-        return make_ret(Err::RecordingStopError);
+        return make_ret(Err::RecordingResumeError);
     }
 
     audioEngine()->pauseStream(false);

--- a/src/record/internal/au3/au3record.cpp
+++ b/src/record/internal/au3/au3record.cpp
@@ -441,6 +441,17 @@ muse::Ret Au3Record::pause()
     return make_ok();
 }
 
+muse::Ret Au3Record::resume()
+{
+    if (!canStopAudioStream()) {
+        return make_ret(Err::RecordingStopError);
+    }
+
+    audioEngine()->pauseStream(false);
+
+    return make_ok();
+}
+
 muse::Ret Au3Record::stop()
 {
     //! NOTE: copied from ProjectAudioManager::Stop

--- a/src/record/internal/au3/au3record.h
+++ b/src/record/internal/au3/au3record.h
@@ -37,6 +37,8 @@ class Au3Record : public IRecord, public muse::async::Asyncable, public muse::Co
     muse::ContextInject<trackedit::ITrackeditInteraction> trackeditInteraction{ this };
     muse::ContextInject<au::trackedit::ISelectionController> selectionController{ this };
 
+    friend class Au3RecordTests;
+
 public:
     Au3Record(const muse::modularity::ContextPtr& ctx)
         : muse::Contextable(ctx) {}

--- a/src/record/internal/au3/au3record.h
+++ b/src/record/internal/au3/au3record.h
@@ -47,6 +47,7 @@ public:
 
     muse::Ret start() override;
     muse::Ret pause() override;
+    muse::Ret resume() override;
     muse::Ret stop() override;
     muse::Ret leadInRecording() override;
 

--- a/src/record/internal/recordcontroller.cpp
+++ b/src/record/internal/recordcontroller.cpp
@@ -108,6 +108,8 @@ void RecordController::start()
         return;
     }
 
+    stopPlaybackIfPaused();
+
     Ret ret = record()->start();
     if (!ret) {
         interactive()->error(muse::trc("record", "Recording error"), ret.text());
@@ -122,6 +124,8 @@ void RecordController::startWithNewTrack()
     IF_ASSERT_FAILED(record()) {
         return;
     }
+
+    stopPlaybackIfPaused();
 
     const int recordingChannels = std::max(1, audioDriverController()->configuration().inputChannels);
 
@@ -183,8 +187,11 @@ void RecordController::leadInRecording()
         return;
     }
 
-    // Store the recording start position and selected tracks before starting
-    m_leadInRecordingStartTime = selectionController()->selectionStartTime();
+    stopPlaybackIfPaused();
+
+    // Store the recording start position and selected tracks before starting;
+    // recording always starts from the current playhead position
+    m_leadInRecordingStartTime = globalContext()->playbackState()->playbackPosition();
     m_leadInRecordingTrackIds = selectionController()->selectedTracks();
 
     Ret ret = record()->leadInRecording();
@@ -195,6 +202,16 @@ void RecordController::leadInRecording()
     }
 
     setCurrentRecordStatus(RecordStatus::LeadIn);
+}
+
+void RecordController::stopPlaybackIfPaused()
+{
+    //! NOTE: recording from a paused playback state must start immediately from
+    //! the playhead; stop playback first so that the paused stream is released
+    //! and the engine pause flag is cleared
+    if (playbackController()->isPaused()) {
+        playbackController()->stop();
+    }
 }
 
 void RecordController::toggleMicMetering()

--- a/src/record/internal/recordcontroller.cpp
+++ b/src/record/internal/recordcontroller.cpp
@@ -86,7 +86,9 @@ Notification RecordController::isRecordingChanged() const
 
 void RecordController::toggleRecord()
 {
-    if (isRecording()) {
+    if (m_currentRecordStatus == RecordStatus::Paused) {
+        resume();
+    } else if (isRecording()) {
         stop();
     } else {
         start();
@@ -157,6 +159,11 @@ void RecordController::pause()
         return;
     }
 
+    if (m_currentRecordStatus == RecordStatus::Paused) {
+        resume();
+        return;
+    }
+
     Ret ret = record()->pause();
     if (!ret) {
         interactive()->error(muse::trc("record", "Recording error"), ret.text());
@@ -164,6 +171,21 @@ void RecordController::pause()
     }
 
     setCurrentRecordStatus(RecordStatus::Paused);
+}
+
+void RecordController::resume()
+{
+    IF_ASSERT_FAILED(record()) {
+        return;
+    }
+
+    Ret ret = record()->resume();
+    if (!ret) {
+        interactive()->error(muse::trc("record", "Recording error"), ret.text());
+        return;
+    }
+
+    setCurrentRecordStatus(RecordStatus::Running);
 }
 
 void RecordController::stop()

--- a/src/record/internal/recordcontroller.h
+++ b/src/record/internal/recordcontroller.h
@@ -84,6 +84,7 @@ private:
     void start();
     void startWithNewTrack();
     void pause();
+    void resume();
     void stop();
     void leadInRecording();
     void stopPlaybackIfPaused();

--- a/src/record/internal/recordcontroller.h
+++ b/src/record/internal/recordcontroller.h
@@ -39,6 +39,8 @@ class RecordController : public IRecordController, public muse::actions::Actiona
     muse::ContextInject<trackedit::ITrackeditInteraction> trackeditInteraction{ this };
     muse::ContextInject<trackedit::ITrackNavigationController> trackNavigationController{ this };
 
+    friend class RecordControllerTests;
+
 public:
     RecordController(const muse::modularity::ContextPtr& ctx)
         : muse::Contextable(ctx) {}
@@ -84,6 +86,7 @@ private:
     void pause();
     void stop();
     void leadInRecording();
+    void stopPlaybackIfPaused();
     void toggleMicMetering();
     void toggleInputMonitoring();
 

--- a/src/record/irecord.h
+++ b/src/record/irecord.h
@@ -24,6 +24,7 @@ public:
 
     virtual muse::Ret start() = 0;
     virtual muse::Ret pause() = 0;
+    virtual muse::Ret resume() = 0;
     virtual muse::Ret stop() = 0;
     virtual muse::Ret leadInRecording() = 0;
 

--- a/src/record/recorderrors.h
+++ b/src/record/recorderrors.h
@@ -17,6 +17,7 @@ enum class Err {
 
     RecordingError,
     RecordingStopError,
+    RecordingResumeError,
     MismatchedSamplingRatesError,
     TooFewCompatibleTracksSelected,
 
@@ -34,6 +35,7 @@ inline muse::Ret make_ret(Err e)
     case Err::UnknownError: return muse::Ret(retCode);
     case Err::RecordingError: return muse::Ret(retCode, muse::trc("record", "Error opening recording device.\nError code: %1"));
     case Err::RecordingStopError: return muse::Ret(retCode, muse::trc("record", "Cannot stop recording"));
+    case Err::RecordingResumeError: return muse::Ret(retCode, muse::trc("record", "Cannot resume recording"));
     case Err::MismatchedSamplingRatesError: return muse::Ret(retCode,
                                                              muse::trc("record",
                                                                        "The tracks selected for recording must all have the same sampling rate"));

--- a/src/record/tests/CMakeLists.txt
+++ b/src/record/tests/CMakeLists.txt
@@ -5,11 +5,26 @@
 set(MODULE_TEST record_tests)
 
 set(MODULE_TEST_SRC
+    ${CMAKE_CURRENT_LIST_DIR}/environment.cpp
+
+    ${CMAKE_CURRENT_LIST_DIR}/../../au3audio/tests/mocks/audioenginemock.h
+    ${CMAKE_CURRENT_LIST_DIR}/mocks/recordconfigurationmock.h
     ${CMAKE_CURRENT_LIST_DIR}/mocks/recordcontrollermock.h
+    ${CMAKE_CURRENT_LIST_DIR}/mocks/recordmock.h
+
+    ${CMAKE_CURRENT_LIST_DIR}/recordcontroller_tests.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/au3record_tests.cpp
+    )
+
+set(MODULE_TEST_INCLUDE
+    ${CMAKE_CURRENT_LIST_DIR}/..
     )
 
 set(MODULE_TEST_LINK
     record
+    au3wrap
+
+    muse::ui
     )
 
 set(MODULE_TEST_DATA_ROOT ${CMAKE_CURRENT_LIST_DIR})

--- a/src/record/tests/au3record_tests.cpp
+++ b/src/record/tests/au3record_tests.cpp
@@ -89,11 +89,15 @@ public:
 
     void TearDown() override
     {
-        PendingTracks::Get(projectRef()).ClearPendingTracks();
-        Au3TrackList::Get(projectRef()).Clear();
+        // Guard against a fatal failure during setup leaving the project
+        // uninitialized; projectRef() would otherwise dereference a null pointer
+        if (m_au3ProjectAccessor && m_au3ProjectAccessor->au3ProjectPtr()) {
+            PendingTracks::Get(projectRef()).ClearPendingTracks();
+            Au3TrackList::Get(projectRef()).Clear();
 
-        m_au3ProjectAccessor->clearSavedState();
-        m_au3ProjectAccessor->close();
+            m_au3ProjectAccessor->clearSavedState();
+            m_au3ProjectAccessor->close();
+        }
 
         testtools::removeProjectIfExists(m_workingProjectPath);
     }

--- a/src/record/tests/au3record_tests.cpp
+++ b/src/record/tests/au3record_tests.cpp
@@ -1,0 +1,227 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+#include <cfloat>
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include "../internal/au3/au3record.h"
+
+#include "actions/tests/mocks/actionsdispatchermock.h"
+#include "context/tests/mocks/globalcontextmock.h"
+#include "context/tests/mocks/playbackstatemock.h"
+#include "project/tests/mocks/audacityprojectmock.h"
+#include "project/tests/testtools.h"
+#include "trackedit/tests/mocks/selectioncontrollermock.h"
+#include "trackedit/tests/mocks/trackeditprojectmock.h"
+
+#include "au3audio/tests/mocks/audioenginemock.h"
+#include "mocks/recordconfigurationmock.h"
+
+#include "au3wrap/internal/au3project.h"
+#include "au3wrap/au3types.h"
+
+#include "au3-track/PendingTracks.h"
+#include "au3-wave-track/WaveTrack.h"
+
+using ::testing::_;
+using ::testing::DoAll;
+using ::testing::InSequence;
+using ::testing::Invoke;
+using ::testing::NiceMock;
+using ::testing::Return;
+using ::testing::SaveArg;
+using ::testing::Truly;
+
+using namespace au::au3;
+
+namespace au::record {
+constexpr static double TEST_SAMPLE_RATE = 44100.0;
+
+class Au3RecordTests : public ::testing::Test
+{
+public:
+    void SetUp() override
+    {
+        m_record = std::make_shared<Au3Record>(muse::modularity::globalCtx());
+
+        m_globalContext = std::make_shared<NiceMock<context::GlobalContextMock> >();
+        m_dispatcher = std::make_shared<NiceMock<muse::actions::ActionsDispatcherMock> >();
+        m_selectionController = std::make_shared<NiceMock<trackedit::SelectionControllerMock> >();
+        m_playbackState = std::make_shared<NiceMock<context::PlaybackStateMock> >();
+        m_audioEngine = std::make_shared<NiceMock<audio::AudioEngineMock> >();
+        m_recordConfiguration = std::make_shared<NiceMock<RecordConfigurationMock> >();
+        m_trackeditProject = std::make_shared<NiceMock<trackedit::TrackeditProjectMock> >();
+        m_currentProject = std::make_shared<NiceMock<project::AudacityProjectMock> >();
+
+        m_record->globalContext.set(m_globalContext);
+        m_record->dispatcher.set(m_dispatcher);
+        m_record->selectionController.set(m_selectionController);
+        m_record->audioEngine.set(m_audioEngine);
+        m_record->recordConfiguration.set(m_recordConfiguration);
+
+        ON_CALL(*m_globalContext, currentProject())
+        .WillByDefault(Return(m_currentProject));
+        ON_CALL(*m_globalContext, playbackState())
+        .WillByDefault(Return(m_playbackState));
+        ON_CALL(*m_globalContext, currentTrackeditProject())
+        .WillByDefault(Return(m_trackeditProject));
+
+        ON_CALL(*m_audioEngine, isBusy())
+        .WillByDefault(Invoke([this]() { return m_engineBusy; }));
+        ON_CALL(*m_audioEngine, isCapturing())
+        .WillByDefault(Return(false));
+        ON_CALL(*m_audioEngine, stopStream())
+        .WillByDefault(Invoke([this]() { m_engineBusy = false; }));
+        ON_CALL(*m_audioEngine, recordingClipChanged())
+        .WillByDefault(Return(m_recordingClipChanged));
+        ON_CALL(*m_audioEngine, startStream(_, _, _, _, _, _))
+        .WillByDefault(Return(1));
+
+        ON_CALL(*m_recordConfiguration, leadInTimeDuration())
+        .WillByDefault(Return(2.0));
+        ON_CALL(*m_recordConfiguration, crossfadeDuration())
+        .WillByDefault(Return(0.0));
+
+        initTestProject();
+    }
+
+    void TearDown() override
+    {
+        PendingTracks::Get(projectRef()).ClearPendingTracks();
+        Au3TrackList::Get(projectRef()).Clear();
+
+        m_au3ProjectAccessor->clearSavedState();
+        m_au3ProjectAccessor->close();
+
+        testtools::removeProjectIfExists(m_workingProjectPath);
+    }
+
+    void initTestProject()
+    {
+        m_au3ProjectAccessor = std::make_shared<Au3ProjectAccessor>(muse::modularity::globalCtx());
+
+        // Load a working copy of the empty-project fixture shared with the trackedit tests
+        const std::string source = std::string(record_tests_DATA_ROOT) + "/../../trackedit/tests/data/empty.aup4";
+        m_workingProjectPath = std::string(record_tests_DATA_ROOT) + "/empty_working.aup4";
+        testtools::removeProjectIfExists(m_workingProjectPath);
+        ASSERT_TRUE(testtools::copyFile(source, m_workingProjectPath));
+
+        constexpr auto discardAutosave = false;
+        muse::Ret ret = m_au3ProjectAccessor->load(muse::io::path_t(m_workingProjectPath), discardAutosave);
+        ASSERT_TRUE(ret);
+
+        ON_CALL(*m_currentProject, au3ProjectPtr())
+        .WillByDefault(Return(m_au3ProjectAccessor->au3ProjectPtr()));
+    }
+
+    Au3Project& projectRef() const
+    {
+        return *reinterpret_cast<Au3Project*>(m_au3ProjectAccessor->au3ProjectPtr());
+    }
+
+    Au3WaveTrack* addSelectedMonoTrack()
+    {
+        auto& trackFactory = Au3WaveTrackFactory::Get(projectRef());
+        auto track = trackFactory.Create(sampleFormat::floatSample, TEST_SAMPLE_RATE);
+        Au3TrackList::Get(projectRef()).Add(track, ::TrackList::DoAssignId::Yes,
+                                            ::TrackList::EventPublicationSynchrony::Synchronous);
+        track->SetSelected(true);
+        return track.get();
+    }
+
+    std::shared_ptr<Au3Record> m_record;
+
+    std::shared_ptr<context::GlobalContextMock> m_globalContext;
+    std::shared_ptr<muse::actions::ActionsDispatcherMock> m_dispatcher;
+    std::shared_ptr<trackedit::SelectionControllerMock> m_selectionController;
+    std::shared_ptr<context::PlaybackStateMock> m_playbackState;
+    std::shared_ptr<audio::AudioEngineMock> m_audioEngine;
+    std::shared_ptr<RecordConfigurationMock> m_recordConfiguration;
+    std::shared_ptr<trackedit::TrackeditProjectMock> m_trackeditProject;
+    std::shared_ptr<project::AudacityProjectMock> m_currentProject;
+
+    std::shared_ptr<Au3ProjectAccessor> m_au3ProjectAccessor;
+    std::string m_workingProjectPath;
+
+    muse::async::Channel<Au3TrackId, Au3ClipId> m_recordingClipChanged;
+    bool m_engineBusy = false;
+};
+
+TEST_F(Au3RecordTests, LeadInRecordingStartsAtPlayheadPosition)
+{
+    //! [GIVEN] A selected track, the playhead at 8s and a stale selection start at 5s
+    //! (e.g. left behind by a previous recording)
+    addSelectedMonoTrack();
+    ON_CALL(*m_playbackState, playbackPosition())
+    .WillByDefault(Return(muse::secs_t(8.0)));
+    ON_CALL(*m_selectionController, selectionStartTime())
+    .WillByDefault(Return(trackedit::secs_t(5.0)));
+
+    double startedAt = -1.0;
+    audio::IAudioEngine::StartStreamOptions streamOptions;
+    EXPECT_CALL(*m_audioEngine, startStream(_, _, _, _, _, _))
+    .WillOnce(DoAll(SaveArg<1>(&startedAt), SaveArg<5>(&streamOptions), Return(1)));
+
+    //! [THEN] The playhead is repositioned to the start of the lead-in (8s - 2s pre-roll)
+    EXPECT_CALL(*m_dispatcher,
+                dispatch(testing::Matcher<const muse::actions::ActionQuery&>(
+                             Truly([](const muse::actions::ActionQuery& q) {
+        return q.param("seekTime").toDouble() == 6.0;
+    }))));
+
+    //! [WHEN] Lead-in recording is initiated
+    muse::Ret ret = m_record->leadInRecording();
+    EXPECT_TRUE(ret);
+
+    //! [THEN] The stream starts recording at the playhead position, not at the
+    //! stale selection start
+    EXPECT_DOUBLE_EQ(startedAt, 8.0);
+    EXPECT_DOUBLE_EQ(streamOptions.leadInTime, 2.0);
+}
+
+TEST_F(Au3RecordTests, LeadInRecordingAtZeroPlayheadFails)
+{
+    //! [GIVEN] A selected track and the playhead at 0s — there is nothing to pre-roll
+    addSelectedMonoTrack();
+    ON_CALL(*m_playbackState, playbackPosition())
+    .WillByDefault(Return(muse::secs_t(0.0)));
+
+    EXPECT_CALL(*m_audioEngine, startStream(_, _, _, _, _, _))
+    .Times(0);
+
+    //! [WHEN] Lead-in recording is initiated
+    muse::Ret ret = m_record->leadInRecording();
+
+    //! [THEN] It fails and no stream is started
+    EXPECT_FALSE(ret);
+}
+
+TEST_F(Au3RecordTests, RecordingWithBusyEngineStartsUnpausedAtPlayhead)
+{
+    //! [GIVEN] A selected track, the playhead at 8s and the engine still holding
+    //! a (possibly paused) playback stream
+    addSelectedMonoTrack();
+    m_engineBusy = true;
+    ON_CALL(*m_playbackState, playbackPosition())
+    .WillByDefault(Return(muse::secs_t(8.0)));
+
+    double startedAt = -1.0;
+
+    //! [THEN] The old stream is stopped, the engine pause flag (which survives
+    //! stream restarts) is cleared, and only then recording starts
+    InSequence seq;
+    EXPECT_CALL(*m_audioEngine, stopStream());
+    EXPECT_CALL(*m_audioEngine, pauseStream(false));
+    EXPECT_CALL(*m_audioEngine, startStream(_, _, _, _, _, _))
+    .WillOnce(DoAll(SaveArg<1>(&startedAt), Return(1)));
+
+    //! [WHEN] Recording is initiated
+    muse::Ret ret = m_record->start();
+    EXPECT_TRUE(ret);
+
+    //! [THEN] Recording starts at the playhead position
+    EXPECT_DOUBLE_EQ(startedAt, 8.0);
+}
+}

--- a/src/record/tests/environment.cpp
+++ b/src/record/tests/environment.cpp
@@ -1,0 +1,59 @@
+/*
+* Audacity: A Digital Audio Editor
+*/
+
+#include "testing/environment.h"
+
+#include "au3wrap/au3wrapmodule.h"
+
+#include "projectscene/tests/mocks/projectsceneconfigurationmock.h"
+#include "project/tests/mocks/projectconfigurationmock.h"
+
+using namespace ::testing;
+using namespace au::projectscene;
+using namespace au::project;
+
+static muse::testing::SuiteEnvironment record_se
+    = muse::testing::SuiteEnvironment()
+      .setDependencyModules({ new au::au3::Au3WrapModule(), })
+      .setPostInit([]() {
+    std::shared_ptr<NiceMock<ProjectSceneConfigurationMock> > projectSceneConfigurator(new NiceMock<ProjectSceneConfigurationMock>(),
+                                                                                       [](ProjectSceneConfigurationMock*) {}); // no delete
+
+    static std::vector<ClipColorInfo> colorInfos = {
+        { "blue", 1 },
+        { "red", 2 },
+    };
+
+    ON_CALL(*projectSceneConfigurator, clipColorInfos())
+    .WillByDefault(ReturnRef(colorInfos));
+
+    muse::modularity::globalIoc()->unregister<IProjectSceneConfiguration>("utests");
+    muse::modularity::globalIoc()->registerExport<IProjectSceneConfiguration>("utests", projectSceneConfigurator);
+}).setPreInit([](){
+    std::shared_ptr<NiceMock<ProjectConfigurationMock> > projectConfigurator(new NiceMock<ProjectConfigurationMock>(),
+                                                                             [](ProjectConfigurationMock*){});
+
+    ON_CALL(*projectConfigurator, temporaryDir())
+    .WillByDefault(Return(""));
+
+    muse::modularity::globalIoc()->registerExport<IProjectConfiguration>("utests", projectConfigurator);
+}).setDeInit([](){
+    std::shared_ptr<IProjectSceneConfiguration> projectSceneConfiguratorPtr
+        = muse::modularity::globalIoc()->resolve<IProjectSceneConfiguration>("utests");
+    muse::modularity::globalIoc()->unregister<IProjectSceneConfiguration>("utests");
+
+    std::shared_ptr<IProjectConfiguration> projectConfiguratorPtr
+        = muse::modularity::globalIoc()->resolve<IProjectConfiguration>("utests");
+    muse::modularity::globalIoc()->unregister<IProjectConfiguration>("utests");
+
+    //! HACK
+    //! There are still live pointers to the projectSceneConfiguratorPtr
+    //! because of this, the projectSceneConfiguratorPtr generates an error stating that it has not been deleted
+    //! This is a hack to remove it manually to get rid of this error
+    IProjectSceneConfiguration* projectSceneConfigurator = projectSceneConfiguratorPtr.get();
+    delete projectSceneConfigurator;
+
+    IProjectConfiguration* projectConfigurator = projectConfiguratorPtr.get();
+    delete projectConfigurator;
+});

--- a/src/record/tests/mocks/recordconfigurationmock.h
+++ b/src/record/tests/mocks/recordconfigurationmock.h
@@ -1,0 +1,30 @@
+/*
+* Audacity: A Digital Audio Editor
+*/
+#pragma once
+
+#include <gmock/gmock.h>
+
+#include "record/irecordconfiguration.h"
+
+namespace au::record {
+class RecordConfigurationMock : public IRecordConfiguration
+{
+public:
+    MOCK_METHOD(bool, isMicMeteringOn, (), (const, override));
+    MOCK_METHOD(void, setIsMicMeteringOn, (bool), (override));
+    MOCK_METHOD(muse::async::Notification, isMicMeteringOnChanged, (), (const, override));
+
+    MOCK_METHOD(bool, isInputMonitoringOn, (), (const, override));
+    MOCK_METHOD(void, setIsInputMonitoringOn, (bool), (override));
+    MOCK_METHOD(muse::async::Notification, isInputMonitoringOnChanged, (), (const, override));
+
+    MOCK_METHOD(double, leadInTimeDuration, (), (const, override));
+    MOCK_METHOD(void, setLeadInTimeDuration, (double), (override));
+    MOCK_METHOD(muse::async::Notification, leadInTimeDurationChanged, (), (const, override));
+
+    MOCK_METHOD(double, crossfadeDuration, (), (const, override));
+    MOCK_METHOD(void, setCrossfadeDuration, (double), (override));
+    MOCK_METHOD(muse::async::Notification, crossfadeDurationChanged, (), (const, override));
+};
+}

--- a/src/record/tests/mocks/recordmock.h
+++ b/src/record/tests/mocks/recordmock.h
@@ -13,6 +13,7 @@ class RecordMock : public IRecord
 public:
     MOCK_METHOD(muse::Ret, start, (), (override));
     MOCK_METHOD(muse::Ret, pause, (), (override));
+    MOCK_METHOD(muse::Ret, resume, (), (override));
     MOCK_METHOD(muse::Ret, stop, (), (override));
     MOCK_METHOD(muse::Ret, leadInRecording, (), (override));
 

--- a/src/record/tests/recordcontroller_tests.cpp
+++ b/src/record/tests/recordcontroller_tests.cpp
@@ -1,0 +1,123 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include "../internal/recordcontroller.h"
+
+#include "context/tests/mocks/globalcontextmock.h"
+#include "context/tests/mocks/playbackstatemock.h"
+#include "playback/tests/mocks/playbackcontrollermock.h"
+#include "trackedit/tests/mocks/selectioncontrollermock.h"
+#include "interactive/tests/mocks/interactivemock.h"
+
+#include "mocks/recordmock.h"
+
+using ::testing::_;
+using ::testing::InSequence;
+using ::testing::NiceMock;
+using ::testing::Return;
+
+namespace au::record {
+class RecordControllerTests : public ::testing::Test
+{
+public:
+    void SetUp() override
+    {
+        m_controller = std::make_shared<RecordController>(muse::modularity::globalCtx());
+
+        m_globalContext = std::make_shared<NiceMock<context::GlobalContextMock> >();
+        m_playbackState = std::make_shared<NiceMock<context::PlaybackStateMock> >();
+        m_playbackController = std::make_shared<NiceMock<playback::PlaybackControllerMock> >();
+        m_selectionController = std::make_shared<NiceMock<trackedit::SelectionControllerMock> >();
+        m_interactive = std::make_shared<NiceMock<muse::InteractiveMock> >();
+        m_record = std::make_shared<NiceMock<RecordMock> >();
+
+        m_controller->globalContext.set(m_globalContext);
+        m_controller->playbackController.set(m_playbackController);
+        m_controller->selectionController.set(m_selectionController);
+        m_controller->interactive.set(m_interactive);
+        m_controller->record.set(m_record);
+
+        ON_CALL(*m_globalContext, playbackState())
+        .WillByDefault(Return(m_playbackState));
+
+        ON_CALL(*m_record, start())
+        .WillByDefault(Return(muse::make_ok()));
+        ON_CALL(*m_record, leadInRecording())
+        .WillByDefault(Return(muse::make_ok()));
+    }
+
+    // The controller's action handlers are private; tests reach them through
+    // the fixture's friendship
+    void leadInRecording()
+    {
+        m_controller->leadInRecording();
+    }
+
+    void toggleRecord()
+    {
+        m_controller->toggleRecord();
+    }
+
+    std::shared_ptr<RecordController> m_controller;
+
+    std::shared_ptr<context::GlobalContextMock> m_globalContext;
+    std::shared_ptr<context::PlaybackStateMock> m_playbackState;
+    std::shared_ptr<playback::PlaybackControllerMock> m_playbackController;
+    std::shared_ptr<trackedit::SelectionControllerMock> m_selectionController;
+    std::shared_ptr<muse::InteractiveMock> m_interactive;
+    std::shared_ptr<RecordMock> m_record;
+};
+
+TEST_F(RecordControllerTests, LeadInRecordingStartsFromPlayheadNotSelectionStart)
+{
+    //! [GIVEN] The playhead is at 8s while the last selection (e.g. from a previous
+    //! recording) started at 5s
+    ON_CALL(*m_playbackState, playbackPosition())
+    .WillByDefault(Return(muse::secs_t(8.0)));
+    ON_CALL(*m_selectionController, selectionStartTime())
+    .WillByDefault(Return(trackedit::secs_t(5.0)));
+
+    //! [WHEN] Lead-in recording is initiated
+    leadInRecording();
+
+    //! [THEN] The recording start position is the current playhead position
+    EXPECT_DOUBLE_EQ(m_controller->leadInRecordingStartTime().to_double(), 8.0);
+}
+
+TEST_F(RecordControllerTests, LeadInRecordingFromPausedPlaybackStopsPlaybackFirst)
+{
+    //! [GIVEN] Playback is paused
+    ON_CALL(*m_playbackController, isPaused())
+    .WillByDefault(Return(true));
+
+    //! [THEN] Playback is stopped before the lead-in recording starts, so that
+    //! recording begins immediately (a paused engine would otherwise stay paused)
+    InSequence seq;
+    EXPECT_CALL(*m_playbackController, stop());
+    EXPECT_CALL(*m_record, leadInRecording())
+    .WillOnce(Return(muse::make_ok()));
+
+    //! [WHEN] Lead-in recording is initiated
+    leadInRecording();
+}
+
+TEST_F(RecordControllerTests, RecordFromPausedPlaybackStopsPlaybackFirst)
+{
+    //! [GIVEN] Playback is paused
+    ON_CALL(*m_playbackController, isPaused())
+    .WillByDefault(Return(true));
+
+    //! [THEN] Playback is stopped before recording starts, so that recording
+    //! begins immediately from the current playhead position
+    InSequence seq;
+    EXPECT_CALL(*m_playbackController, stop());
+    EXPECT_CALL(*m_record, start())
+    .WillOnce(Return(muse::make_ok()));
+
+    //! [WHEN] Recording is initiated
+    toggleRecord();
+}
+}

--- a/src/record/tests/recordcontroller_tests.cpp
+++ b/src/record/tests/recordcontroller_tests.cpp
@@ -120,4 +120,20 @@ TEST_F(RecordControllerTests, RecordFromPausedPlaybackStopsPlaybackFirst)
     //! [WHEN] Recording is initiated
     toggleRecord();
 }
+
+TEST_F(RecordControllerTests, RecordFromStoppedPlaybackDoesNotStopPlayback)
+{
+    //! [GIVEN] Playback is already stopped
+    ON_CALL(*m_playbackController, isPaused())
+    .WillByDefault(Return(false));
+
+    //! [THEN] Playback is not stopped before recording starts
+    EXPECT_CALL(*m_playbackController, stop())
+    .Times(0);
+    EXPECT_CALL(*m_record, start())
+    .WillOnce(Return(muse::make_ok()));
+
+    //! [WHEN] Recording is initiated
+    toggleRecord();
+}
 }

--- a/src/record/tests/recordcontroller_tests.cpp
+++ b/src/record/tests/recordcontroller_tests.cpp
@@ -61,6 +61,16 @@ public:
         m_controller->toggleRecord();
     }
 
+    void pause()
+    {
+        m_controller->pause();
+    }
+
+    bool recordStatusIsRunning() const
+    {
+        return m_controller->m_currentRecordStatus == RecordController::RecordStatus::Running;
+    }
+
     std::shared_ptr<RecordController> m_controller;
 
     std::shared_ptr<context::GlobalContextMock> m_globalContext;
@@ -135,5 +145,47 @@ TEST_F(RecordControllerTests, RecordFromStoppedPlaybackDoesNotStopPlayback)
 
     //! [WHEN] Recording is initiated
     toggleRecord();
+}
+
+TEST_F(RecordControllerTests, ToggleRecordWhilePausedResumesRecording)
+{
+    //! [GIVEN] A recording is running and has been paused
+    ON_CALL(*m_record, pause())
+    .WillByDefault(Return(muse::make_ok()));
+    toggleRecord();
+    pause();
+
+    //! [THEN] The recording is resumed, not stopped
+    EXPECT_CALL(*m_record, resume())
+    .WillOnce(Return(muse::make_ok()));
+    EXPECT_CALL(*m_record, stop())
+    .Times(0);
+
+    //! [WHEN] Record is triggered again
+    toggleRecord();
+
+    //! [THEN] The recording is running again
+    EXPECT_TRUE(recordStatusIsRunning());
+}
+
+TEST_F(RecordControllerTests, PauseWhilePausedResumesRecording)
+{
+    //! [GIVEN] A recording is running and has been paused
+    ON_CALL(*m_record, pause())
+    .WillByDefault(Return(muse::make_ok()));
+    toggleRecord();
+    pause();
+
+    //! [THEN] The recording is resumed rather than paused again
+    EXPECT_CALL(*m_record, resume())
+    .WillOnce(Return(muse::make_ok()));
+    EXPECT_CALL(*m_record, pause())
+    .Times(0);
+
+    //! [WHEN] Pause is triggered again
+    pause();
+
+    //! [THEN] The recording is running again
+    EXPECT_TRUE(recordStatusIsRunning());
 }
 }


### PR DESCRIPTION
Resolves: From Pause state, the current playhead position is ignored if you then try to initiate the (lead-in) recording https://github.com/audacity/audacity/issues/11077

also resolves https://github.com/audacity/audacity/issues/10139 

Start recording from playhead position regardless of playback state

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [ ] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
- [x] initiate lead-in recording from paused state -> recording should start at current playcursor position

Check if recording is initiated correctly on those cases:
- [x] toggle play -> pause -> toggle record
- [x] toggle record -> pause -> toggle record
- [x] toggle record -> pause -> pause again
