### PR TITLE
playback ignore the selection

### DIFF
--- a/src/playback/internal/playbackcontroller.cpp
+++ b/src/playback/internal/playbackcontroller.cpp
@@ -282,20 +282,15 @@ void PlaybackController::doPlay(bool ignoreSelection)
     }
 
     if (!ignoreSelection) {
-        PlaybackRegion selectionRegion = selectionPlaybackRegion();
-        if (selectionRegion.isValid()) {
-            doChangePlaybackRegion(selectionRegion);
+        //! NOTE: a time selection must not constrain playback;
+        //! play from the cursor (lastPlaybackSeekTime) to the project end
+        const muse::secs_t end = totalPlayTime();
+        const muse::secs_t start = lastPlaybackSeekTime();
+        if (end > start) {
+            doChangePlaybackRegion({ start, end });
         } else {
-            //! NOTE: no selection — fall back to the user's cursor (lastPlaybackSeekTime)
-            //! and the project end.
-            const muse::secs_t end = totalPlayTime();
-            const muse::secs_t start = lastPlaybackSeekTime();
-            if (end > start) {
-                doChangePlaybackRegion({ start, end });
-            } else {
-                LOGW() << "playback region is not valid";
-                updatePlaybackRegion();
-            }
+            LOGW() << "playback region is not valid";
+            updatePlaybackRegion();
         }
     } else {
         doChangePlaybackRegion({});

--- a/src/playback/internal/playbackcontroller.cpp
+++ b/src/playback/internal/playbackcontroller.cpp
@@ -313,14 +313,14 @@ void PlaybackController::playSelectionAction()
         return;
     }
 
-    const PlaybackRegion selection = selectionPlaybackRegion();
-    if (!selection.isValid()) {
-        return;
-    }
-
     if (!isStopped()) {
         //! NOTE: just stop, without seek
         player()->stop();
+    }
+
+    const PlaybackRegion selection = selectionPlaybackRegion();
+    if (!selection.isValid()) {
+        return;
     }
 
     doChangePlaybackRegion(selection);

--- a/src/playback/internal/playbackcontroller.cpp
+++ b/src/playback/internal/playbackcontroller.cpp
@@ -12,6 +12,7 @@ using namespace muse::async;
 using namespace muse::actions;
 
 static const ActionQuery PLAYBACK_PLAY_QUERY("action://playback/play");
+static const ActionQuery PLAYBACK_PLAY_SELECTION_QUERY("action://playback/play-selection");
 static const ActionQuery PLAYBACK_PLAY_TRACKS_QUERY("action://playback/play-tracks");
 static const ActionQuery PLAYBACK_PAUSE_QUERY("action://playback/pause");
 static const ActionQuery PLAYBACK_STOP_QUERY("action://playback/stop");
@@ -32,6 +33,7 @@ static const secs_t TIME_EPS = secs_t(1 / 1000.0);
 void PlaybackController::init()
 {
     dispatcher()->reg(this, PLAYBACK_PLAY_QUERY, this, &PlaybackController::togglePlayAction);
+    dispatcher()->reg(this, PLAYBACK_PLAY_SELECTION_QUERY, this, &PlaybackController::playSelectionAction);
     dispatcher()->reg(this, PLAYBACK_PLAY_TRACKS_QUERY, this, &PlaybackController::playTracksAction);
     dispatcher()->reg(this, PLAYBACK_PAUSE_QUERY, this, &PlaybackController::pauseAction);
     dispatcher()->reg(this, PLAYBACK_STOP_QUERY, this, &PlaybackController::stopAction);
@@ -296,6 +298,32 @@ void PlaybackController::doPlay(bool ignoreSelection)
         doChangePlaybackRegion({});
         doSeek(lastPlaybackSeekTime(), false);
     }
+
+    if (!isPlaybackStartPositionValid()) {
+        return;
+    }
+
+    player()->play();
+}
+
+void PlaybackController::playSelectionAction()
+{
+    if (!isPlayAllowed()) {
+        LOGW() << "playback not allowed";
+        return;
+    }
+
+    const PlaybackRegion selection = selectionPlaybackRegion();
+    if (!selection.isValid()) {
+        return;
+    }
+
+    if (!isStopped()) {
+        //! NOTE: just stop, without seek
+        player()->stop();
+    }
+
+    doChangePlaybackRegion(selection);
 
     if (!isPlaybackStartPositionValid()) {
         return;
@@ -767,7 +795,7 @@ bool PlaybackController::canReceiveAction(const ActionCode& code) const
         return false;
     }
 
-    if (code == PLAYBACK_PLAY_QUERY.toString()) {
+    if (code == PLAYBACK_PLAY_QUERY.toString() || code == PLAYBACK_PLAY_SELECTION_QUERY.toString()) {
         return !recordController()->isRecording();
     }
 

--- a/src/playback/internal/playbackcontroller.cpp
+++ b/src/playback/internal/playbackcontroller.cpp
@@ -284,8 +284,7 @@ void PlaybackController::doPlay(bool clearPlaybackRegion)
     }
 
     if (!clearPlaybackRegion) {
-        //! NOTE: a time selection must not constrain playback;
-        //! play from the cursor (lastPlaybackSeekTime) to the project end
+        //! NOTE: play from the cursor to the project end
         const muse::secs_t end = totalPlayTime();
         const muse::secs_t start = lastPlaybackSeekTime();
         if (end > start) {

--- a/src/playback/internal/playbackcontroller.cpp
+++ b/src/playback/internal/playbackcontroller.cpp
@@ -264,7 +264,7 @@ void PlaybackController::togglePlayAction()
         } else if (isShiftPressed) {
             //! NOTE: set the current position as start position
             doSeek(playbackPosition(), false);
-            doPlay(true /* ignoreSelection */);
+            doPlay(true /* clearPlaybackRegion */);
         } else {
             doResume();
         }
@@ -273,17 +273,17 @@ void PlaybackController::togglePlayAction()
             doSeek(0.0, false);
         }
 
-        doPlay(isShiftPressed /* ignoreSelection */);
+        doPlay(isShiftPressed /* clearPlaybackRegion */);
     }
 }
 
