### PR TITLE
Fix mono clip blank channel when dragging to stereo track

### DIFF
--- a/src/projectscene/view/tracksitemsview/au3/connectingdotspainter.cpp
+++ b/src/projectscene/view/tracksitemsview/au3/connectingdotspainter.cpp
@@ -38,10 +38,9 @@ void ConnectingDotsPainter::paint(QPainter& painter, const trackedit::ClipKey& c
         return;
     }
 
-    const std::vector<double> channelHeight {
-        params.geometry.height * params.channelHeightRatio,
-        params.geometry.height * (1 - params.channelHeightRatio),
-    };
+    const size_t displayedChannels = samplespainterutils::displayedChannelCount(*track);
+    const std::vector<double> channelHeight
+        = samplespainterutils::channelHeights(params.geometry.height, params.channelHeightRatio, displayedChannels);
 
     const float dBRange = std::abs(params.dbRange);
     const bool dB = !params.isLinear;
@@ -49,13 +48,14 @@ void ConnectingDotsPainter::paint(QPainter& painter, const trackedit::ClipKey& c
 
     auto waveMetrics = wavepainterutils::getWaveMetrics(globalContext()->currentProject(), clipKey, params);
 
-    for (size_t index = 0; index < waveClip->NChannels(); index++) {
+    for (size_t index = 0; index < displayedChannels; index++) {
         waveMetrics.height = channelHeight[index];
         samplespainterutils::drawBackground(painter, waveMetrics, params.style, trimLeft);
         // Draw center line at the middle of the current channel
         const int centerY = waveMetrics.top + waveMetrics.height / 2;
         samplespainterutils::drawCenterLine(painter, waveMetrics, params.style, centerY);
-        const auto samples = samplespainterutils::getSampleData(*waveClip, index, waveMetrics, dB, dBRange, params.displayBounds.second,
+        const auto samples = samplespainterutils::getSampleData(*waveClip, samplespainterutils::paintChannelIndex(*waveClip, index),
+                                                                waveMetrics, dB, dBRange, params.displayBounds.second,
                                                                 params.displayBounds.first);
         if (samples.size() == 0) {
             continue;

--- a/src/projectscene/view/tracksitemsview/au3/minmaxrmspainter.cpp
+++ b/src/projectscene/view/tracksitemsview/au3/minmaxrmspainter.cpp
@@ -2,6 +2,7 @@
 
 #include "au3wrap/internal/domaccessor.h"
 #include "wavepainterutils.h"
+#include "samplespainterutils.h"
 #include "WaveformPainter.h"
 
 using namespace au::au3;
@@ -49,10 +50,9 @@ void MinMaxRMSPainter::paint(QPainter& painter, const trackedit::ClipKey& clipKe
     const float dbRange = std::abs(params.dbRange);
     const bool dB = !params.isLinear;
 
-    const std::vector<double> channelHeight {
-        params.geometry.height * params.channelHeightRatio,
-        params.geometry.height * (1 - params.channelHeightRatio),
-    };
+    const size_t displayedChannels = samplespainterutils::displayedChannelCount(*track);
+    const std::vector<double> channelHeight
+        = samplespainterutils::channelHeights(params.geometry.height, params.channelHeightRatio, displayedChannels);
 
     const float zoomMin = dB ? getDBValue(params.displayBounds.first, dbRange) : params.displayBounds.first;
     const float zoomMax = dB ? getDBValue(params.displayBounds.second, dbRange) : params.displayBounds.second;
@@ -62,7 +62,7 @@ void MinMaxRMSPainter::paint(QPainter& painter, const trackedit::ClipKey& clipKe
 
     auto metrics = wavepainterutils::getWaveMetrics(globalContext()->currentProject(), clipKey, params);
 
-    for (size_t index = 0; index < waveClip->NChannels(); index++) {
+    for (size_t index = 0; index < displayedChannels; index++) {
         metrics.height = channelHeight[index];
         paintParameters
         .SetDisplayParameters(
@@ -93,7 +93,7 @@ void MinMaxRMSPainter::paint(QPainter& painter, const trackedit::ClipKey& clipKe
 
         metrics.top += static_cast<int>(metrics.height);
 
-        waveformPainter.Draw(index, painter, paintParameters, _metrics);
+        waveformPainter.Draw(samplespainterutils::paintChannelIndex(*waveClip, index), painter, paintParameters, _metrics);
     }
 }
 }

--- a/src/projectscene/view/tracksitemsview/au3/samplespainter.cpp
+++ b/src/projectscene/view/tracksitemsview/au3/samplespainter.cpp
@@ -108,10 +108,9 @@ void SamplesPainter::paint(QPainter& painter, const trackedit::ClipKey& clipKey,
         return;
     }
 
-    const std::vector<double> channelHeight {
-        params.geometry.height * params.channelHeightRatio,
-        params.geometry.height * (1 - params.channelHeightRatio),
-    };
+    const size_t displayedChannels = samplespainterutils::displayedChannelCount(*track);
+    const std::vector<double> channelHeight
+        = samplespainterutils::channelHeights(params.geometry.height, params.channelHeightRatio, displayedChannels);
 
     const float dBRange = std::abs(params.dbRange);
     const bool dB = !params.isLinear;
@@ -119,7 +118,7 @@ void SamplesPainter::paint(QPainter& painter, const trackedit::ClipKey& clipKey,
 
     auto waveMetrics = wavepainterutils::getWaveMetrics(globalContext()->currentProject(), clipKey, params, true);
 
-    for (size_t index = 0; index < waveClip->NChannels(); index++) {
+    for (size_t index = 0; index < displayedChannels; index++) {
         waveMetrics.height = channelHeight[index];
 
         // Draw background with the full channel area
@@ -132,7 +131,8 @@ void SamplesPainter::paint(QPainter& painter, const trackedit::ClipKey& clipKey,
         int yZero = samplespainterutils::getWaveYPos(0.0, params.displayBounds.first, params.displayBounds.second, paddedMetrics.height, dB,
                                                      true, dBRange, false);
         yZero = paddedMetrics.top + std::max(-1, std::min(static_cast<int>(paddedMetrics.height + paddedMetrics.top), yZero));
-        const auto samples = samplespainterutils::getSampleData(*waveClip, index, paddedMetrics, dB, dBRange, params.displayBounds.second,
+        const auto samples = samplespainterutils::getSampleData(*waveClip, samplespainterutils::paintChannelIndex(*waveClip, index),
+                                                                paddedMetrics, dB, dBRange, params.displayBounds.second,
                                                                 params.displayBounds.first);
         if (samples.size() == 0) {
             samplespainterutils::drawCenterLine(painter, waveMetrics, params.style, yZero);

--- a/src/projectscene/view/tracksitemsview/au3/samplespainterutils.cpp
+++ b/src/projectscene/view/tracksitemsview/au3/samplespainterutils.cpp
@@ -230,6 +230,30 @@ void drawClippedSamples(const au::projectscene::SampleData& samples,
     }
 }
 
+size_t displayedChannelCount(const au::au3::Au3WaveTrack& track)
+{
+    // Query the track's own real channel count rather than the (track-wide, and thus
+    // potentially stale mid-drag for clips not involved in the drag) view-state channel
+    // height ratio.
+    return track.NChannels();
+}
+
+size_t paintChannelIndex(const au::au3::Au3WaveClip& clip, size_t displayIndex)
+{
+    // While a mono clip is being dragged onto a stereo track, the track's lanes already show two
+    // channels but the clip itself hasn't been widened to stereo yet (that happens on drop). Until
+    // then, mirror the single channel's data into the extra lane instead of leaving it blank.
+    return std::min(displayIndex, clip.NChannels() - 1);
+}
+
+std::vector<double> channelHeights(double totalHeight, double channelHeightRatio, size_t displayedChannels)
+{
+    if (displayedChannels < 2) {
+        return { totalHeight };
+    }
+    return { totalHeight* channelHeightRatio, totalHeight* (1 - channelHeightRatio) };
+}
+
 SampleData getSampleData(const au::au3::Au3WaveClip& clip, int channelIndex, const au::projectscene::WaveMetrics& metrics,
                          bool dB, float dBRange, float zoomMax, float zoomMin)
 {

--- a/src/projectscene/view/tracksitemsview/au3/samplespainterutils.h
+++ b/src/projectscene/view/tracksitemsview/au3/samplespainterutils.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <vector>
+
 #include "../iwavepainter.h"
 
 #include "project/iaudacityproject.h"
@@ -17,6 +19,9 @@ void drawBackground(QPainter& painter, const au::projectscene::WaveMetrics& metr
 void drawCenterLine(QPainter& painter, const au::projectscene::WaveMetrics& metrics, const IWavePainter::Style& style, int y);
 void drawClippedSamples(const au::projectscene::SampleData& samples, const au::projectscene::WaveMetrics& metrics, QPainter& painter,
                         const au::projectscene::IWavePainter::Style& style);
+size_t displayedChannelCount(const au::au3::Au3WaveTrack& track);
+size_t paintChannelIndex(const au::au3::Au3WaveClip& clip, size_t displayIndex);
+std::vector<double> channelHeights(double totalHeight, double channelHeightRatio, size_t displayedChannels);
 SampleData getSampleData(const au::au3::Au3WaveClip& clip, int channelIndex, const au::projectscene::WaveMetrics& metrics, bool dB,
                          float dBRange, float zoomMax, float zoomMin);
 std::optional<int> hitChannelIndex(std::shared_ptr<au::project::IAudacityProject> project, const trackedit::ClipKey& clipKey,

--- a/src/trackedit/tests/au3clipsinteraction_tests.cpp
+++ b/src/trackedit/tests/au3clipsinteraction_tests.cpp
@@ -1288,4 +1288,49 @@ TEST_F(Au3ClipsInteractionTests, RemoveOverlapsClearsAlreadyOverlappingTrack)
 
     removeTrack(trackId);
 }
+
+TEST_F(Au3ClipsInteractionTests, DragStereoClipOntoNonEmptyMonoTrackMidDragKeepsResidentClipMono)
+{
+    //! [GIVEN] A stereo track with one clip, directly above a mono track with its own resident clip
+    auto& waveFactory = Au3WaveTrackFactory::Get(projectRef());
+    const auto stereoTrack = waveFactory.Create(2, sampleFormat::floatSample, DEFAULT_SAMPLE_RATE);
+    Au3TrackList::Get(projectRef()).Add(stereoTrack, ::TrackList::DoAssignId::Yes, ::TrackList::EventPublicationSynchrony::Synchronous);
+
+    const auto stereoClip = stereoTrack->CreateClip(0.0, "stereoClip");
+    std::vector<float> left(10, 0.5f);
+    std::vector<float> right(10, -0.5f);
+    constSamplePtr buffers[2] = {
+        reinterpret_cast<constSamplePtr>(left.data()),
+        reinterpret_cast<constSamplePtr>(right.data())
+    };
+    stereoClip->Append(buffers, sampleFormat::floatSample, 10, 1, sampleFormat::floatSample);
+    stereoClip->Flush();
+    stereoTrack->InsertInterval(stereoClip, true);
+    const TrackId stereoTrackId = TrackId(stereoTrack->GetId());
+    const auto stereoClipId = stereoClip->GetId();
+
+    const TrackId monoTrackId = createTrack(TestTrackID::TRACK_MIN_SILENCE);
+    ASSERT_NE(monoTrackId, INVALID_TRACK) << "Failed to create mono track";
+    Au3WaveTrack* monoTrackBefore = DomAccessor::findWaveTrack(projectRef(), Au3TrackId(monoTrackId));
+    ASSERT_EQ(monoTrackBefore->NChannels(), 1u) << "Precondition: destination track is mono";
+    const auto residentClipId = monoTrackBefore->GetSortedClipByIndex(0)->GetId();
+
+    //! [WHEN] The stereo clip is dragged down onto the (non-empty) mono track, but the drag
+    //! is not yet released (completed=false), mimicking the mid-drag preview state
+    bool clipsMovedToOtherTracks = false;
+    ClipKeyList selected = { { stereoTrackId, stereoClipId } };
+    m_clipsInteraction->moveClips(selected, 0.0, 1, false, clipsMovedToOtherTracks);
+
+    //! [THEN] The destination track's own channel count, and the untouched resident
+    //! clip's channel count, should not have changed just from the clip hovering over it
+    Au3WaveTrack* monoTrackAfter = DomAccessor::findWaveTrack(projectRef(), Au3TrackId(monoTrackId));
+    ASSERT_TRUE(monoTrackAfter);
+    EXPECT_EQ(monoTrackAfter->NChannels(), 1u) << "Destination track should remain mono mid-drag";
+
+    const auto residentClipAfter = DomAccessor::findWaveClip(monoTrackAfter, residentClipId);
+    ASSERT_TRUE(residentClipAfter) << "Resident clip should still be present";
+    EXPECT_EQ(residentClipAfter->NChannels(), 1u) << "Resident clip should remain mono mid-drag";
+
+    removeTrack(monoTrackId);
+}
 }


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/9682

It also fixes the bug where, when you drag a stereo clip from a stereo track to mono, the mono clip's waveform on the mono track also changes to stereo (duplicating the mono audio data on both channels) before you release the mouse button.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [ ] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [ ] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Mono clip dragged onto an empty and non-empty stereo track
- [ ] Stereo clip dragged onto an empty and non-empty mono track
- [ ] Same-channel-count drags remain visually unaffected
