### PR TITLE
11457 Fix cloud feature on windows

### DIFF
--- a/au3/libraries/au3-cloud-audiocom/CloudSyncService.cpp
+++ b/au3/libraries/au3-cloud-audiocom/CloudSyncService.cpp
@@ -494,7 +494,7 @@ CloudSyncService::GetProjectState(const std::string& projectId)
         return ProjectState::NotAvaliable;
     }
 
-    if (!wxFileExists(ToWXString(projectInfo->LocalPath))) {
+    if (!wxFileExists(ToWXString(projectInfo->LocalPath.Get()))) {
         return ProjectState::NotAvaliable;
     }
 
@@ -567,7 +567,7 @@ void CloudSyncService::SyncCloudSnapshot(
                         ? sync::MakeSafeProjectPath(
         CloudProjectsSavePath.Read(),
         audacity::ToWXString(projectInfo.Name))
-                        : audacity::ToWXString(localProjectInfo->LocalPath);
+                        : audacity::ToWXString(localProjectInfo->LocalPath.Get());
 
     const auto utf8Path = audacity::ToUTF8(wxPath);
 

--- a/au3/libraries/au3-cloud-audiocom/CloudSyncService.h
+++ b/au3/libraries/au3-cloud-audiocom/CloudSyncService.h
@@ -21,6 +21,8 @@
 
 #include "NetworkUtils.h"
 
+#include "sync/CloudSyncDTO.h"
+
 #include "au3-concurrency/concurrency/CancellationContext.h"
 
 class AudacityProject;
@@ -47,7 +49,7 @@ struct ProjectSyncResult final
 
     StatusCode Status { StatusCode::Failed };
     ResponseResult Result;
-    std::string ProjectPath;
+    LocalFilePath ProjectPath;
     TransferStats Stats;
 }; // struct ProjectSyncResult
 
@@ -63,7 +65,7 @@ struct DownloadAudioResult final
 
     StatusCode Status { StatusCode::Failed };
     ResponseResult Result;
-    std::string AudioPath;
+    LocalFilePath AudioPath;
     std::string Title;
     std::string Format;
 }; // struct DownloadAudioResult

--- a/au3/libraries/au3-cloud-audiocom/sync/CloudProjectsDatabase.cpp
+++ b/au3/libraries/au3-cloud-audiocom/sync/CloudProjectsDatabase.cpp
@@ -161,7 +161,7 @@ CloudProjectsDatabase::GetProjectData(std::string_view projectId) const
 }
 
 std::optional<DBProjectData> CloudProjectsDatabase::GetProjectDataForPath(
-    const std::string& projectFilePath) const
+    const LocalFilePath& projectFilePath) const
 {
     auto connection = GetConnection();
 
@@ -176,7 +176,7 @@ std::optional<DBProjectData> CloudProjectsDatabase::GetProjectDataForPath(
         return {};
     }
 
-    return DoGetProjectData(statement->Prepare(projectFilePath).Run());
+    return DoGetProjectData(statement->Prepare(projectFilePath.Get()).Run());
 }
 
 std::vector<DBProjectData>
@@ -356,7 +356,7 @@ bool CloudProjectsDatabase::UpdateProjectData(const DBProjectData& projectData)
                   ->Prepare(
         projectData.ProjectId, projectData.SnapshotId,
         projectData.SavesCount, projectData.LastAudioPreview,
-        projectData.LocalPath, projectData.LastModified,
+        projectData.LocalPath.Get(), projectData.LastModified,
         projectData.LastRead, projectData.SyncStatus,
         projectData.FirstSyncDialogShown)
                   .Run();
@@ -373,7 +373,7 @@ bool CloudProjectsDatabase::UpdateProjectData(const DBProjectData& projectData)
     }
 
     auto missingProjects = listMissingProjects->Prepare(
-        projectData.ProjectId, projectData.LocalPath).Run();
+        projectData.ProjectId, projectData.LocalPath.Get()).Run();
 
     for (auto row : missingProjects) {
         std::string missingProjectId;
@@ -866,9 +866,11 @@ CloudProjectsDatabase::DoGetProjectData(const sqlite::Row& row) const
         return {};
     }
 
