### PR TITLE
Provide fallback UI parameters for LV2 effects

### DIFF
--- a/au3/libraries/au3-lv2/LV2Instance.h
+++ b/au3/libraries/au3-lv2/LV2Instance.h
@@ -31,6 +31,10 @@ public:
 
     const LV2PortStates& GetPortStates() const { return mPortStates; }
 
+    const LV2Ports& GetPorts() const { return mPorts; }
+
+    float GetSampleRate() const { return mFeatures.mSampleRate; }
+
     bool ProcessInitialize(EffectSettings& settings, double sampleRate, ChannelNames chanMap) override;
     size_t ProcessBlock(EffectSettings& settings, const float* const* inBlock, float* const* outBlock, size_t blockLen)
     override;

--- a/src/effects/effects_base/ieffectviewlauncher.h
+++ b/src/effects/effects_base/ieffectviewlauncher.h
@@ -18,6 +18,8 @@ public:
 
     virtual void showRealtimeEffect(const RealtimeEffectStatePtr& state) const = 0;
     virtual void hideRealtimeEffect(const RealtimeEffectStatePtr& state) const = 0;
+
+    virtual bool vendorUiSupported(const EffectId&) const { return true; }
 };
 
 using IEffectViewLauncherPtr = std::shared_ptr<IEffectViewLauncher>;

--- a/src/effects/effects_base/ieffectviewlauncher.h
+++ b/src/effects/effects_base/ieffectviewlauncher.h
@@ -20,6 +20,8 @@ public:
     virtual void hideRealtimeEffect(const RealtimeEffectStatePtr& state) const = 0;
 
     virtual bool vendorUiSupported(const EffectId&) const { return true; }
+
+    virtual void markVendorUiFailed(const EffectId&) {}
 };
 
 using IEffectViewLauncherPtr = std::shared_ptr<IEffectViewLauncher>;

--- a/src/effects/effects_base/qml/Audacity/Effects/DestructiveEffectsViewerDialog.qml
+++ b/src/effects/effects_base/qml/Audacity/Effects/DestructiveEffectsViewerDialog.qml
@@ -188,6 +188,7 @@ EffectStyledDialogView {
             id: topPanelContainer
 
             width: parent.width
+            height: presetsBar.height + prv.separatorHeight + prv.panelMargins * 2
 
             visible: prv.showTopPanel
 
@@ -195,7 +196,7 @@ EffectStyledDialogView {
                 id: topPanel
 
                 width: topPanelContainer.width
-                height: presetsBar.height + prv.separatorHeight + prv.panelMargins * 2
+                height: topPanelContainer.height
 
                 color: ui.theme.backgroundPrimaryColor
 
@@ -252,12 +253,13 @@ EffectStyledDialogView {
             id: bottomPanelContainer
 
             width: parent.width
+            height: prv.panelMargins * 2 + bbox.height
 
             window: Window {
                 id: bottomPanel
 
                 width: bottomPanelContainer.width
-                height: prv.panelMargins * 2 + bbox.height
+                height: bottomPanelContainer.height
 
                 color: ui.theme.backgroundPrimaryColor
 

--- a/src/effects/effects_base/qml/Audacity/Effects/DestructiveEffectsViewerDialog.qml
+++ b/src/effects/effects_base/qml/Audacity/Effects/DestructiveEffectsViewerDialog.qml
@@ -148,6 +148,10 @@ EffectStyledDialogView {
         Lv2Viewer {
             instanceId: root.instanceId
             title: root.title
+
+            onVendorUiFailed: {
+                Qt.callLater(viewerModel.notifyVendorUiFailed)
+            }
         }
     }
 

--- a/src/effects/effects_base/qml/Audacity/Effects/RealtimeEffectViewerDialog.qml
+++ b/src/effects/effects_base/qml/Audacity/Effects/RealtimeEffectViewerDialog.qml
@@ -145,13 +145,18 @@ EffectStyledDialogView {
         anchors.fill: parent
 
         WindowContainer {
+            id: topPanelContainer
+
+            width: root.contentWidth
+            height: presetsBar.height + prv.separatorHeight + prv.panelMargins * 2
+
             visible: prv.showTopPanel
 
             window: Window {
                 id: topPanel
 
-                width: root.contentWidth
-                height: presetsBar.height + prv.separatorHeight + prv.panelMargins * 2
+                width: topPanelContainer.width
+                height: topPanelContainer.height
 
                 color: ui.theme.backgroundPrimaryColor
 

--- a/src/effects/effects_base/qml/Audacity/Effects/RealtimeEffectViewerDialog.qml
+++ b/src/effects/effects_base/qml/Audacity/Effects/RealtimeEffectViewerDialog.qml
@@ -113,6 +113,10 @@ EffectStyledDialogView {
             instanceId: root.instanceId
             effectState: root.effectState // TODO: check if this is really needed !?
             title: root.title
+
+            onVendorUiFailed: {
+                Qt.callLater(viewerModel.notifyVendorUiFailed)
+            }
         }
     }
 

--- a/src/effects/effects_base/view/destructiveeffectviewerdialogmodel.cpp
+++ b/src/effects/effects_base/view/destructiveeffectviewerdialogmodel.cpp
@@ -36,6 +36,7 @@ void DestructiveEffectViewerDialogModel::setInstanceId(int newInstanceId)
         return;
     }
     m_instanceId = newInstanceId;
+    m_vendorUiFailed = false;
     emit instanceIdChanged();
 
     m_effectId = instancesRegister()->effectIdByInstanceId(m_instanceId);
@@ -79,6 +80,15 @@ void DestructiveEffectViewerDialogModel::refreshUIMode()
     emit viewerComponentTypeChanged();
 }
 
+void DestructiveEffectViewerDialogModel::notifyVendorUiFailed()
+{
+    if (m_vendorUiFailed) {
+        return;
+    }
+    m_vendorUiFailed = true;
+    emit viewerComponentTypeChanged();
+}
+
 EffectFamily DestructiveEffectViewerDialogModel::effectFamily() const
 {
     if (m_effectId.empty()) {
@@ -109,7 +119,7 @@ ViewerComponentType DestructiveEffectViewerDialogModel::viewerComponentType() co
     }
 
     // For external plugins (VST3, LV2), check if we should use generated UI
-    const bool shouldUseVendorUI = useVendorUI() && vendorUiSupported();
+    const bool shouldUseVendorUI = useVendorUI() && vendorUiSupported() && !m_vendorUiFailed;
     if (!shouldUseVendorUI) {
         return ViewerComponentType::Generated;
     }

--- a/src/effects/effects_base/view/destructiveeffectviewerdialogmodel.cpp
+++ b/src/effects/effects_base/view/destructiveeffectviewerdialogmodel.cpp
@@ -109,7 +109,7 @@ ViewerComponentType DestructiveEffectViewerDialogModel::viewerComponentType() co
     }
 
     // For external plugins (VST3, LV2), check if we should use generated UI
-    const bool shouldUseVendorUI = useVendorUI();
+    const bool shouldUseVendorUI = useVendorUI() && vendorUiSupported();
     if (!shouldUseVendorUI) {
         return ViewerComponentType::Generated;
     }
@@ -125,6 +125,12 @@ ViewerComponentType DestructiveEffectViewerDialogModel::viewerComponentType() co
     default:
         return ViewerComponentType::Unknown;
     }
+}
+
+bool DestructiveEffectViewerDialogModel::vendorUiSupported() const
+{
+    const IEffectViewLauncherPtr launcher = viewLaunchRegister()->launcher(effectFamily());
+    return launcher ? launcher->vendorUiSupported(m_effectId) : true;
 }
 
 void DestructiveEffectViewerDialogModel::captureInitialSettings()

--- a/src/effects/effects_base/view/destructiveeffectviewerdialogmodel.cpp
+++ b/src/effects/effects_base/view/destructiveeffectviewerdialogmodel.cpp
@@ -36,7 +36,6 @@ void DestructiveEffectViewerDialogModel::setInstanceId(int newInstanceId)
         return;
     }
     m_instanceId = newInstanceId;
-    m_vendorUiFailed = false;
     emit instanceIdChanged();
 
     m_effectId = instancesRegister()->effectIdByInstanceId(m_instanceId);
@@ -82,10 +81,11 @@ void DestructiveEffectViewerDialogModel::refreshUIMode()
 
 void DestructiveEffectViewerDialogModel::notifyVendorUiFailed()
 {
-    if (m_vendorUiFailed) {
+    const IEffectViewLauncherPtr launcher = viewLaunchRegister()->launcher(effectFamily());
+    if (!launcher) {
         return;
     }
-    m_vendorUiFailed = true;
+    launcher->markVendorUiFailed(m_effectId);
     emit viewerComponentTypeChanged();
 }
 
@@ -119,7 +119,7 @@ ViewerComponentType DestructiveEffectViewerDialogModel::viewerComponentType() co
     }
 
     // For external plugins (VST3, LV2), check if we should use generated UI
-    const bool shouldUseVendorUI = useVendorUI() && vendorUiSupported() && !m_vendorUiFailed;
+    const bool shouldUseVendorUI = useVendorUI() && vendorUiSupported();
     if (!shouldUseVendorUI) {
         return ViewerComponentType::Generated;
     }

--- a/src/effects/effects_base/view/destructiveeffectviewerdialogmodel.h
+++ b/src/effects/effects_base/view/destructiveeffectviewerdialogmodel.h
@@ -62,7 +62,6 @@ private:
     QString m_title;
     int m_instanceId = -1;
     EffectId m_effectId;
-    bool m_vendorUiFailed = false;
 
     std::shared_ptr<EffectSettings> m_initialSettings;
 };

