### PR TITLE
playback cleanup

### DIFF
--- a/src/app/configs/data/shortcuts.xml
+++ b/src/app/configs/data/shortcuts.xml
@@ -835,6 +835,9 @@
         <seq>P</seq>
     </SC>
     <SC>
+        <key>action://playback/toggle-play-pause</key>
+    </SC>
+    <SC>
         <key>action://record/start</key>
         <seq>R</seq>
     </SC>
@@ -874,8 +877,11 @@
         <key>s-w-playthrough</key>
     </SC>
     <SC>
-        <key>action://playback/play</key>
+        <key>action://playback/toggle-play-stop</key>
         <seq>Space</seq>
+    </SC>
+    <SC>
+        <key>action://playback/toggle-play-from-cursor</key>
         <seq>Shift+Space</seq>
     </SC>
     <SC>

--- a/src/app/configs/data/shortcuts.xml
+++ b/src/app/configs/data/shortcuts.xml
@@ -832,10 +832,10 @@
     </SC>
     <SC>
         <key>action://playback/pause</key>
-        <seq>P</seq>
     </SC>
     <SC>
         <key>action://playback/toggle-play-pause</key>
+        <seq>P</seq>
     </SC>
     <SC>
         <key>action://record/start</key>

--- a/src/appshell/internal/applicationactioncontroller.cpp
+++ b/src/appshell/internal/applicationactioncontroller.cpp
@@ -525,7 +525,7 @@ void ApplicationActionController::doGlobalCancel()
 void ApplicationActionController::doGlobalTrigger()
 {
     if (isProjectOpened()) {
-        dispatcher()->dispatch("action://playback/play");
+        dispatcher()->dispatch("action://playback/toggle-play-stop");
     } else {
         commandDispatcher()->dispatch(muse::ui::TRIGGER_CONTROL_COMMAND);
     }

--- a/src/playback/internal/playbackcontroller.cpp
+++ b/src/playback/internal/playbackcontroller.cpp
@@ -323,8 +323,14 @@ void PlaybackController::togglePlay(TogglePlayMode mode)
     }
 
     if (isStopped()) {
-        if (isPlaybackPositionOnTheEndOfProject() || isPlaybackPositionOnTheEndOfPlaybackRegion()) {
+        if (isPlaybackPositionOnTheEndOfProject()) {
+            //! NOTE: reached the project end — restart from the beginning
             doSeek(0.0, false);
+        } else if (isPlaybackPositionOnTheEndOfPlaybackRegion()) {
+            //! NOTE: reached the end of a played selection/region — continue from the
+            //! playhead rather than the region start, so the next play resumes where it
+            //! left off instead of jumping back
+            doSeek(playbackPosition(), false);
         }
 
         doPlay(clearPlaybackRegion);

--- a/src/playback/internal/playbackcontroller.cpp
+++ b/src/playback/internal/playbackcontroller.cpp
@@ -11,7 +11,9 @@ using namespace au::playback;
 using namespace muse::async;
 using namespace muse::actions;
 
-static const ActionQuery PLAYBACK_PLAY_QUERY("action://playback/play");
+static const ActionQuery PLAYBACK_TOGGLE_PLAY_PAUSE_QUERY("action://playback/toggle-play-pause");
+static const ActionQuery PLAYBACK_TOGGLE_PLAY_STOP_QUERY("action://playback/toggle-play-stop");
+static const ActionQuery PLAYBACK_TOGGLE_PLAY_FROM_CURSOR_QUERY("action://playback/toggle-play-from-cursor");
 static const ActionQuery PLAYBACK_PLAY_SELECTION_QUERY("action://playback/play-selection");
 static const ActionQuery PLAYBACK_PLAY_TRACKS_QUERY("action://playback/play-tracks");
 static const ActionQuery PLAYBACK_PAUSE_QUERY("action://playback/pause");
@@ -32,7 +34,9 @@ static const secs_t TIME_EPS = secs_t(1 / 1000.0);
 
 void PlaybackController::init()
 {
-    dispatcher()->reg(this, PLAYBACK_PLAY_QUERY, this, &PlaybackController::togglePlayAction);
+    dispatcher()->reg(this, PLAYBACK_TOGGLE_PLAY_PAUSE_QUERY, this, &PlaybackController::togglePlayPauseAction);
+    dispatcher()->reg(this, PLAYBACK_TOGGLE_PLAY_STOP_QUERY, this, &PlaybackController::togglePlayStopAction);
+    dispatcher()->reg(this, PLAYBACK_TOGGLE_PLAY_FROM_CURSOR_QUERY, this, &PlaybackController::togglePlayFromCursorAction);
     dispatcher()->reg(this, PLAYBACK_PLAY_SELECTION_QUERY, this, &PlaybackController::playSelectionAction);
     dispatcher()->reg(this, PLAYBACK_PLAY_TRACKS_QUERY, this, &PlaybackController::playTracksAction);
     dispatcher()->reg(this, PLAYBACK_PAUSE_QUERY, this, &PlaybackController::pauseAction);
@@ -242,38 +246,62 @@ void PlaybackController::onPlaybackPositionChanged()
     }
 }
 
-void PlaybackController::togglePlayAction()
+void PlaybackController::togglePlayPauseAction()
+{
+    togglePlay(TogglePlayMode::PlayPause);
+}
+
+void PlaybackController::togglePlayStopAction()
+{
+    togglePlay(TogglePlayMode::PlayStop);
+}
+
+void PlaybackController::togglePlayFromCursorAction()
+{
+    togglePlay(TogglePlayMode::PlayFromCursor);
+}
+
+void PlaybackController::togglePlay(TogglePlayMode mode)
 {
     if (!isPlayAllowed()) {
         LOGW() << "playback not allowed";
         return;
     }
 
-    const bool isShiftPressed = application()->keyboardModifiers().testFlag(Qt::ShiftModifier);
+    const bool clearPlaybackRegion = mode == TogglePlayMode::PlayFromCursor;
+
     if (isPlaying()) {
-        if (isShiftPressed) {
+        if (mode == TogglePlayMode::PlayStop) {
             stopSeekAndUpdatePlaybackRegion();
         } else {
             doPause();
         }
-    } else if (isPaused()) {
+
+        return;
+    }
+
+    if (isPaused()) {
         if (isSelectionPlaybackRegionChanged()) {
             //! NOTE: just stop, without seek
             player()->stop();
             doPlay(false);
-        } else if (isShiftPressed) {
+        } else if (clearPlaybackRegion) {
             //! NOTE: set the current position as start position
             doSeek(playbackPosition(), false);
             doPlay(true /* clearPlaybackRegion */);
         } else {
             doResume();
         }
-    } else {
+
+        return;
+    }
+
+    if (isStopped()) {
         if (isPlaybackPositionOnTheEndOfProject() || isPlaybackPositionOnTheEndOfPlaybackRegion()) {
             doSeek(0.0, false);
         }
 
-        doPlay(isShiftPressed /* clearPlaybackRegion */);
+        doPlay(clearPlaybackRegion);
     }
 }
 
@@ -795,7 +823,10 @@ bool PlaybackController::canReceiveAction(const ActionCode& code) const
         return false;
     }
 
-    if (code == PLAYBACK_PLAY_QUERY.toString()) {
+    //! NOTE: toggle-play-pause stays available while recording — it pauses the recorder.
+    //! Starting or restarting playback outright must not be possible while recording.
+    if (code == PLAYBACK_TOGGLE_PLAY_STOP_QUERY.toString()
+        || code == PLAYBACK_TOGGLE_PLAY_FROM_CURSOR_QUERY.toString()) {
         return !recordController()->isRecording();
     }
 

--- a/src/playback/internal/playbackcontroller.cpp
+++ b/src/playback/internal/playbackcontroller.cpp
@@ -27,6 +27,9 @@ static const ActionQuery PLAYBACK_CHANGE_PLAYBACK_DEVICE_QUERY("action://playbac
 static const ActionQuery PLAYBACK_CHANGE_RECORDING_DEVICE_QUERY("action://playback/change-recording-device");
 static const ActionQuery PLAYBACK_CHANGE_INPUT_CHANNELS_QUERY("action://playback/change-input-channels");
 
+static const ActionQuery RECORD_PAUSE_QUERY("action://record/pause");
+static const ActionQuery RECORD_STOP_QUERY("action://record/stop");
+
 static const ActionCode PAN_CODE("pan");
 static const ActionCode REPEAT_CODE("repeat");
 
@@ -115,6 +118,15 @@ Notification PlaybackController::isPlayAllowedChanged() const
 
 bool PlaybackController::isPlaying() const
 {
+    //! NOTE: while recording (including the lead-in pre-roll) the audio is driven by the
+    //! record stream, not the player. Report not-playing so every caller sees the same
+    //! state as on the normal record path, where the player stays stopped throughout.
+    //! Otherwise pausing/resuming the lead-in leaves the player "running" and, e.g., the
+    //! record button gets disabled mid-recording.
+    if (recordController()->isRecording()) {
+        return false;
+    }
+
     return player()->playbackStatus() == PlaybackStatus::Running;
 }
 
@@ -248,7 +260,21 @@ void PlaybackController::onPlaybackPositionChanged()
 
 void PlaybackController::togglePlayPauseAction()
 {
-    togglePlay(TogglePlayMode::PlayPause);
+    //! NOTE: while recording, the play/pause button pauses the recorder so it stays a
+    //! single action.
+    if (!recordController()->isRecording()) {
+        togglePlay(TogglePlayMode::PlayPause);
+        return;
+    }
+
+    if (recordController()->isLeadInRecording()) {
+        //! NOTE: during the lead-in pre-roll the audio is driven by the record stream, not by
+        //! the player, so its status is not Running and togglePlay() can't see it as playing.
+        //! Toggle the shared stream directly: pause it, or resume it if already paused.
+        isPaused() ? doResume() : doPause();
+    } else {
+        dispatcher()->dispatch(RECORD_PAUSE_QUERY);
+    }
 }
 
 void PlaybackController::togglePlayStopAction()
@@ -503,6 +529,13 @@ void PlaybackController::doPause()
 
 void PlaybackController::stopAction()
 {
+    //! NOTE: the stop button is a single action; the controller decides whether it
+    //! stops the recorder or the player.
+    if (recordController()->isRecording()) {
+        dispatcher()->dispatch(RECORD_STOP_QUERY);
+        return;
+    }
+
     stopSeekAndUpdatePlaybackRegion();
 }
 

--- a/src/playback/internal/playbackcontroller.h
+++ b/src/playback/internal/playbackcontroller.h
@@ -4,7 +4,7 @@
 #pragma once
 
 #include "framework/global/async/asyncable.h"
-#include "framework/global/iapplication.h"
+#include "framework/global/modularity/ioc.h"
 #include "framework/actions/actionable.h"
 #include "framework/actions/iactionsdispatcher.h"
 #include "framework/interactive/iinteractive.h"
@@ -27,7 +27,6 @@ class PlaybackController : public IPlaybackController, public muse::actions::Act
 {
 public:
     muse::GlobalInject<au::playback::IPlaybackConfiguration> playbackConfiguration;
-    muse::GlobalInject<muse::IApplication> application;
 
     muse::ContextInject<au::context::IGlobalContext> globalContext { this };
     muse::ContextInject<audio::IAudioDevicesProvider> audioDevicesProvider { this };
@@ -112,7 +111,17 @@ private:
     void seekListSelection();
     void seekRangeSelection();
 
-    void togglePlayAction();
+    enum class TogglePlayMode {
+        PlayPause,      //!< pause while playing; resume/replay when not
+        PlayStop,       //!< stop while playing; play when not
+        PlayFromCursor  //!< pause while playing; play from the cursor, clearing the playback region, when not
+    };
+
+    void togglePlay(TogglePlayMode mode);
+
+    void togglePlayPauseAction();
+    void togglePlayStopAction();
+    void togglePlayFromCursorAction();
     void playSelectionAction();
     void doPlay(bool clearPlaybackRegion);
     void stopAction();

--- a/src/playback/internal/playbackuiactions.cpp
+++ b/src/playback/internal/playbackuiactions.cpp
@@ -14,7 +14,9 @@ using namespace muse;
 using namespace muse::ui;
 using namespace muse::actions;
 
-static const ActionQuery PLAYBACK_PLAY_QUERY("action://playback/play");
+static const ActionQuery PLAYBACK_TOGGLE_PLAY_PAUSE_QUERY("action://playback/toggle-play-pause");
+static const ActionQuery PLAYBACK_TOGGLE_PLAY_STOP_QUERY("action://playback/toggle-play-stop");
+static const ActionQuery PLAYBACK_TOGGLE_PLAY_FROM_CURSOR_QUERY("action://playback/toggle-play-from-cursor");
 static const ActionQuery PLAYBACK_PLAY_SELECTION_QUERY("action://playback/play-selection");
 static const ActionQuery PLAYBACK_PAUSE_QUERY("action://playback/pause");
 static const ActionQuery PLAYBACK_STOP_QUERY("action://playback/stop");
@@ -30,11 +32,25 @@ static const ActionQuery PLAYBACK_CHANGE_INPUT_CHANNELS_QUERY("action://playback
 static const ActionQuery PLAYBACK_LEVEL_QUERY("action://playback/level");
 
 const UiActionList PlaybackUiActions::m_mainActions = {
-    UiAction(PLAYBACK_PLAY_QUERY.toString(),
+    UiAction(PLAYBACK_TOGGLE_PLAY_PAUSE_QUERY.toString(),
              au::context::UiCtxProjectOpened,
              au::context::CTX_PROJECT_OPENED,
-             TranslatableString("action", "Play"),
-             TranslatableString("action", "Play"),
+             TranslatableString("action", "Play/Pause"),
+             TranslatableString("action", "Play/Pause"),
+             IconCode::Code::PLAY_FILL
+             ),
+    UiAction(PLAYBACK_TOGGLE_PLAY_STOP_QUERY.toString(),
+             au::context::UiCtxProjectOpened,
+             au::context::CTX_PROJECT_OPENED,
+             TranslatableString("action", "Play/Stop"),
+             TranslatableString("action", "Play/Stop"),
+             IconCode::Code::PLAY_FILL
+             ),
+    UiAction(PLAYBACK_TOGGLE_PLAY_FROM_CURSOR_QUERY.toString(),
+             au::context::UiCtxProjectOpened,
+             au::context::CTX_PROJECT_OPENED,
+             TranslatableString("action", "Play/Pause from cursor"),
+             TranslatableString("action", "Play/Pause from cursor"),
              IconCode::Code::PLAY_FILL
              ),
     UiAction(PLAYBACK_PLAY_SELECTION_QUERY.toString(),
@@ -254,7 +270,9 @@ void PlaybackUiActions::init()
 
     m_controller->isPlayingChanged().onNotify(this, [this]() {
         ActionCodeList codes= {
-            PLAYBACK_PLAY_QUERY.toString(),
+            PLAYBACK_TOGGLE_PLAY_PAUSE_QUERY.toString(),
+            PLAYBACK_TOGGLE_PLAY_STOP_QUERY.toString(),
+            PLAYBACK_TOGGLE_PLAY_FROM_CURSOR_QUERY.toString(),
             PLAYBACK_PLAY_SELECTION_QUERY.toString(),
             PLAYBACK_PAUSE_QUERY.toString(),
             PLAYBACK_REWIND_START_QUERY.toString(),

--- a/src/playback/tests/playbackcontroller_tests.cpp
+++ b/src/playback/tests/playbackcontroller_tests.cpp
@@ -243,6 +243,43 @@ TEST_F(PlaybackControllerTests, TogglePlay_WhenStopped_OnTheEndOfProject)
 }
 
 /**
+ * @brief Toggle play when stopped at the end of a played selection/region
+ * @details Playing a selection leaves the playhead at the region end (mid-project).
+ *          The next play must continue from the playhead, not jump back to project start.
+ */
+TEST_F(PlaybackControllerTests, TogglePlay_WhenStopped_OnTheEndOfPlaybackRegion)
+{
+    //! [GIVEN] Playback is stopped
+    ON_CALL(*m_player, playbackStatus())
+    .WillByDefault(Return(PlaybackStatus::Stopped));
+
+    //! [GIVEN] The played region was a selection {10, 20} and the playhead is at its end
+    ON_CALL(*m_player, playbackRegion())
+    .WillByDefault(Return(PlaybackRegion { secs_t(10.0), secs_t(20.0) }));
+    EXPECT_CALL(*m_player, playbackPosition())
+    .WillRepeatedly(Return(secs_t(20.0)));
+    ON_CALL(*m_player, isLoopRegionActive())
+    .WillByDefault(Return(false));
+
+    //! [THEN] Continue from the playhead (20), not from the project start
+    EXPECT_CALL(*m_player, seek(secs_t(20.0), false))
+    .Times(1);
+    EXPECT_CALL(*m_player, seek(secs_t(0.0), _))
+    .Times(0);
+
+    //! [THEN] Playback region runs from the playhead to the project end
+    EXPECT_CALL(*m_player, setPlaybackRegion(PlaybackRegion { secs_t(20.0), secs_t(100.0) }))
+    .Times(1);
+
+    //! [THEN] Player should start playing
+    EXPECT_CALL(*m_player, play())
+    .Times(1);
+
+    //! [WHEN] Toggle play
+    togglePlayStop();
+}
+
+/**
  * @brief Toggle play when there is selection
  * @details User made a selection, placed the playhead before it and clicked play
  *          A time selection must not constrain playback: it should start from

--- a/src/playback/tests/playbackcontroller_tests.cpp
+++ b/src/playback/tests/playbackcontroller_tests.cpp
@@ -16,6 +16,7 @@
 #include "../internal/playbackcontroller.h"
 
 using ::testing::_;
+using ::testing::Property;
 using ::testing::Return;
 using ::testing::ReturnRef;
 
@@ -109,6 +110,20 @@ public:
         m_controller->playSelectionAction();
     }
 
+    void stop()
+    {
+        m_controller->stopAction();
+    }
+
+    void setRecording(bool isRecording, bool isLeadIn = false)
+    {
+        EXPECT_CALL(*m_recordController, isRecording())
+        .WillRepeatedly(Return(isRecording));
+
+        EXPECT_CALL(*m_recordController, isLeadInRecording())
+        .WillRepeatedly(Return(isLeadIn));
+    }
+
     void changePlaybackRegion(const secs_t start, const secs_t end)
     {
         muse::actions::ActionQuery q(PLAYBACK_CHANGE_PLAY_REGION_QUERY);
@@ -143,7 +158,7 @@ public:
     PlaybackController* m_controller = nullptr;
 
     std::shared_ptr<context::GlobalContextMock> m_globalContext;
-    std::shared_ptr<actions::IActionsDispatcher> m_dispatcher;
+    std::shared_ptr<actions::ActionsDispatcherMock> m_dispatcher;
     std::shared_ptr<record::RecordControllerMock> m_recordController;
     std::shared_ptr<trackedit::SelectionControllerMock> m_selectionController;
     std::shared_ptr<trackedit::TrackeditProjectMock> m_trackeditProject;
@@ -1024,5 +1039,117 @@ TEST_F(PlaybackControllerTests, PlaySelection_WhilePlaying_Restarts)
 
     //! [THEN] The playback cursor is at the selection start
     EXPECT_EQ(m_controller->lastPlaybackSeekTime(), secs_t(10.0));
+}
+
+TEST_F(PlaybackControllerTests, Stop_WhenRecording_StopsTheRecorder)
+{
+    //! [GIVEN] Recording is running
+    setRecording(true);
+
+    //! [THEN] The recorder is stopped, not the player
+    EXPECT_CALL(*m_dispatcher, dispatch(::testing::Matcher<const muse::actions::ActionQuery&>(
+                                            Property(&muse::actions::ActionQuery::toString, "action://record/stop"))))
+    .Times(1);
+
+    EXPECT_CALL(*m_player, stop())
+    .Times(0);
+
+    //! [WHEN] User presses the Stop button
+    stop();
+}
+
+TEST_F(PlaybackControllerTests, TogglePlayPause_WhenRecording_PausesTheRecorder)
+{
+    //! [GIVEN] Recording is running (not in lead-in)
+    setRecording(true, false /* isLeadIn */);
+
+    //! [THEN] The recorder is paused, not the player
+    EXPECT_CALL(*m_dispatcher, dispatch(::testing::Matcher<const muse::actions::ActionQuery&>(
+                                            Property(&muse::actions::ActionQuery::toString, "action://record/pause"))))
+    .Times(1);
+
+    EXPECT_CALL(*m_player, pause())
+    .Times(0);
+
+    //! [WHEN] User presses the Play/Pause button
+    togglePlayPause();
+}
+
+TEST_F(PlaybackControllerTests, TogglePlayPause_DuringLeadIn_PausesThePlayback)
+{
+    //! [GIVEN] The record lead-in pre-roll is playing back. The audio is driven by the
+    //! record stream, not the player, so the player status is not Running.
+    setRecording(true, true /* isLeadIn */);
+
+    ON_CALL(*m_player, playbackStatus())
+    .WillByDefault(Return(PlaybackStatus::Stopped));
+
+    //! [THEN] The shared stream is paused, the recorder is not touched
+    EXPECT_CALL(*m_player, pause())
+    .Times(1);
+
+    EXPECT_CALL(*m_dispatcher, dispatch(::testing::Matcher<const muse::actions::ActionQuery&>(
+                                            Property(&muse::actions::ActionQuery::toString, "action://record/pause"))))
+    .Times(0);
+
+    //! [WHEN] User presses the Play/Pause button during lead-in
+    togglePlayPause();
+}
+
+TEST_F(PlaybackControllerTests, TogglePlayPause_DuringLeadInWhenPaused_ResumesThePlayback)
+{
+    //! [GIVEN] The lead-in pre-roll has been paused (player status is Paused, but the
+    //! recorder is still in lead-in)
+    setRecording(true, true /* isLeadIn */);
+
+    ON_CALL(*m_player, playbackStatus())
+    .WillByDefault(Return(PlaybackStatus::Paused));
+
+    //! [THEN] The shared stream resumes, the recorder is not touched
+    EXPECT_CALL(*m_player, resume())
+    .Times(1);
+
+    EXPECT_CALL(*m_dispatcher, dispatch(::testing::Matcher<const muse::actions::ActionQuery&>(
+                                            Property(&muse::actions::ActionQuery::toString, "action://record/pause"))))
+    .Times(0);
+
+    //! [WHEN] User presses the Play/Pause button to resume the lead-in
+    togglePlayPause();
+}
+
+TEST_F(PlaybackControllerTests, IsPlaying_WhileRecording_ReportsFalse)
+{
+    //! [GIVEN] Recording is running while the player is left "running" (e.g. after
+    //! resuming a lead-in through the shared stream)
+    setRecording(true);
+
+    ON_CALL(*m_player, playbackStatus())
+    .WillByDefault(Return(PlaybackStatus::Running));
+
+    //! [THEN] The controller reports not-playing, matching the normal record path where
+    //! the player stays stopped (so the record button etc. are not treated as playback)
+    EXPECT_FALSE(m_controller->isPlaying());
+}
+
+TEST_F(PlaybackControllerTests, CanReceiveAction_WhileRecording_BlocksPlayStopButNotPlayPause)
+{
+    //! [GIVEN] Recording is running
+    setRecording(true);
+
+    //! [THEN] Space and Shift+Space are blocked, the toolbar button is not
+    EXPECT_FALSE(m_controller->canReceiveAction("action://playback/toggle-play-stop"));
+    EXPECT_FALSE(m_controller->canReceiveAction("action://playback/toggle-play-from-cursor"));
+    EXPECT_TRUE(m_controller->canReceiveAction("action://playback/toggle-play-pause"));
+}
+
+TEST_F(PlaybackControllerTests, CanReceiveAction_WhileNotRecording_AllowsAllTogglePlayActions)
+{
+    //! [GIVEN] Not recording
+    setRecording(false);
+
+    //! [THEN] All toggle-play actions are available
+    EXPECT_TRUE(m_controller->canReceiveAction("action://playback/toggle-play-stop"));
+    EXPECT_TRUE(m_controller->canReceiveAction("action://playback/toggle-play-from-cursor"));
+    EXPECT_TRUE(m_controller->canReceiveAction("action://playback/toggle-play-pause"));
 }
 }

--- a/src/playback/tests/playbackcontroller_tests.cpp
+++ b/src/playback/tests/playbackcontroller_tests.cpp
@@ -6,7 +6,6 @@
 
 #include "actions/tests/mocks/actionsdispatchermock.h"
 #include "context/tests/mocks/globalcontextmock.h"
-#include "global/tests/mocks/applicationmock.h"
 #include "mocks/playbackmock.h"
 #include "mocks/playermock.h"
 #include "project/tests/mocks/audacityprojectmock.h"
@@ -35,9 +34,6 @@ public:
     void SetUp() override
     {
         m_controller = new PlaybackController(muse::modularity::globalCtx());
-
-        m_application = std::make_shared<muse::ApplicationMock>();
-        m_controller->application.set(m_application);
 
         m_globalContext = std::make_shared<context::GlobalContextMock>();
         m_controller->globalContext.set(m_globalContext);
@@ -90,9 +86,22 @@ public:
         delete m_controller;
     }
 
-    void togglePlay()
+    //! NOTE: toolbar Play/Pause button — play/pause
+    void togglePlayPause()
     {
-        m_controller->togglePlayAction();
+        m_controller->togglePlayPauseAction();
+    }
+
+    //! NOTE: Spacebar — play/stop
+    void togglePlayStop()
+    {
+        m_controller->togglePlayStopAction();
+    }
+
+    //! NOTE: Shift+Spacebar — play from cursor, ignoring selection (pause while playing)
+    void togglePlayFromCursor()
+    {
+        m_controller->togglePlayFromCursorAction();
     }
 
     void playSelection()
@@ -133,7 +142,6 @@ public:
 
     PlaybackController* m_controller = nullptr;
 
-    std::shared_ptr<ApplicationMock> m_application;
     std::shared_ptr<context::GlobalContextMock> m_globalContext;
     std::shared_ptr<actions::IActionsDispatcher> m_dispatcher;
     std::shared_ptr<record::RecordControllerMock> m_recordController;
@@ -189,7 +197,7 @@ TEST_F(PlaybackControllerTests, TogglePlay_WhenStopped)
     .Times(1);
 
     //! [WHEN] Toggle play
-    togglePlay();
+    togglePlayStop();
 }
 
 /**
@@ -216,7 +224,7 @@ TEST_F(PlaybackControllerTests, TogglePlay_WhenStopped_OnTheEndOfProject)
     .Times(1);
 
     //! [WHEN] Toggle play
-    togglePlay();
+    togglePlayStop();
 }
 
 /**
@@ -258,7 +266,7 @@ TEST_F(PlaybackControllerTests, TogglePlay_WithSelection_PlaysFromPlayheadThroug
     .Times(1);
 
     //! [WHEN] Toggle play
-    togglePlay();
+    togglePlayStop();
 }
 
 /**
@@ -301,7 +309,7 @@ TEST_F(PlaybackControllerTests, TogglePlay_WithSelection_Clip)
     .Times(1);
 
     //! [WHEN] Toggle play
-    togglePlay();
+    togglePlayStop();
 }
 
 /**
@@ -314,10 +322,6 @@ TEST_F(PlaybackControllerTests, TogglePlay_WithIgnoreSelection)
     //! [GIVEN] Playback is stopped
     ON_CALL(*m_player, playbackStatus())
     .WillByDefault(Return(PlaybackStatus::Stopped));
-
-    //! [GIVEN] Play with Shift modifier
-    ON_CALL(*m_application, keyboardModifiers())
-    .WillByDefault(Return(Qt::ShiftModifier));
 
     //! [THEN] No checking selection
     EXPECT_CALL(*m_selectionController, timeSelectionIsEmpty())
@@ -334,7 +338,7 @@ TEST_F(PlaybackControllerTests, TogglePlay_WithIgnoreSelection)
     .Times(1);
 
     //! [WHEN] Toggle play
-    togglePlay();
+    togglePlayFromCursor();
 }
 
 /**
@@ -353,7 +357,7 @@ TEST_F(PlaybackControllerTests, TogglePlay_WhenPlaying)
     .Times(1);
 
     //! [WHEN] Toggle play
-    togglePlay();
+    togglePlayPause();
 }
 
 TEST_F(PlaybackControllerTests, Pause_WhenSeekTargetChangedDuringPlayback_StopsPlayback)
@@ -404,16 +408,12 @@ TEST_F(PlaybackControllerTests, TogglePlay_WhenPlaying_PlayAgain)
     ON_CALL(*m_player, playbackStatus())
     .WillByDefault(Return(PlaybackStatus::Running));
 
-    //! [GIVEN] Play with Shift modifier
-    ON_CALL(*m_application, keyboardModifiers())
-    .WillByDefault(Return(Qt::ShiftModifier));
-
     //! [THEN] Player should stop playing
     EXPECT_CALL(*m_player, stop())
     .Times(1);
 
     //! [WHEN] Toggle play
-    togglePlay();
+    togglePlayStop();
 }
 
 /**
@@ -432,7 +432,7 @@ TEST_F(PlaybackControllerTests, TogglePlay_WhenPaused)
     .Times(1);
 
     //! [WHEN] Toggle play
-    togglePlay();
+    togglePlayStop();
 }
 
 /**
@@ -445,10 +445,6 @@ TEST_F(PlaybackControllerTests, TogglePlay_WhenPaused_WithIgnoreSelection)
     //! [GIVEN] Playback is paused
     ON_CALL(*m_player, playbackStatus())
     .WillByDefault(Return(PlaybackStatus::Paused));
-
-    //! [GIVEN] Play with Shift modifier
-    ON_CALL(*m_application, keyboardModifiers())
-    .WillByDefault(Return(Qt::ShiftModifier));
 
     //! [THEN] Expect that playbeck should run from current position
     secs_t currentPosition = 10.0;
@@ -466,7 +462,7 @@ TEST_F(PlaybackControllerTests, TogglePlay_WhenPaused_WithIgnoreSelection)
     .Times(1);
 
     //! [WHEN] Toggle play
-    togglePlay();
+    togglePlayFromCursor();
 }
 
 /**
@@ -476,41 +472,34 @@ TEST_F(PlaybackControllerTests, TogglePlay_WhenPaused_WithIgnoreSelection)
  */
 TEST_F(PlaybackControllerTests, TogglePlay_WhenPaused_WithChangingSelection)
 {
-    //! [GIVEN] Play with Shift modifier
-    EXPECT_CALL(*m_application, keyboardModifiers())
-    .WillOnce(Return(Qt::ShiftModifier))
-    .WillRepeatedly(Return(Qt::NoModifier));
-
-    //! [GIVEN] User started playback
+    //! [GIVEN] User started playback, then paused it
     ON_CALL(*m_player, playbackStatus())
     .WillByDefault(Return(PlaybackStatus::Stopped));
-    togglePlay();
+    togglePlayStop();
 
-    //! [GIVEN] And paused it
     ON_CALL(*m_player, playbackStatus())
     .WillByDefault(Return(PlaybackStatus::Running));
-    togglePlay();
+    togglePlayPause();
 
     //! [GIVEN] In paused state
     ON_CALL(*m_player, playbackStatus())
     .WillByDefault(Return(PlaybackStatus::Paused));
 
-    //! [THEN] Expect that playbeck should run from selection start position
+    //! [THEN] Expect that playback should restart from the new selection start
     PlaybackRegion selectionRegion = { secs_t(10.0), secs_t(20.0) };
 
-    //! [THEN] Player should stop playing
+    //! [THEN] Player should stop, then start playing
     EXPECT_CALL(*m_player, stop())
     .Times(1);
 
-    //! [THEN] Player should start playing
     EXPECT_CALL(*m_player, play())
     .Times(1);
 
-    //! [WHEN] Fitst: user changed selection
+    //! [WHEN] First: user changed selection
     changePlaybackRegion(selectionRegion.start, selectionRegion.end);
 
-    //! [WHEN] Second: toggle play
-    togglePlay();
+    //! [WHEN] Second: press Space
+    togglePlayStop();
 
     //! [THEN] Playback restarted from the new selection start
     EXPECT_EQ(m_controller->lastPlaybackSeekTime(), selectionRegion.start);
@@ -541,7 +530,7 @@ TEST_F(PlaybackControllerTests, TogglePlay_StartTimeIsMoreThanTotalTime)
 
     //! [WHEN] Change the playback region and toggle play
     changePlaybackRegion(region.start, region.end);
-    togglePlay();
+    togglePlayStop();
 }
 
 /**
@@ -777,7 +766,7 @@ TEST_F(PlaybackControllerTests, TogglePlay_AfterRecord_PlaysFromSeekToProjectEnd
     .Times(1);
 
     //! [WHEN] User presses Space
-    togglePlay();
+    togglePlayStop();
 }
 
 /**

--- a/src/projectscene/internal/projectsceneuiactions.cpp
+++ b/src/projectscene/internal/projectsceneuiactions.cpp
@@ -352,7 +352,7 @@ const ToolConfig& ProjectSceneUiActions::defaultPlaybackToolBarConfig()
     static ToolConfig config;
     if (!config.isValid()) {
         config.items = {
-            { "action://playback/play", true },
+            { "action://playback/toggle-play-pause", true },
             { "action://playback/stop", true },
             { "action://record/start", true },
             { "action://playback/rewind-start", true },

--- a/src/projectscene/view/toolbars/playbacktoolbarcustomisemodel.cpp
+++ b/src/projectscene/view/toolbars/playbacktoolbarcustomisemodel.cpp
@@ -20,7 +20,7 @@ using namespace muse::actions;
 
 static const QString TOOLBAR_NAME("playbackToolBar");
 
-static const ActionQuery PLAYBACK_PLAY_QUERY("action://playback/play");
+static const ActionQuery PLAYBACK_TOGGLE_PLAY_PAUSE_QUERY("action://playback/toggle-play-pause");
 static const ActionQuery RECORD_START_QUERY("action://record/start");
 
 PlaybackToolBarCustomiseModel::PlaybackToolBarCustomiseModel(QObject* parent)
@@ -236,7 +236,7 @@ PlaybackToolBarCustomiseItem* PlaybackToolBarCustomiseModel::makeSeparatorItem()
 QColor PlaybackToolBarCustomiseModel::iconColor(const muse::ui::UiAction& action) const
 {
     QColor color = QColor(uiConfiguration()->currentTheme().values.value(muse::ui::FONT_PRIMARY_COLOR).toString());
-    if (action.code == PLAYBACK_PLAY_QUERY.toString()) {
+    if (action.code == PLAYBACK_TOGGLE_PLAY_PAUSE_QUERY.toString()) {
         color = uiConfiguration()->currentTheme().values.value(muse::ui::PLAY_COLOR).value<QColor>();
     } else if (action.code == RECORD_START_QUERY.toString()) {
         color = uiConfiguration()->currentTheme().values.value(muse::ui::RECORD_COLOR).value<QColor>();

--- a/src/projectscene/view/toolbars/playbacktoolbarmodel.cpp
+++ b/src/projectscene/view/toolbars/playbacktoolbarmodel.cpp
@@ -23,11 +23,7 @@ using namespace au::playback;
 
 static const QString TOOLBAR_NAME("playbackToolBar");
 
-static const QString PLAY_PAUSE_ITEM_ID("play-pause-id");
-static const QString STOP_ITEM_ID("stop-id");
-
-static const ActionQuery PLAYBACK_PLAY_QUERY("action://playback/play");
-static const ActionQuery PLAYBACK_PAUSE_QUERY("action://playback/pause");
+static const ActionQuery PLAYBACK_TOGGLE_PLAY_PAUSE_QUERY("action://playback/toggle-play-pause");
 static const ActionQuery PLAYBACK_STOP_QUERY("action://playback/stop");
 
 static const ActionQuery RECORD_START_QUERY("action://record/start");
@@ -59,7 +55,7 @@ static PlaybackToolBarModel::ItemType itemType(const ActionCode& actionCode)
         { PLAYBACK_BPM, PlaybackToolBarModel::PLAYBACK_BPM },
         { PLAYBACK_TIME_SIGNATURE, PlaybackToolBarModel::PLAYBACK_TIME_SIGNATURE },
         { RECORD_LEVEL_QUERY.toString(), PlaybackToolBarModel::RECORD_LEVEL },
-        { PLAYBACK_PLAY_QUERY.toString(), PlaybackToolBarModel::PLAYBACK_CONTROL },
+        { PLAYBACK_TOGGLE_PLAY_PAUSE_QUERY.toString(), PlaybackToolBarModel::PLAYBACK_CONTROL },
         { PLAYBACK_STOP_QUERY.toString(), PlaybackToolBarModel::PLAYBACK_CONTROL },
         { RECORD_START_QUERY.toString(), PlaybackToolBarModel::PLAYBACK_CONTROL },
         { PLAYBACK_REWIND_START_QUERY.toString(), PlaybackToolBarModel::PLAYBACK_CONTROL },
@@ -133,7 +129,7 @@ void PlaybackToolBarModel::onActionsStateChanges(const muse::actions::ActionCode
         return;
     }
 
-    if (containsAction(codes, PLAYBACK_PLAY_QUERY.toString()) || containsAction(codes, PLAYBACK_PAUSE_QUERY.toString())
+    if (containsAction(codes, PLAYBACK_TOGGLE_PLAY_PAUSE_QUERY.toString())
         || containsAction(codes, RECORD_PAUSE_QUERY.toString())) {
         updatePlayState();
     }
@@ -146,7 +142,7 @@ void PlaybackToolBarModel::onActionsStateChanges(const muse::actions::ActionCode
         updateRecordState();
     }
 
-    if (containsAction(codes, "toggle-loop-region")) {
+    if (containsAction(codes, LOOP_ACTION_CODE)) {
         updateLoopState();
     }
 
@@ -166,35 +162,37 @@ void PlaybackToolBarModel::updateStates()
 
 void PlaybackToolBarModel::updatePlayState()
 {
-    PlaybackToolBarControlItem* item = dynamic_cast<PlaybackToolBarControlItem*>(findItemPtr(PLAY_PAUSE_ITEM_ID));
+    PlaybackToolBarControlItem* item = dynamic_cast<PlaybackToolBarControlItem*>(findItemPtr(PLAYBACK_TOGGLE_PLAY_PAUSE_QUERY.toString()));
 
     if (item == nullptr) {
         return;
     }
 
     bool isPlaying = playbackController()->isPlaying();
+    bool isPaused = playbackController()->isPaused();
     bool isRecording = recordController()->isRecording();
     bool isLeadIn = recordController()->isLeadInRecording();
 
-    ActionCode code = (isPlaying || isLeadIn) ? PLAYBACK_PAUSE_QUERY.toString() : PLAYBACK_PLAY_QUERY.toString();
-    if (isRecording && !isLeadIn) {
-        code = RECORD_PAUSE_QUERY.toString();
-    }
-
-    UiAction action = uiActionsRegister()->action(code);
-    item->setAction(action);
+    // During recording it pauses the recorder
+    UiAction action = uiActionsRegister()->action(PLAYBACK_TOGGLE_PLAY_PAUSE_QUERY.toString());
 
     // During lead-in, show as playing (green background) since audio is playing back
     bool showAsPlaying = isPlaying || isLeadIn;
+
+    bool leadInPaused = isLeadIn && isPaused;
+    if ((showAsPlaying && !leadInPaused) || (isRecording && !isLeadIn)) {
+        action.iconCode = IconCode::Code::PAUSE_FILL;
+    }
+    item->setAction(action);
     item->setSelected(showAsPlaying);
 
-    QColor iconColor = uiConfiguration()->currentTheme().values.value(muse::ui::PLAY_COLOR).value<QColor>();
-    QColor backgroundColor = QColor(uiConfiguration()->currentTheme().values.value(muse::ui::BUTTON_COLOR).toString());
+    QColor iconColor = themeColor(PLAY_COLOR);
+    QColor backgroundColor = themeColor(BUTTON_COLOR);
     if (showAsPlaying) {
-        iconColor = QColor(uiConfiguration()->currentTheme().values.value(muse::ui::FONT_PRIMARY_COLOR).toString());
-        backgroundColor = uiConfiguration()->currentTheme().values.value(muse::ui::PLAY_COLOR).value<QColor>();
+        iconColor = themeColor(FONT_PRIMARY_COLOR);
+        backgroundColor = themeColor(PLAY_COLOR);
     } else if (isRecording) {
-        iconColor = QColor(uiConfiguration()->currentTheme().values.value(muse::ui::FONT_PRIMARY_COLOR).toString());
+        iconColor = themeColor(FONT_PRIMARY_COLOR);
     }
 
     item->setIconColor(iconColor);
@@ -203,17 +201,15 @@ void PlaybackToolBarModel::updatePlayState()
 
 void PlaybackToolBarModel::updateStopState()
 {
-    PlaybackToolBarControlItem* item = dynamic_cast<PlaybackToolBarControlItem*>(findItemPtr(STOP_ITEM_ID));
+    PlaybackToolBarControlItem* item = dynamic_cast<PlaybackToolBarControlItem*>(findItemPtr(PLAYBACK_STOP_QUERY.toString()));
 
     if (item == nullptr) {
         return;
     }
 
-    const bool isRecording = recordController()->isRecording();
-    const ActionCode code = isRecording ? RECORD_STOP_QUERY.toString() : PLAYBACK_STOP_QUERY.toString();
-    const UiAction action = uiActionsRegister()->action(code);
+    const UiAction action = uiActionsRegister()->action(PLAYBACK_STOP_QUERY.toString());
     item->setAction(action);
-    const QColor iconColor = QColor(uiConfiguration()->currentTheme().values.value(muse::ui::FONT_PRIMARY_COLOR).toString());
+    const QColor iconColor = themeColor(FONT_PRIMARY_COLOR);
     item->setIconColor(iconColor);
 }
 
@@ -231,11 +227,11 @@ void PlaybackToolBarModel::updateRecordState()
     // During lead-in pre-roll, the button should not appear as actively recording
     item->setSelected(isRecording && !isLeadIn);
 
-    QColor iconColor = uiConfiguration()->currentTheme().values.value(muse::ui::RECORD_COLOR).value<QColor>();
-    QColor backgroundColor = QColor(uiConfiguration()->currentTheme().values.value(muse::ui::BUTTON_COLOR).toString());
+    QColor iconColor = themeColor(RECORD_COLOR);
+    QColor backgroundColor = themeColor(BUTTON_COLOR);
     if (isRecording && !isLeadIn) {
-        iconColor = QColor(uiConfiguration()->currentTheme().values.value(muse::ui::BACKGROUND_PRIMARY_COLOR).toString());
-        backgroundColor = uiConfiguration()->currentTheme().values.value(muse::ui::RECORD_COLOR).value<QColor>();
+        iconColor = themeColor(BACKGROUND_PRIMARY_COLOR);
+        backgroundColor = themeColor(RECORD_COLOR);
     }
 
     item->setIconColor(iconColor);
@@ -253,15 +249,20 @@ void PlaybackToolBarModel::updateLoopState()
     bool isLooping = playbackController()->isLoopRegionActive();
     item->setSelected(isLooping);
 
-    QColor iconColor = QColor(uiConfiguration()->currentTheme().values.value(muse::ui::FONT_PRIMARY_COLOR).toString());
-    QColor backgroundColor = QColor(uiConfiguration()->currentTheme().values.value(muse::ui::BUTTON_COLOR).toString());
-    if (isLooping) {
-        iconColor = QColor(uiConfiguration()->currentTheme().values.value(muse::ui::FONT_PRIMARY_COLOR).toString());
-        backgroundColor = QColor(uiConfiguration()->currentTheme().values.value(muse::ui::ACCENT_COLOR).toString());
+    item->setIconColor(themeColor(FONT_PRIMARY_COLOR));
+    item->setBackgroundColor(themeColor(isLooping ? ACCENT_COLOR : BUTTON_COLOR));
+}
+
+void PlaybackToolBarModel::updateToggleState(const ActionCode& actionCode, bool isOn)
+{
+    PlaybackToolBarControlItem* item = dynamic_cast<PlaybackToolBarControlItem*>(findItemPtr(actionCode));
+
+    if (item == nullptr) {
+        return;
     }
 
-    item->setIconColor(iconColor);
-    item->setBackgroundColor(backgroundColor);
+    item->setSelected(isOn);
+    item->setBackgroundColor(themeColor(isOn ? ACCENT_COLOR : BUTTON_COLOR));
 }
 
 void PlaybackToolBarModel::updateClipGainAutomationState()
@@ -272,23 +273,7 @@ void PlaybackToolBarModel::updateClipGainAutomationState()
         return;
     }
 
-    PlaybackToolBarControlItem* item = dynamic_cast<PlaybackToolBarControlItem*>(findItemPtr(CLIP_GAIN_AUTOMATION_CODE));
-
-    if (item == nullptr) {
-        return;
-    }
-
-    auto vs = prj->viewState();
-
-    bool clipGainAutomationEnabled = vs->clipGainAutomationEnabled().val;
-    item->setSelected(clipGainAutomationEnabled);
-
-    QColor backgroundColor = QColor(uiConfiguration()->currentTheme().values.value(muse::ui::BUTTON_COLOR).toString());
-    if (clipGainAutomationEnabled) {
-        backgroundColor = QColor(uiConfiguration()->currentTheme().values.value(muse::ui::ACCENT_COLOR).toString());
-    }
-
-    item->setBackgroundColor(backgroundColor);
+    updateToggleState(CLIP_GAIN_AUTOMATION_CODE, prj->viewState()->clipGainAutomationEnabled().val);
 }
 
 void PlaybackToolBarModel::updateSplitState()
@@ -299,23 +284,7 @@ void PlaybackToolBarModel::updateSplitState()
         return;
     }
 
-    PlaybackToolBarControlItem* item = dynamic_cast<PlaybackToolBarControlItem*>(findItemPtr(SPLIT_TOOL_ACTION_CODE));
-
-    if (item == nullptr) {
-        return;
-    }
-
-    auto vs = prj->viewState();
-
-    bool splitToolEnabled = vs->splitToolEnabled().val;
-    item->setSelected(splitToolEnabled);
-
-    QColor backgroundColor = QColor(uiConfiguration()->currentTheme().values.value(muse::ui::BUTTON_COLOR).toString());
-    if (splitToolEnabled) {
-        backgroundColor = QColor(uiConfiguration()->currentTheme().values.value(muse::ui::ACCENT_COLOR).toString());
-    }
-
-    item->setBackgroundColor(backgroundColor);
+    updateToggleState(SPLIT_TOOL_ACTION_CODE, prj->viewState()->splitToolEnabled().val);
 }
 
 void PlaybackToolBarModel::updateGlobalSpectrogramViewState()
@@ -326,19 +295,12 @@ void PlaybackToolBarModel::updateGlobalSpectrogramViewState()
         return;
     }
 
-    PlaybackToolBarControlItem* const item
-        = dynamic_cast<PlaybackToolBarControlItem*>(findItemPtr(TOGGLE_GLOBAL_SPECTROGRAM_VIEW_ACTION_CODE));
+    updateToggleState(TOGGLE_GLOBAL_SPECTROGRAM_VIEW_ACTION_CODE, prj->viewState()->globalSpectrogramToggleIsOn());
+}
 
-    if (item == nullptr) {
-        return;
-    }
-
-    const auto vs = prj->viewState();
-    const bool isOn = vs->globalSpectrogramToggleIsOn();
-    item->setSelected(isOn);
-    const auto key = isOn ? muse::ui::ThemeStyleKey::ACCENT_COLOR : muse::ui::ThemeStyleKey::BUTTON_COLOR;
-    const QColor backgroundColor{ uiConfiguration()->currentTheme().values.value(key).toString() };
-    item->setBackgroundColor(backgroundColor);
+QColor PlaybackToolBarModel::themeColor(muse::ui::ThemeStyleKey key) const
+{
+    return uiConfiguration()->currentTheme().values.value(key).value<QColor>();
 }
 
 void PlaybackToolBarModel::updateActions()
@@ -368,14 +330,6 @@ void PlaybackToolBarModel::updateActions()
         ToolBarItem* item = makeLocalItem(citem.action);
         if (!item) {
             continue;
-        }
-
-        if (citem.action == PLAYBACK_PLAY_QUERY.toString()) {
-            item->setId(PLAY_PAUSE_ITEM_ID); // for quick finding
-        }
-
-        if (citem.action == PLAYBACK_STOP_QUERY.toString()) {
-            item->setId(STOP_ITEM_ID); // for quick finding
         }
 
         item->setIsTransparent(false);
@@ -417,8 +371,8 @@ ToolBarItem* PlaybackToolBarModel::makeLocalItem(const ActionCode& actionCode)
         break;
     case PlaybackToolBarModel::PLAYBACK_CONTROL: {
         PlaybackToolBarControlItem* item = new PlaybackToolBarControlItem(action, static_cast<ToolBarItemType::Type>(type), this);
-        item->setIconColor(QColor(uiConfiguration()->currentTheme().values.value(muse::ui::FONT_PRIMARY_COLOR).toString()));
-        item->setBackgroundColor(QColor(uiConfiguration()->currentTheme().values.value(muse::ui::BUTTON_COLOR).toString()));
+        item->setIconColor(themeColor(FONT_PRIMARY_COLOR));
+        item->setBackgroundColor(themeColor(BUTTON_COLOR));
         result = std::move(item);
         break;
     }

--- a/src/projectscene/view/toolbars/playbacktoolbarmodel.h
+++ b/src/projectscene/view/toolbars/playbacktoolbarmodel.h
@@ -16,7 +16,6 @@
 #include "playback/iplaybackuistate.h"
 #include "playback/iplaybackcontroller.h"
 #include "record/irecordcontroller.h"
-#include "record/irecordconfiguration.h"
 
 namespace au::project {
 class IAudacityProject;
@@ -31,7 +30,6 @@ class PlaybackToolBarModel : public muse::uicomponents::AbstractToolBarModel
 
     muse::GlobalInject<muse::ui::IUiConfiguration> uiConfiguration;
     muse::GlobalInject<playback::IPlaybackConfiguration> configuration;
-    muse::GlobalInject<record::IRecordConfiguration> recordConfiguration;
 
     muse::ContextInject<muse::ui::IUiState> uiState { this };
     muse::ContextInject<muse::ui::IUiActionsRegister> uiActionsRegister{ this };
@@ -46,7 +44,6 @@ public:
 
     enum ItemType
     {
-        UNDEFINED,
         PLAYBACK_LEVEL = muse::uicomponents::ToolBarItemType::USER_TYPE + 1,
         RECORD_LEVEL,
         PLAYBACK_TIME,
@@ -80,7 +77,9 @@ private:
     void updateSplitState();
     void updateGlobalSpectrogramViewState();
 
-    void setupConnections();
+    void updateToggleState(const muse::actions::ActionCode& actionCode, bool isOn);
+
+    QColor themeColor(muse::ui::ThemeStyleKey key) const;
 
     void updateActions();
 


### PR DESCRIPTION
Resolves: 
- inverse Play/Pause by Play/Stop
- cleanup internal logic
- expose Shift action (the alternate play/pause mode bind) as a shortcut

checks
- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