-    if (!row.Get(4, data.LocalPath)) {
+    std::string localPath;
+    if (!row.Get(4, localPath)) {
         return {};
     }
+    data.LocalPath = std::move(localPath);
 
     if (!row.Get(5, data.LastModified)) {
         return {};

--- a/au3/libraries/au3-cloud-audiocom/sync/CloudProjectsDatabase.h
+++ b/au3/libraries/au3-cloud-audiocom/sync/CloudProjectsDatabase.h
@@ -26,7 +26,7 @@ struct DBProjectData final
     std::string SnapshotId;
     int64_t SavesCount       = 0;
     int64_t LastAudioPreview = 0;
-    std::string LocalPath;
+    LocalFilePath LocalPath;
     int64_t LastModified = 0;
     int64_t LastRead     = 0;
 
@@ -91,7 +91,7 @@ public:
     std::optional<DBProjectData>
     GetProjectData(std::string_view projectId) const;
     std::optional<DBProjectData>
-    GetProjectDataForPath(const std::string& projectPath) const;
+    GetProjectDataForPath(const LocalFilePath& projectPath) const;
 
     std::vector<DBProjectData> GetCloudProjects() const;
 

--- a/au3/libraries/au3-cloud-audiocom/sync/CloudSyncDTO.cpp
+++ b/au3/libraries/au3-cloud-audiocom/sync/CloudSyncDTO.cpp
@@ -926,6 +926,27 @@ wxString SafeName(wxString name)
 }
 } // namespace
 