--- a/src/effects/effects_base/view/destructiveeffectviewerdialogmodel.h
+++ b/src/effects/effects_base/view/destructiveeffectviewerdialogmodel.h
@@ -37,6 +37,7 @@ public:
 
     Q_INVOKABLE void load();
     Q_INVOKABLE void refreshUIMode();
+    Q_INVOKABLE void notifyVendorUiFailed();
 
     Q_INVOKABLE void rollbackSettings();
 
@@ -61,6 +62,7 @@ private:
     QString m_title;
     int m_instanceId = -1;
     EffectId m_effectId;
+    bool m_vendorUiFailed = false;
 
     std::shared_ptr<EffectSettings> m_initialSettings;
 };

--- a/src/effects/effects_base/view/destructiveeffectviewerdialogmodel.h
+++ b/src/effects/effects_base/view/destructiveeffectviewerdialogmodel.h
@@ -6,6 +6,7 @@
 #include "ieffectinstancesregister.h"
 #include "ieffectsprovider.h"
 #include "ieffectsconfiguration.h"
+#include "ieffectviewlaunchregister.h"
 #include "effectstypes.h"
 #include "effectsviewtypes.h"
 
@@ -28,6 +29,7 @@ class DestructiveEffectViewerDialogModel : public QObject, public muse::Contexta
     muse::GlobalInject<IEffectsConfiguration> configuration;
     muse::GlobalInject<IEffectsProvider> effectsProvider;
     muse::GlobalInject<IEffectInstancesRegister> instancesRegister;
+    muse::ContextInject<IEffectViewLaunchRegister> viewLaunchRegister{ this };
 
 public:
     explicit DestructiveEffectViewerDialogModel(QObject* parent = nullptr);
@@ -54,6 +56,7 @@ signals:
 
 private:
     void captureInitialSettings();
+    bool vendorUiSupported() const;
 
     QString m_title;
     int m_instanceId = -1;

--- a/src/effects/effects_base/view/presetscontextmenumodel.cpp
+++ b/src/effects/effects_base/view/presetscontextmenumodel.cpp
@@ -73,9 +73,11 @@ void PresetsContextMenuModel::reload()
     }
 
     const EffectMeta effectMeta = effectsProvider()->meta(effectId);
+    const IEffectViewLauncherPtr launcher = viewLaunchRegister()->launcher(effectMeta.family);
     const bool hasVendorUI = effectMeta.family != EffectFamily::Builtin
                              && effectMeta.family != EffectFamily::Nyquist
-                             && effectMeta.family != EffectFamily::Unknown;
+                             && effectMeta.family != EffectFamily::Unknown
+                             && (!launcher || launcher->vendorUiSupported(effectId));
     if (hasVendorUI) {
         items << makeSeparator();
 

--- a/src/effects/effects_base/view/presetscontextmenumodel.h
+++ b/src/effects/effects_base/view/presetscontextmenumodel.h
@@ -9,6 +9,7 @@
 #include "effects/effects_base/ieffectsconfiguration.h"
 #include "effects/effects_base/ieffectinstancesregister.h"
 #include "effects/effects_base/ieffectsprovider.h"
+#include "effects/effects_base/ieffectviewlaunchregister.h"
 
 namespace au::effects {
 class PresetsContextMenuModel : public muse::uicomponents::AbstractMenuModel
@@ -20,6 +21,7 @@ class PresetsContextMenuModel : public muse::uicomponents::AbstractMenuModel
     muse::GlobalInject<IEffectsConfiguration> configuration;
     muse::GlobalInject<IEffectsProvider> effectsProvider;
     muse::GlobalInject<IEffectInstancesRegister> instancesRegister;
+    muse::ContextInject<IEffectViewLaunchRegister> viewLaunchRegister{ this };
 
 public:
     explicit PresetsContextMenuModel(QObject* parent = nullptr);

--- a/src/effects/effects_base/view/realtimeeffectviewerdialogmodel.cpp
+++ b/src/effects/effects_base/view/realtimeeffectviewerdialogmodel.cpp
@@ -114,6 +114,7 @@ void RealtimeEffectViewerDialogModel::prop_setEffectState(const QString& effectS
     }
 
     m_effectState = reinterpret_cast<RealtimeEffectState*>(effectState.toULongLong())->shared_from_this();
+    m_vendorUiFailed = false;
     const auto effectId = m_effectState->GetID().ToStdString();
     const auto instance = std::dynamic_pointer_cast<effects::EffectInstance>(m_effectState->GetInstance());
     instancesRegister()->regInstance(muse::String::fromStdString(effectId), instance, m_effectState->GetAccess());
@@ -196,6 +197,15 @@ void RealtimeEffectViewerDialogModel::refreshUIMode()
     emit viewerComponentTypeChanged();
 }
 
+void RealtimeEffectViewerDialogModel::notifyVendorUiFailed()
+{
+    if (m_vendorUiFailed) {
+        return;
+    }
+    m_vendorUiFailed = true;
+    emit viewerComponentTypeChanged();
+}
+
 ViewerComponentType RealtimeEffectViewerDialogModel::viewerComponentType() const
 {
     const EffectFamily family = prop_effectFamily();
@@ -213,7 +223,7 @@ ViewerComponentType RealtimeEffectViewerDialogModel::viewerComponentType() const
     }
 
     // For external plugins (VST3, LV2), check if we should use generated UI
-    const bool shouldUseVendorUI = useVendorUI() && vendorUiSupported();
+    const bool shouldUseVendorUI = useVendorUI() && vendorUiSupported() && !m_vendorUiFailed;
     if (!shouldUseVendorUI) {
         return ViewerComponentType::Generated;
     }

--- a/src/effects/effects_base/view/realtimeeffectviewerdialogmodel.cpp
+++ b/src/effects/effects_base/view/realtimeeffectviewerdialogmodel.cpp
@@ -213,7 +213,7 @@ ViewerComponentType RealtimeEffectViewerDialogModel::viewerComponentType() const
     }
 
     // For external plugins (VST3, LV2), check if we should use generated UI
-    const bool shouldUseVendorUI = useVendorUI();
+    const bool shouldUseVendorUI = useVendorUI() && vendorUiSupported();
     if (!shouldUseVendorUI) {
         return ViewerComponentType::Generated;
     }