-void PlaybackController::doPlay(bool ignoreSelection)
+void PlaybackController::doPlay(bool clearPlaybackRegion)
 {
     IF_ASSERT_FAILED(player()) {
         return;
     }
 
-    if (!ignoreSelection) {
+    if (!clearPlaybackRegion) {
         //! NOTE: a time selection must not constrain playback;
         //! play from the cursor (lastPlaybackSeekTime) to the project end
         const muse::secs_t end = totalPlayTime();
@@ -295,6 +295,7 @@ void PlaybackController::doPlay(bool ignoreSelection)
             updatePlaybackRegion();
         }
     } else {
+        //! NOTE: no playback region; play from the cursor with no defined end
         doChangePlaybackRegion({});
         doSeek(lastPlaybackSeekTime(), false);
     }

--- a/src/playback/internal/playbackcontroller.cpp
+++ b/src/playback/internal/playbackcontroller.cpp
@@ -795,8 +795,14 @@ bool PlaybackController::canReceiveAction(const ActionCode& code) const
         return false;
     }
 
-    if (code == PLAYBACK_PLAY_QUERY.toString() || code == PLAYBACK_PLAY_SELECTION_QUERY.toString()) {
+    if (code == PLAYBACK_PLAY_QUERY.toString()) {
         return !recordController()->isRecording();
+    }
+
+    if (code == PLAYBACK_PLAY_SELECTION_QUERY.toString()) {
+        //! NOTE: when playback is active the action stops it, so it stays available without a selection
+        return !recordController()->isRecording()
+               && (!isStopped() || !selectionController()->timeSelectionIsEmpty());
     }
 
     if (code == PLAYBACK_REWIND_START_QUERY.toString() || code == PLAYBACK_REWIND_END_QUERY.toString()) {

--- a/src/playback/internal/playbackcontroller.cpp
+++ b/src/playback/internal/playbackcontroller.cpp
@@ -315,7 +315,7 @@ void PlaybackController::playSelectionAction()
 
     if (!isStopped()) {
         //! NOTE: just stop, without seek
-        player()->stop();
+        stop();
     }
 
     const PlaybackRegion selection = selectionPlaybackRegion();

--- a/src/playback/internal/playbackcontroller.h
+++ b/src/playback/internal/playbackcontroller.h
@@ -114,7 +114,7 @@ private:
 
     void togglePlayAction();
     void playSelectionAction();
-    void doPlay(bool ignoreSelection);
+    void doPlay(bool clearPlaybackRegion);
     void stopAction();
     void playTracksAction(const muse::actions::ActionQuery& q);
     void rewindToStartAction();

--- a/src/playback/internal/playbackcontroller.h
+++ b/src/playback/internal/playbackcontroller.h
@@ -113,6 +113,7 @@ private:
     void seekRangeSelection();
 
     void togglePlayAction();
+    void playSelectionAction();
     void doPlay(bool ignoreSelection);
     void stopAction();
     void playTracksAction(const muse::actions::ActionQuery& q);

--- a/src/playback/internal/playbackuiactions.cpp
+++ b/src/playback/internal/playbackuiactions.cpp
@@ -15,6 +15,7 @@ using namespace muse::ui;
 using namespace muse::actions;
 
 static const ActionQuery PLAYBACK_PLAY_QUERY("action://playback/play");
+static const ActionQuery PLAYBACK_PLAY_SELECTION_QUERY("action://playback/play-selection");
 static const ActionQuery PLAYBACK_PAUSE_QUERY("action://playback/pause");
 static const ActionQuery PLAYBACK_STOP_QUERY("action://playback/stop");
 
@@ -34,6 +35,13 @@ const UiActionList PlaybackUiActions::m_mainActions = {
              au::context::CTX_PROJECT_OPENED,
              TranslatableString("action", "Play"),
              TranslatableString("action", "Play"),
+             IconCode::Code::PLAY_FILL
+             ),
+    UiAction(PLAYBACK_PLAY_SELECTION_QUERY.toString(),
+             au::context::UiCtxProjectOpened,
+             au::context::CTX_PROJECT_OPENED,
+             TranslatableString("action", "Play selection"),
+             TranslatableString("action", "Play the selected time range"),
              IconCode::Code::PLAY_FILL
              ),
     UiAction(PLAYBACK_PAUSE_QUERY.toString(),

--- a/src/playback/internal/playbackuiactions.cpp
+++ b/src/playback/internal/playbackuiactions.cpp
@@ -255,12 +255,21 @@ void PlaybackUiActions::init()
     m_controller->isPlayingChanged().onNotify(this, [this]() {
         ActionCodeList codes= {
             PLAYBACK_PLAY_QUERY.toString(),
+            PLAYBACK_PLAY_SELECTION_QUERY.toString(),
             PLAYBACK_PAUSE_QUERY.toString(),
             PLAYBACK_REWIND_START_QUERY.toString(),
             PLAYBACK_REWIND_END_QUERY.toString()
         };
 
         m_actionEnabledChanged.send(codes);
+    });
+
+    selectionController()->dataSelectedStartTimeChanged().onReceive(this, [this](muse::secs_t) {
+        m_actionEnabledChanged.send({ PLAYBACK_PLAY_SELECTION_QUERY.toString() });
+    });
+
+    selectionController()->dataSelectedEndTimeChanged().onReceive(this, [this](muse::secs_t) {
+        m_actionEnabledChanged.send({ PLAYBACK_PLAY_SELECTION_QUERY.toString() });
     });
 
     audioDevicesProvider()->apiChanged().onNotify(this, [this]() {

--- a/src/playback/internal/playbackuiactions.h
+++ b/src/playback/internal/playbackuiactions.h
@@ -10,12 +10,14 @@
 #include "audio/iaudiodevicesprovider.h"
 #include "context/iuicontextresolver.h"
 #include "internal/playbackcontroller.h"
+#include "trackedit/iselectioncontroller.h"
 
 namespace au::playback {
 class PlaybackUiActions : public muse::ui::IUiActionsModule, public muse::async::Asyncable, public muse::Contextable
 {
     muse::ContextInject<context::IUiContextResolver> uiContextResolver{ this };
     muse::ContextInject<audio::IAudioDevicesProvider> audioDevicesProvider{ this };
+    muse::ContextInject<trackedit::ISelectionController> selectionController{ this };
 
 public:
     PlaybackUiActions(const muse::modularity::ContextPtr& ctx, std::shared_ptr<PlaybackController> controller);

--- a/src/playback/tests/playbackcontroller_tests.cpp
+++ b/src/playback/tests/playbackcontroller_tests.cpp
@@ -925,6 +925,29 @@ TEST_F(PlaybackControllerTests, PlaySelection_WithoutSelection_DoesNothing)
 }
 
 /**
+ * @brief Play selection without a selection stops active playback
+ */
+TEST_F(PlaybackControllerTests, PlaySelection_WhilePlaying_NoSelection_Stops)
+{
+    //! [GIVEN] Playback is running
+    ON_CALL(*m_player, playbackStatus())
+    .WillByDefault(Return(PlaybackStatus::Running));
+
+    //! [GIVEN] No time selection
+    ON_CALL(*m_selectionController, timeSelectionIsEmpty())
+    .WillByDefault(Return(true));
+
+    //! [THEN] Player is stopped and not restarted
+    EXPECT_CALL(*m_player, stop())
+    .Times(1);
+    EXPECT_CALL(*m_player, play())
+    .Times(0);
+
+    //! [WHEN] Play selection
+    playSelection();
+}
+
+/**
  * @brief Play selection does nothing while recording
  */
 TEST_F(PlaybackControllerTests, PlaySelection_WhileRecording_DoesNothing)

--- a/src/playback/tests/playbackcontroller_tests.cpp
+++ b/src/playback/tests/playbackcontroller_tests.cpp
@@ -60,6 +60,10 @@ public:
 
         m_player = std::make_shared<PlayerMock>();
 
+        //! NOTE: use a persistent channel so tests can inject playback position events
+        ON_CALL(*m_player, playbackPositionChanged())
+        .WillByDefault(Return(m_playbackPositionChanged));
+
         EXPECT_CALL(*m_playback, player(_))
         .WillOnce(Return(m_player));
 
@@ -134,6 +138,8 @@ public:
 
     std::shared_ptr<PlaybackMock> m_playback;
     std::shared_ptr<PlayerMock> m_player;
+
+    muse::async::Channel<muse::secs_t> m_playbackPositionChanged;
 };
 
 /**
@@ -156,9 +162,9 @@ TEST_F(PlaybackControllerTests, TogglePlay_WhenStopped)
     EXPECT_CALL(*m_player, playbackPosition())
     .WillRepeatedly(Return(currentPosition));
 
-    //! [GIVEN] No time selection
+    //! [GIVEN] The selection is never consulted for playback
     EXPECT_CALL(*m_selectionController, timeSelectionIsEmpty())
-    .WillOnce(Return(true));
+    .Times(0);
 
     //! [GIVEN] No loop region active
     EXPECT_CALL(*m_player, isLoopRegionActive())
@@ -210,26 +216,36 @@ TEST_F(PlaybackControllerTests, TogglePlay_WhenStopped_OnTheEndOfProject)
 
 /**
  * @brief Toggle play when there is selection
- * @details User made a selection and clicked play
- *          Playback should be started from selection's start
+ * @details User made a selection, placed the playhead before it and clicked play
+ *          A time selection must not constrain playback: it should start from
+ *          the playhead and flow through the selection to the project end
  */
-TEST_F(PlaybackControllerTests, TogglePlay_WithSelection)
+TEST_F(PlaybackControllerTests, TogglePlay_WithSelection_PlaysFromPlayheadThroughSelection)
 {
     //! [GIVEN] Playback is stopped
     ON_CALL(*m_player, playbackStatus())
     .WillByDefault(Return(PlaybackStatus::Stopped));
 
-    //! [GIVEN] There is selection from 10 to 20 secs
-    PlaybackRegion selectionRegion = { secs_t(10.0), secs_t(20.0) };
-    EXPECT_CALL(*m_selectionController, timeSelectionIsEmpty())
-    .WillOnce(Return(false));
-    EXPECT_CALL(*m_selectionController, dataSelectedStartTime())
-    .WillOnce(Return(selectionRegion.start));
-    EXPECT_CALL(*m_selectionController, dataSelectedEndTime())
-    .WillOnce(Return(selectionRegion.end));
+    //! [GIVEN] Playhead is at 5 secs
+    const secs_t playheadPosition = 5.0;
+    EXPECT_CALL(*m_player, seek(playheadPosition, false))
+    .Times(1);
+    seek(playheadPosition);
 
-    //! [THEN] Expect that we will take into account the selection region
-    EXPECT_CALL(*m_player, setPlaybackRegion(selectionRegion))
+    //! [GIVEN] There is selection from 10 to 20 secs
+    ON_CALL(*m_selectionController, timeSelectionIsEmpty())
+    .WillByDefault(Return(false));
+    ON_CALL(*m_selectionController, dataSelectedStartTime())
+    .WillByDefault(Return(secs_t(10.0)));
+    ON_CALL(*m_selectionController, dataSelectedEndTime())
+    .WillByDefault(Return(secs_t(20.0)));
+
+    //! [THEN] The selection is never consulted for playback
+    EXPECT_CALL(*m_selectionController, timeSelectionIsEmpty())
+    .Times(0);
+
+    //! [THEN] Playback region is {playhead, totalPlayTime}, not the selection
+    EXPECT_CALL(*m_player, setPlaybackRegion(PlaybackRegion { playheadPosition, secs_t(100.0) }))
     .Times(1);
 
     //! [THEN] Player should start playing
@@ -262,9 +278,9 @@ TEST_F(PlaybackControllerTests, TogglePlay_WithSelection_Clip)
     ON_CALL(*m_selectionController, rightMostSelectedItemEndTime())
     .WillByDefault(Return(std::optional<secs_t>(secs_t(20.0))));
 
-    //! [GIVEN] No time selection
+    //! [GIVEN] The selection is never consulted for playback
     EXPECT_CALL(*m_selectionController, timeSelectionIsEmpty())
-    .WillOnce(Return(true));
+    .Times(0);
 
     //! [THEN] The clip selection is ignored: playback region falls back to
     //! {lastPlaybackSeekTime, totalPlayTime}
@@ -476,16 +492,6 @@ TEST_F(PlaybackControllerTests, TogglePlay_WhenPaused_WithChangingSelection)
 
     //! [THEN] Expect that playbeck should run from selection start position
     PlaybackRegion selectionRegion = { secs_t(10.0), secs_t(20.0) };
-    EXPECT_CALL(*m_selectionController, timeSelectionIsEmpty())
-    .WillOnce(Return(false));
-    EXPECT_CALL(*m_selectionController, dataSelectedStartTime())
-    .WillOnce(Return(selectionRegion.start));
-    EXPECT_CALL(*m_selectionController, dataSelectedEndTime())
-    .WillOnce(Return(selectionRegion.end));
-
-    //! [THEN] Expect that we will take into account the selection region
-    EXPECT_CALL(*m_player, setPlaybackRegion(selectionRegion))
-    .WillRepeatedly(Return());
 
     //! [THEN] Player should stop playing
     EXPECT_CALL(*m_player, stop())
@@ -500,37 +506,36 @@ TEST_F(PlaybackControllerTests, TogglePlay_WhenPaused_WithChangingSelection)
 
     //! [WHEN] Second: toggle play
     togglePlay();
+
+    //! [THEN] Playback restarted from the new selection start
+    EXPECT_EQ(m_controller->lastPlaybackSeekTime(), selectionRegion.start);
 }
 
 /**
- * @brief Toggle play when there is selection wich start time is more than total time
- * @details User made a selection and clicked play
+ * @brief Toggle play when the playback region start time is more than total time
+ * @details The playback region was set past the project end
  *          Playback shouldn't be started
  */
-TEST_F(PlaybackControllerTests, TogglePlay_WithSelection_StartTimeIsMoreThanTotalTime)
+TEST_F(PlaybackControllerTests, TogglePlay_StartTimeIsMoreThanTotalTime)
 {
     //! [GIVEN] Playback is stopped
     ON_CALL(*m_player, playbackStatus())
     .WillByDefault(Return(PlaybackStatus::Stopped));
 
-    //! [GIVEN] There is selection from 10 to 20 secs
-    PlaybackRegion selectionRegion = { secs_t(1000.0), secs_t(2000.0) };
-    EXPECT_CALL(*m_selectionController, timeSelectionIsEmpty())
-    .WillOnce(Return(false));
-    EXPECT_CALL(*m_selectionController, dataSelectedStartTime())
-    .WillOnce(Return(selectionRegion.start));
-    EXPECT_CALL(*m_selectionController, dataSelectedEndTime())
-    .WillOnce(Return(selectionRegion.end));
+    //! [GIVEN] The playback region is past the project end (totalTime = 100)
+    PlaybackRegion region = { secs_t(1000.0), secs_t(2000.0) };
 
-    //! [THEN] Expect that we will take into account the selection region
-    EXPECT_CALL(*m_player, setPlaybackRegion(selectionRegion))
-    .Times(1);
+    //! [THEN] The region is forwarded to the player (once by the region change,
+    //! once by the invalid-region fallback in doPlay)
+    EXPECT_CALL(*m_player, setPlaybackRegion(region))
+    .Times(2);
 
-    //! [THEN] Player should start playing
+    //! [THEN] Player shouldn't start playing
     EXPECT_CALL(*m_player, play())
     .Times(0);
 
-    //! [WHEN] Toggle play
+    //! [WHEN] Change the playback region and toggle play
+    changePlaybackRegion(region.start, region.end);
     togglePlay();
 }
 
@@ -754,9 +759,9 @@ TEST_F(PlaybackControllerTests, TogglePlay_AfterRecord_PlaysFromSeekToProjectEnd
     EXPECT_CALL(*m_player, playbackPosition())
     .WillRepeatedly(Return(recordEnd));
 
-    //! [GIVEN] No selection
+    //! [GIVEN] The selection is never consulted for playback
     EXPECT_CALL(*m_selectionController, timeSelectionIsEmpty())
-    .WillOnce(Return(true));
+    .Times(0);
 
     //! [THEN] Playback region is {cursor, totalPlayTime}
     EXPECT_CALL(*m_player, setPlaybackRegion(PlaybackRegion { recordEnd, secs_t(100.0) }))
@@ -768,5 +773,88 @@ TEST_F(PlaybackControllerTests, TogglePlay_AfterRecord_PlaysFromSeekToProjectEnd
 
     //! [WHEN] User presses Space
     togglePlay();
+}
+
+/**
+ * @brief Playback does not stop when passing a former selection end
+ * @details Playback runs with region {5, 100} (playhead to project end).
+ *          Reaching a position in the middle (e.g. the end of a time selection
+ *          at 20s) must not stop the player.
+ */
+TEST_F(PlaybackControllerTests, PlaybackPosition_InsideRegion_DoesNotStop)
+{
+    //! [GIVEN] Playback is running with region {5, 100}
+    ON_CALL(*m_player, playbackStatus())
+    .WillByDefault(Return(PlaybackStatus::Running));
+    ON_CALL(*m_player, playbackRegion())
+    .WillByDefault(Return(PlaybackRegion { secs_t(5.0), secs_t(100.0) }));
+    ON_CALL(*m_player, isLoopRegionActive())
+    .WillByDefault(Return(false));
+
+    //! [GIVEN] Playback position is at 20s (inside the region)
+    ON_CALL(*m_player, playbackPosition())
+    .WillByDefault(Return(secs_t(20.0)));
+
+    //! [THEN] Player is not stopped
+    EXPECT_CALL(*m_player, stop())
+    .Times(0);
+
+    //! [WHEN] Playback position changed
+    m_playbackPositionChanged.send(secs_t(20.0));
+}
+
+/**
+ * @brief Playback stops at the end of the playback region / project
+ */
+TEST_F(PlaybackControllerTests, PlaybackPosition_OnRegionEnd_Stops)
+{
+    //! [GIVEN] The playback region is {5, 100}
+    ON_CALL(*m_player, playbackStatus())
+    .WillByDefault(Return(PlaybackStatus::Stopped));
+    changePlaybackRegion(5.0, 100.0);
+
+    //! [GIVEN] Playback is running with that region
+    ON_CALL(*m_player, playbackStatus())
+    .WillByDefault(Return(PlaybackStatus::Running));
+    ON_CALL(*m_player, playbackRegion())
+    .WillByDefault(Return(PlaybackRegion { secs_t(5.0), secs_t(100.0) }));
+    ON_CALL(*m_player, isLoopRegionActive())
+    .WillByDefault(Return(false));
+
+    //! [GIVEN] Playback position reached the region end
+    ON_CALL(*m_player, playbackPosition())
+    .WillByDefault(Return(secs_t(100.0)));
+
+    //! [THEN] Player is stopped
+    EXPECT_CALL(*m_player, stop())
+    .Times(1);
+
+    //! [WHEN] Playback position changed
+    m_playbackPositionChanged.send(secs_t(100.0));
+}
+
+/**
+ * @brief Loop playback is not stopped at the loop region end
+ */
+TEST_F(PlaybackControllerTests, PlaybackPosition_OnLoopRegionEnd_DoesNotStop)
+{
+    //! [GIVEN] Playback is running with an active loop region {10, 20}
+    ON_CALL(*m_player, playbackStatus())
+    .WillByDefault(Return(PlaybackStatus::Running));
+    ON_CALL(*m_player, playbackRegion())
+    .WillByDefault(Return(PlaybackRegion { secs_t(10.0), secs_t(20.0) }));
+    ON_CALL(*m_player, isLoopRegionActive())
+    .WillByDefault(Return(true));
+
+    //! [GIVEN] Playback position reached the loop region end
+    ON_CALL(*m_player, playbackPosition())
+    .WillByDefault(Return(secs_t(20.0)));
+
+    //! [THEN] Player is not stopped (the loop wraps around)
+    EXPECT_CALL(*m_player, stop())
+    .Times(0);
+
+    //! [WHEN] Playback position changed
+    m_playbackPositionChanged.send(secs_t(20.0));
 }
 }

--- a/src/playback/tests/playbackcontroller_tests.cpp
+++ b/src/playback/tests/playbackcontroller_tests.cpp
@@ -925,6 +925,35 @@ TEST_F(PlaybackControllerTests, PlaySelection_WithoutSelection_DoesNothing)
 }
 
 /**
+ * @brief Play selection availability depends on selection and playback state
+ */
+TEST_F(PlaybackControllerTests, PlaySelection_CanReceiveAction)
+{
+    const muse::actions::ActionCode code = "action://playback/play-selection";
+
+    //! [GIVEN] Playback is stopped
+    ON_CALL(*m_player, playbackStatus())
+    .WillByDefault(Return(PlaybackStatus::Stopped));
+
+    //! [THEN] Without a selection the action is unavailable
+    ON_CALL(*m_selectionController, timeSelectionIsEmpty())
+    .WillByDefault(Return(true));
+    EXPECT_FALSE(m_controller->canReceiveAction(code));
+
+    //! [THEN] With a selection it is available
+    ON_CALL(*m_selectionController, timeSelectionIsEmpty())
+    .WillByDefault(Return(false));
+    EXPECT_TRUE(m_controller->canReceiveAction(code));
+
+    //! [THEN] While playing it is available even without a selection (it stops playback)
+    ON_CALL(*m_selectionController, timeSelectionIsEmpty())
+    .WillByDefault(Return(true));
+    ON_CALL(*m_player, playbackStatus())
+    .WillByDefault(Return(PlaybackStatus::Running));
+    EXPECT_TRUE(m_controller->canReceiveAction(code));
+}
+
+/**
  * @brief Play selection without a selection stops active playback
  */
 TEST_F(PlaybackControllerTests, PlaySelection_WhilePlaying_NoSelection_Stops)

--- a/src/playback/tests/playbackcontroller_tests.cpp
+++ b/src/playback/tests/playbackcontroller_tests.cpp
@@ -925,6 +925,37 @@ TEST_F(PlaybackControllerTests, PlaySelection_WithoutSelection_DoesNothing)
 }
 
 /**
+ * @brief Play selection does nothing while recording
+ */
+TEST_F(PlaybackControllerTests, PlaySelection_WhileRecording_DoesNothing)
+{
+    //! [GIVEN] Recording is in progress
+    EXPECT_CALL(*m_recordController, isRecording())
+    .WillRepeatedly(Return(true));
+
+    //! [GIVEN] There is selection from 10 to 20 secs
+    ON_CALL(*m_selectionController, timeSelectionIsEmpty())
+    .WillByDefault(Return(false));
+    ON_CALL(*m_selectionController, dataSelectedStartTime())
+    .WillByDefault(Return(secs_t(10.0)));
+    ON_CALL(*m_selectionController, dataSelectedEndTime())
+    .WillByDefault(Return(secs_t(20.0)));
+
+    //! [THEN] The action is not available and nothing happens
+    EXPECT_FALSE(m_controller->canReceiveAction("action://playback/play-selection"));
+
+    EXPECT_CALL(*m_player, setPlaybackRegion(_))
+    .Times(0);
+    EXPECT_CALL(*m_player, stop())
+    .Times(0);
+    EXPECT_CALL(*m_player, play())
+    .Times(0);
+
+    //! [WHEN] Play selection
+    playSelection();
+}
+
+/**
  * @brief Play selection while playing restarts playback from the selection
  */
 TEST_F(PlaybackControllerTests, PlaySelection_WhilePlaying_Restarts)

--- a/src/playback/tests/playbackcontroller_tests.cpp
+++ b/src/playback/tests/playbackcontroller_tests.cpp
@@ -95,6 +95,11 @@ public:
         m_controller->togglePlayAction();
     }
 
+    void playSelection()
+    {
+        m_controller->playSelectionAction();
+    }
+
     void changePlaybackRegion(const secs_t start, const secs_t end)
     {
         muse::actions::ActionQuery q(PLAYBACK_CHANGE_PLAY_REGION_QUERY);
@@ -856,5 +861,96 @@ TEST_F(PlaybackControllerTests, PlaybackPosition_OnLoopRegionEnd_DoesNotStop)
 
     //! [WHEN] Playback position changed
     m_playbackPositionChanged.send(secs_t(20.0));
+}
+
+/**
+ * @brief Play selection plays exactly the selected time range
+ * @details User triggered the "play-selection" action with a selection of 10-20 secs
+ *          Playback region should be the selection, so playback starts at 10s
+ *          and stops at 20s (via the end-of-region check)
+ */
+TEST_F(PlaybackControllerTests, PlaySelection_WithSelection)
+{
+    //! [GIVEN] Playback is stopped
+    ON_CALL(*m_player, playbackStatus())
+    .WillByDefault(Return(PlaybackStatus::Stopped));
+
+    //! [GIVEN] There is selection from 10 to 20 secs
+    PlaybackRegion selectionRegion = { secs_t(10.0), secs_t(20.0) };
+    ON_CALL(*m_selectionController, timeSelectionIsEmpty())
+    .WillByDefault(Return(false));
+    ON_CALL(*m_selectionController, dataSelectedStartTime())
+    .WillByDefault(Return(selectionRegion.start));
+    ON_CALL(*m_selectionController, dataSelectedEndTime())
+    .WillByDefault(Return(selectionRegion.end));
+
+    //! [THEN] The playback region is the selection
+    EXPECT_CALL(*m_player, setPlaybackRegion(selectionRegion))
+    .Times(1);
+
+    //! [THEN] Player should start playing
+    EXPECT_CALL(*m_player, play())
+    .Times(1);
+
+    //! [WHEN] Play selection
+    playSelection();
+
+    //! [THEN] The playback cursor is at the selection start
+    EXPECT_EQ(m_controller->lastPlaybackSeekTime(), selectionRegion.start);
+}
+
+/**
+ * @brief Play selection does nothing without a time selection
+ */
+TEST_F(PlaybackControllerTests, PlaySelection_WithoutSelection_DoesNothing)
+{
+    //! [GIVEN] Playback is stopped
+    ON_CALL(*m_player, playbackStatus())
+    .WillByDefault(Return(PlaybackStatus::Stopped));
+
+    //! [GIVEN] No time selection
+    ON_CALL(*m_selectionController, timeSelectionIsEmpty())
+    .WillByDefault(Return(true));
+
+    //! [THEN] Nothing happens
+    EXPECT_CALL(*m_player, setPlaybackRegion(_))
+    .Times(0);
+    EXPECT_CALL(*m_player, stop())
+    .Times(0);
+    EXPECT_CALL(*m_player, play())
+    .Times(0);
+
+    //! [WHEN] Play selection
+    playSelection();
+}
+
+/**
+ * @brief Play selection while playing restarts playback from the selection
+ */
+TEST_F(PlaybackControllerTests, PlaySelection_WhilePlaying_Restarts)
+{
+    //! [GIVEN] Playback is running
+    ON_CALL(*m_player, playbackStatus())
+    .WillByDefault(Return(PlaybackStatus::Running));
+
+    //! [GIVEN] There is selection from 10 to 20 secs
+    ON_CALL(*m_selectionController, timeSelectionIsEmpty())
+    .WillByDefault(Return(false));
+    ON_CALL(*m_selectionController, dataSelectedStartTime())
+    .WillByDefault(Return(secs_t(10.0)));
+    ON_CALL(*m_selectionController, dataSelectedEndTime())
+    .WillByDefault(Return(secs_t(20.0)));
+
+    //! [THEN] Player is stopped, then restarted
+    EXPECT_CALL(*m_player, stop())
+    .Times(1);
+    EXPECT_CALL(*m_player, play())
+    .Times(1);
+
+    //! [WHEN] Play selection
+    playSelection();
+
+    //! [THEN] The playback cursor is at the selection start
+    EXPECT_EQ(m_controller->lastPlaybackSeekTime(), secs_t(10.0));
 }
 }


### PR DESCRIPTION
Resolves: playback should flow in and out of time selection
resolves: https://github.com/audacity/audacity/issues/11274

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