+LocalFilePath::LocalFilePath(std::string path)
+    : mPath{std::move(path)}
+{
+#if defined(__WXMSW__)
+    if (mPath.rfind("\\\\?\\", 0) == 0) {
+        mPath.erase(0, 4);
+    }
+    std::replace(mPath.begin(), mPath.end(), '\\', '/');
+#endif
+}
+
+const std::string& LocalFilePath::Get() const noexcept
+{
+    return mPath;
+}
+
+bool LocalFilePath::IsEmpty() const noexcept
+{
+    return mPath.empty();
+}
+
 wxString
 MakeSafeFilePath(const wxString& rootDir, const wxString& fileName, const wxString& fileExtension)
 {

--- a/au3/libraries/au3-cloud-audiocom/sync/CloudSyncDTO.h
+++ b/au3/libraries/au3-cloud-audiocom/sync/CloudSyncDTO.h
@@ -269,6 +269,19 @@ std::optional<AppTaskPollResponse> DeserializeAppTaskPollResponse(const std::str
 
 std::string Serialize(NetworkStats stats);
 
+class CLOUD_AUDIOCOM_API LocalFilePath final
+{
+public:
+    LocalFilePath() = default;
+    LocalFilePath(std::string path);
+
+    const std::string& Get() const noexcept;
+    bool IsEmpty() const noexcept;
+
+private:
+    std::string mPath;
+};
+
 CLOUD_AUDIOCOM_API wxString
 MakeSafeProjectPath(const wxString& rootDir, const wxString& projectName);
 

--- a/au3/libraries/au3-cloud-audiocom/sync/CloudSyncHousekeeper.cpp
+++ b/au3/libraries/au3-cloud-audiocom/sync/CloudSyncHousekeeper.cpp
@@ -57,7 +57,7 @@ private:
                 return;
             }
 
-            const auto path = ToWXString(project.LocalPath);
+            const auto path = ToWXString(project.LocalPath.Get());
 
             if (!wxFileExists(path)) {
                 cloudProjectsDatabase.DeleteProject(project.ProjectId);

--- a/au3/libraries/au3-cloud-audiocom/sync/RemoteProjectSnapshot.cpp
+++ b/au3/libraries/au3-cloud-audiocom/sync/RemoteProjectSnapshot.cpp
@@ -235,7 +235,7 @@ std::string RemoteProjectSnapshot::AttachOriginalDB()
     // that has AudacityProject schema installed, even if it's a detached
     // or was deleted from the disk before
     auto attachStmt = db->CreateStatement("ATTACH DATABASE ? AS ?");
-    auto result     = attachStmt->Prepare(projectData->LocalPath, dbName).Run();
+    auto result     = attachStmt->Prepare(projectData->LocalPath.Get(), dbName).Run();
 
     if (!result.IsOk()) {
         return {};

--- a/au3/modules/sharing/mod-cloud-audiocom/CloudProjectOpenUtils.cpp
+++ b/au3/modules/sharing/mod-cloud-audiocom/CloudProjectOpenUtils.cpp
@@ -238,7 +238,7 @@ AudacityProject* OpenProjectFromCloud(
     }
 
     auto project = ProjectManager::OpenProject(
-        GetPotentialTarget(), audacity::ToWXString(result.ProjectPath), true,
+        GetPotentialTarget(), audacity::ToWXString(result.ProjectPath.Get()), true,
         false);
 
     if (project != nullptr && mode == CloudSyncService::SyncMode::ForceNew) {

--- a/src/au3cloud/internal/au3audiocomservice.cpp
+++ b/src/au3cloud/internal/au3audiocomservice.cpp
@@ -14,7 +14,7 @@
 #include "framework/global/log.h"
 #include "framework/global/runtime.h"
 #include "framework/global/types/ret.h"
-#include "framework/global/io/dir.h"
+#include "framework/global/io/path.h"
 #include "framework/global/progress.h"
 
 #include "au3-cloud-audiocom/sync/ProjectUploadOperation.h"
@@ -566,7 +566,7 @@ muse::RetVal<muse::ProgressPtr> Au3AudioComService::downloadAudioFile(const std:
             return;
         }
 
-        progress->finish(muse::RetVal<muse::Val>::make_ok(muse::Val(muse::io::path_t(result.AudioPath))));
+        progress->finish(muse::RetVal<muse::Val>::make_ok(muse::Val(muse::io::path_t(result.AudioPath.Get()))));
     }).detach();
 
     return muse::RetVal<muse::ProgressPtr>::make_ok(progress);
@@ -626,10 +626,10 @@ muse::RetVal<muse::ProgressPtr> Au3AudioComService::openCloudProject(const muse:
         //! no explicit snapshot is requested; otherwise fall through to OpenFromCloud.
         auto cancelCheck = [progress](double) -> bool { return !progress->isCanceled(); };
         if (!forceOverwrite && snapshotId.empty() && dbProjectData.has_value()) {
-            const auto normalizedLocalPath = muse::io::Dir::fromNativeSeparators(muse::io::path_t(dbProjectData->LocalPath));
-            if (self->filesystem()->exists(normalizedLocalPath)
+            const auto localPath = muse::io::path_t { dbProjectData->LocalPath.Get() };
+            if (self->filesystem()->exists(localPath)
                 && self->isSnapshotUpToDate(dbProjectData, cancelCheck, cancellationContext)) {
-                progress->finish(muse::RetVal<muse::Val>::make_ok(muse::Val(normalizedLocalPath)));
+                progress->finish(muse::RetVal<muse::Val>::make_ok(muse::Val(localPath)));
                 return;
             }
         }
@@ -646,8 +646,7 @@ muse::RetVal<muse::ProgressPtr> Au3AudioComService::openCloudProject(const muse:
         }
 
         if (result.Status == sync::ProjectSyncResult::StatusCode::Succeeded) {
-            const auto normalizedLocalPath = muse::io::Dir::fromNativeSeparators(result.ProjectPath);
-            progress->finish(muse::RetVal<muse::Val>::make_ok(muse::Val(muse::io::path_t(normalizedLocalPath))));
+            progress->finish(muse::RetVal<muse::Val>::make_ok(muse::Val(muse::io::path_t(result.ProjectPath.Get()))));
         } else {
             const auto err = syncResultCodeToErr(result.Result.Code);
             progress->finish(make_ret(err));

--- a/src/au3cloud/internal/cloudprojectsprovider.cpp
+++ b/src/au3cloud/internal/cloudprojectsprovider.cpp
@@ -3,6 +3,8 @@
 */
 #include "cloudprojectsprovider.h"
 
+#include "framework/global/io/dir.h"
+
 #include "au3-cloud-audiocom/sync/CloudProjectsDatabase.h"
 #include "au3-cloud-audiocom/sync/CloudSyncDTO.h"
 #include "au3-string-utils/CodeConversions.h"
@@ -20,7 +22,7 @@ std::optional<CloudProjectRecord> toCloudProjectRecord(
     CloudProjectRecord record;
     record.projectId = data->ProjectId;
     record.snapshotId = data->SnapshotId;
-    record.localPath = muse::io::path_t(data->LocalPath);
+    record.localPath = muse::io::path_t(data->LocalPath.Get());
     return record;
 }
 }
@@ -43,5 +45,5 @@ muse::io::path_t CloudProjectsProvider::makeSafeFilePath(const muse::io::path_t&
     namespace sync = audacity::cloud::audiocom::sync;
     const wxString path = sync::MakeSafeFilePath(audacity::ToWXString(rootDir.toStdString()), audacity::ToWXString(fileName),
                                                  audacity::ToWXString(fileExtension));
-    return muse::io::path_t(audacity::ToUTF8(path));
+    return muse::io::Dir::fromNativeSeparators(muse::io::path_t(audacity::ToUTF8(path)));
 }

--- a/src/project/internal/projectactionscontroller.cpp
+++ b/src/project/internal/projectactionscontroller.cpp
@@ -601,12 +601,17 @@ muse::Ret ProjectActionsController::saveProjectToCloud(const CloudProjectInfo& c
         return make_ret(Ret::Code::UnknownError, std::string { "Cloud projects path is not set" });
     }
 
-    io::path_t projectFilePath = cloudProjectsProvider()->makeSafeFilePath(cloudProjectsPath, cloudInfo.name.toStdString(),
-                                                                           au::project::AUP4);
-
     IAudacityProjectPtr project = currentProject();
     if (!project) {
         return make_ret(Ret::Code::UnknownError, std::string { "No project opened" });
+    }
+
+    io::path_t projectFilePath;
+    if (cloudSaveMode != CloudSaveMode::CreateNew && project->isCloudProject()) {
+        projectFilePath = project->path();
+    } else {
+        projectFilePath = cloudProjectsProvider()->makeSafeFilePath(cloudProjectsPath, cloudInfo.name.toStdString(),
+                                                                    au::project::AUP4);
     }
 
     auto [uploadRet, progress] = audioComService()->uploadProject(project, cloudInfo.name.toStdString(), [this, projectFilePath]() {

--- a/src/project/internal/projectactionscontroller.cpp
+++ b/src/project/internal/projectactionscontroller.cpp
@@ -941,7 +941,12 @@ muse::Ret ProjectActionsController::openProject(const muse::io::path_t& path, co
         return make_ret(Ret::Code::Ok);
     }
 
-    //! Step 5. Open project in the current window
+    //! Step 5. Check, if the project is a known cloud project, then open it through the cloud flow
+    if (const auto record = cloudProjectsProvider()->projectRecordForPath(actualPath)) {
+        return openCloudProject(actualPath, muse::String::fromStdString(record->projectId));
+    }
+
+    //! Step 6. Open project in the current window
     return doOpenProject(actualPath);
 }
 


### PR DESCRIPTION
Resolves: #11457 

This PR fixes two major issues.
1. Normalize windows local path before database access. This is fixed on au3 cloud database layer to avoid breaking this again in the future by forgetting to call `fromNativeSeparators` on au4 code.
2. au3 `makeSafeFilePath` returns a new filename if the file already exists. The code should check if it is a new project before calling this function.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

Please remove cloud database and cloud project files before running the tests.

- [ ] Testflow test cases have been run
