### PR TITLE
Disable "Rename clip" unless a single clip is selected, add "Rename label"

### DIFF
--- a/src/app/configs/data/shortcuts.xml
+++ b/src/app/configs/data/shortcuts.xml
@@ -1052,7 +1052,6 @@
     </SC>
     <SC>
         <key>envelope-tool</key>
-        <seq>F2</seq>
     </SC>
     <SC>
         <key>draw-tool</key>
@@ -1106,7 +1105,7 @@
     </SC>
     <SC>
         <key>rename-item</key>
-        <seq>Ctrl+F2</seq>
+        <seq>F2</seq>
     </SC>
     <SC>
         <key>clip-pitch-speed-open</key>

--- a/src/appshell/qml/Audacity/AppShell/appmenumodel.cpp
+++ b/src/appshell/qml/Audacity/AppShell/appmenumodel.cpp
@@ -21,6 +21,7 @@
  */
 #include "appmenumodel.h"
 
+#include "global/containers.h"
 #include "types/translatablestring.h"
 
 #include "muse_framework_config.h"
@@ -46,6 +47,10 @@ static QString makeId(const ActionCode& actionCode, int itemIndex)
 {
     return QString::fromStdString(actionCode) + QString::number(itemIndex);
 }
+
+static const ActionCode RENAME_ITEM_CODE("rename-item");
+static const QString RENAME_CLIP_ITEM_ID("rename-clip-item");
+static const QString RENAME_LABEL_ITEM_ID("rename-label-item");
 
 AppMenuModel::AppMenuModel(QObject* parent)
     : AbstractMenuModel(parent)
@@ -156,6 +161,19 @@ void AppMenuModel::setupConnections()
     extensionsProvider()->manifestChanged().onReceive(this, [this](const Manifest&) {
         findMenu("menu-tools").setSubitems(makeToolItems());
     });
+
+    updateRenameItemsState();
+}
+
+void AppMenuModel::onActionsStateChanges(const muse::actions::ActionCodeList& codes)
+{
+    AbstractMenuModel::onActionsStateChanges(codes);
+
+    //! NOTE "rename-item" drives both the "Rename clip" and "Rename label" items; split its
+    //! state between them depending on whether a clip or a label is selected
+    if (muse::contains(codes, RENAME_ITEM_CODE)) {
+        updateRenameItemsState();
+    }
 }
 
 void AppMenuModel::setItemIsChecked(const QString& itemId, bool checked)
@@ -179,6 +197,25 @@ void AppMenuModel::updateUndoRedoItems()
     redoItem.setTitle(redoActionName.isEmpty()
                       ? TranslatableString("action", "Redo")
                       : TranslatableString("action", "Redo ‘%1’").arg(redoActionName));
+}
+
+void AppMenuModel::updateRenameItemsState()
+{
+    const UiActionState actionState = uiActionsRegister()->actionState(RENAME_ITEM_CODE);
+
+    MenuItem& renameClipItem = findItem(RENAME_CLIP_ITEM_ID);
+    if (renameClipItem.isValid()) {
+        UiActionState state = actionState;
+        state.enabled = state.enabled && selectionController()->selectedClips().size() == 1;
+        renameClipItem.setState(state);
+    }
+
+    MenuItem& renameLabelItem = findItem(RENAME_LABEL_ITEM_ID);
+    if (renameLabelItem.isValid()) {
+        UiActionState state = actionState;
+        state.enabled = state.enabled && selectionController()->selectedLabels().size() == 1;
+        renameLabelItem.setState(state);
+    }
 }
 
 MenuItem* AppMenuModel::makeMenuItem(const actions::ActionCode& actionCode, MenuItemRole menuRole)