@@ -229,5 +229,16 @@ ViewerComponentType RealtimeEffectViewerDialogModel::viewerComponentType() const
     default:
         return ViewerComponentType::Unknown;
     }
+}
+
+bool RealtimeEffectViewerDialogModel::vendorUiSupported() const
+{
+    if (!m_effectState) {
+        return true;
+    }
+
+    const EffectId effectId = muse::String::fromStdString(m_effectState->GetID().ToStdString());
+    const IEffectViewLauncherPtr launcher = viewLaunchRegister()->launcher(prop_effectFamily());
+    return launcher ? launcher->vendorUiSupported(effectId) : true;
 }
 }

--- a/src/effects/effects_base/view/realtimeeffectviewerdialogmodel.cpp
+++ b/src/effects/effects_base/view/realtimeeffectviewerdialogmodel.cpp
@@ -114,7 +114,6 @@ void RealtimeEffectViewerDialogModel::prop_setEffectState(const QString& effectS
     }
 
     m_effectState = reinterpret_cast<RealtimeEffectState*>(effectState.toULongLong())->shared_from_this();
-    m_vendorUiFailed = false;
     const auto effectId = m_effectState->GetID().ToStdString();
     const auto instance = std::dynamic_pointer_cast<effects::EffectInstance>(m_effectState->GetInstance());
     instancesRegister()->regInstance(muse::String::fromStdString(effectId), instance, m_effectState->GetAccess());
@@ -199,10 +198,16 @@ void RealtimeEffectViewerDialogModel::refreshUIMode()
 
 void RealtimeEffectViewerDialogModel::notifyVendorUiFailed()
 {
-    if (m_vendorUiFailed) {
+    if (!m_effectState) {
         return;
     }
-    m_vendorUiFailed = true;
+
+    const EffectId effectId = muse::String::fromStdString(m_effectState->GetID().ToStdString());
+    const IEffectViewLauncherPtr launcher = viewLaunchRegister()->launcher(prop_effectFamily());
+    if (!launcher) {
+        return;
+    }
+    launcher->markVendorUiFailed(effectId);
     emit viewerComponentTypeChanged();
 }
 
@@ -223,7 +228,7 @@ ViewerComponentType RealtimeEffectViewerDialogModel::viewerComponentType() const
     }
 
     // For external plugins (VST3, LV2), check if we should use generated UI
-    const bool shouldUseVendorUI = useVendorUI() && vendorUiSupported() && !m_vendorUiFailed;
+    const bool shouldUseVendorUI = useVendorUI() && vendorUiSupported();
     if (!shouldUseVendorUI) {
         return ViewerComponentType::Generated;
     }

--- a/src/effects/effects_base/view/realtimeeffectviewerdialogmodel.h
+++ b/src/effects/effects_base/view/realtimeeffectviewerdialogmodel.h
@@ -7,6 +7,7 @@
 #include "ieffectinstancesregister.h"
 #include "ieffectsconfiguration.h"
 #include "ieffectsprovider.h"
+#include "ieffectviewlaunchregister.h"
 #include "effectstypes.h"
 #include "effectsviewtypes.h"
 #include "effects/effects_base/irealtimeeffectservice.h"
@@ -43,6 +44,7 @@ class RealtimeEffectViewerDialogModel : public QObject, public muse::Contextable
     muse::ContextInject<effects::IRealtimeEffectService> realtimeEffectService{ this };
     muse::ContextInject<context::IGlobalContext> globalContext{ this };
     muse::ContextInject<muse::ui::INavigationController> navigationController{ this };
+    muse::ContextInject<IEffectViewLaunchRegister> viewLaunchRegister{ this };
 
 public:
     Q_INVOKABLE void load();
@@ -86,6 +88,7 @@ signals:
 private:
     void subscribe();
     void unregisterState();
+    bool vendorUiSupported() const;
 
     RealtimeEffectStatePtr m_effectState;
     muse::uicomponents::DialogView* m_dialogView = nullptr;

--- a/src/effects/effects_base/view/realtimeeffectviewerdialogmodel.h
+++ b/src/effects/effects_base/view/realtimeeffectviewerdialogmodel.h
@@ -94,6 +94,5 @@ private:
     RealtimeEffectStatePtr m_effectState;
     muse::uicomponents::DialogView* m_dialogView = nullptr;
     muse::ui::NavigationPanel* m_navigationPanel = nullptr;
-    bool m_vendorUiFailed = false;
 };
 }

--- a/src/effects/effects_base/view/realtimeeffectviewerdialogmodel.h
+++ b/src/effects/effects_base/view/realtimeeffectviewerdialogmodel.h
@@ -49,6 +49,7 @@ class RealtimeEffectViewerDialogModel : public QObject, public muse::Contextable
 public:
     Q_INVOKABLE void load();
     Q_INVOKABLE void refreshUIMode();
+    Q_INVOKABLE void notifyVendorUiFailed();
 
     RealtimeEffectViewerDialogModel(QObject* parent = nullptr);
     ~RealtimeEffectViewerDialogModel() override;
@@ -93,5 +94,6 @@ private:
     RealtimeEffectStatePtr m_effectState;
     muse::uicomponents::DialogView* m_dialogView = nullptr;
     muse::ui::NavigationPanel* m_navigationPanel = nullptr;
+    bool m_vendorUiFailed = false;
 };
 }

--- a/src/effects/lv2/CMakeLists.txt
+++ b/src/effects/lv2/CMakeLists.txt
@@ -17,6 +17,8 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/internal/lv2pluginmetareader.cpp
     ${CMAKE_CURRENT_LIST_DIR}/internal/lv2pluginmetareader.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/lv2pluginsscanner.h
+    ${CMAKE_CURRENT_LIST_DIR}/internal/lv2uiselect.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/internal/lv2uiselect.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/lv2viewlauncher.cpp
     ${CMAKE_CURRENT_LIST_DIR}/internal/lv2viewlauncher.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/lv2types.h

--- a/src/effects/lv2/CMakeLists.txt
+++ b/src/effects/lv2/CMakeLists.txt
@@ -12,6 +12,8 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/lv2effectsmodule.h
 
     ${CMAKE_CURRENT_LIST_DIR}/internal/lv2effectloader.h
+    ${CMAKE_CURRENT_LIST_DIR}/internal/lv2parameterextractorservice.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/internal/lv2parameterextractorservice.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/lv2pluginmetareader.cpp
     ${CMAKE_CURRENT_LIST_DIR}/internal/lv2pluginmetareader.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/lv2pluginsscanner.h

