### PR TITLE
Fix timeline cursor

### DIFF
--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TrackClipsContainer.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TrackClipsContainer.qml
@@ -266,6 +266,17 @@ TrackItemsContainer {
                         root.updateItemGuideline(time)
                     }
 
+                    Connections {
+                        target: root.context
+
+                        function onFrameTimeChanged() {
+                            if (clipsContainerMouseArea.containsMouse && !root.moveActive && !root.selectionInProgress) {
+                                let time = root.context.findGuideline(root.context.positionToTime(clipsContainerMouseArea.mouseX, true))
+                                root.updateItemGuideline(time)
+                            }
+                        }
+                    }
+
                     onContainsMouseChanged: function () {
                         if (root.isNearSample || root.isBrush) {
                             clipsContainer.mapToAllClips({

--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TrackLabelsContainer.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TrackLabelsContainer.qml
@@ -96,6 +96,15 @@ TrackItemsContainer {
                             }
                         }
 
+                        function clearGuidelineIfPointerLeft() {
+                            const overAnyLabel = labelsContainer.checkIfAnyLabel(function (labelItem) {
+                                return labelItem && labelItem.hover
+                            })
+                            if (!labelsContainerMouseArea.containsMouse && !overAnyLabel) {
+                                root.clearItemGuideline()
+                            }
+                        }
+
                         Component.onCompleted: updateCustomCursor()
                         Connections {
                             target: root
@@ -124,6 +133,9 @@ TrackItemsContainer {
                             labelsContainer.mapToAllLabels(e, function (labelItem, mouseEvent) {
                                 labelItem.labelItemMousePositionChanged(mouseEvent.x, mouseEvent.y)
                             })
+
+                            let time = root.context.findGuideline(root.context.positionToTime(e.x, true))
+                            root.updateItemGuideline(time)
                         }
 
                         onContainsMouseChanged: function () {
@@ -133,6 +145,10 @@ TrackItemsContainer {
                             }, function (labelItem, mouseEvent) {
                                 labelItem.setContainsMouse(containsMouse)
                             })
+
+                            if (!containsMouse) {
+                                Qt.callLater(labelsContainerMouseArea.clearGuidelineIfPointerLeft)
+                            }
                         }
                     }
 

--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TrackLabelsContainer.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TrackLabelsContainer.qml
@@ -150,6 +150,17 @@ TrackItemsContainer {
                                 Qt.callLater(labelsContainerMouseArea.clearGuidelineIfPointerLeft)
                             }
                         }
+
+                        Connections {
+                            target: root.context
+
+                            function onFrameTimeChanged() {
+                                if (labelsContainerMouseArea.containsMouse && !root.moveActive && !root.selectionInProgress) {
+                                    let time = root.context.findGuideline(root.context.positionToTime(labelsContainerMouseArea.mouseX, true))
+                                    root.updateItemGuideline(time)
+                                }
+                            }
+                        }
                     }
 
                     Repeater {

--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TracksItemsView.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TracksItemsView.qml
@@ -351,7 +351,8 @@ Rectangle {
             property double displayedPlayCursorX: playCursorController.positionX
 
             function updateCursorPosition(x, y) {
-                lineCursor.x = x
+                const snappedTime = timeline.context.applyDetectedSnap(timeline.context.positionToTime(x))
+                lineCursor.x = timeline.context.timeToPosition(snappedTime)
                 timeline.context.updateMousePositionTime(x)
                 tracksViewState.setMouseY(Math.max(0, Math.min(y, mainMouseArea.height)))
             }

--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TracksItemsView.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TracksItemsView.qml
@@ -697,7 +697,8 @@ Rectangle {
             }
         }
 
-        // Drives the snap guideline while hovering empty project space below the last track.
+        // Keeps the timeline cursor following the mouse anywhere over the view,
+        // and drives the snap guideline while hovering empty project space below the last track.
         HoverHandler {
             id: emptyAreaGuidelineHandler
 
@@ -709,12 +710,13 @@ Rectangle {
                 }
 
                 let pos = point.position
+                timeline.updateCursorPosition(pos.x, pos.y)
+
                 if (tracksViewState.trackAtPosition(pos.x, pos.y) !== -1) {
                     // Over a track: let the track container own the guideline.
                     return
                 }
 
-                timeline.updateCursorPosition(pos.x, pos.y)
                 root.snapGuidelineToPosition(pos.x)
             }
 

--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TracksItemsView.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TracksItemsView.qml
@@ -698,18 +698,13 @@ Rectangle {
             }
         }
 
-        // Keeps the timeline cursor following the mouse anywhere over the view,
-        // and drives the snap guideline while hovering empty project space below the last track.
+        // Drives the snap guideline while hovering empty project space below the last track.
         HoverHandler {
             id: emptyAreaGuidelineHandler
 
             enabled: root.interactionState !== TracksItemsView.State.DraggingItem
 
-            onPointChanged: {
-                if (!hovered) {
-                    return
-                }
-
+            function processHover() {
                 let pos = point.position
                 timeline.updateCursorPosition(pos.x, pos.y)
 
@@ -721,9 +716,25 @@ Rectangle {
                 root.snapGuidelineToPosition(pos.x)
             }
 
+            onPointChanged: {
+                if (hovered) {
+                    processHover()
+                }
+            }
+
             onHoveredChanged: {
                 if (!hovered) {
                     root.hideGuideline()
+                }
+            }
+        }
+
+        Connections {
+            target: timeline.context
+
+            function onFrameTimeChanged() {
+                if (emptyAreaGuidelineHandler.hovered && !mainMouseArea.pressed && root.interactionState === TracksItemsView.State.Idle) {
+                    emptyAreaGuidelineHandler.processHover()
                 }
             }
         }


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/11435

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
- [x] Check if timelineruler cursor updates no matter where you hover on the clips view
- [x] Check if timelineruler cursor snaps just like guidelines snap
- [x] Check if timelineruler cursor and guidelines keep the same position if you zoom-in/out
- [x] Check if guidelines are shown when hovering over labels tracks too