@@ -572,8 +609,11 @@ MenuItemList AppMenuModel::makeExportItems()
 
 MenuItemList AppMenuModel::makeClipItems()
 {
+    MenuItem* renameClipItem = makeMenuItem(RENAME_ITEM_CODE, TranslatableString("appshell-menu-clip", "Rename clip"));
+    renameClipItem->setId(RENAME_CLIP_ITEM_ID);
+
     MenuItemList items {
-        makeMenuItem("rename-item", TranslatableString("appshell-menu-clip", "Rename clip")),
+        renameClipItem,
         makeMenuItem("trim-clip"),
         makeSeparator(),
         makeMenuItem("split"),
@@ -590,8 +630,12 @@ MenuItemList AppMenuModel::makeClipItems()
 
 MenuItemList AppMenuModel::makeLabelItems()
 {
+    MenuItem* renameLabelItem = makeMenuItem(RENAME_ITEM_CODE, TranslatableString("appshell-menu-label", "Rename label"));
+    renameLabelItem->setId(RENAME_LABEL_ITEM_ID);
+
     MenuItemList items {
         makeMenuItem("label-add"),
+        renameLabelItem,
         makeMenuItem("paste-new-label"),
         makeSeparator(),
         makeMenuItem("open-label-editor", TranslatableString("action", "Manage labels")),

--- a/src/appshell/qml/Audacity/AppShell/appmenumodel.h
+++ b/src/appshell/qml/Audacity/AppShell/appmenumodel.h
@@ -45,6 +45,7 @@ Q_MOC_INCLUDE(< QWindow >)
 #include "effects/effects_base/effectstypes.h"
 #include "effects/effects_base/ieffectsmenuprovider.h"
 #include "trackedit/iprojecthistory.h"
+#include "trackedit/iselectioncontroller.h"
 
 //! TODO AU4
 // #include "workspace/iworkspacemanager.h"
@@ -72,6 +73,7 @@ public:
     muse::ContextInject<muse::ui::IUiActionsRegister> uiActionsRegister = { this };
     muse::ContextInject<effects::IEffectsMenuProvider> effectsMenuProvider = { this };
     muse::ContextInject<trackedit::IProjectHistory> projectHistory = { this };
+    muse::ContextInject<trackedit::ISelectionController> selectionController = { this };
 
     //! TODO AU4
     // muse::ContextInject<workspace::IWorkspaceManager> workspacesManager = { this };
@@ -86,6 +88,8 @@ public:
 private:
     void setupConnections();
     void onEffectsChanged();
+
+    void onActionsStateChanges(const muse::actions::ActionCodeList& codes) override;
 
     // effects::IEffectMenuItemFactory
     muse::uicomponents::MenuItem* makeMenuSeparator() override { return makeSeparator(); }
@@ -138,6 +142,7 @@ private:
     void setItemIsChecked(const QString& itemId, bool checked);
 
     void updateUndoRedoItems();
+    void updateRenameItemsState();
 
     std::shared_ptr<muse::uicomponents::AbstractMenuModel> m_workspacesMenuModel;
 

--- a/src/project/internal/projectuiactions.cpp
+++ b/src/project/internal/projectuiactions.cpp
@@ -128,12 +128,6 @@ const UiActionList ProjectUiActions::m_actions = {
              TranslatableString("action", "Insert"),
              TranslatableString("action", "Insert")
              ),
-    UiAction("rename-item",
-             au::context::UiCtxAny,
-             au::context::CTX_ANY,
-             TranslatableString("action", "Rename item"),
-             TranslatableString("action", "Rename item")
-             ),
     UiAction("trim-clip",
              au::context::UiCtxUnknown,
              au::context::CTX_ANY,

--- a/src/projectscene/internal/projectsceneuiactions.cpp
+++ b/src/projectscene/internal/projectsceneuiactions.cpp
@@ -161,13 +161,6 @@ static UiActionList STATIC_ACTIONS = {
              TranslatableString("action", "Clip properties"),
              TranslatableString("action", "Show clip properties")
              ),
-    UiAction("clip-rename",
-             au::context::UiCtxAny,
-             au::context::CTX_ANY,
-             TranslatableString("action", "Rename clip"),
-             TranslatableString("action", "Rename clip"),
-             Checkable::Yes
-             ),
     UiAction("action://delete",
              au::context::UiCtxProjectOpened,
              au::context::CTX_PROJECT_OPENED,

--- a/src/trackedit/internal/trackeditactionscontroller.cpp
+++ b/src/trackedit/internal/trackeditactionscontroller.cpp
@@ -102,6 +102,7 @@ static const ActionCode STRETCH_ENABLED_CODE("stretch-clip-to-match-tempo");
 
 static const ActionCode GROUP_CLIPS_CODE("group-clips");
 static const ActionCode UNGROUP_CLIPS_CODE("ungroup-clips");
+static const ActionCode RENAME_ITEM_CODE("rename-item");
 
 static const ActionCode SELECT_ALL("select-all");
 static const ActionCode SELECT_CLEAR("clear-selection");
@@ -345,6 +346,11 @@ void TrackeditActionsController::init()
         notifyActionEnabledChanged(UNGROUP_CLIPS_CODE);
         notifyActionEnabledChanged(JOIN_CODE);
         notifyActionEnabledChanged(SILENCE_AUDIO_SELECTION);
+        notifyActionEnabledChanged(RENAME_ITEM_CODE);
+    });
+
+    selectionController()->labelsSelected().onReceive(this, [this](const trackedit::LabelKeyList&) {
+        notifyActionEnabledChanged(RENAME_ITEM_CODE);
     });
 
     selectionController()->clipsIntersectingRangeSelectionChanged().onReceive(this, [this](const trackedit::ClipKeyList&) {
@@ -2287,6 +2293,8 @@ bool TrackeditActionsController::canReceiveAction(const ActionCode& actionCode) 
         return contiguousSelectedClipsSpan().has_value();
     } else if (actionCode == SILENCE_AUDIO_SELECTION) {
         return canSilenceAudio();
+    } else if (actionCode == RENAME_ITEM_CODE) {
+        return clipsForInteraction().size() + labelsForInteraction().size() == 1;
     }
 
     return true;

--- a/src/trackedit/internal/trackeditoperationcontroller.cpp
+++ b/src/trackedit/internal/trackeditoperationcontroller.cpp
@@ -87,7 +87,7 @@ bool TrackeditOperationController::changeTrackTitle(const trackedit::TrackId tra
 bool TrackeditOperationController::changeClipTitle(const ClipKey& clipKey, const muse::String& newTitle)
 {
     if (clipsInteraction()->changeClipTitle(clipKey, newTitle)) {
-        projectHistory()->pushHistoryState("Clip Title", "Changed Clip Title");
+        projectHistory()->pushHistoryState("Clip Title", "Changed clip title");
         return true;
     }
     return false;
@@ -895,7 +895,7 @@ bool TrackeditOperationController::addLabelToSelection()
 bool TrackeditOperationController::changeLabelTitle(const LabelKey& labelKey, const muse::String& title)
 {
     if (labelsInteraction()->changeLabelTitle(labelKey, title)) {
-        projectHistory()->pushHistoryState("Label title changed", "Change label title");
+        projectHistory()->pushHistoryState("Label title changed", "Changed label title");
         return true;
     }
     return false;

--- a/src/trackedit/internal/trackedituiactions.cpp
+++ b/src/trackedit/internal/trackedituiactions.cpp
@@ -18,6 +18,12 @@ namespace {
 constexpr const char16_t* TRACK_FORMAT_CHANGE_ACTION = u"action://trackedit/track/change-format?format=%1";
 constexpr const char16_t* TRACK_RATE_CHANGE_ACTION = u"action://trackedit/track/change-rate?rate=%1";
 UiActionList STATIC_ACTIONS = {
+    UiAction("rename-item",
+             au::context::UiCtxAny,
+             au::context::CTX_ANY,
+             TranslatableString("action", "Rename item"),
+             TranslatableString("action", "Rename item")
+             ),
     UiAction("action://trackedit/copy",
              au::context::UiCtxProjectOpened,
              au::context::CTX_DISABLED,

--- a/src/trackedit/internal/trackedituiactions.cpp
+++ b/src/trackedit/internal/trackedituiactions.cpp
@@ -21,8 +21,8 @@ UiActionList STATIC_ACTIONS = {
     UiAction("rename-item",
              au::context::UiCtxAny,
              au::context::CTX_ANY,
-             TranslatableString("action", "Rename item"),
-             TranslatableString("action", "Rename item")
+             TranslatableString("action", "Rename item (clip/label)"),
+             TranslatableString("action", "Rename item (clip/label)")
              ),
     UiAction("action://trackedit/copy",
              au::context::UiCtxProjectOpened,


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/10860
Resolves: https://github.com/audacity/audacity/issues/11466

"Edit > Clip > Rename clip" used to be enabled regardless of selection, so it stayed clickable during a range selection, with nothing selected, or with a label selected.

This PR:
- Adds an "Edit > Label > Rename label" item right under "Add label".
- Enables the two rename items mutually exclusively: "Rename clip" only when exactly one audio clip is selected/focused, "Rename label" only when exactly one label is. State refreshes on clip/label selection and focus changes.
- Both items keep the shared `rename-item` action code, so the shortcut is shown on both and keeps renaming whichever item type is uniquely selected.
- Changes the rename shortcut from `Ctrl+F2` to `F2` (`F2` was previously bound to `envelope-tool`, a dead entry with no action or handler).

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [x] Mutual exclusivity (clip vs. label): with one label selected, "Rename clip" must be greyed out and "Rename label" enabled; with one clip selected, the reverse
- [x] Both `rename clip` and `rename label` are disabled when either no selection or a time selection is made
- [x] F2 shortcut: it renames the uniquely selected clip or label, no longer fires the old envelope tool, and `Ctrl+F2` no longer renames
- [x] Rename still works from the right-click context menu on both a clip and a label
- [x] The rename actually commits the new name