--- a/src/effects/lv2/internal/lv2parameterextractorservice.cpp
+++ b/src/effects/lv2/internal/lv2parameterextractorservice.cpp
@@ -196,7 +196,7 @@ bool Lv2ParameterExtractorService::setParameterValue(EffectInstance* instance, c
 
     float value = static_cast<float>(fullRangeValue) / displayFactor(port, *lookup->instance);
     if (port.mToggle) {
-        value = value > 0.5f ? 1.0f : 0.0f;
+        value = value > 0.0f ? 1.0f : 0.0f;
     } else {
         if (port.mHasLo) {
             value = std::max(value, port.mMin);

--- a/src/effects/lv2/internal/lv2parameterextractorservice.cpp
+++ b/src/effects/lv2/internal/lv2parameterextractorservice.cpp
@@ -1,0 +1,264 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+#include "lv2parameterextractorservice.h"
+
+#include "framework/global/log.h"
+
+#include "au3wrap/internal/wxtypes_convert.h"
+
+#include "au3-lv2/LV2Instance.h"
+#include "au3-lv2/LV2Ports.h"
+
+using namespace au::effects;
+using namespace muse;
+
+namespace {
+struct PortLookup {
+    const LV2Instance* instance = nullptr;
+    LV2ControlPortPtr port;
+    size_t valueIndex = 0;
+};
+
+const LV2Instance* toLv2Instance(au::effects::EffectInstance* instance)
+{
+    return dynamic_cast<const LV2Instance*>(instance);
+}
+
+std::optional<PortLookup> findPort(au::effects::EffectInstance* instance, const String& parameterId)
+{
+    const LV2Instance* lv2Instance = toLv2Instance(instance);
+    if (!lv2Instance) {
+        return std::nullopt;
+    }
+
+    const wxString symbol = au::au3::wxFromString(parameterId);
+    const LV2ControlPortArray& ports = lv2Instance->GetPorts().mControlPorts;
+    for (size_t i = 0; i < ports.size(); ++i) {
+        if (ports[i]->mIsInput && ports[i]->mSymbol == symbol) {
+            return PortLookup { lv2Instance, ports[i], i };
+        }
+    }
+    return std::nullopt;
+}
+
+const LV2EffectSettings* lv2Settings(const EffectSettings& settings)
+{
+    return settings.cast<LV2EffectSettings>();
+}
+
+float storedValue(const PortLookup& lookup, const au::effects::EffectSettingsAccessPtr& settingsAccess)
+{
+    if (settingsAccess) {
+        if (const LV2EffectSettings* settings = lv2Settings(settingsAccess->Get())) {
+            if (lookup.valueIndex < settings->values.size()) {
+                return settings->values[lookup.valueIndex];
+            }
+        }
+    }
+    return lookup.port->mDef;
+}
+
+float displayFactor(const LV2ControlPort& port, const LV2Instance& instance)
+{
+    return port.mSampleRate ? instance.GetSampleRate() : 1.0f;
+}
+
+String formatValue(const ParameterInfo& info, double value)
+{
+    if (info.type == ParameterType::Dropdown) {
+        for (size_t i = 0; i < info.enumIndices.size(); ++i) {
+            if (std::abs(info.enumIndices[i] - value) < 0.001) {
+                return info.enumValues[i];
+            }
+        }
+    }
+    return String::number(value, info.numDecimals());
+}
+
+ParameterInfo makeInfo(const PortLookup& lookup, float stored)
+{
+    const LV2ControlPort& port = *lookup.port;
+    const float factor = displayFactor(port, *lookup.instance);
+
+    ParameterInfo info;
+    info.id = au::au3::wxToString(port.mSymbol);
+    info.name = au::au3::wxToString(port.mName);
+    info.group = au::au3::wxToString(port.mGroup.Translation());
+    info.units = au::au3::wxToString(port.mUnits);
+
+    info.minValue = port.mMin * factor;
+    info.maxValue = port.mMax * factor;
+    info.defaultValue = port.mDef * factor;
+
+    double value = stored * factor;
+
+    if (port.mToggle) {
+        info.type = ParameterType::Toggle;
+        info.minValue = 0.0;
+        info.maxValue = 1.0;
+        info.stepCount = 1;
+        info.stepSize = 1.0;
+        info.isInteger = true;
+        value = value > 0.0 ? 1.0 : 0.0;
+    } else if (port.mEnumeration && !port.mScaleValues.empty()) {
+        info.type = ParameterType::Dropdown;
+        info.enumValues.reserve(port.mScaleValues.size());
+        info.enumIndices.reserve(port.mScaleValues.size());
+        for (size_t i = 0; i < port.mScaleValues.size(); ++i) {
+            info.enumValues.push_back(i < port.mScaleLabels.size()
+                                      ? au::au3::wxToString(port.mScaleLabels[i])
+                                      : String::number(port.mScaleValues[i]));
+            info.enumIndices.push_back(port.mScaleValues[i] * factor);
+        }
+        info.isInteger = port.mInteger;
+        value = port.mScaleValues[port.Discretize(stored)] * factor;
+    } else {
+        info.type = ParameterType::Slider;
+        info.isInteger = port.mInteger;
+        info.isLogarithmic = port.mLogarithmic;
+        if (port.mInteger) {
+            info.stepSize = 1.0;
+        }
+    }
+
+    info.currentValue = value;
+    info.currentValueString = formatValue(info, value);
+
+    return info;
+}
+} // anonymous namespace
+
+ParameterInfoList Lv2ParameterExtractorService::extractParameters(EffectInstance* instance,
+                                                                  EffectSettingsAccessPtr settingsAccess) const
+{
+    const LV2Instance* lv2Instance = toLv2Instance(instance);
+    if (!lv2Instance) {
+        LOGW() << "Lv2ParameterExtractorService: instance is not an LV2Instance";
+        return {};
+    }
+
+    if (!settingsAccess) {
+        settingsAccess = sessionSettings(instance);
+    }
+
+    const LV2ControlPortArray& ports = lv2Instance->GetPorts().mControlPorts;
+
+    ParameterInfoList result;
+    result.reserve(ports.size());
+
+    for (size_t i = 0; i < ports.size(); ++i) {
+        const LV2ControlPortPtr& port = ports[i];
+        //! Output ports are meters, and trigger ports are momentary actions;
+        //! neither maps onto the generic parameter model.
+        if (!port->mIsInput || port->mTrigger) {
+            continue;
+        }
+        const PortLookup lookup { lv2Instance, port, i };
+        result.push_back(makeInfo(lookup, storedValue(lookup, settingsAccess)));
+    }
+
+    return result;
+}
+
+ParameterInfo Lv2ParameterExtractorService::getParameter(EffectInstance* instance, const String& parameterId) const
+{
+    const std::optional<PortLookup> lookup = findPort(instance, parameterId);
+    if (!lookup) {
+        return {};
+    }
+
+    return makeInfo(*lookup, storedValue(*lookup, sessionSettings(instance)));
+}
+
+double Lv2ParameterExtractorService::getParameterValue(EffectInstance* instance, const String& parameterId) const
+{
+    return getParameter(instance, parameterId).currentValue;
+}
+
+bool Lv2ParameterExtractorService::setParameterValue(EffectInstance* instance, const String& parameterId,
+                                                     double fullRangeValue, EffectSettingsAccessPtr settingsAccess)
+{
+    const std::optional<PortLookup> lookup = findPort(instance, parameterId);
+    if (!lookup) {
+        return false;
+    }
+
+    if (!settingsAccess) {
+        settingsAccess = sessionSettings(instance);
+    }
+    if (!settingsAccess) {
+        LOGW() << "Lv2ParameterExtractorService: no settings access for parameter " << parameterId;
+        return false;
+    }
+
+    const LV2ControlPort& port = *lookup->port;
+
+    float value = static_cast<float>(fullRangeValue) / displayFactor(port, *lookup->instance);
+    if (port.mToggle) {
+        value = value > 0.5f ? 1.0f : 0.0f;
+    } else {
+        if (port.mHasLo) {
+            value = std::max(value, port.mMin);
+        }
+        if (port.mHasHi) {
+            value = std::min(value, port.mMax);
+        }
+        if (port.mInteger && !port.mEnumeration) {
+            value = std::round(value);
+        }
+    }
+
+    settingsAccess->ModifySettings([&](EffectSettings& settings) {
+        if (LV2EffectSettings* lv2 = settings.cast<LV2EffectSettings>()) {
+            if (lookup->valueIndex < lv2->values.size()) {
+                lv2->values[lookup->valueIndex] = value;
+            }
+        }
+        return nullptr;
+    });
+
+    return true;
+}
+
+String Lv2ParameterExtractorService::getParameterValueString(EffectInstance* instance, const String& parameterId,
+                                                             double value) const
+{
+    const std::optional<PortLookup> lookup = findPort(instance, parameterId);
+    if (!lookup) {
+        return {};
+    }
+
+    return formatValue(makeInfo(*lookup, storedValue(*lookup, sessionSettings(instance))), value);
+}
+
+void Lv2ParameterExtractorService::endParameterGesture(EffectInstance* instance, const String&)
+{
+    if (const EffectSettingsAccessPtr settingsAccess = sessionSettings(instance)) {
+        settingsAccess->Flush();
+    }
+}
+
+void Lv2ParameterExtractorService::onInstanceDestroyed(EffectInstance* instance)
+{
+    m_sessionSettings.erase(instance);
+}
+
+void Lv2ParameterExtractorService::beginParameterEditing(EffectInstance* instance, EffectSettingsAccessPtr settingsAccess)
+{
+    m_sessionSettings[instance] = settingsAccess;
+}
+
+void Lv2ParameterExtractorService::endParameterEditing(EffectInstance* instance)
+{
+    if (const EffectSettingsAccessPtr settingsAccess = sessionSettings(instance)) {
+        settingsAccess->Flush();
+    }
+    m_sessionSettings.erase(instance);
+}
+
+EffectSettingsAccessPtr Lv2ParameterExtractorService::sessionSettings(EffectInstance* instance) const
+{
+    const auto it = m_sessionSettings.find(instance);
+    return it != m_sessionSettings.end() ? it->second : nullptr;
+}

--- a/src/effects/lv2/internal/lv2parameterextractorservice.h
+++ b/src/effects/lv2/internal/lv2parameterextractorservice.h
@@ -35,6 +35,6 @@ public:
 private:
     EffectSettingsAccessPtr sessionSettings(EffectInstance* instance) const;
 
-    mutable std::map<EffectInstance*, EffectSettingsAccessPtr> m_sessionSettings;
+    std::map<EffectInstance*, EffectSettingsAccessPtr> m_sessionSettings;
 };
 }

--- a/src/effects/lv2/internal/lv2parameterextractorservice.h
+++ b/src/effects/lv2/internal/lv2parameterextractorservice.h
@@ -1,0 +1,40 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+#pragma once
+
+#include "effects/effects_base/iparameterextractorservice.h"
+
+#include <map>
+
+namespace au::effects {
+class Lv2ParameterExtractorService : public IParameterExtractorService
+{
+public:
+    EffectFamily family() const override { return EffectFamily::LV2; }
+
+    ParameterInfoList extractParameters(EffectInstance* instance, EffectSettingsAccessPtr settingsAccess = nullptr) const override;
+
+    ParameterInfo getParameter(EffectInstance* instance, const muse::String& parameterId) const override;
+
+    double getParameterValue(EffectInstance* instance, const muse::String& parameterId) const override;
+
+    bool setParameterValue(EffectInstance* instance, const muse::String& parameterId, double fullRangeValue,
+                           EffectSettingsAccessPtr settingsAccess = nullptr) override;
+
+    muse::String getParameterValueString(EffectInstance* instance, const muse::String& parameterId, double value) const override;
+
+    void endParameterGesture(EffectInstance* instance, const muse::String& parameterId) override;
+
+    void onInstanceDestroyed(EffectInstance* instance) override;
+
+    void beginParameterEditing(EffectInstance* instance, EffectSettingsAccessPtr settingsAccess) override;
+
+    void endParameterEditing(EffectInstance* instance) override;
+
+private:
+    EffectSettingsAccessPtr sessionSettings(EffectInstance* instance) const;
+
+    mutable std::map<EffectInstance*, EffectSettingsAccessPtr> m_sessionSettings;
+};
+}

--- a/src/effects/lv2/internal/lv2uiselect.cpp
+++ b/src/effects/lv2/internal/lv2uiselect.cpp
@@ -1,0 +1,62 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+#include "lv2uiselect.h"
+
+#include <cstring>
+
+#include "au3-lv2/LV2Symbols.h"
+
+#include "lv2/ui/ui.h"
+
+namespace au::effects {
+namespace {
+unsigned uiIsSupported(const char* hostTypeUri, const char* uiTypeUri)
+{
+    if (strcmp(hostTypeUri, uiTypeUri) == 0
+        ||
+        // We give X11 UIs a chance to be run externally.
+        strcmp(uiTypeUri, LV2_UI__X11UI) == 0) {
+        return 1;
+    }
+    return 0;
+}
+}
+
+Lv2UiSelection selectPluginUi(const LilvPlugin& plugin)
+{
+    using namespace LV2Symbols;
+
+    Lv2UiSelection result;
+    result.uis.reset(lilv_plugin_get_uis(&plugin));
+    if (!result.uis) {
+        return result;
+    }
+
+    const LilvNodePtr hostUiType { lilv_new_uri(gWorld, LV2_UI__Qt6UI) };
+    if (!hostUiType) {
+        return result;
+    }
+
+    LILV_FOREACH(uis, iter, result.uis.get()) {
+        const LilvUI* ui = lilv_uis_get(result.uis.get(), iter);
+        const LilvNode* type = nullptr;
+        if (lilv_ui_is_supported(ui, uiIsSupported, hostUiType.get(), &type)) {
+            result.ui = ui;
+            result.type = type;
+            return result;
+        }
+    }
+
+    LILV_FOREACH(uis, iter, result.uis.get()) {
+        const LilvUI* ui = lilv_uis_get(result.uis.get(), iter);
+        if (lilv_ui_is_a(ui, node_ExternalUI) || lilv_ui_is_a(ui, node_ExternalUIOld)) {
+            result.ui = ui;
+            result.type = node_ExternalUI;
+            return result;
+        }
+    }
+
+    return result;
+}
+}

--- a/src/effects/lv2/internal/lv2uiselect.h
+++ b/src/effects/lv2/internal/lv2uiselect.h
@@ -1,0 +1,18 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+#pragma once
+
+#include "au3-lv2/LV2Utils.h"
+
+namespace au::effects {
+struct Lv2UiSelection {
+    Lilv_ptr<LilvUIs, lilv_uis_free> uis;
+    const LilvUI* ui = nullptr;
+    const LilvNode* type = nullptr;
+
+    bool isValid() const { return ui != nullptr; }
+};
+
+Lv2UiSelection selectPluginUi(const LilvPlugin& plugin);
+}

--- a/src/effects/lv2/internal/lv2viewlauncher.cpp
+++ b/src/effects/lv2/internal/lv2viewlauncher.cpp
@@ -38,6 +38,10 @@ bool Lv2ViewLauncher::vendorUiSupported(const EffectId& effectId) const
 {
     using namespace LV2Symbols;
 
+    if (m_vendorUiFailed.count(effectId)) {
+        return false;
+    }
+
     const auto* effect = dynamic_cast<const LV2EffectBase*>(effectsProvider()->effect(effectId));
     if (!effect) {
         return false;
@@ -62,4 +66,9 @@ bool Lv2ViewLauncher::vendorUiSupported(const EffectId& effectId) const
     }
 
     return false;
+}
+
+void Lv2ViewLauncher::markVendorUiFailed(const EffectId& effectId)
+{
+    m_vendorUiFailed.insert(effectId);
 }

--- a/src/effects/lv2/internal/lv2viewlauncher.cpp
+++ b/src/effects/lv2/internal/lv2viewlauncher.cpp
@@ -3,16 +3,22 @@
  */
 #include "lv2viewlauncher.h"
 
+#include "lv2uiselect.h"
+
 #include "au3-components/EffectInterface.h"
 #include "au3-effects/Effect.h"
 #include "au3-lv2/LV2EffectBase.h"
-#include "au3-lv2/LV2Symbols.h"
-#include "au3-lv2/LV2Utils.h"
 #include "au3-realtime-effects/RealtimeEffectState.h"
 
-#include "lv2/ui/ui.h"
-
 using namespace au::effects;
+
+Lv2ViewLauncher::Lv2ViewLauncher(const muse::modularity::ContextPtr& ctx)
+    : AbstractViewLauncher(ctx)
+{
+    effectsProvider()->effectMetaListChanged().onNotify(this, [this]() {
+        m_vendorUiFailed.clear();
+    });
+}
 
 muse::Ret Lv2ViewLauncher::showEffect(const EffectInstanceId& instanceId) const
 {
@@ -24,20 +30,8 @@ void Lv2ViewLauncher::showRealtimeEffect(const RealtimeEffectStatePtr& state) co
     doShowRealtimeEffect(state);
 }
 
-namespace {
-unsigned uiTypeSupported(const char* hostTypeUri, const char* uiTypeUri)
-{
-    if (strcmp(hostTypeUri, uiTypeUri) == 0 || strcmp(uiTypeUri, LV2_UI__X11UI) == 0) {
-        return 1;
-    }
-    return 0;
-}
-}
-
 bool Lv2ViewLauncher::vendorUiSupported(const EffectId& effectId) const
 {
-    using namespace LV2Symbols;
-
     if (m_vendorUiFailed.count(effectId)) {
         return false;
     }
@@ -47,25 +41,7 @@ bool Lv2ViewLauncher::vendorUiSupported(const EffectId& effectId) const
         return false;
     }
 
-    using LilvUIsPtr = Lilv_ptr<LilvUIs, lilv_uis_free>;
-    const LilvUIsPtr uis { lilv_plugin_get_uis(&effect->mPlug) };
-    if (!uis) {
-        return false;
-    }
-
-    const LilvNodePtr hostUiType { lilv_new_uri(gWorld, LV2_UI__Qt6UI) };
-    LILV_FOREACH(uis, iter, uis.get()) {
-        const LilvUI* ui = lilv_uis_get(uis.get(), iter);
-        const LilvNode* uiType = nullptr;
-        if (lilv_ui_is_supported(ui, uiTypeSupported, hostUiType.get(), &uiType)) {
-            return true;
-        }
-        if (lilv_ui_is_a(ui, node_ExternalUI) || lilv_ui_is_a(ui, node_ExternalUIOld)) {
-            return true;
-        }
-    }
-
-    return false;
+    return selectPluginUi(effect->mPlug).isValid();
 }
 
 void Lv2ViewLauncher::markVendorUiFailed(const EffectId& effectId)

