### PR TITLE
Stop auto-scroll when item edit gesture completes

### DIFF
--- a/src/projectscene/view/tracksitemsview/trackitemslistmodel.cpp
+++ b/src/projectscene/view/tracksitemsview/trackitemslistmodel.cpp
@@ -471,7 +471,7 @@ void TrackItemsListModel::handleAutoScroll(bool ok, bool completed, const std::f
     }
 
     // handle auto-scroll over the edge
-    if (!ok) {
+    if (!ok || completed) {
         m_context->stopAutoScroll();
     } else {
         m_context->startAutoScroll(m_context->mousePositionTime());


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/11425

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
