### PR TITLE
Fix sample rate dropdowns alignment in audio settings

### DIFF
--- a/src/preferences/qml/Audacity/Preferences/internal/ComboBoxWithTitle.qml
+++ b/src/preferences/qml/Audacity/Preferences/internal/ComboBoxWithTitle.qml
@@ -32,9 +32,6 @@ Column {
 
     property real columnWidth: 208
 
-    // Lets a parent Row force this title to the same height as its siblings'
-    // titles, so that the controls below stay aligned even when only some
-    // of the titles wrap onto an extra line. -1 means "size to content".
     property real titleHeight: -1
     readonly property alias titleImplicitHeight: titleLabel.implicitHeight
 

--- a/src/preferences/qml/Audacity/Preferences/internal/ComboBoxWithTitle.qml
+++ b/src/preferences/qml/Audacity/Preferences/internal/ComboBoxWithTitle.qml
@@ -32,6 +32,12 @@ Column {
 
     property real columnWidth: 208
 
+    // Lets a parent Row force this title to the same height as its siblings'
+    // titles, so that the controls below stay aligned even when only some
+    // of the titles wrap onto an extra line. -1 means "size to content".
+    property real titleHeight: -1
+    readonly property alias titleImplicitHeight: titleLabel.implicitHeight
+
     property alias currentIndex: comboBox.currentIndex
     property alias currentValue: comboBox.currentValue
     property alias textRole: comboBox.textRole
@@ -53,8 +59,10 @@ Column {
         id: titleLabel
 
         width: root.columnWidth
+        height: root.titleHeight >= 0 ? root.titleHeight : implicitHeight
 
         horizontalAlignment: Qt.AlignLeft
+        verticalAlignment: Text.AlignTop
         wrapMode: Text.WordWrap
         maximumLineCount: 2
     }

--- a/src/preferences/qml/Audacity/Preferences/internal/SampleRateSection.qml
+++ b/src/preferences/qml/Audacity/Preferences/internal/SampleRateSection.qml
@@ -44,11 +44,19 @@ BaseSection {
     }
 
     Row {
+        id: sampleRateFormatRow
         spacing: root.spacing
 
+        // Ensures the two dropdowns below stay aligned even if only one of
+        // the titles wraps onto a second line (e.g. in longer translations).
+        property real sharedTitleHeight: Math.max(sampleRateCombo.titleImplicitHeight, sampleFormatCombo.titleImplicitHeight)
+
         ComboBoxWithTitle {
+            id: sampleRateCombo
+
             title: qsTrc("preferences", "Default sample rate")
             columnWidth: root.columnWidth
+            titleHeight: sampleRateFormatRow.sharedTitleHeight
 
             enabled: !playbackState.isPlaying
 
@@ -66,8 +74,11 @@ BaseSection {
         }
 
         ComboBoxWithTitle {
+            id: sampleFormatCombo
+
             title: qsTrc("preferences", "Default sample format")
             columnWidth: root.columnWidth
+            titleHeight: sampleRateFormatRow.sharedTitleHeight
 
             enabled: !playbackState.isPlaying
 

--- a/src/preferences/qml/Audacity/Preferences/internal/SampleRateSection.qml
+++ b/src/preferences/qml/Audacity/Preferences/internal/SampleRateSection.qml
@@ -47,8 +47,6 @@ BaseSection {
         id: sampleRateFormatRow
         spacing: root.spacing
 
-        // Ensures the two dropdowns below stay aligned even if only one of
-        // the titles wraps onto a second line (e.g. in longer translations).
         property real sharedTitleHeight: Math.max(sampleRateCombo.titleImplicitHeight, sampleFormatCombo.titleImplicitHeight)
 
         ComboBoxWithTitle {


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/11372

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [ ] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [x] switch language back to English, confirm both dropdowns still align exactly as before (titles are 1 line each, no extra gap introduced by the fix)
- [x]  try a language where both labels wrap to 2 lines (e.g. German); dropdowns should still align 
- [x] tab through the Sample Rate section; focus order should be unchanged