--- a/src/effects/lv2/internal/lv2viewlauncher.cpp
+++ b/src/effects/lv2/internal/lv2viewlauncher.cpp
@@ -4,7 +4,13 @@
 #include "lv2viewlauncher.h"
 
 #include "au3-components/EffectInterface.h"
+#include "au3-effects/Effect.h"
+#include "au3-lv2/LV2EffectBase.h"
+#include "au3-lv2/LV2Symbols.h"
+#include "au3-lv2/LV2Utils.h"
 #include "au3-realtime-effects/RealtimeEffectState.h"
+
+#include "lv2/ui/ui.h"
 
 using namespace au::effects;
 
@@ -16,4 +22,44 @@ muse::Ret Lv2ViewLauncher::showEffect(const EffectInstanceId& instanceId) const
 void Lv2ViewLauncher::showRealtimeEffect(const RealtimeEffectStatePtr& state) const
 {
     doShowRealtimeEffect(state);
+}
+
+namespace {
+unsigned uiTypeSupported(const char* hostTypeUri, const char* uiTypeUri)
+{
+    if (strcmp(hostTypeUri, uiTypeUri) == 0 || strcmp(uiTypeUri, LV2_UI__X11UI) == 0) {
+        return 1;
+    }
+    return 0;
+}
+}
+
+bool Lv2ViewLauncher::vendorUiSupported(const EffectId& effectId) const
+{
+    using namespace LV2Symbols;
+
+    const auto* effect = dynamic_cast<const LV2EffectBase*>(effectsProvider()->effect(effectId));
+    if (!effect) {
+        return false;
+    }
+
+    using LilvUIsPtr = Lilv_ptr<LilvUIs, lilv_uis_free>;
+    const LilvUIsPtr uis { lilv_plugin_get_uis(&effect->mPlug) };
+    if (!uis) {
+        return false;
+    }
+
+    const LilvNodePtr hostUiType { lilv_new_uri(gWorld, LV2_UI__Qt6UI) };
+    LILV_FOREACH(uis, iter, uis.get()) {
+        const LilvUI* ui = lilv_uis_get(uis.get(), iter);
+        const LilvNode* uiType = nullptr;
+        if (lilv_ui_is_supported(ui, uiTypeSupported, hostUiType.get(), &uiType)) {
+            return true;
+        }
+        if (lilv_ui_is_a(ui, node_ExternalUI) || lilv_ui_is_a(ui, node_ExternalUIOld)) {
+            return true;
+        }
+    }
+
+    return false;
 }

