### PR TITLE
White waveform fix

### DIFF
--- a/src/trackedit/iclipboarddata.h
+++ b/src/trackedit/iclipboarddata.h
@@ -23,5 +23,8 @@ public:
 
     virtual void setMultiSelectionCopy(bool val) = 0;
     virtual bool isMultiSelectionCopy() const = 0;
+
+    virtual void setRangeSelectionCopy(bool val) = 0;
+    virtual bool isRangeSelectionCopy() const = 0;
 };
 }

--- a/src/trackedit/internal/au3/au3trackeditclipboard.cpp
+++ b/src/trackedit/internal/au3/au3trackeditclipboard.cpp
@@ -96,6 +96,16 @@ bool Au3TrackeditClipboard::isMultiSelectionCopy() const
     return clipboardData()->isMultiSelectionCopy();
 }
 
+void Au3TrackeditClipboard::setRangeSelectionCopy(bool newValue)
+{
+    clipboardData()->setRangeSelectionCopy(newValue);
+}
+
+bool Au3TrackeditClipboard::isRangeSelectionCopy() const
+{
+    return clipboardData()->isRangeSelectionCopy();
+}
+
 std::vector<muse::io::path_t> Au3TrackeditClipboard::systemClipboardFilePaths() const
 {
     const QClipboard* cb = QGuiApplication::clipboard();

--- a/src/trackedit/internal/au3/au3trackeditclipboard.h
+++ b/src/trackedit/internal/au3/au3trackeditclipboard.h
@@ -32,6 +32,9 @@ public:
     void setMultiSelectionCopy(bool newValue) override;
     bool isMultiSelectionCopy() const override;
 
+    void setRangeSelectionCopy(bool newValue) override;
+    bool isRangeSelectionCopy() const override;
+
     std::vector<muse::io::path_t> systemClipboardFilePaths() const override;
     void clearSystemClipboard() override;
 

--- a/src/trackedit/internal/clipboarddata.cpp
+++ b/src/trackedit/internal/clipboarddata.cpp
@@ -19,6 +19,7 @@ void ClipboardData::clearTrackData()
 {
     m_tracksData.clear();
     m_isMultiSelectionCopy = false;
+    m_isRangeSelectionCopy = false;
 }
 
 bool ClipboardData::trackDataEmpty() const
@@ -39,4 +40,14 @@ void ClipboardData::setMultiSelectionCopy(bool val)
 bool ClipboardData::isMultiSelectionCopy() const
 {
     return m_isMultiSelectionCopy;
+}
+
+void ClipboardData::setRangeSelectionCopy(bool val)
+{
+    m_isRangeSelectionCopy = val;
+}
+
+bool ClipboardData::isRangeSelectionCopy() const
+{
+    return m_isRangeSelectionCopy;
 }

--- a/src/trackedit/internal/clipboarddata.h
+++ b/src/trackedit/internal/clipboarddata.h
@@ -18,8 +18,12 @@ public:
     void setMultiSelectionCopy(bool val) override;
     bool isMultiSelectionCopy() const override;
 
+    void setRangeSelectionCopy(bool val) override;
+    bool isRangeSelectionCopy() const override;
+
 private:
     std::vector<ITrackDataPtr> m_tracksData;
     bool m_isMultiSelectionCopy = false;
+    bool m_isRangeSelectionCopy = false;
 };
 }

--- a/src/trackedit/internal/trackeditactionscontroller.cpp
+++ b/src/trackedit/internal/trackeditactionscontroller.cpp
@@ -582,7 +582,7 @@ void TrackeditActionsController::doGlobalCutAllTracksRipple()
         secs_t selectedEndTime = selectionController()->dataSelectedEndTime();
 
         trackeditInteraction()->clearClipboard();
-        trackeditInteraction()->cutItemDataIntoClipboard(tracks, selectedStartTime, selectedEndTime, true);
+        trackeditInteraction()->cutItemDataIntoClipboard(tracks, selectedStartTime, selectedEndTime, true, true /*isRangeSelection*/);
 
         selectionController()->resetDataSelection();
         return;
@@ -593,7 +593,8 @@ void TrackeditActionsController::doGlobalCutAllTracksRipple()
 
     if (selectedStartTime.has_value() && selectedEndTime.has_value()) {
         trackeditInteraction()->clearClipboard();
-        trackeditInteraction()->cutItemDataIntoClipboard(tracks, selectedStartTime.value(), selectedEndTime.value(), true);
+        trackeditInteraction()->cutItemDataIntoClipboard(tracks, selectedStartTime.value(), selectedEndTime.value(), true,
+                                                         false /*isRangeSelection*/);
 
         selectionController()->resetSelectedClips();
         selectionController()->resetSelectedLabels();
@@ -1119,7 +1120,8 @@ void TrackeditActionsController::rangeSelectionCut(const ActionData& args)
     secs_t selectedEndTime = selectionController()->dataSelectedEndTime();
 
     trackeditInteraction()->clearClipboard();
-    trackeditInteraction()->cutItemDataIntoClipboard(selectedTracks, selectedStartTime, selectedEndTime, moveClips);
+    trackeditInteraction()->cutItemDataIntoClipboard(selectedTracks, selectedStartTime, selectedEndTime, moveClips,
+                                                     true /*isRangeSelection*/);
 
     selectionController()->resetDataSelection();
 }

