### PR TITLE
Suppress programmatically setting playhead position on drag operations 11176

### DIFF
--- a/au3/libraries/au3-audio-io/PlaybackSchedule.h
+++ b/au3/libraries/au3-audio-io/PlaybackSchedule.h
@@ -24,7 +24,7 @@ struct AudioIOStartStreamOptions;
 class BoundedEnvelope;
 using PRCrossfadeData = std::vector< std::vector < float > >;
 
-// This can become a bottleneck to the update rate of the play cursor position.
+// This can become a bottleneck to the update rate of the playhead position.
 // Let's set this to 10ms at 48kHz. Even at 16kHz, that'd be a refresh rate of 33fps.
 constexpr size_t TimeQueueGrainSize = 480;
 
@@ -106,7 +106,7 @@ public:
     virtual bool Done(PlaybackSchedule& schedule, unsigned long outputFrames //!< how many playback frames were taken from RingBuffers
                       );
 
-    //! Called when the play head needs to jump a certain distance
+    //! Called when the playhead needs to jump a certain distance
     /*! @param offset signed amount requested to be added to schedule::GetSequenceTime()
        @return the new value that will be set as the schedule's track time
      */
@@ -200,7 +200,7 @@ struct AUDIO_IO_API PlaybackSchedule {
 
      The consumer thread uses that information, and also makes known to the main
      thread, what the last consumed track time is.  The main thread can use that
-     for other purposes such as refreshing the display of the play head position.
+     for other purposes such as refreshing the display of the playhead position.
      */
     class AUDIO_IO_API TimeQueue
     {

--- a/au3/src/AdornedRulerPanel.cpp
+++ b/au3/src/AdornedRulerPanel.cpp
@@ -929,7 +929,7 @@ double GetPlayHeadFraction(const AudacityProject* pProject, wxCoord xx)
     return std::max(0.0, std::min(1.0, fraction));
 }
 
-// Handle for dragging the pinned play head, which so far does not need
+// Handle for dragging the pinned playhead, which so far does not need
 // to be a friend of the AdornedRulerPanel class, so we don't make it nested.
 class PlayheadHandle : public UIHandle
 {
@@ -1083,7 +1083,7 @@ std::vector<UIHandlePtr> AdornedRulerPanel::QPCell::HitTest(
     auto xx = state.state.m_x;
 
     {
-        // Allow click and drag on the play head even while recording
+        // Allow click and drag on the playhead even while recording
         // Make this handle more prominent then the quick play handle
         auto result = PlayheadHandle::HitTest(pProject, *mParent, xx);
         if (result) {

--- a/au3/src/ProjectAudioManager.cpp
+++ b/au3/src/ProjectAudioManager.cpp
@@ -1277,7 +1277,7 @@ bool ProjectAudioManager::DoPlayStopSelect(bool click, bool shift)
         if (click && (scrubber.WasSpeedPlaying() || scrubber.WasKeyboardScrubbing())) {
             // don't change the selection.
         } else if (shift && click) {
-            // Change the region selection, as if by shift-click at the play head
+            // Change the region selection, as if by shift-click at the playhead
             auto t0 = selection.t0(), t1 = selection.t1();
             if (time < t0) {
                 // Grow selection
@@ -1297,7 +1297,7 @@ bool ProjectAudioManager::DoPlayStopSelect(bool click, bool shift)
         } else if (click) {
             // avoid a point at negative time.
             time = wxMax(time, 0);
-            // Set a point selection, as if by a click at the play head
+            // Set a point selection, as if by a click at the playhead
             selection.setTimes(time, time);
         } else {
             // How stop and set cursor always worked

--- a/au3/src/menus/SelectMenus.cpp
+++ b/au3/src/menus/SelectMenus.cpp
@@ -305,7 +305,7 @@ void SeekWhenAudioInactive
     viewport.ScrollIntoView(newT);
 }
 
-// Handle small cursor and play head movements
+// Handle small cursor and playhead movements
 void SeekLeftOrRight
     (AudacityProject& project, double direction, SelectionOperation operation,
     SeekInfo& info)

--- a/au3/src/tracks/ui/PlayIndicatorOverlay.cpp
+++ b/au3/src/tracks/ui/PlayIndicatorOverlay.cpp
@@ -182,7 +182,7 @@ void PlayIndicatorOverlay::OnTimer(Observer::Message)
         const Mode mode = scroller.GetMode();
         const bool pinned = (mode == Mode::Pinned || mode == Mode::Right);
 
-        // Use a small tolerance to avoid flicker of play head pinned all the way
+        // Use a small tolerance to avoid flicker of playhead pinned all the way
         // left or right
         const auto tolerance = pinned
                                ? 1.5 * std::chrono::duration<double> { kTimerInterval }.count()

--- a/au3/src/tracks/ui/Scrubbing.cpp
+++ b/au3/src/tracks/ui/Scrubbing.cpp
@@ -37,7 +37,7 @@ Paul Licameli split from TrackPanel.cpp
 #include <wx/timer.h>
 
 // Yet another experimental scrub would drag the track under a
-// stationary play head
+// stationary playhead
 #undef DRAG_SCRUB
 
 enum {
@@ -171,7 +171,7 @@ void Scrubber::ScrubPoller::Notify()
 {
     // Call Continue functions here in a timer handler
     // rather than in SelectionHandleDrag()
-    // so that even without drag events, we can instruct the play head to
+    // so that even without drag events, we can instruct the playhead to
     // keep approaching the mouse cursor, when its maximum speed is limited.
 
 #ifndef USE_SCRUB_THREAD

--- a/src/au3audio/internal/defaultplaybackpolicy.cpp
+++ b/src/au3audio/internal/defaultplaybackpolicy.cpp
@@ -197,7 +197,7 @@ bool DefaultPlaybackPolicy::RepositionPlayback(
     constexpr auto allowance = 0.5;
 
     // Looping may become enabled if the main thread said so, but require too
-    // that the loop region is non-empty and the play head is not far to its
+    // that the loop region is non-empty and the playhead is not far to its
     // right
     bool loopWasEnabled = !RevertToOldDefault(schedule);
     mLoopEnabled = data.mLoopEnabled && !empty
@@ -234,7 +234,7 @@ bool DefaultPlaybackPolicy::RepositionPlayback(
             newTime = schedule.mT0;
         }
 
-        // So that the play head will redraw in the right place:
+        // So that the playhead will redraw in the right place:
         schedule.mTimeQueue.SetLastTime(newTime);
 
         schedule.RealTimeInit(newTime);

--- a/src/playback/tests/mocks/playbackcontrollermock.h
+++ b/src/playback/tests/mocks/playbackcontrollermock.h
@@ -1,0 +1,58 @@
+/*
+* Audacity: A Digital Audio Editor
+*/
+#pragma once
+
+#include <gmock/gmock.h>
+
+#include "playback/iplaybackcontroller.h"
+
+namespace au::playback {
+class PlaybackControllerMock : public IPlaybackController
+{
+public:
+    MOCK_METHOD(bool, isPlayAllowed, (), (const, override));
+    MOCK_METHOD(muse::async::Notification, isPlayAllowedChanged, (), (const, override));
+
+    MOCK_METHOD(bool, isPlaying, (), (const, override));
+    MOCK_METHOD(muse::async::Notification, isPlayingChanged, (), (const, override));
+    MOCK_METHOD(PlaybackStatus, playbackStatus, (), (const, override));
+
+    MOCK_METHOD(PlaybackRegion, loopRegion, (), (const, override));
+    MOCK_METHOD(void, loopEditingBegin, (), (override));
+    MOCK_METHOD(void, loopEditingEnd, (), (override));
+    MOCK_METHOD(void, setLoopRegion, (const PlaybackRegion&), (override));
+    MOCK_METHOD(void, setLoopRegionStart, (const muse::secs_t), (override));
+    MOCK_METHOD(void, setLoopRegionEnd, (const muse::secs_t), (override));
+    MOCK_METHOD(void, clearLoopRegion, (), (override));
+    MOCK_METHOD(bool, isLoopRegionClear, (), (const, override));
+    MOCK_METHOD(muse::async::Notification, loopRegionChanged, (), (const, override));
+
+    MOCK_METHOD(bool, isLoopRegionActive, (), (const, override));
+    MOCK_METHOD(void, setLoopRegionActive, (const bool), (override));
+    MOCK_METHOD(void, toggleLoopPlayback, (), (override));
+
+    MOCK_METHOD(bool, isPaused, (), (const, override));
+    MOCK_METHOD(bool, isStopped, (), (const, override));
+
+    MOCK_METHOD(void, stop, (), (override));
+    MOCK_METHOD(void, stopSeekAndUpdatePlaybackRegion, (), (override));
+
+    MOCK_METHOD(muse::async::Channel<uint32_t>, midiTickPlayed, (), (const, override));
+
+    MOCK_METHOD(muse::async::Channel<playback::TrackId>, trackAdded, (), (const, override));
+    MOCK_METHOD(muse::async::Channel<playback::TrackId>, trackRemoved, (), (const, override));
+
+    MOCK_METHOD(bool, actionChecked, (const muse::actions::ActionCode&), (const, override));
+    MOCK_METHOD(muse::async::Channel<muse::actions::ActionCode>, actionCheckedChanged, (), (const, override));
+
+    MOCK_METHOD(muse::secs_t, totalPlayTime, (), (const, override));
+    MOCK_METHOD(muse::async::Notification, totalPlayTimeChanged, (), (const, override));
+
+    MOCK_METHOD(muse::secs_t, lastPlaybackSeekTime, (), (const, override));
+    MOCK_METHOD(void, setLastPlaybackSeekTime, (muse::secs_t), (override));
+    MOCK_METHOD(muse::async::Notification, lastPlaybackSeekTimeChanged, (), (const, override));
+
+    MOCK_METHOD(muse::Progress, loadingProgress, (), (const, override));
+};
+}

--- a/src/projectscene/internal/projectsceneuiactions.cpp
+++ b/src/projectscene/internal/projectsceneuiactions.cpp
@@ -219,6 +219,18 @@ static UiActionList STATIC_ACTIONS = {
              TranslatableString("action", "Contract selection from right"),
              TranslatableString("action", "Contract selection from right")
              ),
+    UiAction("curs-sel-start",
+             au::context::UiCtxProjectOpened,
+             muse::shortcuts::CTX_PROJECT_OPENED,
+             TranslatableString("action", "Move play cursor to selection start"),
+             TranslatableString("action", "Move play cursor to selection start")
+             ),
+    UiAction("curs-sel-end",
+             au::context::UiCtxProjectOpened,
+             muse::shortcuts::CTX_PROJECT_OPENED,
+             TranslatableString("action", "Move play cursor to selection end"),
+             TranslatableString("action", "Move play cursor to selection end")
+             ),
     UiAction("clip-pitch-speed",
              au::context::UiCtxAny,
              au::context::CTX_ANY,

--- a/src/projectscene/internal/projectsceneuiactions.cpp
+++ b/src/projectscene/internal/projectsceneuiactions.cpp
@@ -143,8 +143,8 @@ static UiActionList STATIC_ACTIONS = {
     UiAction("toggle-pinned-play-head",
              au::context::UiCtxAny,
              au::context::CTX_ANY,
-             TranslatableString("action", "Pinned play head"),
-             TranslatableString("action", "Pinned play head"),
+             TranslatableString("action", "Pinned playhead"),
+             TranslatableString("action", "Pinned playhead"),
              Checkable::Yes
              ),
     UiAction("toggle-playback-on-ruler-click-enabled",
@@ -186,14 +186,14 @@ static UiActionList STATIC_ACTIONS = {
     UiAction("play-position-decrease",
              au::context::UiCtxProjectOpened,
              muse::shortcuts::CTX_PROJECT_FOCUSED,
-             TranslatableString("action", "Move play cursor left"),
-             TranslatableString("action", "Move play cursor left")
+             TranslatableString("action", "Move playhead left"),
+             TranslatableString("action", "Move playhead left")
              ),
     UiAction("play-position-increase",
              au::context::UiCtxProjectOpened,
              muse::shortcuts::CTX_PROJECT_FOCUSED,
-             TranslatableString("action", "Move play cursor right"),
-             TranslatableString("action", "Move play cursor right")
+             TranslatableString("action", "Move playhead right"),
+             TranslatableString("action", "Move playhead right")
              ),
     UiAction("sel-ext-left",
              au::context::UiCtxProjectOpened,
@@ -222,14 +222,14 @@ static UiActionList STATIC_ACTIONS = {
     UiAction("curs-sel-start",
              au::context::UiCtxProjectOpened,
              muse::shortcuts::CTX_PROJECT_OPENED,
-             TranslatableString("action", "Move play cursor to selection start"),
-             TranslatableString("action", "Move play cursor to selection start")
+             TranslatableString("action", "Move playhead to selection start"),
+             TranslatableString("action", "Move playhead to selection start")
              ),
     UiAction("curs-sel-end",
              au::context::UiCtxProjectOpened,
              muse::shortcuts::CTX_PROJECT_OPENED,
-             TranslatableString("action", "Move play cursor to selection end"),
-             TranslatableString("action", "Move play cursor to selection end")
+             TranslatableString("action", "Move playhead to selection end"),
+             TranslatableString("action", "Move playhead to selection end")
              ),
     UiAction("clip-pitch-speed",
              au::context::UiCtxAny,

--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TrackClipsContainer.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TrackClipsContainer.qml
@@ -661,9 +661,6 @@ TrackItemsContainer {
 
                 onSelectionResize: function (x1, x2, completed) {
                     root.selectionResize(x1, x2, completed)
-                    if (completed) {
-                        root.seekToX(Math.min(x1, x2))
-                    }
                 }
 
                 onRequestSelectionContextMenu: function (x, y) {
@@ -707,9 +704,6 @@ TrackItemsContainer {
 
                 onSelectionHorizontalResize: function (x1, x2, completed) {
                     root.selectionResize(x1, x2, completed)
-                    if (completed) {
-                        root.seekToX(Math.min(x1, x2))
-                    }
                 }
 
                 onVerticalDragActiveChanged: {

--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TrackItemsContainer.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TrackItemsContainer.qml
@@ -54,7 +54,6 @@ Item {
 
     signal updateMouseMoveActive(bool completed)
 
-    signal seekToX(var x)
     signal insureVerticallyVisible
 
     signal handleTimeGuideline(real x, bool completed)

--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TrackLabelsContainer.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TrackLabelsContainer.qml
@@ -378,9 +378,6 @@ TrackItemsContainer {
 
                 onSelectionResize: function (x1, x2, completed) {
                     root.selectionResize(x1, x2, completed)
-                    if (completed) {
-                        root.seekToX(Math.min(x1, x2))
-                    }
                 }
 
                 onRequestSelectionContextMenu: function (x, y) {

--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TracksItemsView.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TracksItemsView.qml
@@ -646,15 +646,12 @@ Rectangle {
                         let releaseTime = timeline.context.positionToTime(e.x)
                         selectionViewController.onReleased(releaseTime, e.y);
 
-                        // Deferred from the press: moves the playhead only if this was a plain
-                        // click — dragging a selection must not move the playhead
-                        playCursorController.endSeekGesture()
-
-                        if (e.modifiers & (Qt.ControlModifier | Qt.ShiftModifier)) {
-                            playCursorController.seekToTime(timeline.context.selectionStartTime)
+                        // Deferred from the press. Only a plain click repositions the playhead
+                        // and the next playback start; a drag selection leaves both alone —
+                        // playback derives its region from the selection when it starts.
+                        if (playCursorController.endSeekGesture()) {
+                            playCursorController.setPlaybackRegionByTime(timeline.context.selectionStartTime, timeline.context.selectionEndTime)
                         }
-
-                        playCursorController.setPlaybackRegionByTime(timeline.context.selectionStartTime, timeline.context.selectionEndTime)
                     } else {
                         playCursorController.cancelSeekGesture()
                     }
@@ -1008,10 +1005,6 @@ Rectangle {
                                 selectionViewController.onSelectionHorizontalResize(timeline.context.positionToTime(x1), timeline.context.positionToTime(x2), completed)
                             }
 
-                            onSeekToX: function (x) {
-                                playCursorController.seekToTime(timeline.context.positionToTime(x))
-                            }
-
                             onInsureVerticallyVisible: function () {
                                 tracksItemsView.insureVerticallyVisible(this)
                             }
@@ -1176,10 +1169,6 @@ Rectangle {
                                 root.hoveredItemKey = null
                                 root.itemHeaderHovered = false
                                 tracksItemsView.mouseMoveActive = false
-                            }
-
-                            onSeekToX: function (x) {
-                                playCursorController.seekToTime(timeline.context.positionToTime(x))
                             }
 
                             onSelectionResize: function (x1, x2, completed) {

--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TracksItemsView.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TracksItemsView.qml
@@ -644,7 +644,7 @@ Rectangle {
 
                     if (selectionViewController.selectionInProgress) {
                         let releaseTime = timeline.context.positionToTime(e.x)
-                        selectionViewController.onReleased(releaseTime, e.y)
+                        selectionViewController.onReleased(releaseTime, e.y);
 
                         // Deferred from the press: moves the playhead only if this was a plain
                         // click — dragging a selection must not move the playhead

--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TracksItemsView.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TracksItemsView.qml
@@ -570,11 +570,9 @@ Rectangle {
                         const pressBelongsToSplitTool = splitToolController.active && splitToolController.trackSplittable(tracksViewState.trackAtPosition(e.x, e.y))
 
                         if (!((e.modifiers & (Qt.ControlModifier | Qt.ShiftModifier)) || pressBelongsToSplitTool)) {
-                            let time = timeline.context.positionToTime(e.x)
-                            if (playbackState.isPlaying) {
-                                playbackState.setLastPlaybackSeekTime(time)
-                            }
-                            playCursorController.seekToTime(time)
+                            // Don't move the playhead yet: the seek is deferred to the release
+                            // and dropped if this press turns into a drag
+                            playCursorController.beginSeekGesture(timeline.context.positionToTime(e.x), e.x, e.y)
                         }
 
                         if (!pressBelongsToSplitTool) {
@@ -603,6 +601,7 @@ Rectangle {
             onPositionChanged: function (e) {
                 timeline.updateCursorPosition(e.x, e.y)
                 splitToolController.mouseMove(e.x)
+                playCursorController.updateSeekGesture(e.x, e.y)
 
                 if (root.interactionState === TracksItemsView.State.DraggingItem && !itemWasMoved) {
                     var dx = Math.abs(e.x - pressStartPosition.x)
@@ -645,15 +644,19 @@ Rectangle {
 
                     if (selectionViewController.selectionInProgress) {
                         let releaseTime = timeline.context.positionToTime(e.x)
-                        if (selectionViewController.isLeftSelection(releaseTime)) {
-                            playCursorController.seekToTime(releaseTime)
-                        }
                         selectionViewController.onReleased(releaseTime, e.y)
+
+                        // Deferred from the press: moves the playhead only if this was a plain
+                        // click — dragging a selection must not move the playhead
+                        playCursorController.endSeekGesture()
+
                         if (e.modifiers & (Qt.ControlModifier | Qt.ShiftModifier)) {
                             playCursorController.seekToTime(timeline.context.selectionStartTime)
                         }
 
                         playCursorController.setPlaybackRegionByTime(timeline.context.selectionStartTime, timeline.context.selectionEndTime)
+                    } else {
+                        playCursorController.cancelSeekGesture()
                     }
 
                     itemsSelection.visible = false
@@ -663,6 +666,7 @@ Rectangle {
 
             onCanceled: e => {
                 root.interactionState = TracksItemsView.State.Idle
+                playCursorController.cancelSeekGesture()
                 prv.cancelItemDragEdit()
             }
 

--- a/src/projectscene/tests/CMakeLists.txt
+++ b/src/projectscene/tests/CMakeLists.txt
@@ -13,6 +13,7 @@ set(MODULE_TEST_SRC
     ${CMAKE_CURRENT_LIST_DIR}/trackitemsselection_tests.cpp
     ${CMAKE_CURRENT_LIST_DIR}/findguideline_tests.cpp
     ${CMAKE_CURRENT_LIST_DIR}/playcursorcontroller_tests.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/playpositionactioncontroller_tests.cpp
 
     ${CMAKE_CURRENT_LIST_DIR}/snaptestaccess.h
     ${CMAKE_CURRENT_LIST_DIR}/mocks/globalcontextmock.h

--- a/src/projectscene/tests/playcursorcontroller_tests.cpp
+++ b/src/projectscene/tests/playcursorcontroller_tests.cpp
@@ -16,6 +16,7 @@
 #include "project/tests/mocks/audacityprojectmock.h"
 #include "mocks/audiooutputmock.h"
 #include "playback/tests/mocks/playbackmock.h"
+#include "playback/tests/mocks/playbackcontrollermock.h"
 #include "context/tests/mocks/playbackstatemock.h"
 #include "trackedit/tests/mocks/trackeditprojectmock.h"
 #include "actions/tests/mocks/actionsdispatchermock.h"
@@ -37,6 +38,7 @@ protected:
         m_trackeditProject = std::make_shared<NiceMock<trackedit::TrackeditProjectMock> >();
         m_viewState = std::make_shared<ProjectViewState>(muse::modularity::globalCtx());
         m_playback = std::make_shared<NiceMock<playback::PlaybackMock> >();
+        m_playbackController = std::make_shared<NiceMock<playback::PlaybackControllerMock> >();
         m_audioOutput = std::make_shared<NiceMock<playback::AudioOutputMock> >();
         m_playbackState = std::make_shared<NiceMock<context::PlaybackStateMock> >();
         m_dispatcher = std::make_shared<NiceMock<muse::actions::ActionsDispatcherMock> >();
@@ -64,7 +66,7 @@ protected:
         SnapTestAccess::wireContext(m_context, m_globalContext, m_playback);
 
         m_controller = new PlayCursorController();
-        SnapTestAccess::wireCursor(m_controller, m_globalContext, m_dispatcher);
+        SnapTestAccess::wireCursor(m_controller, m_globalContext, m_dispatcher, m_playbackController);
         m_controller->setTimelineContext(m_context);
     }
 
@@ -91,6 +93,7 @@ protected:
     std::shared_ptr<NiceMock<trackedit::TrackeditProjectMock> > m_trackeditProject;
     std::shared_ptr<ProjectViewState> m_viewState;
     std::shared_ptr<NiceMock<playback::PlaybackMock> > m_playback;
+    std::shared_ptr<NiceMock<playback::PlaybackControllerMock> > m_playbackController;
     std::shared_ptr<NiceMock<playback::AudioOutputMock> > m_audioOutput;
     std::shared_ptr<NiceMock<context::PlaybackStateMock> > m_playbackState;
     std::shared_ptr<NiceMock<muse::actions::ActionsDispatcherMock> > m_dispatcher;
@@ -191,5 +194,171 @@ TEST_F(PlayCursorControllerTests, SetPlaybackRegionByTime_SnapsAndClampsEdges)
 
     EXPECT_DOUBLE_EQ(captured.param("start").toDouble(), 0.0);
     EXPECT_DOUBLE_EQ(captured.param("end").toDouble(), 10.0);
+}
+
+//! Seek gesture: pressing in the track area must never move the playhead by
+//! itself — the seek is deferred to the release, and dropped entirely when the
+//! press turned into a drag of something other than the play cursor.
+//! Default zoom (1.0) / frame start (0.0) make position and time 1:1.
+
+TEST_F(PlayCursorControllerTests, SeekGesture_Press_DoesNotDispatchSeek)
+{
+    //! CASE Mousedown alone must not move the playhead.
+    useGridSnapOff({});
+
+    EXPECT_CALL(*m_dispatcher, dispatch(A<const muse::actions::ActionQuery&>()))
+    .Times(0);
+
+    m_controller->beginSeekGesture(20.0, 20.0, 50.0);
+}
+
+TEST_F(PlayCursorControllerTests, SeekGesture_PlainClick_SeeksOnRelease)
+{
+    //! CASE A press + release without dragging seeks to the pressed time on release.
+    useGridSnapOff({});
+
+    muse::actions::ActionQuery captured;
+    EXPECT_CALL(*m_dispatcher, dispatch(A<const muse::actions::ActionQuery&>()))
+    .WillOnce(SaveArg<0>(&captured));
+
+    m_controller->beginSeekGesture(20.0, 20.0, 50.0);
+    EXPECT_TRUE(m_controller->endSeekGesture());
+
+    EXPECT_DOUBLE_EQ(captured.param("seekTime").toDouble(), 20.0);
+    EXPECT_FALSE(captured.param("triggerPlay").toBool());
+}
+
+TEST_F(PlayCursorControllerTests, SeekGesture_ClickWithinDragThreshold_StillSeeks)
+{
+    //! CASE Small jitter below the drag threshold is still a click.
+    useGridSnapOff({});
+
+    muse::actions::ActionQuery captured;
+    EXPECT_CALL(*m_dispatcher, dispatch(A<const muse::actions::ActionQuery&>()))
+    .WillOnce(SaveArg<0>(&captured));
+
+    m_controller->beginSeekGesture(20.0, 20.0, 50.0);
+    m_controller->updateSeekGesture(22.0, 52.0); // < 5px in both axes
+    EXPECT_TRUE(m_controller->endSeekGesture());
+
+    EXPECT_DOUBLE_EQ(captured.param("seekTime").toDouble(), 20.0);
+}
+
+TEST_F(PlayCursorControllerTests, SeekGesture_ClickAppliesSnap)
+{
+    //! CASE The deferred seek is snapped exactly like a direct seekToTime.
+    useGridSnapOff({ 10.0 });
+
+    muse::actions::ActionQuery captured;
+    EXPECT_CALL(*m_dispatcher, dispatch(A<const muse::actions::ActionQuery&>()))
+    .WillOnce(SaveArg<0>(&captured));
+
+    m_controller->beginSeekGesture(10.5, 10.5, 50.0); // within the 4px(=4s at zoom 1) clip-snap tolerance
+    EXPECT_TRUE(m_controller->endSeekGesture());
+
+    EXPECT_DOUBLE_EQ(captured.param("seekTime").toDouble(), 10.0);
+}
+
+TEST_F(PlayCursorControllerTests, SeekGesture_HorizontalDrag_DoesNotSeek)
+{
+    //! CASE Dragging (e.g. a time selection) suppresses the seek: no dispatch
+    //! during the drag and none on release.
+    useGridSnapOff({});
+
+    EXPECT_CALL(*m_dispatcher, dispatch(A<const muse::actions::ActionQuery&>()))
+    .Times(0);
+
+    m_controller->beginSeekGesture(20.0, 20.0, 50.0);
+    m_controller->updateSeekGesture(30.0, 50.0);
+    EXPECT_FALSE(m_controller->endSeekGesture());
+}
+
+TEST_F(PlayCursorControllerTests, SeekGesture_VerticalDrag_DoesNotSeek)
+{
+    //! CASE A vertical drag (multi-track selection) is a drag too.
+    useGridSnapOff({});
+
+    EXPECT_CALL(*m_dispatcher, dispatch(A<const muse::actions::ActionQuery&>()))
+    .Times(0);
+
+    m_controller->beginSeekGesture(20.0, 20.0, 50.0);
+    m_controller->updateSeekGesture(20.0, 80.0);
+    EXPECT_FALSE(m_controller->endSeekGesture());
+}
+
+TEST_F(PlayCursorControllerTests, SeekGesture_DragReturningToOrigin_StillNoSeek)
+{
+    //! CASE Once the drag threshold is crossed the gesture stays a drag, even
+    //! if the pointer returns to the press position before release.
+    useGridSnapOff({});
+
+    EXPECT_CALL(*m_dispatcher, dispatch(A<const muse::actions::ActionQuery&>()))
+    .Times(0);
+
+    m_controller->beginSeekGesture(20.0, 20.0, 50.0);
+    m_controller->updateSeekGesture(40.0, 50.0);
+    m_controller->updateSeekGesture(20.0, 50.0);
+    EXPECT_FALSE(m_controller->endSeekGesture());
+}
+
+TEST_F(PlayCursorControllerTests, SeekGesture_Cancel_DoesNotSeek)
+{
+    //! CASE A canceled gesture (e.g. the press turned into an item drag or a
+    //! double-click took over) never seeks.
+    useGridSnapOff({});
+
+    EXPECT_CALL(*m_dispatcher, dispatch(A<const muse::actions::ActionQuery&>()))
+    .Times(0);
+
+    m_controller->beginSeekGesture(20.0, 20.0, 50.0);
+    m_controller->cancelSeekGesture();
+    EXPECT_FALSE(m_controller->endSeekGesture());
+}
+
+TEST_F(PlayCursorControllerTests, SeekGesture_EndWithoutBegin_IsNoop)
+{
+    //! CASE Releases without a matching press (item drags never begin a
+    //! gesture) do nothing.
+    useGridSnapOff({});
+
+    EXPECT_CALL(*m_dispatcher, dispatch(A<const muse::actions::ActionQuery&>()))
+    .Times(0);
+
+    EXPECT_FALSE(m_controller->endSeekGesture());
+}
+
+TEST_F(PlayCursorControllerTests, SeekGesture_ClickWhilePlaying_RecordsSeekTime_DoesNotMovePlayhead)
+{
+    //! CASE Clicking during playback must not interrupt playback: no seek is
+    //! dispatched, but the click position is remembered so that stopping
+    //! returns there.
+    useGridSnapOff({});
+    ON_CALL(*m_playbackState, isPlaying())
+    .WillByDefault(Return(true));
+
+    EXPECT_CALL(*m_dispatcher, dispatch(A<const muse::actions::ActionQuery&>()))
+    .Times(0);
+    EXPECT_CALL(*m_playbackController, setLastPlaybackSeekTime(muse::secs_t(20.0)));
+
+    m_controller->beginSeekGesture(20.0, 20.0, 50.0);
+    EXPECT_TRUE(m_controller->endSeekGesture());
+}
+
+TEST_F(PlayCursorControllerTests, SeekGesture_DragWhilePlaying_DoesNotTouchPlayback)
+{
+    //! CASE Dragging during playback leaves playback completely alone —
+    //! no seek, no seek-time bookkeeping.
+    useGridSnapOff({});
+    ON_CALL(*m_playbackState, isPlaying())
+    .WillByDefault(Return(true));
+
+    EXPECT_CALL(*m_dispatcher, dispatch(A<const muse::actions::ActionQuery&>()))
+    .Times(0);
+    EXPECT_CALL(*m_playbackController, setLastPlaybackSeekTime(_))
+    .Times(0);
+
+    m_controller->beginSeekGesture(20.0, 20.0, 50.0);
+    m_controller->updateSeekGesture(60.0, 50.0);
+    EXPECT_FALSE(m_controller->endSeekGesture());
 }
 }

--- a/src/projectscene/tests/playcursorcontroller_tests.cpp
+++ b/src/projectscene/tests/playcursorcontroller_tests.cpp
@@ -199,6 +199,11 @@ TEST_F(PlayCursorControllerTests, SetPlaybackRegionByTime_SnapsAndClampsEdges)
 //! Seek gesture: pressing in the track area must never move the playhead by
 //! itself — the seek is deferred to the release, and dropped entirely when the
 //! press turned into a drag of something other than the play cursor.
+//!
+//! endSeekGesture()'s return value is the contract the view branches on: true
+//! means "this was a plain click, playback position state may be updated",
+//! false means "this was a drag — leave both the playhead and the next
+//! playback start position alone".
 //! Default zoom (1.0) / frame start (0.0) make position and time 1:1.
 
 TEST_F(PlayCursorControllerTests, SeekGesture_Press_DoesNotDispatchSeek)
@@ -261,11 +266,15 @@ TEST_F(PlayCursorControllerTests, SeekGesture_ClickAppliesSnap)
 
 TEST_F(PlayCursorControllerTests, SeekGesture_HorizontalDrag_DoesNotSeek)
 {
-    //! CASE Dragging (e.g. a time selection) suppresses the seek: no dispatch
-    //! during the drag and none on release.
+    //! CASE Dragging a time selection updates neither the playhead nor the next
+    //! playback start position: no dispatch during the drag, none on release,
+    //! and no seek-time bookkeeping. The false return tells the view to skip
+    //! the playback-region update too.
     useGridSnapOff({});
 
     EXPECT_CALL(*m_dispatcher, dispatch(A<const muse::actions::ActionQuery&>()))
+    .Times(0);
+    EXPECT_CALL(*m_playbackController, setLastPlaybackSeekTime(_))
     .Times(0);
 
     m_controller->beginSeekGesture(20.0, 20.0, 50.0);

--- a/src/projectscene/tests/playcursorcontroller_tests.cpp
+++ b/src/projectscene/tests/playcursorcontroller_tests.cpp
@@ -353,6 +353,33 @@ TEST_F(PlayCursorControllerTests, SeekGesture_ClickWhilePlaying_RecordsSeekTime_
     EXPECT_TRUE(m_controller->endSeekGesture());
 }
 
+TEST_F(PlayCursorControllerTests, SeekGesture_ClickWhilePlaying_RecordsSnappedSeekTime)
+{
+    //! CASE The remembered position is snapped exactly like the playhead would
+    //! be by a click when not playing, so that stopping lands on the boundary.
+    useGridSnapOff({ 10.0 });
+    ON_CALL(*m_playbackState, isPlaying())
+    .WillByDefault(Return(true));
+
+    EXPECT_CALL(*m_playbackController, setLastPlaybackSeekTime(muse::secs_t(10.0)));
+
+    m_controller->beginSeekGesture(10.5, 10.5, 50.0); // within the clip-snap tolerance
+    EXPECT_TRUE(m_controller->endSeekGesture());
+}
+
+TEST_F(PlayCursorControllerTests, SeekGesture_ClickWhilePlaying_RecordsGridSnappedSeekTime)
+{
+    //! CASE Same, with grid snap on.
+    useGridSnapOn(SnapType::Seconds);
+    ON_CALL(*m_playbackState, isPlaying())
+    .WillByDefault(Return(true));
+
+    EXPECT_CALL(*m_playbackController, setLastPlaybackSeekTime(muse::secs_t(7.0)));
+
+    m_controller->beginSeekGesture(7.4, 7.4, 50.0);
+    EXPECT_TRUE(m_controller->endSeekGesture());
+}
+
 TEST_F(PlayCursorControllerTests, SeekGesture_DragWhilePlaying_DoesNotTouchPlayback)
 {
     //! CASE Dragging during playback leaves playback completely alone —

--- a/src/projectscene/tests/playpositionactioncontroller_tests.cpp
+++ b/src/projectscene/tests/playpositionactioncontroller_tests.cpp
@@ -1,0 +1,177 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include "projectscene/view/playcursor/playpositionactioncontroller.h"
+#include "projectscene/view/timeline/timelinecontext.h"
+#include "projectscene/internal/projectviewstate.h"
+
+#include "snaptestaccess.h"
+
+#include "context/tests/mocks/globalcontextmock.h"
+#include "project/tests/mocks/audacityprojectmock.h"
+#include "mocks/audiooutputmock.h"
+#include "playback/tests/mocks/playbackmock.h"
+#include "context/tests/mocks/playbackstatemock.h"
+#include "trackedit/tests/mocks/selectioncontrollermock.h"
+#include "trackedit/tests/mocks/trackeditprojectmock.h"
+#include "actions/tests/mocks/actionsdispatchermock.h"
+
+using namespace ::testing;
+
+namespace au::projectscene {
+//! Exercises the "move play cursor to selection start/end" actions.
+//! These move the play position only — unlike the stepping actions, they must
+//! leave the time selection untouched.
+class PlayPositionActionControllerTests : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        m_globalContext = std::make_shared<NiceMock<context::GlobalContextMock> >();
+        m_project = std::make_shared<NiceMock<project::AudacityProjectMock> >();
+        m_trackeditProject = std::make_shared<NiceMock<trackedit::TrackeditProjectMock> >();
+        m_viewState = std::make_shared<ProjectViewState>(muse::modularity::globalCtx());
+        m_playback = std::make_shared<NiceMock<playback::PlaybackMock> >();
+        m_audioOutput = std::make_shared<NiceMock<playback::AudioOutputMock> >();
+        m_playbackState = std::make_shared<NiceMock<context::PlaybackStateMock> >();
+        m_selectionController = std::make_shared<NiceMock<trackedit::SelectionControllerMock> >();
+        m_dispatcher = std::make_shared<NiceMock<muse::actions::ActionsDispatcherMock> >();
+
+        ON_CALL(*m_globalContext, currentProject())
+        .WillByDefault(Return(m_project));
+        ON_CALL(*m_globalContext, currentTrackeditProject())
+        .WillByDefault(Return(m_trackeditProject));
+        ON_CALL(*m_globalContext, playbackState())
+        .WillByDefault(Return(m_playbackState));
+        ON_CALL(*m_project, viewState())
+        .WillByDefault(Return(m_viewState));
+        ON_CALL(*m_playback, audioOutput())
+        .WillByDefault(Return(m_audioOutput));
+        ON_CALL(*m_audioOutput, sampleRate())
+        .WillByDefault(Return(static_cast<uint64_t>(44100)));
+        ON_CALL(*m_trackeditProject, timeSignature())
+        .WillByDefault(Return(trackedit::TimeSignature { 120.0, 4, 4 }));
+        ON_CALL(*m_playbackState, isPlaying())
+        .WillByDefault(Return(false));
+
+        m_context = new TimelineContext();
+        SnapTestAccess::wireContext(m_context, m_globalContext, m_playback);
+
+        m_controller = new PlayPositionActionController();
+        SnapTestAccess::wirePlayPosition(m_controller, m_globalContext, m_dispatcher, m_selectionController);
+        m_controller->setTimelineContext(m_context);
+    }
+
+    void TearDown() override
+    {
+        delete m_controller;
+        delete m_context;
+    }
+
+    void useTimeSelection(double start, double end)
+    {
+        ON_CALL(*m_selectionController, timeSelectionIsEmpty())
+        .WillByDefault(Return(false));
+        ON_CALL(*m_selectionController, dataSelectedStartTime())
+        .WillByDefault(Return(muse::secs_t(start)));
+        ON_CALL(*m_selectionController, dataSelectedEndTime())
+        .WillByDefault(Return(muse::secs_t(end)));
+    }
+
+    void useEmptyTimeSelection()
+    {
+        ON_CALL(*m_selectionController, timeSelectionIsEmpty())
+        .WillByDefault(Return(true));
+    }
+
+    std::shared_ptr<NiceMock<context::GlobalContextMock> > m_globalContext;
+    std::shared_ptr<NiceMock<project::AudacityProjectMock> > m_project;
+    std::shared_ptr<NiceMock<trackedit::TrackeditProjectMock> > m_trackeditProject;
+    std::shared_ptr<ProjectViewState> m_viewState;
+    std::shared_ptr<NiceMock<playback::PlaybackMock> > m_playback;
+    std::shared_ptr<NiceMock<playback::AudioOutputMock> > m_audioOutput;
+    std::shared_ptr<NiceMock<context::PlaybackStateMock> > m_playbackState;
+    std::shared_ptr<NiceMock<trackedit::SelectionControllerMock> > m_selectionController;
+    std::shared_ptr<NiceMock<muse::actions::ActionsDispatcherMock> > m_dispatcher;
+
+    TimelineContext* m_context = nullptr;
+    PlayPositionActionController* m_controller = nullptr;
+};
+
+TEST_F(PlayPositionActionControllerTests, CursorToSelectionStart_SeeksToSelectionStart)
+{
+    //! CASE The play position moves to the start edge of the time selection.
+    useTimeSelection(5.0, 12.0);
+
+    muse::actions::ActionQuery captured;
+    EXPECT_CALL(*m_dispatcher, dispatch(A<const muse::actions::ActionQuery&>()))
+    .WillOnce(SaveArg<0>(&captured));
+
+    m_controller->cursorToSelectionStart();
+
+    EXPECT_DOUBLE_EQ(captured.param("seekTime").toDouble(), 5.0);
+    EXPECT_FALSE(captured.param("triggerPlay").toBool());
+}
+
+TEST_F(PlayPositionActionControllerTests, CursorToSelectionEnd_SeeksToSelectionEnd)
+{
+    //! CASE The play position moves to the end edge of the time selection.
+    useTimeSelection(5.0, 12.0);
+
+    muse::actions::ActionQuery captured;
+    EXPECT_CALL(*m_dispatcher, dispatch(A<const muse::actions::ActionQuery&>()))
+    .WillOnce(SaveArg<0>(&captured));
+
+    m_controller->cursorToSelectionEnd();
+
+    EXPECT_DOUBLE_EQ(captured.param("seekTime").toDouble(), 12.0);
+    EXPECT_FALSE(captured.param("triggerPlay").toBool());
+}
+
+TEST_F(PlayPositionActionControllerTests, CursorToSelectionStart_KeepsSelectionIntact)
+{
+    //! CASE Moving the cursor to an edge must not collapse or alter the
+    //! selection — that is the whole difference from the stepping actions.
+    useTimeSelection(5.0, 12.0);
+
+    EXPECT_CALL(*m_selectionController, setDataSelectedStartTime(_, _))
+    .Times(0);
+    EXPECT_CALL(*m_selectionController, setDataSelectedEndTime(_, _))
+    .Times(0);
+
+    m_controller->cursorToSelectionStart();
+    m_controller->cursorToSelectionEnd();
+}
+
+TEST_F(PlayPositionActionControllerTests, CursorToSelection_NoSelection_DoesNothing)
+{
+    //! CASE With no time selection there is no edge to move to.
+    useEmptyTimeSelection();
+
+    EXPECT_CALL(*m_dispatcher, dispatch(A<const muse::actions::ActionQuery&>()))
+    .Times(0);
+
+    m_controller->cursorToSelectionStart();
+    m_controller->cursorToSelectionEnd();
+}
+
+TEST_F(PlayPositionActionControllerTests, CursorToSelection_WhilePlaying_StillMovesPlayPosition)
+{
+    //! CASE Unlike a click in the track area, this is an explicit request to
+    //! move the play position, so it applies during playback too.
+    useTimeSelection(5.0, 12.0);
+    ON_CALL(*m_playbackState, isPlaying())
+    .WillByDefault(Return(true));
+
+    muse::actions::ActionQuery captured;
+    EXPECT_CALL(*m_dispatcher, dispatch(A<const muse::actions::ActionQuery&>()))
+    .WillOnce(SaveArg<0>(&captured));
+
+    m_controller->cursorToSelectionStart();
+
+    EXPECT_DOUBLE_EQ(captured.param("seekTime").toDouble(), 5.0);
+}
+}

--- a/src/projectscene/tests/snaptestaccess.h
+++ b/src/projectscene/tests/snaptestaccess.h
@@ -11,9 +11,12 @@
 #include "playback/iplaybackcontroller.h"
 #include "actions/iactionsdispatcher.h"
 
+#include "trackedit/iselectioncontroller.h"
+
 #include "projectscene/view/timeline/timelinecontext.h"
 #include "projectscene/view/timeline/snaptimeformatter.h"
 #include "projectscene/view/playcursor/playcursorcontroller.h"
+#include "projectscene/view/playcursor/playpositionactioncontroller.h"
 
 namespace au::projectscene {
 //! Test-only helper that reaches the private injects of TimelineContext and
@@ -39,6 +42,16 @@ struct SnapTestAccess {
         if (playbackController) {
             cursor->playbackController.set(playbackController);
         }
+    }
+
+    static void wirePlayPosition(PlayPositionActionController* controller,
+                                 const std::shared_ptr<context::IGlobalContext>& globalContext,
+                                 const std::shared_ptr<muse::actions::IActionsDispatcher>& dispatcher,
+                                 const std::shared_ptr<trackedit::ISelectionController>& selectionController)
+    {
+        controller->globalContext.set(globalContext);
+        controller->dispatcher.set(dispatcher);
+        controller->selectionController.set(selectionController);
     }
 };
 }

--- a/src/projectscene/tests/snaptestaccess.h
+++ b/src/projectscene/tests/snaptestaccess.h
@@ -8,6 +8,7 @@
 #include "modularity/ioc.h"
 #include "context/iglobalcontext.h"
 #include "playback/iplayback.h"
+#include "playback/iplaybackcontroller.h"
 #include "actions/iactionsdispatcher.h"
 
 #include "projectscene/view/timeline/timelinecontext.h"
@@ -30,10 +31,14 @@ struct SnapTestAccess {
 
     static void wireCursor(PlayCursorController* cursor,
                            const std::shared_ptr<context::IGlobalContext>& globalContext,
-                           const std::shared_ptr<muse::actions::IActionsDispatcher>& dispatcher)
+                           const std::shared_ptr<muse::actions::IActionsDispatcher>& dispatcher,
+                           const std::shared_ptr<playback::IPlaybackController>& playbackController = nullptr)
     {
         cursor->globalContext.set(globalContext);
         cursor->dispatcher.set(dispatcher);
+        if (playbackController) {
+            cursor->playbackController.set(playbackController);
+        }
     }
 };
 }

--- a/src/projectscene/view/playcursor/playcursorcontroller.cpp
+++ b/src/projectscene/view/playcursor/playcursorcontroller.cpp
@@ -121,8 +121,10 @@ bool PlayCursorController::endSeekGesture()
 
     if (playbackState()->isPlaying()) {
         //! NOTE: while playing the playhead is not moved, but the click position
-        //! is remembered so that stopping returns there
-        playbackController()->setLastPlaybackSeekTime(std::max(0.0, m_seekGestureTime));
+        //! is remembered so that stopping returns there. Snap it here: seekToTime
+        //! bails out before snapping while playing, so it would be stored raw and
+        //! stopping would land off the boundary a normal click snaps to.
+        playbackController()->setLastPlaybackSeekTime(std::max(0.0, snapTime(m_seekGestureTime)));
     }
     seekToTime(m_seekGestureTime);
 

--- a/src/projectscene/view/playcursor/playcursorcontroller.cpp
+++ b/src/projectscene/view/playcursor/playcursorcontroller.cpp
@@ -22,6 +22,9 @@
 
 #include "playcursorcontroller.h"
 
+#include <algorithm>
+#include <cmath>
+
 #include "global/realfn.h"
 
 using namespace au::projectscene;
@@ -32,6 +35,7 @@ static const ActionQuery PLAYBACK_CHANGE_PLAY_REGION_QUERY("action://playback/pl
 
 static constexpr int SCROLL_SUPPRESSION_TIMEOUT_MS = 3000;
 static constexpr double ANIMATION_DURATION_SEC = TimelineContext::ANIMATION_DURATION_MS / 1000.0;
+static constexpr double SEEK_GESTURE_DRAG_THRESHOLD_PX = 5.0;
 
 PlayCursorController::PlayCursorController(QObject* parent)
     : QObject(parent), muse::Contextable(muse::iocCtxForQmlObject(this))
@@ -81,6 +85,54 @@ void PlayCursorController::animatedSeekToTime(double secs)
     }
 
     seekToTime(secs);
+}
+
+void PlayCursorController::beginSeekGesture(double time, double x, double y)
+{
+    m_seekGestureActive = true;
+    m_seekGestureDragged = false;
+    m_seekGestureTime = time;
+    m_seekGesturePressPos = QPointF(x, y);
+}
+
+void PlayCursorController::updateSeekGesture(double x, double y)
+{
+    if (!m_seekGestureActive || m_seekGestureDragged) {
+        return;
+    }
+
+    if (std::abs(x - m_seekGesturePressPos.x()) >= SEEK_GESTURE_DRAG_THRESHOLD_PX
+        || std::abs(y - m_seekGesturePressPos.y()) >= SEEK_GESTURE_DRAG_THRESHOLD_PX) {
+        m_seekGestureDragged = true;
+    }
+}
+
+bool PlayCursorController::endSeekGesture()
+{
+    if (!m_seekGestureActive) {
+        return false;
+    }
+
+    m_seekGestureActive = false;
+
+    if (m_seekGestureDragged) {
+        return false;
+    }
+
+    if (playbackState()->isPlaying()) {
+        //! NOTE: while playing the playhead is not moved, but the click position
+        //! is remembered so that stopping returns there
+        playbackController()->setLastPlaybackSeekTime(std::max(0.0, m_seekGestureTime));
+    }
+    seekToTime(m_seekGestureTime);
+
+    return true;
+}
+
+void PlayCursorController::cancelSeekGesture()
+{
+    m_seekGestureActive = false;
+    m_seekGestureDragged = false;
 }
 
 void PlayCursorController::setPlaybackRegionByTime(double t1, double t2)

--- a/src/projectscene/view/playcursor/playcursorcontroller.h
+++ b/src/projectscene/view/playcursor/playcursorcontroller.h
@@ -22,12 +22,14 @@
 #pragma once
 
 #include <QObject>
+#include <QPointF>
 #include <QTimer>
 
 #include "global/async/asyncable.h"
 
 #include "modularity/ioc.h"
 #include "context/iglobalcontext.h"
+#include "playback/iplaybackcontroller.h"
 #include "record/irecordcontroller.h"
 #include "actions/iactionsdispatcher.h"
 
@@ -43,6 +45,7 @@ class PlayCursorController : public QObject, public muse::async::Asyncable, publ
     Q_PROPERTY(double positionX READ positionX NOTIFY positionXChanged FINAL)
 
     muse::ContextInject<context::IGlobalContext> globalContext{ this };
+    muse::ContextInject<playback::IPlaybackController> playbackController{ this };
     muse::ContextInject<record::IRecordController> recordController{ this };
     muse::ContextInject<muse::actions::IActionsDispatcher> dispatcher{ this };
 
@@ -57,6 +60,17 @@ public:
     Q_INVOKABLE void seekToTime(double secs, bool triggerPlay = false);
     Q_INVOKABLE void animatedSeekToTime(double secs);
     Q_INVOKABLE void setPlaybackRegionByTime(double time1, double time2);
+
+    //! NOTE Deferred seek: a press in the track area must not move the playhead
+    //! immediately, otherwise the viewport can shift mid-gesture (e.g. while
+    //! dragging a clip or a selection). The target is remembered on press and
+    //! the seek is dispatched on release, and only when the gesture stayed a
+    //! plain click — dragging anything other than the play cursor itself never
+    //! moves the playhead.
+    Q_INVOKABLE void beginSeekGesture(double time, double x, double y);
+    Q_INVOKABLE void updateSeekGesture(double x, double y);
+    Q_INVOKABLE bool endSeekGesture();
+    Q_INVOKABLE void cancelSeekGesture();
 
 signals:
     void timelineContextChanged();
@@ -82,6 +96,11 @@ private:
     QTimer m_scrollSuppressionTimer;
     bool m_viewUpdatesSuppressed = false;
     bool m_seekAnimated = false;
+
+    bool m_seekGestureActive = false;
+    bool m_seekGestureDragged = false;
+    double m_seekGestureTime = 0.0;
+    QPointF m_seekGesturePressPos;
 
     friend struct SnapTestAccess;
 };

--- a/src/projectscene/view/playcursor/playpositionactioncontroller.cpp
+++ b/src/projectscene/view/playcursor/playpositionactioncontroller.cpp
@@ -33,6 +33,8 @@ static const ActionCode SEL_EXT_LEFT("sel-ext-left");
 static const ActionCode SEL_EXT_RIGHT("sel-ext-right");
 static const ActionCode SEL_CNTR_LEFT("sel-cntr-left");
 static const ActionCode SEL_CNTR_RIGHT("sel-cntr-right");
+static const ActionCode CURS_SEL_START("curs-sel-start");
+static const ActionCode CURS_SEL_END("curs-sel-end");
 static const ActionQuery PLAYBACK_SEEK_QUERY("action://playback/seek");
 
 au::projectscene::PlayPositionActionController::PlayPositionActionController(QObject* parent)
@@ -48,6 +50,8 @@ void PlayPositionActionController::init()
     dispatcher()->reg(this, SEL_EXT_RIGHT, this, &PlayPositionActionController::selectionExtendRight);
     dispatcher()->reg(this, SEL_CNTR_LEFT, this, &PlayPositionActionController::selectionContractLeft);
     dispatcher()->reg(this, SEL_CNTR_RIGHT, this, &PlayPositionActionController::selectionContractRight);
+    dispatcher()->reg(this, CURS_SEL_START, this, &PlayPositionActionController::cursorToSelectionStart);
+    dispatcher()->reg(this, CURS_SEL_END, this, &PlayPositionActionController::cursorToSelectionEnd);
 
     globalContext()->currentProjectChanged().onNotify(this, [this](){
         onProjectChanged();
@@ -100,17 +104,48 @@ void PlayPositionActionController::applySingleStep(Direction direction)
     const muse::secs_t secs = stepFromTime(currentPlaybackPosition, direction);
 
     if (muse::RealIsEqualOrMore(secs, 0.0)) {
-        muse::actions::ActionQuery q(PLAYBACK_SEEK_QUERY);
-        q.addParam("seekTime", muse::Val(secs));
-        q.addParam("triggerPlay", muse::Val(false));
-        dispatcher()->dispatch(q);
+        movePlayPositionTo(secs);
 
         if (!playbackState()->isPlaying()) {
             selectionController()->setDataSelectedStartTime(secs, true);
             selectionController()->setDataSelectedEndTime(secs, true);
         }
+    }
+}
 
-        m_context->animatedInsureVisible(secs);
+void PlayPositionActionController::movePlayPositionTo(muse::secs_t secs)
+{
+    muse::actions::ActionQuery q(PLAYBACK_SEEK_QUERY);
+    q.addParam("seekTime", muse::Val(secs));
+    q.addParam("triggerPlay", muse::Val(false));
+    dispatcher()->dispatch(q);
+
+    m_context->animatedInsureVisible(secs);
+}
+
+void PlayPositionActionController::cursorToSelectionStart()
+{
+    //! NOTE: unlike stepping the cursor, this keeps the selection intact —
+    //! it only moves the play position to one of its edges
+    if (selectionController()->timeSelectionIsEmpty()) {
+        return;
+    }
+
+    const muse::secs_t secs = selectionController()->dataSelectedStartTime();
+    if (muse::RealIsEqualOrMore(secs, 0.0)) {
+        movePlayPositionTo(secs);
+    }
+}
+
+void PlayPositionActionController::cursorToSelectionEnd()
+{
+    if (selectionController()->timeSelectionIsEmpty()) {
+        return;
+    }
+
+    const muse::secs_t secs = selectionController()->dataSelectedEndTime();
+    if (muse::RealIsEqualOrMore(secs, 0.0)) {
+        movePlayPositionTo(secs);
     }
 }
 

--- a/src/projectscene/view/playcursor/playpositionactioncontroller.h
+++ b/src/projectscene/view/playcursor/playpositionactioncontroller.h
@@ -59,6 +59,9 @@ public:
     void selectionContractLeft();
     void selectionContractRight();
 
+    void cursorToSelectionStart();
+    void cursorToSelectionEnd();
+
 signals:
     void timelineContextChanged();
 
@@ -67,11 +70,14 @@ private:
 
     void snapCurrentPosition();
     void applySingleStep(Direction direction);
+    void movePlayPositionTo(muse::secs_t secs);
 
     muse::secs_t stepFromTime(muse::secs_t from, Direction direction) const;
 
     context::IPlaybackStatePtr playbackState() const;
 
     TimelineContext* m_context = nullptr;
+
+    friend struct SnapTestAccess;
 };
 }

--- a/src/projectscene/view/tracksitemsview/selectionviewcontroller.cpp
+++ b/src/projectscene/view/tracksitemsview/selectionviewcontroller.cpp
@@ -439,15 +439,6 @@ void SelectionViewController::resetDataSelection()
     frequencySelectionController()->resetFrequencySelection();
 }
 
-bool SelectionViewController::isLeftSelection(double time) const
-{
-    if (!isProjectOpened()) {
-        return false;
-    }
-
-    return m_selectionStartTime > time;
-}
-
 IProjectViewStatePtr SelectionViewController::viewState() const
 {
     IAudacityProjectPtr prj = globalContext()->currentProject();

--- a/src/projectscene/view/tracksitemsview/selectionviewcontroller.h
+++ b/src/projectscene/view/tracksitemsview/selectionviewcontroller.h
@@ -76,7 +76,6 @@ public:
     Q_INVOKABLE void resetSelectedClips();
     Q_INVOKABLE void resetSelectedLabel();
     Q_INVOKABLE void resetDataSelection();
-    Q_INVOKABLE bool isLeftSelection(double time) const;
 
     bool selectionActive() const;
     bool selectionEditInProgress() const;


### PR DESCRIPTION
Resolves: Suppress programmatically setting playhead position on drag operations https://github.com/audacity/audacity/issues/11176

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
-------
- [x] Click in track area → playhead moves on **release**, not on press
- [x] Drag a clip → playhead never moves
- [x] Small jitter click (<5 px) still moves playhead; drag out-and-back does not
- [x] Drag a long clip with edges off-screen → no viewport jump (the original bug)
- [x] Drag selection (both directions, multi-track, Ctrl/Shift, edge handles) → playhead unmoved
- [x] Play after drag selection → plays the selection
- [x] Stop after that → playhead returns to its pre-selection position ⚠️ intended, most visible change
- [x] Click while playing → playback uninterrupted; Stop lands on clicked spot, **snapped** (test near clip edge + grid snap)
- [x] Known limitation: dragging a clip during playback still stops playback (pre-existing) — but no playhead jump
- [x] No regression: ruler click (incl. playback-on-ruler-click), playhead handle drag, double-click clip/track, split tool, Ctrl/Shift clip clicks, Esc/focus-loss mid-drag
- [x] New actions "Move play cursor to selection start/end" (unbound, bind in Preferences → Shortcuts): jump to edge, selection survives, no-op without selection, works during playback