--- a/src/effects/lv2/internal/lv2viewlauncher.h
+++ b/src/effects/lv2/internal/lv2viewlauncher.h
@@ -22,5 +22,9 @@ public:
     muse::Ret showEffect(const EffectInstanceId& instanceId) const override;
     void showRealtimeEffect(const RealtimeEffectStatePtr& state) const override;
     bool vendorUiSupported(const EffectId& effectId) const override;
+    void markVendorUiFailed(const EffectId& effectId) override;
+
+private:
+    std::set<EffectId> m_vendorUiFailed;
 };
 }

--- a/src/effects/lv2/internal/lv2viewlauncher.h
+++ b/src/effects/lv2/internal/lv2viewlauncher.h
@@ -5,20 +5,23 @@
 
 #include "effects/effects_base/internal/abstractviewlauncher.h"
 
+#include "framework/global/async/asyncable.h"
 #include "framework/global/modularity/ioc.h"
 #include "framework/interactive/iinteractive.h"
 
 #include "effects/effects_base/ieffectinstancesregister.h"
 #include "effects/effects_base/ieffectsprovider.h"
 
+#include <set>
+
 namespace au::effects {
-class Lv2ViewLauncher final : public AbstractViewLauncher
+class Lv2ViewLauncher final : public AbstractViewLauncher, public muse::async::Asyncable
 {
     muse::GlobalInject<IEffectsProvider> effectsProvider;
 
 public:
-    Lv2ViewLauncher(const muse::modularity::ContextPtr& ctx)
-        : AbstractViewLauncher(ctx) {}
+    Lv2ViewLauncher(const muse::modularity::ContextPtr& ctx);
+
     muse::Ret showEffect(const EffectInstanceId& instanceId) const override;
     void showRealtimeEffect(const RealtimeEffectStatePtr& state) const override;
     bool vendorUiSupported(const EffectId& effectId) const override;

--- a/src/effects/lv2/internal/lv2viewlauncher.h
+++ b/src/effects/lv2/internal/lv2viewlauncher.h
@@ -9,14 +9,18 @@
 #include "framework/interactive/iinteractive.h"
 
 #include "effects/effects_base/ieffectinstancesregister.h"
+#include "effects/effects_base/ieffectsprovider.h"
 
 namespace au::effects {
 class Lv2ViewLauncher final : public AbstractViewLauncher
 {
+    muse::GlobalInject<IEffectsProvider> effectsProvider;
+
 public:
     Lv2ViewLauncher(const muse::modularity::ContextPtr& ctx)
         : AbstractViewLauncher(ctx) {}
     muse::Ret showEffect(const EffectInstanceId& instanceId) const override;
     void showRealtimeEffect(const RealtimeEffectStatePtr& state) const override;
+    bool vendorUiSupported(const EffectId& effectId) const override;
 };
 }

--- a/src/effects/lv2/lv2effectsmodule.cpp
+++ b/src/effects/lv2/lv2effectsmodule.cpp
@@ -8,9 +8,11 @@
 
 #include "effects/effects_base/ieffectloadersregister.h"
 #include "effects/effects_base/ieffectviewlaunchregister.h"
+#include "effects/effects_base/iparameterextractorregistry.h"
 #include "effects/effects_base/view/effectsviewutils.h"
 
 #include "internal/lv2effectloader.h"
+#include "internal/lv2parameterextractorservice.h"
 #include "internal/lv2pluginmetareader.h"
 #include "internal/lv2pluginsscanner.h"
 #include "internal/lv2viewlauncher.h"
@@ -61,6 +63,11 @@ void Lv2EffectsModule::resolveImports()
     auto loadersRegister = globalIoc()->resolve<IEffectLoadersRegister>(mname);
     if (loadersRegister) {
         loadersRegister->registerLoader(m_effectLoader);
+    }
+
+    auto paramExtractorRegistry = globalIoc()->resolve<IParameterExtractorRegistry>(mname);
+    if (paramExtractorRegistry) {
+        paramExtractorRegistry->registerExtractor(std::make_shared<Lv2ParameterExtractorService>());
     }
 
     // auto ir = ioc()->resolve<IInteractiveUriRegister>(mname);

--- a/src/effects/lv2/qml/Audacity/Lv2/Lv2Viewer.qml
+++ b/src/effects/lv2/qml/Audacity/Lv2/Lv2Viewer.qml
@@ -84,7 +84,7 @@ Rectangle {
         width: visible ? 300 : 0
         height: visible ? 100 : 0
         anchors.centerIn: parent
-        text: "No available UI:\n" + prv.viewModel.unsupportedUiReason + "\n(Plain UI not implemented yet)"
+        text: "No available UI:\n" + prv.viewModel.unsupportedUiReason
         color: ui.theme.fontPrimaryColor
         verticalAlignment: Text.AlignVCenter
         horizontalAlignment: Text.AlignHCenter

--- a/src/effects/lv2/qml/Audacity/Lv2/Lv2Viewer.qml
+++ b/src/effects/lv2/qml/Audacity/Lv2/Lv2Viewer.qml
@@ -84,7 +84,7 @@ Rectangle {
         width: visible ? 300 : 0
         height: visible ? 100 : 0
         anchors.centerIn: parent
-        text: "No available UI:\n" + prv.viewModel.unsupportedUiReason
+        text: qsTrc("effects/lv2", "No available UI:\n%1").arg(prv.viewModel.unsupportedUiReason)
         color: ui.theme.fontPrimaryColor
         verticalAlignment: Text.AlignVCenter
         horizontalAlignment: Text.AlignHCenter

--- a/src/effects/lv2/qml/Audacity/Lv2/Lv2Viewer.qml
+++ b/src/effects/lv2/qml/Audacity/Lv2/Lv2Viewer.qml
@@ -20,6 +20,8 @@ Rectangle {
     property string title: prv.viewModel.title
     property bool isPreviewing: prv.viewModel.isPreviewing
 
+    signal vendorUiFailed
+
     implicitWidth: textItem.width
     implicitHeight: textItem.height
     color: ui.theme.backgroundPrimaryColor
@@ -27,11 +29,16 @@ Rectangle {
     QtObject {
         id: prv
 
+        property bool vendorUiFailed: false
         property AbstractMenuModel activeMenuModel: null
         property var viewModel: {
             var viewModel = Lv2ViewModelFactory.createModel(root, root.instanceId, root.effectState)
             viewModel.onExternalUiClosed.connect(function () {
                 window.close()
+            })
+            viewModel.onVendorUiFailed.connect(function () {
+                prv.vendorUiFailed = true
+                root.vendorUiFailed()
             })
             return viewModel
         }
@@ -39,7 +46,10 @@ Rectangle {
 
     Component.onCompleted: {
         prv.viewModel.init()
-        Qt.callLater(presetsBarModel.load)
+
+        if (!prv.vendorUiFailed) {
+            Qt.callLater(presetsBarModel.load)
+        }
     }
 
     Component.onDestruction: {

--- a/src/effects/lv2/view/lv2viewmodel.cpp
+++ b/src/effects/lv2/view/lv2viewmodel.cpp
@@ -23,6 +23,7 @@
 #include "suil/suil.h"
 
 #include "global/defer.h"
+#include "global/translation.h"
 #include "log.h"
 
 #include <dlfcn.h>
@@ -233,7 +234,8 @@ bool Lv2ViewModel::buildFancy()
 
     // No usable UI found
     if (ui == nullptr) {
-        m_unsupportedUiReason = "No UI provided by the plugin (Please report if AU3 provides a UI for this plugin)";
+        m_unsupportedUiReason
+            = muse::trc("effects/lv2", "No UI provided by the plugin (Please report if AU3 provides a UI for this plugin)");
         emit unsupportedUiReasonChanged();
         return false;
     }
@@ -253,7 +255,7 @@ bool Lv2ViewModel::buildFancy()
     m_isX11Window = strcmp(uiTypeUri, LV2_UI__X11UI) == 0;
 
     if (isGtkUI) {
-        m_unsupportedUiReason = "GTK UIs are not supported";
+        m_unsupportedUiReason = muse::trc("effects/lv2", "GTK UIs are not supported");
         emit unsupportedUiReasonChanged();
         return false;
     }
@@ -281,7 +283,9 @@ bool Lv2ViewModel::buildFancy()
                                            uiBinaryPath.get(), featurePointers.data()));
 
     if (!m_suilInstance || suil_instance_get_widget(m_suilInstance.get()) == nullptr) {
-        m_unsupportedUiReason = usesX11(uiTypeUri) ? "X11 UI refusing to be externalized" : "Unknown reason (please report)";
+        m_unsupportedUiReason = usesX11(uiTypeUri)
+                                ? muse::trc("effects/lv2", "X11 UI refusing to be externalized")
+                                : muse::trc("effects/lv2", "Unknown reason (please report)");
         emit unsupportedUiReasonChanged();
         return false;
     }
@@ -295,7 +299,7 @@ bool Lv2ViewModel::buildFancy()
     if (auto idleUi = tryCreateLv2IdleUi(*m_suilInstance, isExternalUi)) {
         m_pluginUi = std::move(idleUi);
     } else {
-        m_unsupportedUiReason = "Idle UI creation failed";
+        m_unsupportedUiReason = muse::trc("effects/lv2", "Idle UI creation failed");
         emit unsupportedUiReasonChanged();
         return false;
     }

--- a/src/effects/lv2/view/lv2viewmodel.cpp
+++ b/src/effects/lv2/view/lv2viewmodel.cpp
@@ -144,6 +144,7 @@ void Lv2ViewModel::doInit()
     }
 
     if (!buildFancy()) {
+        emit vendorUiFailed();
         return;
     }
 

--- a/src/effects/lv2/view/lv2viewmodel.cpp
+++ b/src/effects/lv2/view/lv2viewmodel.cpp
@@ -5,6 +5,8 @@
 #include "lv2idleuifactory.h"
 #include "ilv2idleui.h"
 
+#include "effects/lv2/internal/lv2uiselect.h"
+
 #include "effects/effects_base/effectstypes.h"
 #include "au3wrap/internal/wxtypes_convert.h"
 #include "playback/iaudiooutput.h"
@@ -96,39 +98,31 @@ bool usesX11(const char* pluginTypeUri)
 {
     return !strcmp(pluginTypeUri, LV2_UI__X11UI);
 }
-
-unsigned uiIsSupported(const char* hostTypeUri,
-                       const char* pluginTypeUri)
-{
-    if (!strcmp(hostTypeUri, pluginTypeUri)
-        ||
-        // We give X11 UIs a chance to be run externally.
-        usesX11(pluginTypeUri)) {
-        return 1;
-    }
-    return 0;
-}
 }
 
 void Lv2ViewModel::doInit()
 {
     IF_ASSERT_FAILED(instanceId() >= 0) {
+        emit vendorUiFailed();
         return;
     }
 
     m_instance = std::dynamic_pointer_cast<LV2Instance>(instancesRegister()->instanceById(instanceId()));
     IF_ASSERT_FAILED(m_instance) {
+        emit vendorUiFailed();
         return;
     }
 
     const EffectSettings* settings = instancesRegister()->settingsById(instanceId());
     IF_ASSERT_FAILED(settings) {
+        emit vendorUiFailed();
         return;
     }
 
     const EffectId id = instancesRegister()->effectIdByInstanceId(instanceId());
     const LV2Effect* const effect = dynamic_cast<LV2Effect*>(effectsProvider()->effect(id));
     IF_ASSERT_FAILED(effect) {
+        emit vendorUiFailed();
         return;
     }
 
@@ -140,6 +134,7 @@ void Lv2ViewModel::doInit()
     const auto sampleRate = playback()->audioOutput()->sampleRate();
     m_wrapper = m_instance->MakeWrapper(*settings, sampleRate, nullptr);
     IF_ASSERT_FAILED(m_wrapper) {
+        emit vendorUiFailed();
         return;
     }
 
@@ -148,7 +143,7 @@ void Lv2ViewModel::doInit()
         return;
     }
 
-    startUiTimer(true);
+    startUiTimer();
     if (isRealtimeInstance()) {
         startSettingsTimer();
     }
@@ -195,51 +190,17 @@ void Lv2ViewModel::startSettingsTimer()
 bool Lv2ViewModel::buildFancy()
 {
     using namespace LV2Symbols;
-    // Set the native UI type
-    const char* const hostNativeType = LV2_UI__Qt6UI;
 
-    // Determine if the plugin has a supported UI
-    const LilvUI* ui = nullptr;
-    const LilvNode* uiType = nullptr;
-    using LilvUIsPtr = Lilv_ptr<LilvUIs, lilv_uis_free>;
-
-    LilvUIsPtr uis{ lilv_plugin_get_uis(m_lilvPlugin) };
-    if (uis) {
-        if (LilvNodePtr ui_host_uri{ lilv_new_uri(gWorld, hostNativeType) }) {
-            LILV_FOREACH(uis, iter, uis.get()) {
-                ui = lilv_uis_get(uis.get(), iter);
-                if (lilv_ui_is_supported(ui,
-                                         uiIsSupported, ui_host_uri.get(), &uiType)) {
-                    break;
-                }
-                if (lilv_ui_is_a(ui, node_Gtk) || lilv_ui_is_a(ui, node_Gtk3)) {
-                    uiType = node_Gtk;
-                    break;
-                }
-                ui = nullptr;
-            }
-        }
-    }
-
-    // Check for other supported UIs
-    if (!ui && uis) {
-        LILV_FOREACH(uis, iter, uis.get()) {
-            ui = lilv_uis_get(uis.get(), iter);
-            if (lilv_ui_is_a(ui, node_ExternalUI) || lilv_ui_is_a(ui, node_ExternalUIOld)) {
-                uiType = node_ExternalUI;
-                break;
-            }
-            ui = nullptr;
-        }
-    }
-
-    // No usable UI found
-    if (ui == nullptr) {
+    const Lv2UiSelection selection = selectPluginUi(*m_lilvPlugin);
+    if (!selection.isValid()) {
         m_unsupportedUiReason
             = muse::trc("effects/lv2", "No UI provided by the plugin (Please report if AU3 provides a UI for this plugin)");
         emit unsupportedUiReasonChanged();
         return false;
     }
+
+    const LilvUI* ui = selection.ui;
+    const LilvNode* uiType = selection.type;
 
     const auto uinode = lilv_ui_get_uri(ui);
     lilv_world_load_resource(gWorld, uinode);
@@ -251,15 +212,7 @@ bool Lv2ViewModel::buildFancy()
 
     const char* const uiTypeUri = lilv_node_as_uri(uiType);
     const auto isExternalUi = strcmp(uiTypeUri, lilv_node_as_string(node_ExternalUI)) == 0;
-    const bool isGtkUI
-        = strcmp(uiTypeUri, LV2_UI__GtkUI) == 0 || strcmp(uiTypeUri, LV2_UI__Gtk3UI) == 0 || strcmp(uiTypeUri, LV2_UI__Gtk4UI) == 0;
     m_isX11Window = strcmp(uiTypeUri, LV2_UI__X11UI) == 0;
-
-    if (isGtkUI) {
-        m_unsupportedUiReason = muse::trc("effects/lv2", "GTK UIs are not supported");
-        emit unsupportedUiReasonChanged();
-        return false;
-    }
 
     const char* const containerTypeUri
         = isExternalUi ? LV2_EXTERNAL_UI__Widget
@@ -317,7 +270,7 @@ bool Lv2ViewModel::buildFancy()
     return true;
 }
 
-void Lv2ViewModel::startUiTimer(bool fancy)
+void Lv2ViewModel::startUiTimer()
 {
     const auto& mySettings = GetSettings(m_settingsAccess->Get());
     const LV2Wrapper* const pMaster = m_instance->GetMaster();
@@ -345,18 +298,14 @@ void Lv2ViewModel::startUiTimer(bool fancy)
         }
     }
 
-    if (fancy) {
-        assert(m_suilInstance);
-        size_t index = 0;
-        for (auto& port : m_ports->mControlPorts) {
-            constexpr uint32_t floatFormat = 0;
-            if (port->mIsInput) {
-                suil_instance_port_event(m_suilInstance.get(), port->mIndex, sizeof(float), floatFormat, &values[index]);
-            }
-            ++index;
+    assert(m_suilInstance);
+    size_t index = 0;
+    for (auto& port : m_ports->mControlPorts) {
+        constexpr uint32_t floatFormat = 0;
+        if (port->mIsInput) {
+            suil_instance_port_event(m_suilInstance.get(), port->mIndex, sizeof(float), floatFormat, &values[index]);
         }
-    } else {
-        // TODO
+        ++index;
     }
 
     connect(&m_uiTimer, &QTimer::timeout, this, &Lv2ViewModel::onIdle);

--- a/src/effects/lv2/view/lv2viewmodel.cpp
+++ b/src/effects/lv2/view/lv2viewmodel.cpp
@@ -142,16 +142,11 @@ void Lv2ViewModel::doInit()
         return;
     }
 
-    const auto fancy
-        = buildFancy() ? std::make_optional(true)
-          : buildPlain() ? std::make_optional(false)
-          : std::nullopt;
-    if (!fancy.has_value()) {
-        // Do not assert before we've implemented buildPlain()
+    if (!buildFancy()) {
         return;
     }
 
-    startUiTimer(*fancy);
+    startUiTimer(true);
     if (isRealtimeInstance()) {
         startSettingsTimer();
     }
@@ -258,7 +253,7 @@ bool Lv2ViewModel::buildFancy()
     m_isX11Window = strcmp(uiTypeUri, LV2_UI__X11UI) == 0;
 
     if (isGtkUI) {
-        m_unsupportedUiReason = "GTK UIs not supported, will fall back to plain UI when it's there :)";
+        m_unsupportedUiReason = "GTK UIs are not supported";
         emit unsupportedUiReasonChanged();
         return false;
     }
@@ -315,11 +310,6 @@ bool Lv2ViewModel::buildFancy()
     }
 
     return true;
-}
-
-bool Lv2ViewModel::buildPlain()
-{
-    return false;
 }
 
 void Lv2ViewModel::startUiTimer(bool fancy)

--- a/src/effects/lv2/view/lv2viewmodel.h
+++ b/src/effects/lv2/view/lv2viewmodel.h
@@ -72,7 +72,6 @@ private:
     using SuilInstancePtr = Lilv_ptr<SuilInstance, suil_instance_free>;
 
     bool buildFancy();
-    bool buildPlain();
     void startUiTimer(bool fancy);
     void startSettingsTimer();
     void onIdle();

--- a/src/effects/lv2/view/lv2viewmodel.h
+++ b/src/effects/lv2/view/lv2viewmodel.h
@@ -73,7 +73,7 @@ private:
     using SuilInstancePtr = Lilv_ptr<SuilInstance, suil_instance_free>;
 
     bool buildFancy();
-    void startUiTimer(bool fancy);
+    void startUiTimer();
     void startSettingsTimer();
     void onIdle();
     void makeDirty();

--- a/src/effects/lv2/view/lv2viewmodel.h
+++ b/src/effects/lv2/view/lv2viewmodel.h
@@ -53,6 +53,7 @@ signals:
     void titleChanged();
     void externalUiClosed();
     void unsupportedUiReasonChanged();
+    void vendorUiFailed();
 
 private:
     friend class Lv2UiHandler;


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/11289

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
- [ ] Calf plugins should load a fallback UI (GTK vendor UI's are not supported so it's not possible to open that version)
- [ ] Check other effect types (on all platforms) -> opening vendor/fallback UIs, check if layout of effect dialogs are ok