--- a/src/trackedit/internal/trackeditinteraction.cpp
+++ b/src/trackedit/internal/trackeditinteraction.cpp
@@ -111,9 +111,10 @@ bool TrackeditInteraction::cutClipIntoClipboard(const ClipKey& clipKey)
     return withPlaybackStop(&ITrackeditInteraction::cutClipIntoClipboard, clipKey);
 }
 
-bool TrackeditInteraction::cutItemDataIntoClipboard(const TrackIdList& tracksIds, secs_t begin, secs_t end, bool moveClips)
+bool TrackeditInteraction::cutItemDataIntoClipboard(const TrackIdList& tracksIds, secs_t begin, secs_t end, bool moveClips,
+                                                    bool isRangeSelection)
 {
-    return withPlaybackStop(&ITrackeditInteraction::cutItemDataIntoClipboard, tracksIds, begin, end, moveClips);
+    return withPlaybackStop(&ITrackeditInteraction::cutItemDataIntoClipboard, tracksIds, begin, end, moveClips, isRangeSelection);
 }
 
 bool TrackeditInteraction::copyClipIntoClipboard(const trackedit::ClipKey& clipKey)

--- a/src/trackedit/internal/trackeditinteraction.h
+++ b/src/trackedit/internal/trackeditinteraction.h
@@ -41,7 +41,7 @@ private:
     void clearClipboard() override;
     muse::Ret pasteFromClipboard(secs_t begin, bool moveClips, bool moveAllTracks) override;
     bool cutClipIntoClipboard(const ClipKey& clipKey) override;
-    bool cutItemDataIntoClipboard(const TrackIdList& tracksIds, secs_t begin, secs_t end, bool moveClips) override;
+    bool cutItemDataIntoClipboard(const TrackIdList& tracksIds, secs_t begin, secs_t end, bool moveClips, bool isRangeSelection) override;
     bool copyClipIntoClipboard(const trackedit::ClipKey& clipKey) override;
     bool copyNonContinuousTrackDataIntoClipboard(const TrackId trackId, const ClipKeyList& clipKeys, secs_t offset) override;
     bool copyContinuousTrackDataIntoClipboard(const TrackId trackId, secs_t begin, secs_t end) override;

--- a/src/trackedit/internal/trackeditoperationcontroller.cpp
+++ b/src/trackedit/internal/trackeditoperationcontroller.cpp
@@ -525,6 +525,7 @@ bool TrackeditOperationController::splitCutSelectedOnTracks(const TrackIdList tr
     for (auto& trackData : tracksData) {
         clipboard()->addTrackData(std::move(trackData));
     }
+    clipboard()->setRangeSelectionCopy(true);
     projectHistory()->pushHistoryState("Split-cut to the clipboard", "Split cut");
     return true;
 }

--- a/src/trackedit/internal/trackeditoperationcontroller.cpp
+++ b/src/trackedit/internal/trackeditoperationcontroller.cpp
@@ -187,7 +187,7 @@ muse::Ret TrackeditOperationController::pasteFromClipboard(secs_t begin, bool mo
         for (const ITrackDataPtr& data : trackData) {
             pastedDataEndTime = std::max(pastedDataEndTime, data->endTime());
         }
-        recreateRangeSelection = !clipboard()->isMultiSelectionCopy();
+        recreateRangeSelection = clipboard()->isRangeSelectionCopy();
 
         ret = tracksInteraction()->paste(trackData, begin, moveClips, moveAllTracks,
                                          clipboard()->isMultiSelectionCopy(), modifiedState);
@@ -222,7 +222,8 @@ bool TrackeditOperationController::cutClipIntoClipboard(const ClipKey& clipKey)
     return true;
 }
 
-bool TrackeditOperationController::cutItemDataIntoClipboard(const TrackIdList& tracksIds, secs_t begin, secs_t end, bool moveClips)
+bool TrackeditOperationController::cutItemDataIntoClipboard(const TrackIdList& tracksIds, secs_t begin, secs_t end, bool moveClips,
+                                                            bool isRangeSelection)
 {
     clipboard()->clearSystemClipboard();
     std::vector<ITrackDataPtr> tracksData;
@@ -236,6 +237,7 @@ bool TrackeditOperationController::cutItemDataIntoClipboard(const TrackIdList& t
     for (auto& trackData : tracksData) {
         clipboard()->addTrackData(std::move(trackData));
     }
+    clipboard()->setRangeSelectionCopy(isRangeSelection);
     projectHistory()->pushHistoryState("Cut to the clipboard", "Cut");
     return true;
 }
@@ -274,6 +276,7 @@ bool TrackeditOperationController::copyContinuousTrackDataIntoClipboard(const Tr
         return false;
     }
     clipboard()->addTrackData(std::move(data));
+    clipboard()->setRangeSelectionCopy(true);
     return true;
 }
 

