### PR TITLE
Fix file filter for ffmpeg selection dialog on linux

### DIFF
--- a/src/importexport/export/view/customffmpegpreferencesmodel.cpp
+++ b/src/importexport/export/view/customffmpegpreferencesmodel.cpp
@@ -179,9 +179,13 @@ void CustomFFmpegPreferencesModel::locateFFmpegLibrary()
         initialPath = globalConfiguration()->userDataPath();
     }
 
-    std::string libFileName = avformatString().toStdString();
-    const std::string filter
-        =libFileName.replace(libFileName.find('.'), 0, "*");
+    const std::string libFileName = avformatString().toStdString();
+    std::string filter = libFileName;
+    filter.insert(filter.find_last_of('.'), "*");
+#if !defined(Q_OS_WIN) && !defined(Q_OS_MACOS)
+    // linux and other *nix systems use versioned libraries: libavformat.so.62
+    filter += "*";
+#endif
     muse::io::path_t directory = interactive()->selectOpeningFileSync(muse::qtrc("preferences",
                                                                                  "Locate %1").arg(
                                                                           libFileName).toStdString(), initialPath, { filter });
@@ -198,9 +202,9 @@ void CustomFFmpegPreferencesModel::locateFFmpegLibrary()
 
 QString CustomFFmpegPreferencesModel::avformatString() const
 {
-#if defined(__WXMSW__)
+#if defined(Q_OS_WIN)
     return "avformat.dll";
-#elif defined(__WXMAC__)
+#elif defined(Q_OS_MACOS)
     return "libavformat.dylib";
 #else
     return "libavformat.so";


### PR DESCRIPTION
Resolves: #11104

Add an extra asterisk for file mask on linux to cover versioned so's

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