--- a/src/trackedit/internal/trackeditoperationcontroller.h
+++ b/src/trackedit/internal/trackeditoperationcontroller.h
@@ -60,7 +60,7 @@ public:
     void clearClipboard() override;
     muse::Ret pasteFromClipboard(secs_t begin, bool moveClips, bool moveAllTracks=false) override;
     bool cutClipIntoClipboard(const ClipKey& clipKey) override;
-    bool cutItemDataIntoClipboard(const TrackIdList& tracksIds, secs_t begin, secs_t end, bool moveClips) override;
+    bool cutItemDataIntoClipboard(const TrackIdList& tracksIds, secs_t begin, secs_t end, bool moveClips, bool isRangeSelection) override;
     bool copyClipIntoClipboard(const ClipKey& clipKey) override;
     bool copyNonContinuousTrackDataIntoClipboard(const TrackId trackId, const TrackItemKeyList& itemKeys, secs_t offset) override;
     bool copyContinuousTrackDataIntoClipboard(const TrackId trackId, secs_t begin, secs_t end) override;

--- a/src/trackedit/itrackeditclipboard.h
+++ b/src/trackedit/itrackeditclipboard.h
@@ -28,6 +28,9 @@ public:
     virtual void setMultiSelectionCopy(bool newValue) = 0;
     virtual bool isMultiSelectionCopy() const = 0;
 
+    virtual void setRangeSelectionCopy(bool newValue) = 0;
+    virtual bool isRangeSelectionCopy() const = 0;
+
     virtual std::vector<muse::io::path_t> systemClipboardFilePaths() const = 0;
     virtual void clearSystemClipboard() = 0;
 };

--- a/src/trackedit/itrackeditinteraction.h
+++ b/src/trackedit/itrackeditinteraction.h
@@ -48,7 +48,8 @@ public:
     virtual void clearClipboard() = 0;
     virtual muse::Ret pasteFromClipboard(secs_t begin, bool moveClips, bool moveAllTracks=false) = 0;
     virtual bool cutClipIntoClipboard(const ClipKey& clipKey) = 0;
-    virtual bool cutItemDataIntoClipboard(const TrackIdList& tracksIds, secs_t begin, secs_t end, bool moveClips) = 0;
+    virtual bool cutItemDataIntoClipboard(const TrackIdList& tracksIds, secs_t begin, secs_t end, bool moveClips,
+                                          bool isRangeSelection) = 0;
     virtual bool copyClipIntoClipboard(const ClipKey& clipKey) = 0;
     virtual bool copyNonContinuousTrackDataIntoClipboard(const TrackId trackId, const TrackItemKeyList& itemKeys, secs_t offset) = 0;
     virtual bool copyContinuousTrackDataIntoClipboard(const TrackId trackId, secs_t begin, secs_t end) = 0;

--- a/src/trackedit/tests/mocks/clipboardmock.h
+++ b/src/trackedit/tests/mocks/clipboardmock.h
@@ -21,6 +21,9 @@ public:
     MOCK_METHOD(void, setMultiSelectionCopy, (bool newValue), (override));
     MOCK_METHOD(bool, isMultiSelectionCopy, (), (const, override));
 
+    MOCK_METHOD(void, setRangeSelectionCopy, (bool newValue), (override));
+    MOCK_METHOD(bool, isRangeSelectionCopy, (), (const, override));
+
     MOCK_METHOD(std::vector<muse::io::path_t>, systemClipboardFilePaths, (), (const, override));
     MOCK_METHOD(void, clearSystemClipboard, (), (override));
 };

--- a/src/trackedit/tests/mocks/trackeditinteractionmock.h
+++ b/src/trackedit/tests/mocks/trackeditinteractionmock.h
@@ -35,7 +35,7 @@ public:
     MOCK_METHOD(void, clearClipboard, (), (override));
     MOCK_METHOD(muse::Ret, pasteFromClipboard, (secs_t, bool, bool), (override));
     MOCK_METHOD(bool, cutClipIntoClipboard, (const ClipKey&), (override));
-    MOCK_METHOD(bool, cutItemDataIntoClipboard, (const TrackIdList&, secs_t, secs_t, bool), (override));
+    MOCK_METHOD(bool, cutItemDataIntoClipboard, (const TrackIdList&, secs_t, secs_t, bool, bool), (override));
     MOCK_METHOD(bool, copyClipIntoClipboard, (const ClipKey&), (override));
     MOCK_METHOD(bool, copyNonContinuousTrackDataIntoClipboard, (const TrackId, const TrackItemKeyList&, secs_t), (override));
     MOCK_METHOD(bool, copyContinuousTrackDataIntoClipboard, (const TrackId, secs_t, secs_t), (override));


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/11432

I introduced this bug in 25255afd7f -> paste was making a range selection unconditionally no matter if you pasted range or clip selection so you could end up having both selections at once. Now clipboard is aware of range selection intention.

Additionally removed "Export clip" action from clip context menu.

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
- [x] Check copying&pasting range selection (empty space included) -> it should make range selection in the pasted area
- [x] Check copying&pasting clips (multi clips too) -> no range selection should be made after paste, only clip selection
- [x] "Export clip" action from clip context menu is removed
