### PR TITLE
11497 cloud update audio preview

### DIFF
--- a/au3/libraries/au3-cloud-audiocom/sync/DataUploader.h
+++ b/au3/libraries/au3-cloud-audiocom/sync/DataUploader.h
@@ -18,7 +18,7 @@
 #include <vector>
 
 #include "CloudSyncDTO.h"
-#include "NetworkUtils.h"
+#include "../NetworkUtils.h"
 
 #include "au3-concurrency/concurrency/CancellationContext.h"
 
@@ -57,7 +57,7 @@ private:
 
     std::mutex mResponseMutex;
 
-    using ResponsesList = std::vector<std::shared_ptr<UploadOperation>>;
+    using ResponsesList = std::vector<std::shared_ptr<UploadOperation> >;
     ResponsesList mResponses;
 };
 } // namespace audacity::cloud::audiocom::sync

--- a/src/appshell/qml/Audacity/AppShell/appmenumodel.cpp
+++ b/src/appshell/qml/Audacity/AppShell/appmenumodel.cpp
@@ -203,6 +203,7 @@ MenuItem* AppMenuModel::makeFileMenu()
         makeMenuItem("file-save"),
         makeMenuItem("file-save-to-cloud"),
         makeMenuItem("file-save-as"),
+        makeMenuItem("audacity://cloud/update-audio-preview"),
 
         makeSeparator(),
 

--- a/src/au3cloud/au3clouderrors.h
+++ b/src/au3cloud/au3clouderrors.h
@@ -66,6 +66,9 @@ enum class Err {
     OpenProjectCancelled,
     CloudProjectNotFullySynced,
     CloudProjectNeverSynced,
+
+    // audio preview
+    AudioPreviewUpToDate,
 };
 
 inline muse::Ret make_ret(Err e)

--- a/src/au3cloud/iau3audiocomservice.h
+++ b/src/au3cloud/iau3audiocomservice.h
@@ -57,6 +57,8 @@ public:
                                                           std::function<bool()> projectSaveCallback = nullptr,
                                                           UploadMode uploadMode = UploadMode::NormalUpdate) = 0;
 
+    virtual muse::RetVal<muse::ProgressPtr> updateAudioPreview(au::project::IAudacityProjectPtr project) = 0;
+
     virtual muse::RetVal<muse::ProgressPtr> openCloudProject(const muse::io::path_t& localPath, const std::string& projectId = {},
                                                              const std::string& snapshotId = {}, bool forceOverwrite = false) = 0;
     virtual muse::RetVal<muse::ProgressPtr> resumeProjectSync(au::project::IAudacityProjectPtr project) = 0;

--- a/src/au3cloud/internal/au3audiocomservice.cpp
+++ b/src/au3cloud/internal/au3audiocomservice.cpp
@@ -430,7 +430,6 @@ muse::RetVal<muse::ProgressPtr> Au3AudioComService::updateAudioPreview(au::proje
         return muse::RetVal<muse::ProgressPtr>::make_ret(muse::Ret::Code::InternalError, muse::trc("cloud", "Invalid project"));
     }
 
-    //auto& projectCloudExtension = audacity::cloud::audiocom::sync::ProjectCloudExtension::Get(*au3Project);
     if (!project->isCloudProject()) {
         return muse::RetVal<muse::ProgressPtr>::make_ret(muse::Ret::Code::InternalError,
                                                          muse::trc("cloud", "Project is not saved to the cloud"));
@@ -449,6 +448,19 @@ muse::RetVal<muse::ProgressPtr> Au3AudioComService::updateAudioPreview(au::proje
     }
 
     muse::ProgressPtr progress = std::make_shared<muse::Progress>();
+
+    if (auto oldProgress = std::exchange(m_audioPreviewProgress, progress)) {
+        oldProgress->cancel();
+    }
+
+    std::weak_ptr<muse::Progress> weakProgress = progress;
+    progress->finished().onReceive(this, [this, weakProgress](const auto&) {
+        muse::async::Async::call(this, [this, weakProgress]() {
+            if (weakProgress.lock() == m_audioPreviewProgress) {
+                m_audioPreviewProgress.reset();
+            }
+        });
+    });
 
     auto cancellationContext = CancellationContext::Create();
     progress->canceled().onNotify(this, [cancellationContext]() {

--- a/src/au3cloud/internal/au3audiocomservice.cpp
+++ b/src/au3cloud/internal/au3audiocomservice.cpp
@@ -3,6 +3,7 @@
 */
 #include "au3audiocomservice.h"
 
+#include <algorithm>
 #include <atomic>
 #include <chrono>
 #include <cstdint>
@@ -25,12 +26,18 @@
 #include "au3-cloud-audiocom/sync/CloudSyncDTO.h"
 #include "au3-cloud-audiocom/sync/CloudProjectsDatabase.h"
 #include "au3-cloud-audiocom/sync/ProjectCloudExtension.h"
+#include "au3-cloud-audiocom/NetworkUtils.h"
+#include "au3-cloud-audiocom/sync/DataUploader.h"
 #include "au3-cloud-audiocom/sync/LocalProjectSnapshot.h"
+#include "au3-network-manager/IResponse.h"
+#include "au3-network-manager/NetworkManager.h"
+#include "au3-network-manager/Request.h"
 #include "au3-cloud-audiocom/sync/ResumedSnaphotUploadOperation.h"
 #include "au3-cloud-audiocom/UploadService.h"
 #include "au3-concurrency/concurrency/CancellationContext.h"
 #include "au3-import-export/ExportUtils.h"
 #include "au3-project-rate/ProjectRate.h"
+#include "au3-wave-track/WaveTrack.h"
 
 #include "au3audiocomtypeconv.h"
 #include "au3cloud/au3clouderrors.h"
@@ -407,6 +414,151 @@ muse::RetVal<muse::ProgressPtr> Au3AudioComService::uploadProject(au::project::I
                                                       AudiocomTrace::SaveProjectSaveToCloudMenu);
             }, muse::runtime::mainThreadId());
         }
+    }).detach();
+
+    return muse::RetVal<muse::ProgressPtr>::make_ok(progress);
+}
+
+muse::RetVal<muse::ProgressPtr> Au3AudioComService::updateAudioPreview(au::project::IAudacityProjectPtr project)
+{
+    if (!project) {
+        return muse::RetVal<muse::ProgressPtr>::make_ret(muse::Ret::Code::InternalError, muse::trc("cloud", "Invalid project"));
+    }
+
+    au::au3::Au3Project* au3Project = reinterpret_cast<au::au3::Au3Project*>(project->au3ProjectPtr());
+    if (!au3Project) {
+        return muse::RetVal<muse::ProgressPtr>::make_ret(muse::Ret::Code::InternalError, muse::trc("cloud", "Invalid project"));
+    }
+
+    //auto& projectCloudExtension = audacity::cloud::audiocom::sync::ProjectCloudExtension::Get(*au3Project);
+    if (!project->isCloudProject()) {
+        return muse::RetVal<muse::ProgressPtr>::make_ret(muse::Ret::Code::InternalError,
+                                                         muse::trc("cloud", "Project is not saved to the cloud"));
+    }
+
+    const auto cloudRecord = project->cloudRecord();
+    IF_ASSERT_FAILED(cloudRecord) {
+        return muse::RetVal<muse::ProgressPtr>::make_ret(muse::Ret::Code::InternalError,
+                                                         muse::trc("cloud", "Project is not saved to the cloud"));
+    }
+    const std::string& projectId = cloudRecord.value().projectId;
+    const std::string& snapshotId = cloudRecord.value().snapshotId;
+    if (projectId.empty() || snapshotId.empty()) {
+        return muse::RetVal<muse::ProgressPtr>::make_ret(muse::Ret::Code::InternalError,
+                                                         muse::trc("cloud", "Project is not synced with the cloud"));
+    }
+
+    muse::ProgressPtr progress = std::make_shared<muse::Progress>();
+
+    auto cancellationContext = CancellationContext::Create();
+    progress->canceled().onNotify(this, [cancellationContext]() {
+        cancellationContext->Cancel();
+    });
+
+    std::thread([weak = weak_from_this(), project, progress, cancellationContext, projectId, snapshotId]() {
+        auto self = weak.lock();
+        if (!self) {
+            progress->finish(muse::make_ret(muse::Ret::Code::InternalError, muse::trc("cloud", "Service destroyed")));
+            return;
+        }
+
+        au::au3::Au3Project* au3Project = reinterpret_cast<au::au3::Au3Project*>(project->au3ProjectPtr());
+        if (!au3Project) {
+            progress->finish(muse::make_ret(muse::Ret::Code::InternalError, muse::trc("cloud", "Invalid project")));
+            return;
+        }
+
+        const auto preferredFormats = self->exporter()->cloudPreferredAudioFormats();
+        if (preferredFormats.empty()) {
+            progress->finish(make_ret(Err::NoExportPlugin));
+            return;
+        }
+
+        const std::string format = preferredFormats.front();
+        const auto extensions = self->exporter()->formatExtensions(format);
+        if (extensions.empty()) {
+            progress->finish(make_ret(Err::NoExtensions));
+            return;
+        }
+
+        auto waveTracks = TrackList::Get(*au3Project).Any<const WaveTrack>();
+        const bool mono = std::all_of(waveTracks.begin(), waveTracks.end(), [](const WaveTrack* track) {
+            return track->NChannels() == 1 && track->GetPan() == 0;
+        });
+
+        muse::ValList paramsList;
+        for (const auto& [id, val] : self->exporter()->cloudExportParameters(format)) {
+            muse::ValMap entry;
+            entry["id"] = muse::Val(id);
+            entry["value"] = std::visit([](auto v) -> muse::Val { return muse::Val(v); }, val);
+            paramsList.push_back(muse::Val(entry));
+        }
+
+        importexport::IExporter::Options options;
+        options[importexport::IExporter::OptionKey::Format] = muse::Val(format);
+        options[importexport::IExporter::OptionKey::ProcessType] = muse::Val(importexport::ExportProcessType::FULL_PROJECT_AUDIO);
+        options[importexport::IExporter::OptionKey::ExportChannelsType]
+            = muse::Val(static_cast<int>(mono ? importexport::ExportChannelsPref::ExportChannels::MONO
+                                         : importexport::ExportChannelsPref::ExportChannels::STEREO));
+        options[importexport::IExporter::OptionKey::ExportChannels] = muse::Val(mono ? 1 : 2);
+        options[importexport::IExporter::OptionKey::ExportSampleRate]
+            = muse::Val(static_cast<int>(ProjectRate::Get(*au3Project).GetRate()));
+        options[importexport::IExporter::OptionKey::Parameters] = muse::Val(paramsList);
+
+        const muse::io::path_t tempPath
+            = getTempFileName(self->projectConfiguration()->temporaryDir(), extensions.front());
+
+        const auto exportRet = self->exporter()->exportData(tempPath, options, progress, project);
+        if (!exportRet) {
+            self->filesystem()->remove(tempPath);
+            progress->finish(exportRet);
+            return;
+        }
+
+        audacity::network_manager::Request request(
+            audacity::cloud::audiocom::GetServiceConfig().GetSnapshotSyncUrl(projectId, snapshotId));
+        audacity::cloud::audiocom::SetCommonHeaders(request);
+
+        auto response = audacity::network_manager::NetworkManager::GetInstance().doGet(request);
+        cancellationContext->OnCancelled(response);
+
+        response->setRequestFinishedCallback(
+            [self, response, progress, cancellationContext, tempPath](auto) {
+            if (response->getError() != audacity::network_manager::NetworkError::NoError) {
+                self->filesystem()->remove(tempPath);
+                progress->finish(muse::make_ret(muse::Ret::Code::UnknownError, response->getErrorString()));
+                return;
+            }
+
+            const auto syncState
+                = audacity::cloud::audiocom::sync::DeserializeProjectSyncState(response->readAll<std::string>());
+            if (!syncState || syncState->MixdownUrls.UploadUrl.empty()) {
+                self->filesystem()->remove(tempPath);
+                progress->finish(muse::make_ret(muse::Ret::Code::UnknownError,
+                                                muse::trc("cloud", "Failed to get audio preview upload URLs")));
+                return;
+            }
+
+            audacity::cloud::audiocom::sync::DataUploader::Get().Upload(
+                cancellationContext,
+                audacity::cloud::audiocom::GetServiceConfig(),
+                syncState->MixdownUrls,
+                tempPath.toStdString(),
+                [progress, tempPath, filesystem = self->filesystem()](audacity::cloud::audiocom::ResponseResult result) {
+                filesystem->remove(tempPath);
+
+                if (result.Code == audacity::cloud::audiocom::SyncResultCode::Success) {
+                    progress->finish(muse::make_ok());
+                } else if (result.Code == audacity::cloud::audiocom::SyncResultCode::Cancelled) {
+                    progress->finish(make_ret(Err::Cancelled));
+                } else {
+                    progress->finish(muse::make_ret(muse::Ret::Code::UnknownError, result.Content));
+                }
+            },
+                [progress](double uploadProgress) {
+                progress->progress(static_cast<int64_t>(uploadProgress * 100), 100);
+            });
+        });
     }).detach();
 
     return muse::RetVal<muse::ProgressPtr>::make_ok(progress);

--- a/src/au3cloud/internal/au3audiocomservice.cpp
+++ b/src/au3cloud/internal/au3audiocomservice.cpp
@@ -544,10 +544,16 @@ muse::RetVal<muse::ProgressPtr> Au3AudioComService::updateAudioPreview(au::proje
 
             const auto syncState
                 = audacity::cloud::audiocom::sync::DeserializeProjectSyncState(response->readAll<std::string>());
-            if (!syncState || syncState->MixdownUrls.UploadUrl.empty()) {
+            if (!syncState) {
                 self->filesystem()->remove(tempPath);
                 progress->finish(muse::make_ret(muse::Ret::Code::UnknownError,
                                                 muse::trc("cloud", "Failed to get audio preview upload URLs")));
+                return;
+            }
+
+            if (syncState->MixdownUrls.UploadUrl.empty()) {
+                self->filesystem()->remove(tempPath);
+                progress->finish(make_ret(Err::AudioPreviewUpToDate));
                 return;
             }
 

--- a/src/au3cloud/internal/au3audiocomservice.cpp
+++ b/src/au3cloud/internal/au3audiocomservice.cpp
@@ -523,7 +523,9 @@ muse::RetVal<muse::ProgressPtr> Au3AudioComService::updateAudioPreview(au::proje
         const auto exportRet = self->exporter()->exportData(tempPath, options, progress, project);
         if (!exportRet) {
             self->filesystem()->remove(tempPath);
-            progress->finish(exportRet);
+            if (!progress->isCanceled()) {
+                progress->finish(exportRet);
+            }
             return;
         }
 
@@ -538,7 +540,9 @@ muse::RetVal<muse::ProgressPtr> Au3AudioComService::updateAudioPreview(au::proje
             [self, response, progress, cancellationContext, tempPath](auto) {
             if (response->getError() != audacity::network_manager::NetworkError::NoError) {
                 self->filesystem()->remove(tempPath);
-                progress->finish(muse::make_ret(muse::Ret::Code::UnknownError, response->getErrorString()));
+                if (!progress->isCanceled()) {
+                    progress->finish(muse::make_ret(muse::Ret::Code::UnknownError, response->getErrorString()));
+                }
                 return;
             }
 
@@ -546,8 +550,10 @@ muse::RetVal<muse::ProgressPtr> Au3AudioComService::updateAudioPreview(au::proje
                 = audacity::cloud::audiocom::sync::DeserializeProjectSyncState(response->readAll<std::string>());
             if (!syncState) {
                 self->filesystem()->remove(tempPath);
-                progress->finish(muse::make_ret(muse::Ret::Code::UnknownError,
-                                                muse::trc("cloud", "Failed to get audio preview upload URLs")));
+                if (!progress->isCanceled()) {
+                    progress->finish(muse::make_ret(muse::Ret::Code::UnknownError,
+                                                    muse::trc("cloud", "Failed to get audio preview upload URLs")));
+                }
                 return;
             }
 
@@ -564,6 +570,10 @@ muse::RetVal<muse::ProgressPtr> Au3AudioComService::updateAudioPreview(au::proje
                 tempPath.toStdString(),
                 [progress, tempPath, filesystem = self->filesystem()](audacity::cloud::audiocom::ResponseResult result) {
                 filesystem->remove(tempPath);
+
+                if (progress->isCanceled()) {
+                    return;
+                }
 
                 if (result.Code == audacity::cloud::audiocom::SyncResultCode::Success) {
                     progress->finish(muse::make_ok());

--- a/src/au3cloud/internal/au3audiocomservice.h
+++ b/src/au3cloud/internal/au3audiocomservice.h
@@ -63,6 +63,8 @@ public:
     muse::RetVal<muse::ProgressPtr> uploadProject(au::project::IAudacityProjectPtr project, const std::string& name,
                                                   std::function<bool()> projectSaveCallback, UploadMode uploadMode) override;
 
+    muse::RetVal<muse::ProgressPtr> updateAudioPreview(au::project::IAudacityProjectPtr project) override;
+
     muse::RetVal<muse::ProgressPtr> openCloudProject(const muse::io::path_t& localPath, const std::string& projectId = {},
                                                      const std::string& snapshotId = {}, bool forceOverwrite = false) override;
 

--- a/src/au3cloud/internal/au3audiocomservice.h
+++ b/src/au3cloud/internal/au3audiocomservice.h
@@ -122,5 +122,6 @@ private:
 
     muse::ValCh<bool> m_syncingInProgressChangedChannel;
     muse::ProgressPtr m_syncInProgress;
+    muse::ProgressPtr m_audioPreviewProgress;
 };
 }

--- a/src/au3cloud/internal/cloudurlhandler.cpp
+++ b/src/au3cloud/internal/cloudurlhandler.cpp
@@ -32,6 +32,10 @@ void CloudUrlHandler::handle(const QString& url)
         return;
     }
 
+    if (tryHandleGenerateAudioLink(parsed)) {
+        return;
+    }
+
     LOGW() << "Unhandled audacity:// URL: " << url;
 }
 
@@ -54,6 +58,26 @@ bool CloudUrlHandler::tryHandleProjectLink(const QUrl& parsed)
     data.setArg<QString>(0, projectId);
     data.setArg<QString>(1, snapshotId);
     dispatcher()->dispatch("cloud-file-open", data);
+
+    return true;
+}
+
+bool CloudUrlHandler::tryHandleGenerateAudioLink(const QUrl& parsed)
+{
+    if (parsed.host() != QStringLiteral("generate-audio")) {
+        return false;
+    }
+
+    const QUrlQuery query(parsed);
+    const QString projectId = query.queryItemValue(QStringLiteral("projectId"));
+    if (projectId.isEmpty()) {
+        return false;
+    }
+
+    muse::actions::ActionQuery action("audacity://cloud/update-audio-preview");
+    action.addParam("id", muse::Val(projectId));
+
+    dispatcher()->dispatch(action);
 
     return true;
 }

--- a/src/au3cloud/internal/cloudurlhandler.cpp
+++ b/src/au3cloud/internal/cloudurlhandler.cpp
@@ -74,7 +74,7 @@ bool CloudUrlHandler::tryHandleGenerateAudioLink(const QUrl& parsed)
         return false;
     }
 
-    muse::actions::ActionQuery action("audacity://cloud/update-audio-preview");
+    muse::actions::ActionQuery action("audacity://cloud/update-audio-preview-for-project");
     action.addParam("id", muse::Val(projectId));
 
     dispatcher()->dispatch(action);

--- a/src/au3cloud/internal/cloudurlhandler.h
+++ b/src/au3cloud/internal/cloudurlhandler.h
@@ -14,6 +14,7 @@ namespace au::au3cloud {
 //! Audio.com:
 //! "audacity://open?projectId=<id>[&snapshotId=<id>]"
 //! "audacity://open?audioId=<id>"
+//! "audacity://generate-audio?projectId=<id>"
 class CloudUrlHandler : public muse::Contextable
 {
     muse::ContextInject<muse::actions::IActionsDispatcher> dispatcher { this };
@@ -26,5 +27,6 @@ public:
 private:
     bool tryHandleProjectLink(const QUrl& parsedUrl);
     bool tryHandleAudioLink(const QUrl& parsedUrl);
+    bool tryHandleGenerateAudioLink(const QUrl& parsedUrl);
 };
 }

--- a/src/importexport/export/iexporter.h
+++ b/src/importexport/export/iexporter.h
@@ -12,6 +12,8 @@
 #include "framework/global/progress.h"
 #include "framework/global/types/val.h"
 
+#include "project/iaudacityproject.h"
+
 #include "types/exporttypes.h"
 #include "types/ret.h"
 
@@ -38,7 +40,8 @@ public:
     virtual ~IExporter() = default;
 
     virtual void init() = 0;
-    virtual muse::Ret exportData(const muse::io::path_t& path, const Options& options = {}, muse::ProgressPtr progress = nullptr) = 0;
+    virtual muse::Ret exportData(const muse::io::path_t& path, const Options& options = {}, muse::ProgressPtr progress = nullptr,
+                                 au::project::IAudacityProjectPtr project = nullptr) = 0;
 
     virtual std::vector<std::string> formatsList() const = 0;
     virtual int formatIndex(const std::string& format) const = 0;

--- a/src/importexport/export/internal/au3/au3exporter.cpp
+++ b/src/importexport/export/internal/au3/au3exporter.cpp
@@ -37,6 +37,33 @@ ExportPlugin* formatPlugin(const std::string& format)
 
     return nullptr;
 }
+
+std::vector<bool> prepareChannelMask(TrackList& trackList, bool selectedOnly)
+{
+    auto tracks = trackList.Any<WaveTrack>();
+    std::vector<bool> channelMask(
+        tracks.sum([](const auto track) { return track->NChannels(); }),
+        false);
+    unsigned trackIndex = 0;
+    for (const auto track : tracks) {
+        if (track->GetSolo()) {
+            channelMask.assign(channelMask.size(), false);
+            for (unsigned i = 0; i < track->NChannels(); ++i) {
+                channelMask[trackIndex++] = true;
+            }
+            break;
+        }
+        if (!track->GetMute() && (!selectedOnly || track->GetSelected())) {
+            for (unsigned i = 0; i < track->NChannels(); ++i) {
+                channelMask[trackIndex++] = true;
+            }
+        } else {
+            trackIndex += track->NChannels();
+        }
+    }
+
+    return channelMask;
+}
 }
 
 class ProgressDelegate : public ExportProcessorDelegate, public muse::async::Asyncable
@@ -117,8 +144,15 @@ void Au3Exporter::init()
     ExportPluginRegistry::Get().Initialize();
 }
 
-muse::Ret Au3Exporter::exportData(const muse::io::path_t& path, const Options& options, muse::ProgressPtr progress)
+muse::Ret Au3Exporter::exportData(const muse::io::path_t& path, const Options& options, muse::ProgressPtr progress,
+                                  au::project::IAudacityProjectPtr project)
 {
+    auto exportProject = project ? project : globalContext()->currentProject();
+
+    IF_ASSERT_FAILED(exportProject) {
+        return muse::make_ret(muse::Ret::Code::InternalError);
+    }
+
     const std::string formatName = options.count(OptionKey::Format)
                                    ? options.at(OptionKey::Format).toString()
                                    : exportConfiguration()->currentFormat();
@@ -181,8 +215,8 @@ muse::Ret Au3Exporter::exportData(const muse::io::path_t& path, const Options& o
 
     wxFileName wxfilename = wxFromPath(path);
 
-    Au3Project* project = reinterpret_cast<Au3Project*>(globalContext()->currentProject()->au3ProjectPtr());
-    IF_ASSERT_FAILED(project) {
+    Au3Project* au3Project = reinterpret_cast<Au3Project*>(exportProject->au3ProjectPtr());
+    IF_ASSERT_FAILED(au3Project) {
         return muse::make_ret(muse::Ret::Code::InternalError);
     }
 
@@ -217,15 +251,15 @@ muse::Ret Au3Exporter::exportData(const muse::io::path_t& path, const Options& o
         m_t0 = region.start;
         m_t1 = region.end;
     } else {
-        auto trackeditProject = globalContext()->currentProject()->trackeditProject();
+        auto trackeditProject = exportProject->trackeditProject();
 
         m_t0 = 0.0;
         m_t1 = trackeditProject->totalTime().to_double();
     }
 
-    m_tags = &Tags::Get(*project);
+    m_tags = &Tags::Get(*au3Project);
 
-    auto exportedTracks = ExportUtils::FindExportWaveTracks(TrackList::Get(*project), m_selectedOnly);
+    auto exportedTracks = ExportUtils::FindExportWaveTracks(TrackList::Get(*au3Project), m_selectedOnly);
     if (exportedTracks.empty()) {
         //! NOTE: All selected audio is muted
         return muse::make_ret(muse::Ret::Code::InternalError, muse::trc("export", "All selected audio is muted"));
@@ -254,7 +288,8 @@ muse::Ret Au3Exporter::exportData(const muse::io::path_t& path, const Options& o
         //all tracks regardless of their mute/solo state, but
         //muted channels should not be present in exported file -
         //apply channel mask to exclude them
-        auto channelMask = prepareChannelMask();
+        auto& trackList = TrackList::Get(*au3Project);
+        auto channelMask = prepareChannelMask(trackList, m_selectedOnly);
         downMix = std::make_unique<MixerOptions::Downmix>(*downMix, channelMask);
         m_mixerSpec = downMix.get();
 
@@ -282,7 +317,7 @@ muse::Ret Au3Exporter::exportData(const muse::io::path_t& path, const Options& o
 
     try {
         auto processor = m_plugin->CreateProcessor(m_format);
-        if (!processor->Initialize(*project,
+        if (!processor->Initialize(*au3Project,
                                    m_parameters,
                                    wxfilename.GetFullPath(),
                                    m_t0, m_t1, m_selectedOnly,
@@ -579,36 +614,4 @@ OptionsEditorUPtr Au3Exporter::optionsEditor() const
     }
 
     return nullptr;
-}
-
-std::vector<bool> Au3Exporter::prepareChannelMask() const
-{
-    Au3Project* project = reinterpret_cast<Au3Project*>(globalContext()->currentProject()->au3ProjectPtr());
-    IF_ASSERT_FAILED(project) {
-        return {};
-    }
-
-    auto tracks = TrackList::Get(*project).Any<WaveTrack>();
-    std::vector<bool> channelMask(
-        tracks.sum([](const auto track) { return track->NChannels(); }),
-        false);
-    unsigned trackIndex = 0;
-    for (const auto track : tracks) {
-        if (track->GetSolo()) {
-            channelMask.assign(channelMask.size(), false);
-            for (unsigned i = 0; i < track->NChannels(); ++i) {
-                channelMask[trackIndex++] = true;
-            }
-            break;
-        }
-        if (!track->GetMute() && (!m_selectedOnly || track->GetSelected())) {
-            for (unsigned i = 0; i < track->NChannels(); ++i) {
-                channelMask[trackIndex++] = true;
-            }
-        } else {
-            trackIndex += track->NChannels();
-        }
-    }
-
-    return channelMask;
 }

--- a/src/importexport/export/internal/au3/au3exporter.h
+++ b/src/importexport/export/internal/au3/au3exporter.h
@@ -31,7 +31,8 @@ public:
         : muse::Contextable(ctx) {}
 
     void init() override;
-    muse::Ret exportData(const muse::io::path_t& path, const Options& options = {}, muse::ProgressPtr progress = nullptr) override;
+    muse::Ret exportData(const muse::io::path_t& path, const Options& options = {}, muse::ProgressPtr progress = nullptr,
+                         au::project::IAudacityProjectPtr project = nullptr) override;
 
     std::vector<std::string> formatsList() const override;
     int formatIndex(const std::string& format) const override;
@@ -51,8 +52,6 @@ public:
     void setValue(int id, const OptionValue&) override;
 
     OptionsEditorUPtr optionsEditor() const;
-
-    std::vector<bool> prepareChannelMask() const;
 
 private:
     double m_t0 {};

--- a/src/project/CMakeLists.txt
+++ b/src/project/CMakeLists.txt
@@ -67,6 +67,8 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/internal/audacityproject.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/projectconfiguration.cpp
     ${CMAKE_CURRENT_LIST_DIR}/internal/projectconfiguration.h
+    ${CMAKE_CURRENT_LIST_DIR}/internal/projectcreator.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/internal/projectcreator.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/projectuiactions.cpp
     ${CMAKE_CURRENT_LIST_DIR}/internal/projectuiactions.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/projectautosaver.cpp

--- a/src/project/iaudacityproject.h
+++ b/src/project/iaudacityproject.h
@@ -33,7 +33,7 @@ public:
     virtual bool isNewlyCreated() const = 0;
     virtual bool isImported() const = 0;
     virtual bool isCloudProject() const = 0;
-    virtual const std::optional<CloudProjectRecord>& cloudRecord() const = 0;
+    virtual const std::optional<CloudProjectRecord> cloudRecord() const = 0;
 
     virtual muse::String title() const { return muse::String(); }
 

--- a/src/project/iaudacityproject.h
+++ b/src/project/iaudacityproject.h
@@ -33,6 +33,7 @@ public:
     virtual bool isNewlyCreated() const = 0;
     virtual bool isImported() const = 0;
     virtual bool isCloudProject() const = 0;
+    virtual muse::async::Notification isCloudProjectChanged() const = 0;
     virtual const std::optional<CloudProjectRecord> cloudRecord() const = 0;
 
     virtual muse::String title() const { return muse::String(); }

--- a/src/project/internal/audacityproject.cpp
+++ b/src/project/internal/audacityproject.cpp
@@ -269,6 +269,12 @@ void Audacity4Project::setPath(const io::path_t& path)
 
     m_path = path;
     m_pathChanged.notify();
+
+    const bool isCloud = isCloudProject();
+    if (m_isCloudProject != isCloud) {
+        m_isCloudProject = isCloud;
+        m_isCloudProjectChanged.notify();
+    }
 }
 
 bool Audacity4Project::isNewlyCreated() const
@@ -284,6 +290,11 @@ bool Audacity4Project::isImported() const
 bool Audacity4Project::isCloudProject() const
 {
     return cloudProjectsProvider()->projectRecordForPath(m_path).has_value();
+}
+
+muse::async::Notification Audacity4Project::isCloudProjectChanged() const
+{
+    return m_isCloudProjectChanged;
 }
 
 const std::optional<CloudProjectRecord> Audacity4Project::cloudRecord() const

--- a/src/project/internal/audacityproject.cpp
+++ b/src/project/internal/audacityproject.cpp
@@ -268,9 +268,6 @@ void Audacity4Project::setPath(const io::path_t& path)
     }
 
     m_path = path;
-
-    m_cloudRecord = cloudProjectsProvider()->projectRecordForPath(m_path);
-
     m_pathChanged.notify();
 }
 
@@ -286,12 +283,12 @@ bool Audacity4Project::isImported() const
 
 bool Audacity4Project::isCloudProject() const
 {
-    return m_cloudRecord.has_value();
+    return cloudProjectsProvider()->projectRecordForPath(m_path).has_value();
 }
 
-const std::optional<CloudProjectRecord>& Audacity4Project::cloudRecord() const
+const std::optional<CloudProjectRecord> Audacity4Project::cloudRecord() const
 {
-    return m_cloudRecord;
+    return cloudProjectsProvider()->projectRecordForPath(m_path);
 }
 
 String Audacity4Project::title() const

--- a/src/project/internal/audacityproject.h
+++ b/src/project/internal/audacityproject.h
@@ -82,7 +82,7 @@ public:
     bool isNewlyCreated() const override;
     bool isImported() const override;
     bool isCloudProject() const override;
-    const std::optional<CloudProjectRecord>& cloudRecord() const override;
+    const std::optional<CloudProjectRecord> cloudRecord() const override;
 
     muse::String title() const override;
 
@@ -123,7 +123,6 @@ private:
     muse::async::Notification m_aboutCloseEnd;
 
     muse::io::path_t m_path;
-    std::optional<CloudProjectRecord> m_cloudRecord;
     muse::async::Notification m_pathChanged;
     muse::async::Notification m_displayNameChanged;
     muse::async::Notification m_needSaveNotification;

--- a/src/project/internal/audacityproject.h
+++ b/src/project/internal/audacityproject.h
@@ -82,6 +82,7 @@ public:
     bool isNewlyCreated() const override;
     bool isImported() const override;
     bool isCloudProject() const override;
+    muse::async::Notification isCloudProjectChanged() const override;
     const std::optional<CloudProjectRecord> cloudRecord() const override;
 
     muse::String title() const override;
@@ -124,11 +125,13 @@ private:
 
     muse::io::path_t m_path;
     muse::async::Notification m_pathChanged;
+    muse::async::Notification m_isCloudProjectChanged;
     muse::async::Notification m_displayNameChanged;
     muse::async::Notification m_needSaveNotification;
 
     bool m_isNewlyCreated = false; /// true if the file has never been saved yet
     bool m_isImported = false;
+    bool m_isCloudProject = false;
     bool m_needAutoSave = false;
 
     std::shared_ptr<au::au3::IAu3Project> m_au3Project;

--- a/src/project/internal/projectactionscontroller.cpp
+++ b/src/project/internal/projectactionscontroller.cpp
@@ -109,9 +109,11 @@ void ProjectActionsController::init()
 
     globalContext()->currentTrackeditProjectChanged().onNotify(this, [this]() {
         listenTrackeditProjectChanges();
+        listenCloudProjectChanges();
     });
 
     listenTrackeditProjectChanges();
+    listenCloudProjectChanges();
 
     recordController()->isRecordingChanged().onNotify(this, [this]() {
         m_actionEnabledChanged.send(prohibitedActionsWhileRecording());
@@ -130,6 +132,20 @@ void ProjectActionsController::listenTrackeditProjectChanges()
     }, muse::async::Asyncable::Mode::SetReplace);
 
     m_actionEnabledChanged.send({ "file-share-audio" });
+}
+
+void ProjectActionsController::listenCloudProjectChanges()
+{
+    IAudacityProjectPtr prj = currentProject();
+    if (!prj) {
+        return;
+    }
+
+    prj->isCloudProjectChanged().onNotify(this, [this]() {
+        m_actionEnabledChanged.send({ UPDATE_AUDIO_PREVIEW_ACTION.toString() });
+    }, muse::async::Asyncable::Mode::SetReplace);
+
+    m_actionEnabledChanged.send({ UPDATE_AUDIO_PREVIEW_ACTION.toString() });
 }
 
 muse::async::Channel<muse::actions::ActionCodeList> ProjectActionsController::actionEnabledChanged() const

--- a/src/project/internal/projectactionscontroller.cpp
+++ b/src/project/internal/projectactionscontroller.cpp
@@ -40,6 +40,7 @@ static const muse::actions::ActionCode OPEN_METADATA_DIALOG("open-metadata-dialo
 static const muse::actions::ActionCode OPEN_CUSTOM_MAPPING("open-custom-mapping");
 static const muse::actions::ActionQuery OPEN_CLOUD_AUDIO_FILE_URI("audacity://cloud/open-audio-file");
 static const muse::actions::ActionQuery UPDATE_AUDIO_PREVIEW_ACTION("audacity://cloud/update-audio-preview");
+static const muse::actions::ActionQuery UPDATE_AUDIO_PREVIEW_FOR_PROJECT_ACTION("audacity://cloud/update-audio-preview-for-project");
 
 namespace {
 au::au3cloud::UploadMode toUploadMode(CloudSaveMode mode)
@@ -82,6 +83,7 @@ void ProjectActionsController::init()
     dispatcher()->reg(this, "file-share-audio", this, &ProjectActionsController::shareAudio);
     dispatcher()->reg(this, OPEN_CLOUD_AUDIO_FILE_URI, this, &ProjectActionsController::openCloudAudioFile);
     dispatcher()->reg(this, UPDATE_AUDIO_PREVIEW_ACTION, this, &ProjectActionsController::updateCloudAudioPreview);
+    dispatcher()->reg(this, UPDATE_AUDIO_PREVIEW_FOR_PROJECT_ACTION, this, &ProjectActionsController::updateCloudAudioPreview);
 
     dispatcher()->reg(this, "export-audio", this, &ProjectActionsController::exportAudio);
     dispatcher()->reg(this, "export-labels", this, &ProjectActionsController::exportLabels);
@@ -164,12 +166,16 @@ bool ProjectActionsController::canReceiveAction(const muse::actions::ActionCode&
             "continue-last-session",
             "clear-recent",
             "audacity://cloud/open-audio-file",
-            "audacity://cloud/update-audio-preview",
+            "audacity://cloud/update-audio-preview-for-project",
             "plugin-manager",
             "project-show-in-folder",
         };
 
         return muse::contains(DONT_REQUIRE_OPEN_PROJECT, code);
+    }
+
+    if (code == "audacity://cloud/update-audio-preview") {
+        return currentProject()->isCloudProject();
     }
 
     const bool recording = recordController()->isRecording();
@@ -1533,7 +1539,7 @@ bool ProjectActionsController::dispatchAudioPreviewToWindowWithProject(const mus
             window->requestShowOnFront();
         }
 
-        muse::actions::ActionQuery action(UPDATE_AUDIO_PREVIEW_ACTION);
+        muse::actions::ActionQuery action(UPDATE_AUDIO_PREVIEW_FOR_PROJECT_ACTION);
         action.addParam("id", Val(projectId));
         ctxDispatcher->dispatch(action);
 

--- a/src/project/internal/projectactionscontroller.cpp
+++ b/src/project/internal/projectactionscontroller.cpp
@@ -39,6 +39,7 @@ static const muse::actions::ActionCode OPEN_CUSTOM_FFMPEG_OPTIONS("open-custom-f
 static const muse::actions::ActionCode OPEN_METADATA_DIALOG("open-metadata-dialog");
 static const muse::actions::ActionCode OPEN_CUSTOM_MAPPING("open-custom-mapping");
 static const muse::actions::ActionQuery OPEN_CLOUD_AUDIO_FILE_URI("audacity://cloud/open-audio-file");
+static const muse::actions::ActionQuery UPDATE_AUDIO_PREVIEW_ACTION("audacity://cloud/update-audio-preview");
 
 namespace {
 au::au3cloud::UploadMode toUploadMode(CloudSaveMode mode)
@@ -80,6 +81,7 @@ void ProjectActionsController::init()
 
     dispatcher()->reg(this, "file-share-audio", this, &ProjectActionsController::shareAudio);
     dispatcher()->reg(this, OPEN_CLOUD_AUDIO_FILE_URI, this, &ProjectActionsController::openCloudAudioFile);
+    dispatcher()->reg(this, UPDATE_AUDIO_PREVIEW_ACTION, this, &ProjectActionsController::updateCloudAudioPreview);
 
     dispatcher()->reg(this, "export-audio", this, &ProjectActionsController::exportAudio);
     dispatcher()->reg(this, "export-labels", this, &ProjectActionsController::exportLabels);
@@ -162,6 +164,7 @@ bool ProjectActionsController::canReceiveAction(const muse::actions::ActionCode&
             "continue-last-session",
             "clear-recent",
             "audacity://cloud/open-audio-file",
+            "audacity://cloud/update-audio-preview",
             "plugin-manager",
             "project-show-in-folder",
         };
@@ -586,7 +589,8 @@ bool ProjectActionsController::saveProject(const muse::io::path_t& path)
     return saveProject(SaveMode::Save);
 }
 
-muse::Ret ProjectActionsController::saveProjectToCloud(const CloudProjectInfo& cloudInfo, CloudSaveMode cloudSaveMode)
+muse::Ret ProjectActionsController::saveProjectToCloud(const CloudProjectInfo& cloudInfo, CloudSaveMode cloudSaveMode,
+                                                       std::function<void()> onSuccess)
 {
     if (!audioComService()->enabled()) {
         return make_ret(Ret::Code::NotSupported, std::string { "Cloud support is not available" });
@@ -624,10 +628,13 @@ muse::Ret ProjectActionsController::saveProjectToCloud(const CloudProjectInfo& c
     }
 
     if (!progress) {
+        if (onSuccess) {
+            onSuccess();
+        }
         return make_ok();
     }
 
-    progress->finished().onReceive(this, [this, projectFilePath](const ProgressResult& result) {
+    progress->finished().onReceive(this, [this, projectFilePath, onSuccess](const ProgressResult& result) {
         if (!result.ret.success()) {
             handleCloudSaveError(result.ret);
             return;
@@ -648,6 +655,10 @@ muse::Ret ProjectActionsController::saveProjectToCloud(const CloudProjectInfo& c
                 platformInteractive()->openUrl(url);
             }
         });
+
+        if (onSuccess) {
+            onSuccess();
+        }
     });
 
     const bool dismissible = false;
@@ -1338,6 +1349,198 @@ void ProjectActionsController::openCloudAudioFile(const muse::actions::ActionQue
     });
 
     interactive()->showProgress(muse::trc("cloud", "Downloading audio from cloud…"), *progress);
+}
+
+void ProjectActionsController::updateCloudAudioPreview(const muse::actions::ActionQuery& query)
+{
+    const std::string projectId = query.param("id").toString();
+
+    auto project = currentProject();
+
+    bool isCurrentProject = false;
+    if (project) {
+        isCurrentProject = projectId.empty()
+                           ? project->isCloudProject()
+                           : project->cloudRecord() && project->cloudRecord()->projectId == projectId;
+    }
+
+    if (!isCurrentProject) {
+        if (projectId.empty()) {
+            return;
+        }
+
+        muse::io::path_t localPath;
+        if (const auto record = cloudProjectsProvider()->projectRecordForId(projectId); record&& !record->localPath.empty()) {
+            localPath = record->localPath;
+        }
+
+        if (localPath.empty()) {
+            return;
+        }
+
+        if (dispatchAudioPreviewToWindowWithProject(localPath, projectId)) {
+            return;
+        }
+
+        downloadCloudProject(projectId, localPath, [this](IAudacityProjectPtr downloaded) {
+            auto [ret, progress] = audioComService()->updateAudioPreview(downloaded);
+            if (!ret) {
+                downloaded->close();
+                interactive()->error(trc("cloud", "Generate audio preview"), ret.text());
+                return;
+            }
+
+            if (!progress) {
+                downloaded->close();
+                return;
+            }
+
+            progress->finished().onReceive(this, [this, downloaded](const ProgressResult& result) {
+                downloaded->close();
+                if (result.ret.success()) {
+                    toastService()->showSuccess(trc("cloud", "Cloud audio preview updated"),
+                                                trc("cloud", "The audio preview has been uploaded to audio.com"));
+                    return;
+                }
+
+                if (result.ret.code() != static_cast<int>(Ret::Code::Cancel)) {
+                    interactive()->error(trc("cloud", "Generate audio preview"), result.ret.text());
+                }
+            });
+        });
+        return;
+    }
+
+    if (project->hasUnsavedChanges()) {
+        const IInteractive::Result result = interactive()->warningSync(
+            trc("cloud", "The project must be saved before updating the audio preview"),
+            trc("cloud", "Save your changes to continue, or cancel the update."),
+            { IInteractive::Button::Cancel, IInteractive::Button::Save },
+            IInteractive::Button::Save,
+            { IInteractive::Option::WithIcon },
+            trc("cloud", "Unsaved changes"));
+
+        if (result.standardButton() != IInteractive::Button::Save) {
+            return;
+        }
+    }
+
+    saveProjectToCloud(CloudProjectInfo { project->displayName() }, CloudSaveMode::NormalUpdate, [this, project]() {
+        auto [ret, progress] = audioComService()->updateAudioPreview(project);
+        if (!ret) {
+            interactive()->error(trc("cloud", "Generate audio preview"), ret.text());
+            return;
+        }
+
+        if (!progress) {
+            return;
+        }
+
+        progress->finished().onReceive(this, [this](const ProgressResult& result) {
+            if (result.ret.success()) {
+                toastService()->showSuccess(trc("cloud", "Cloud audio preview updated"),
+                                            trc("cloud", "The audio preview has been uploaded to audio.com"));
+                return;
+            }
+
+            if (result.ret.code() != static_cast<int>(Ret::Code::Cancel)) {
+                interactive()->error(trc("cloud", "Generate audio preview"), result.ret.text());
+            }
+        });
+
+        const bool dismissible = false;
+        const bool showProgressInfo = true;
+        toastService()->showWithProgress(
+            trc("cloud", "Updating cloud audio preview…"),
+            {},
+            progress,
+            muse::ui::IconCode::Code::CLOUD,
+            dismissible,
+        {
+            { trc("project", "Dismiss"), au::toast::ToastActionCode::None },
+            { trc("global", "Stop"), au::toast::ToastActionCode::Custom }
+        },
+            showProgressInfo
+            ).onResolve(this, [progress = progress](const au::toast::ToastActionCode& actionCode) {
+            if (actionCode == au::toast::ToastActionCode::Custom) {
+                progress->cancel();
+            }
+        });
+    });
+}
+
+void ProjectActionsController::downloadCloudProject(const std::string& projectId, const muse::io::path_t& localPath,
+                                                    std::function<void(IAudacityProjectPtr)> onSuccess)
+{
+    auto [ret, progress] = audioComService()->openCloudProject(localPath, projectId);
+    if (!ret) {
+        interactive()->error(trc("cloud", "Generate audio preview"), ret.text());
+        return;
+    }
+
+    if (!progress) {
+        return;
+    }
+
+    progress->finished().onReceive(this, [this, localPath, onSuccess](const ProgressResult& result) {
+        if (!result.ret) {
+            if (result.ret.code() != static_cast<int>(Ret::Code::Cancel)
+                && result.ret.code() != static_cast<int>(au::au3cloud::Err::OpenProjectCancelled)) {
+                interactive()->error(trc("cloud", "Generate audio preview"), result.ret.text());
+            }
+            return;
+        }
+
+        const muse::io::path_t projectPath = !result.val.isNull() ? result.val.toPath() : localPath;
+
+        const RetVal<IAudacityProjectPtr> loaded = loadProject(projectPath);
+        if (!loaded.ret) {
+            interactive()->error(trc("cloud", "Generate audio preview"), loaded.ret.text());
+            return;
+        }
+
+        if (onSuccess) {
+            onSuccess(loaded.val);
+        }
+    });
+
+    interactive()->showProgress(trc("project", "Syncing project from cloud…"), *progress);
+}
+
+bool ProjectActionsController::dispatchAudioPreviewToWindowWithProject(const muse::io::path_t& projectPath, const std::string& projectId)
+{
+    for (const auto& ctx : application()->contexts()) {
+        if (ctx == iocContext()) {
+            continue;
+        }
+
+        auto ctxGlobalContext = muse::modularity::ioc(ctx)->resolve<au::context::IGlobalContext>("project");
+        if (!ctxGlobalContext) {
+            continue;
+        }
+
+        auto project = ctxGlobalContext->currentProject();
+        if (!project || project->path() != projectPath) {
+            continue;
+        }
+
+        auto ctxDispatcher = muse::modularity::ioc(ctx)->resolve<muse::actions::IActionsDispatcher>("project");
+        IF_ASSERT_FAILED(ctxDispatcher) {
+            return false;
+        }
+
+        if (auto window = muse::modularity::ioc(ctx)->resolve<muse::ui::IMainWindow>("project")) {
+            window->requestShowOnFront();
+        }
+
+        muse::actions::ActionQuery action(UPDATE_AUDIO_PREVIEW_ACTION);
+        action.addParam("id", Val(projectId));
+        ctxDispatcher->dispatch(action);
+
+        return true;
+    }
+
+    return false;
 }
 
 void ProjectActionsController::exportAudio()

--- a/src/project/internal/projectactionscontroller.cpp
+++ b/src/project/internal/projectactionscontroller.cpp
@@ -1409,6 +1409,12 @@ void ProjectActionsController::updateCloudAudioPreview(const muse::actions::Acti
                     return;
                 }
 
+                if (result.ret.code() == static_cast<int>(au::au3cloud::Err::AudioPreviewUpToDate)) {
+                    interactive()->info(trc("cloud", "Audio preview is up to date"),
+                                        trc("cloud", "The audio preview already matches the latest saved version of this project."));
+                    return;
+                }
+
                 if (result.ret.code() != static_cast<int>(Ret::Code::Cancel)) {
                     interactive()->error(trc("cloud", "Generate audio preview"), result.ret.text());
                 }
@@ -1446,6 +1452,12 @@ void ProjectActionsController::updateCloudAudioPreview(const muse::actions::Acti
             if (result.ret.success()) {
                 toastService()->showSuccess(trc("cloud", "Cloud audio preview updated"),
                                             trc("cloud", "The audio preview has been uploaded to audio.com"));
+                return;
+            }
+
+            if (result.ret.code() == static_cast<int>(au::au3cloud::Err::AudioPreviewUpToDate)) {
+                interactive()->info(trc("cloud", "Audio preview is up to date"),
+                                    trc("cloud", "The audio preview already matches the latest saved version of this project."));
                 return;
             }
 

--- a/src/project/internal/projectactionscontroller.cpp
+++ b/src/project/internal/projectactionscontroller.cpp
@@ -1413,20 +1413,16 @@ void ProjectActionsController::updateCloudAudioPreview(const muse::actions::Acti
             return;
         }
 
-        muse::io::path_t localPath;
+        std::optional<muse::io::path_t> localPath;
         if (const auto record = cloudProjectsProvider()->projectRecordForId(projectId); record&& !record->localPath.empty()) {
             localPath = record->localPath;
         }
 
-        if (localPath.empty()) {
+        if (localPath && dispatchAudioPreviewToWindowWithProject(*localPath, projectId)) {
             return;
         }
 
-        if (dispatchAudioPreviewToWindowWithProject(localPath, projectId)) {
-            return;
-        }
-
-        downloadCloudProject(projectId, localPath, [this](IAudacityProjectPtr downloaded) {
+        downloadCloudProject(projectId, localPath.value_or(muse::io::path_t {}), [this](IAudacityProjectPtr downloaded) {
             doUpdateCloudAudioPreview(downloaded, [downloaded]() { downloaded->close(); });
         });
         return;
@@ -1522,6 +1518,11 @@ void ProjectActionsController::downloadCloudProject(const std::string& projectId
             }
 
             const muse::io::path_t projectPath = !result.val.isNull() ? result.val.toPath() : localPath;
+            if (projectPath.empty()) {
+                interactive()->error(trc("cloud", "Generate audio preview"),
+                                     trc("cloud", "Could not determine the local path of the downloaded project"));
+                return;
+            }
 
             const RetVal<IAudacityProjectPtr> loaded = loadProject(projectPath);
             if (!loaded.ret) {

--- a/src/project/internal/projectactionscontroller.cpp
+++ b/src/project/internal/projectactionscontroller.cpp
@@ -56,6 +56,64 @@ au::au3cloud::UploadMode toUploadMode(CloudSaveMode mode)
 
     return au::au3cloud::UploadMode::NormalUpdate;
 }
+
+const muse::actions::ActionCodeList& prohibitedWhileRecording()
+{
+    static const muse::actions::ActionCodeList codes {
+        "file-close",
+        "project-import",
+        "file-save",
+        "file-save-to-cloud",
+        "file-save-as",
+        "export-audio",
+        "export-labels",
+        "export-midi",
+        "file-share-audio",
+        "audacity://cloud/update-audio-preview",
+        "audacity://cloud/update-audio-preview-for-project",
+    };
+
+    return codes;
+}
+
+const std::unordered_set<muse::actions::ActionCode>& dontRequireOpenProject()
+{
+    static const std::unordered_set<muse::actions::ActionCode> codes {
+        "file-new",
+        "file-open",
+        "file-open-recent",
+        "project-import-startup-media",
+        "cloud-file-open",
+        "continue-last-session",
+        "clear-recent",
+        "audacity://cloud/open-audio-file",
+        "audacity://cloud/update-audio-preview-for-project",
+        "plugin-manager",
+        "project-show-in-folder",
+    };
+
+    return codes;
+}
+
+const std::unordered_set<muse::actions::ActionCode>& prohibitedOnNonCloudProject()
+{
+    static const std::unordered_set<muse::actions::ActionCode> codes {
+        "audacity://cloud/update-audio-preview",
+    };
+
+    return codes;
+}
+
+const std::unordered_set<muse::actions::ActionCode>& prohibitedWithoutAudio()
+{
+    static const std::unordered_set<muse::actions::ActionCode> codes {
+        "file-share-audio",
+        "audacity://cloud/update-audio-preview",
+        "export-audio",
+    };
+
+    return codes;
+}
 }
 
 ProjectActionsController::ProjectActionsController(muse::modularity::ContextPtr ctx)
@@ -116,7 +174,7 @@ void ProjectActionsController::init()
     listenCloudProjectChanges();
 
     recordController()->isRecordingChanged().onNotify(this, [this]() {
-        m_actionEnabledChanged.send(prohibitedActionsWhileRecording());
+        m_actionEnabledChanged.send(prohibitedWhileRecording());
     });
 }
 
@@ -153,62 +211,26 @@ muse::async::Channel<muse::actions::ActionCodeList> ProjectActionsController::ac
     return m_actionEnabledChanged;
 }
 
-const muse::actions::ActionCodeList& ProjectActionsController::prohibitedActionsWhileRecording() const
-{
-    static const std::vector<muse::actions::ActionCode> PROHIBITED_WHILE_RECORDING {
-        "file-close",
-        "project-import",
-        "file-save",
-        "file-save-to-cloud",
-        "file-save-as",
-        "export-audio",
-        "export-labels",
-        "export-midi",
-        "file-share-audio",
-    };
-
-    return PROHIBITED_WHILE_RECORDING;
-}
-
 bool ProjectActionsController::canReceiveAction(const muse::actions::ActionCode& code) const
 {
-    if (!currentProject()) {
-        static const std::unordered_set<actions::ActionCode> DONT_REQUIRE_OPEN_PROJECT {
-            "file-new",
-            "file-open",
-            "file-open-recent",
-            "project-import-startup-media",
-            "cloud-file-open",
-            "continue-last-session",
-            "clear-recent",
-            "audacity://cloud/open-audio-file",
-            "audacity://cloud/update-audio-preview-for-project",
-            "plugin-manager",
-            "project-show-in-folder",
-        };
-
-        return muse::contains(DONT_REQUIRE_OPEN_PROJECT, code);
+    const IAudacityProjectPtr project = currentProject();
+    if (!project) {
+        return muse::contains(dontRequireOpenProject(), code);
     }
 
-    if (code == "audacity://cloud/update-audio-preview") {
-        return currentProject()->isCloudProject();
+    if (muse::contains(prohibitedOnNonCloudProject(), code) && !project->isCloudProject()) {
+        return false;
     }
 
-    const bool recording = recordController()->isRecording();
-
-    if (code == "file-share-audio") {
-        trackedit::ITrackeditProjectPtr prj = globalContext()->currentTrackeditProject();
-        if (!prj) {
-            return false;
-        }
-
-        if (!prj->hasAudioContent().val) {
+    if (muse::contains(prohibitedWithoutAudio(), code)) {
+        const trackedit::ITrackeditProjectPtr trackeditProject = globalContext()->currentTrackeditProject();
+        if (!trackeditProject || !trackeditProject->hasAudioContent().val) {
             return false;
         }
     }
 
-    if (recording) {
-        return !muse::contains(prohibitedActionsWhileRecording(), code);
+    if (muse::contains(prohibitedWhileRecording(), code) && recordController()->isRecording()) {
+        return false;
     }
 
     return true;

--- a/src/project/internal/projectactionscontroller.cpp
+++ b/src/project/internal/projectactionscontroller.cpp
@@ -1427,36 +1427,7 @@ void ProjectActionsController::updateCloudAudioPreview(const muse::actions::Acti
         }
 
         downloadCloudProject(projectId, localPath, [this](IAudacityProjectPtr downloaded) {
-            auto [ret, progress] = audioComService()->updateAudioPreview(downloaded);
-            if (!ret) {
-                downloaded->close();
-                interactive()->error(trc("cloud", "Generate audio preview"), ret.text());
-                return;
-            }
-
-            if (!progress) {
-                downloaded->close();
-                return;
-            }
-
-            progress->finished().onReceive(this, [this, downloaded](const ProgressResult& result) {
-                downloaded->close();
-                if (result.ret.success()) {
-                    toastService()->showSuccess(trc("cloud", "Cloud audio preview updated"),
-                                                trc("cloud", "The audio preview has been uploaded to audio.com"));
-                    return;
-                }
-
-                if (result.ret.code() == static_cast<int>(au::au3cloud::Err::AudioPreviewUpToDate)) {
-                    interactive()->info(trc("cloud", "Audio preview is up to date"),
-                                        trc("cloud", "The audio preview already matches the latest saved version of this project."));
-                    return;
-                }
-
-                if (result.ret.code() != static_cast<int>(Ret::Code::Cancel)) {
-                    interactive()->error(trc("cloud", "Generate audio preview"), result.ret.text());
-                }
-            });
+            doUpdateCloudAudioPreview(downloaded, [downloaded]() { downloaded->close(); });
         });
         return;
     }
@@ -1476,20 +1447,39 @@ void ProjectActionsController::updateCloudAudioPreview(const muse::actions::Acti
     }
 
     saveProjectToCloud(CloudProjectInfo { project->displayName() }, CloudSaveMode::NormalUpdate, [this, project]() {
-        auto [ret, progress] = audioComService()->updateAudioPreview(project);
-        if (!ret) {
-            interactive()->error(trc("cloud", "Generate audio preview"), ret.text());
-            return;
+        doUpdateCloudAudioPreview(project);
+    });
+}
+
+void ProjectActionsController::doUpdateCloudAudioPreview(const IAudacityProjectPtr& project, const std::function<void()>& onFinished)
+{
+    auto [ret, progress] = audioComService()->updateAudioPreview(project);
+    if (!ret) {
+        if (onFinished) {
+            onFinished();
         }
 
-        if (!progress) {
-            return;
+        interactive()->error(trc("cloud", "Generate audio preview"), ret.text());
+        return;
+    }
+
+    if (!progress) {
+        if (onFinished) {
+            onFinished();
         }
 
-        progress->finished().onReceive(this, [this](const ProgressResult& result) {
+        return;
+    }
+
+    progress->finished().onReceive(this, [this, onFinished](const ProgressResult& result) {
+        async::Async::call(this, [this, onFinished, result]() {
+            if (onFinished) {
+                onFinished();
+            }
+
             if (result.ret.success()) {
-                toastService()->showSuccess(trc("cloud", "Cloud audio preview updated"),
-                                            trc("cloud", "The audio preview has been uploaded to audio.com"));
+                interactive()->info(trc("cloud", "Cloud audio preview updated"),
+                                    trc("cloud", "The audio preview has been uploaded to audio.com"));
                 return;
             }
 
@@ -1503,26 +1493,9 @@ void ProjectActionsController::updateCloudAudioPreview(const muse::actions::Acti
                 interactive()->error(trc("cloud", "Generate audio preview"), result.ret.text());
             }
         });
-
-        const bool dismissible = false;
-        const bool showProgressInfo = true;
-        toastService()->showWithProgress(
-            trc("cloud", "Updating cloud audio preview…"),
-            {},
-            progress,
-            muse::ui::IconCode::Code::CLOUD,
-            dismissible,
-        {
-            { trc("project", "Dismiss"), au::toast::ToastActionCode::None },
-            { trc("global", "Stop"), au::toast::ToastActionCode::Custom }
-        },
-            showProgressInfo
-            ).onResolve(this, [progress = progress](const au::toast::ToastActionCode& actionCode) {
-            if (actionCode == au::toast::ToastActionCode::Custom) {
-                progress->cancel();
-            }
-        });
     });
+
+    interactive()->showProgress(trc("cloud", "Updating cloud audio preview…"), *progress);
 }
 
 void ProjectActionsController::downloadCloudProject(const std::string& projectId, const muse::io::path_t& localPath,
@@ -1539,25 +1512,27 @@ void ProjectActionsController::downloadCloudProject(const std::string& projectId
     }
 
     progress->finished().onReceive(this, [this, localPath, onSuccess](const ProgressResult& result) {
-        if (!result.ret) {
-            if (result.ret.code() != static_cast<int>(Ret::Code::Cancel)
-                && result.ret.code() != static_cast<int>(au::au3cloud::Err::OpenProjectCancelled)) {
-                interactive()->error(trc("cloud", "Generate audio preview"), result.ret.text());
+        async::Async::call(this, [this, localPath, onSuccess, result]() {
+            if (!result.ret) {
+                if (result.ret.code() != static_cast<int>(Ret::Code::Cancel)
+                    && result.ret.code() != static_cast<int>(au::au3cloud::Err::OpenProjectCancelled)) {
+                    interactive()->error(trc("cloud", "Generate audio preview"), result.ret.text());
+                }
+                return;
             }
-            return;
-        }
 
-        const muse::io::path_t projectPath = !result.val.isNull() ? result.val.toPath() : localPath;
+            const muse::io::path_t projectPath = !result.val.isNull() ? result.val.toPath() : localPath;
 
-        const RetVal<IAudacityProjectPtr> loaded = loadProject(projectPath);
-        if (!loaded.ret) {
-            interactive()->error(trc("cloud", "Generate audio preview"), loaded.ret.text());
-            return;
-        }
+            const RetVal<IAudacityProjectPtr> loaded = loadProject(projectPath);
+            if (!loaded.ret) {
+                interactive()->error(trc("cloud", "Generate audio preview"), loaded.ret.text());
+                return;
+            }
 
-        if (onSuccess) {
-            onSuccess(loaded.val);
-        }
+            if (onSuccess) {
+                onSuccess(loaded.val);
+            }
+        });
     });
 
     interactive()->showProgress(trc("project", "Syncing project from cloud…"), *progress);

--- a/src/project/internal/projectactionscontroller.h
+++ b/src/project/internal/projectactionscontroller.h
@@ -146,6 +146,7 @@ private:
     muse::Ret ensureAuthorization();
 
     void listenTrackeditProjectChanges();
+    void listenCloudProjectChanges();
 
     bool m_isProjectSaving = false;
     bool m_isProjectClosing = false;

--- a/src/project/internal/projectactionscontroller.h
+++ b/src/project/internal/projectactionscontroller.h
@@ -4,6 +4,7 @@
 #include "framework/global/async/asyncable.h"
 #include "framework/global/modularity/ioc.h"
 #include "framework/global/io/ifilesystem.h"
+#include "framework/global/iapplication.h"
 
 #include "framework/actions/actionable.h"
 #include "framework/actions/iactionsdispatcher.h"
@@ -35,6 +36,7 @@ namespace au::project {
 class ProjectActionsController : public IProjectFilesController, public muse::actions::Actionable, public muse::async::Asyncable,
     public muse::Contextable
 {
+    muse::GlobalInject<muse::IApplication> application;
     muse::GlobalInject<IProjectConfiguration> configuration;
     muse::GlobalInject<muse::io::IFileSystem> fileSystem;
     muse::GlobalInject<importexport::ExportConfiguration> exportConfiguration;
@@ -69,7 +71,8 @@ public:
     bool closeOpenedProject(bool quitApp = false) override;
     bool saveProject(const muse::io::path_t& path = muse::io::path_t()) override;
     bool saveProjectLocally(const muse::io::path_t& filePath = muse::io::path_t(), SaveMode saveMode = SaveMode::Save) override;
-    muse::Ret saveProjectToCloud(const CloudProjectInfo& cloudInfo, CloudSaveMode cloudSaveMode = CloudSaveMode::NormalUpdate) override;
+    muse::Ret saveProjectToCloud(const CloudProjectInfo& cloudInfo, CloudSaveMode cloudSaveMode = CloudSaveMode::NormalUpdate,
+                                 std::function<void()> onSuccess = nullptr) override;
 
     const ProjectBeingDownloaded& projectBeingDownloaded() const override;
     muse::async::Notification projectBeingDownloadedChanged() const override;
@@ -130,6 +133,11 @@ private:
 
     void shareAudio();
     void openCloudAudioFile(const muse::actions::ActionQuery& query);
+
+    void updateCloudAudioPreview(const muse::actions::ActionQuery& query);
+    void downloadCloudProject(const std::string& projectId, const muse::io::path_t& localPath,
+                              std::function<void(IAudacityProjectPtr)> onSuccess);
+    bool dispatchAudioPreviewToWindowWithProject(const muse::io::path_t& projectPath, const std::string& projectId);
 
     void openCustomFFmpegOptions();
     void openMetadataDialog();

--- a/src/project/internal/projectactionscontroller.h
+++ b/src/project/internal/projectactionscontroller.h
@@ -78,7 +78,6 @@ public:
     muse::async::Notification projectBeingDownloadedChanged() const override;
 
     bool isProjectOpened(const muse::io::path_t& projectPath) const;
-    const muse::actions::ActionCodeList& prohibitedActionsWhileRecording() const;
     muse::async::Channel<muse::actions::ActionCodeList> actionEnabledChanged() const;
 
 private:

--- a/src/project/internal/projectactionscontroller.h
+++ b/src/project/internal/projectactionscontroller.h
@@ -134,6 +134,7 @@ private:
     void openCloudAudioFile(const muse::actions::ActionQuery& query);
 
     void updateCloudAudioPreview(const muse::actions::ActionQuery& query);
+    void doUpdateCloudAudioPreview(const IAudacityProjectPtr& project, const std::function<void()>& onFinished = nullptr);
     void downloadCloudProject(const std::string& projectId, const muse::io::path_t& localPath,
                               std::function<void(IAudacityProjectPtr)> onSuccess);
     bool dispatchAudioPreviewToWindowWithProject(const muse::io::path_t& projectPath, const std::string& projectId);

--- a/src/project/internal/projectcreator.cpp
+++ b/src/project/internal/projectcreator.cpp
@@ -1,0 +1,25 @@
+/*
+* Audacity: A Digital Audio Editor
+*/
+#include "projectcreator.h"
+
+#include "audacityproject.h"
+
+using namespace au::project;
+
+IAudacityProjectPtr ProjectCreator::newProject() const
+{
+    return std::make_shared<Audacity4Project>(iocContext());
+}
+
+muse::RetVal<IAudacityProjectPtr> ProjectCreator::loadProject(const muse::io::path_t& path) const
+{
+    IAudacityProjectPtr project = std::make_shared<Audacity4Project>(iocContext());
+
+    const muse::Ret ret = project->load(path);
+    if (!ret) {
+        return muse::RetVal<IAudacityProjectPtr>::make_ret(ret);
+    }
+
+    return muse::RetVal<IAudacityProjectPtr>::make_ok(project);
+}

--- a/src/project/internal/projectcreator.h
+++ b/src/project/internal/projectcreator.h
@@ -1,0 +1,20 @@
+/*
+* Audacity: A Digital Audio Editor
+*/
+#pragma once
+
+#include "framework/global/modularity/ioc.h"
+
+#include "../iprojectcreator.h"
+
+namespace au::project {
+class ProjectCreator : public IProjectCreator, public muse::Contextable
+{
+public:
+    ProjectCreator(const muse::modularity::ContextPtr& ctx)
+        : muse::Contextable(ctx) {}
+
+    IAudacityProjectPtr newProject() const override;
+    muse::RetVal<IAudacityProjectPtr> loadProject(const muse::io::path_t& path) const override;
+};
+}

--- a/src/project/internal/projectuiactions.cpp
+++ b/src/project/internal/projectuiactions.cpp
@@ -11,6 +11,7 @@ using namespace au::project;
 
 namespace {
 const muse::actions::ActionCode UPDATE_AUDIO_PREVIEW_ACTION_CODE("audacity://cloud/update-audio-preview");
+const muse::actions::ActionCode UPDATE_AUDIO_PREVIEW_FOR_PROJECT_ACTION_CODE("audacity://cloud/update-audio-preview-for-project");
 }
 
 const UiActionList ProjectUiActions::m_actions = {
@@ -598,6 +599,12 @@ const UiActionList ProjectUiActions::m_actions = {
              au::context::CTX_ANY,
              TranslatableString("action", "Update cloud audio preview"),
              TranslatableString("action", "Update cloud audio preview")
+             ),
+    UiAction(UPDATE_AUDIO_PREVIEW_FOR_PROJECT_ACTION_CODE,
+             au::context::UiCtxAny,
+             au::context::CTX_ANY,
+             TranslatableString("action", "Update audio preview"),
+             TranslatableString("action", "Update audio preview")
              ),
 
     UiAction("project-properties",

--- a/src/project/internal/projectuiactions.cpp
+++ b/src/project/internal/projectuiactions.cpp
@@ -9,6 +9,10 @@ using namespace muse;
 using namespace muse::ui;
 using namespace au::project;
 
+namespace {
+const muse::actions::ActionCode UPDATE_AUDIO_PREVIEW_ACTION_CODE("audacity://cloud/update-audio-preview");
+}
+
 const UiActionList ProjectUiActions::m_actions = {
     //! TODO AU4
     //! Here are all of app menu UiActions - not all of them belong here,
@@ -588,6 +592,12 @@ const UiActionList ProjectUiActions::m_actions = {
              TranslatableString("action", "Share audio"),
              TranslatableString("action", "Share audio"),
              IconCode::Code::SHARE_AUDIO
+             ),
+    UiAction(UPDATE_AUDIO_PREVIEW_ACTION_CODE,
+             au::context::UiCtxAny,
+             au::context::CTX_ANY,
+             TranslatableString("action", "Update cloud audio preview"),
+             TranslatableString("action", "Update cloud audio preview")
              ),
 
     UiAction("project-properties",

--- a/src/project/iprojectcreator.h
+++ b/src/project/iprojectcreator.h
@@ -1,27 +1,8 @@
 /*
- * SPDX-License-Identifier: GPL-3.0-only
- * Audacity-CLA-applies
- *
- * Audacity
- * Music Composition & Notation
- *
- * Copyright (C) 2024 Audacity BVBA and others
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License version 3 as
- * published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
- */
-#ifndef AU_PROJECT_IPROJECTCREATOR_H
-#define AU_PROJECT_IPROJECTCREATOR_H
+* Audacity: A Digital Audio Editor
+*/
 
+#pragma once
 #include "iaudacityproject.h"
 
 #include "modularity/imoduleinterface.h"
@@ -36,7 +17,6 @@ public:
     virtual ~IProjectCreator() = default;
 
     virtual IAudacityProjectPtr newProject() const = 0;
+    virtual muse::RetVal<IAudacityProjectPtr> loadProject(const muse::io::path_t& path) const = 0;
 };
 }
-
-#endif // AU_PROJECT_IPROJECTCREATOR_H

--- a/src/project/iprojectfilescontroller.h
+++ b/src/project/iprojectfilescontroller.h
@@ -22,6 +22,8 @@
 #ifndef AU_PROJECT_IPROJECTFILESCONTROLLER_H
 #define AU_PROJECT_IPROJECTFILESCONTROLLER_H
 
+#include <functional>
+
 #include "modularity/imoduleinterface.h"
 #include "types/ret.h"
 #include "io/path.h"
@@ -44,7 +46,8 @@ public:
     virtual bool closeOpenedProject(bool quitApp = false) = 0;
     virtual bool saveProject(const muse::io::path_t& path = muse::io::path_t()) = 0;
     virtual bool saveProjectLocally(const muse::io::path_t& path = muse::io::path_t(), SaveMode saveMode = SaveMode::Save) = 0;
-    virtual muse::Ret saveProjectToCloud(const CloudProjectInfo& cloudInfo, CloudSaveMode cloudSaveMode = CloudSaveMode::NormalUpdate) = 0;
+    virtual muse::Ret saveProjectToCloud(const CloudProjectInfo& cloudInfo, CloudSaveMode cloudSaveMode = CloudSaveMode::NormalUpdate,
+                                         std::function<void()> onSuccess = nullptr) = 0;
 
     virtual const ProjectBeingDownloaded& projectBeingDownloaded() const = 0;
     virtual muse::async::Notification projectBeingDownloadedChanged() const = 0;

--- a/src/project/projectmodule.cpp
+++ b/src/project/projectmodule.cpp
@@ -27,6 +27,7 @@
 #include "framework/interactive/iinteractiveuriregister.h"
 
 #include "internal/projectconfiguration.h"
+#include "internal/projectcreator.h"
 #include "internal/projectuiactions.h"
 #include "internal/thumbnailcreator.h"
 #include "internal/projectautosaver.h"
@@ -141,6 +142,7 @@ void ProjectContext::registerExports()
     m_thumbnailCreator = std::make_shared<ThumbnailCreator>();
     m_tagsAccessor = std::make_shared<Au3Metadata>(iocContext());
 
+    ioc()->registerExport<IProjectCreator>(mname, std::make_shared<ProjectCreator>(iocContext()));
     ioc()->registerExport<IProjectFilesController>(mname, m_actionsController);
     ioc()->registerExport<muse::mi::IProjectProvider>(mname, std::make_shared<ProjectProvider>(iocContext()));
     ioc()->registerExport<IOpenSaveProjectScenario>(mname, new OpenSaveProjectScenario(iocContext()));

--- a/src/project/tests/mocks/audacityprojectmock.h
+++ b/src/project/tests/mocks/audacityprojectmock.h
@@ -28,7 +28,7 @@ public:
     MOCK_METHOD(bool, isNewlyCreated, (), (const, override));
     MOCK_METHOD(bool, isImported, (), (const, override));
     MOCK_METHOD(bool, isCloudProject, (), (const, override));
-    MOCK_METHOD((const std::optional<CloudProjectRecord>&), cloudRecord, (), (const, override));
+    MOCK_METHOD((const std::optional<CloudProjectRecord>), cloudRecord, (), (const, override));
 
     MOCK_METHOD(muse::String, title, (), (const, override));
 

--- a/src/project/tests/mocks/audacityprojectmock.h
+++ b/src/project/tests/mocks/audacityprojectmock.h
@@ -28,6 +28,7 @@ public:
     MOCK_METHOD(bool, isNewlyCreated, (), (const, override));
     MOCK_METHOD(bool, isImported, (), (const, override));
     MOCK_METHOD(bool, isCloudProject, (), (const, override));
+    MOCK_METHOD(muse::async::Notification, isCloudProjectChanged, (), (const, override));
     MOCK_METHOD((const std::optional<CloudProjectRecord>), cloudRecord, (), (const, override));
 
     MOCK_METHOD(muse::String, title, (), (const, override));

--- a/src/project/tests/mocks/projectfilescontrollermock.h
+++ b/src/project/tests/mocks/projectfilescontrollermock.h
@@ -17,7 +17,7 @@ public:
     MOCK_METHOD(bool, closeOpenedProject, (bool), (override));
     MOCK_METHOD(bool, saveProject, (const muse::io::path_t&), (override));
     MOCK_METHOD(bool, saveProjectLocally, (const muse::io::path_t&, SaveMode), (override));
-    MOCK_METHOD(muse::Ret, saveProjectToCloud, (const CloudProjectInfo&, CloudSaveMode), (override));
+    MOCK_METHOD(muse::Ret, saveProjectToCloud, (const CloudProjectInfo&, CloudSaveMode, std::function<void()>), (override));
     MOCK_METHOD(const ProjectBeingDownloaded&, projectBeingDownloaded, (), (const, override));
     MOCK_METHOD(muse::async::Notification, projectBeingDownloadedChanged, (), (const, override));
 };

--- a/src/project/view/cloudprojectcontextmenumodel.cpp
+++ b/src/project/view/cloudprojectcontextmenumodel.cpp
@@ -10,6 +10,7 @@ using namespace au::project;
 namespace {
 constexpr const char* OPEN_PROJECT_ACTION = "cloud-file-open";
 constexpr const char* OPEN_PROJECT_PAGE_ACTION = "audacity://cloud/open-project-page";
+constexpr const char* UPDATE_AUDIO_PREVIEW_ACTION = "audacity://cloud/update-audio-preview-for-project";
 }
 
 CloudProjectContextMenuModel::CloudProjectContextMenuModel(QString projectId, QObject* parent)
@@ -23,8 +24,9 @@ void CloudProjectContextMenuModel::load()
 
     muse::uicomponents::MenuItem* openItem = makeMenuItem(OPEN_PROJECT_ACTION);
     muse::uicomponents::MenuItem* viewProjectPage = makeMenuItem(OPEN_PROJECT_PAGE_ACTION);
+    muse::uicomponents::MenuItem* updateAudioPreview = makeMenuItem(UPDATE_AUDIO_PREVIEW_ACTION);
 
-    setItems({ openItem, viewProjectPage });
+    setItems({ openItem, viewProjectPage, updateAudioPreview });
 }
 
 void CloudProjectContextMenuModel::handleMenuItem(const QString& itemId)
@@ -44,6 +46,17 @@ void CloudProjectContextMenuModel::handleMenuItem(const QString& itemId)
         }
 
         muse::actions::ActionQuery query(OPEN_PROJECT_PAGE_ACTION);
+        query.addParam("id", muse::Val(m_projectId));
+        dispatch(query);
+        return;
+    }
+
+    if (itemId == UPDATE_AUDIO_PREVIEW_ACTION) {
+        if (m_projectId.isEmpty()) {
+            return;
+        }
+
+        muse::actions::ActionQuery query(UPDATE_AUDIO_PREVIEW_ACTION);
         query.addParam("id", muse::Val(m_projectId));
         dispatch(query);
         return;

--- a/src/project/view/recentprojectcontextmenumodel.cpp
+++ b/src/project/view/recentprojectcontextmenumodel.cpp
@@ -14,6 +14,7 @@ using namespace au::project;
 namespace {
 constexpr const char* OPEN_PROJECT_ACTION = "file-open";
 constexpr const char* OPEN_PROJECT_PAGE_ACTION = "audacity://cloud/open-project-page";
+constexpr const char* UPDATE_AUDIO_PREVIEW_ACTION = "audacity://cloud/update-audio-preview-for-project";
 constexpr const char* SHOW_IN_FOLDER_ACTION = "project-show-in-folder";
 }
 
@@ -34,6 +35,7 @@ void RecentProjectContextMenuModel::load()
     muse::uicomponents::MenuItemList items = { openItem };
     if (isCloudProject) {
         items.append(makeMenuItem(OPEN_PROJECT_PAGE_ACTION));
+        items.append(makeMenuItem(UPDATE_AUDIO_PREVIEW_ACTION));
     }
 
     if (!m_path.isEmpty()) {
@@ -67,6 +69,17 @@ void RecentProjectContextMenuModel::handleMenuItem(const QString& itemId)
 
         muse::actions::ActionQuery query(OPEN_PROJECT_PAGE_ACTION);
         query.addParam("path", muse::Val(muse::io::path_t(m_path.toStdString())));
+        dispatch(query);
+        return;
+    }
+
+    if (itemId == UPDATE_AUDIO_PREVIEW_ACTION) {
+        if (m_cloudProjectId.isEmpty()) {
+            return;
+        }
+
+        muse::actions::ActionQuery query(UPDATE_AUDIO_PREVIEW_ACTION);
+        query.addParam("id", muse::Val(m_cloudProjectId));
         dispatch(query);
         return;
     }

--- a/src/stubs/au3cloud/au3audiocomservicestub.cpp
+++ b/src/stubs/au3cloud/au3audiocomservicestub.cpp
@@ -38,6 +38,11 @@ muse::RetVal<muse::ProgressPtr> Au3AudioComServiceStub::uploadProject(au::projec
     return muse::RetVal<muse::ProgressPtr>::make_ret(muse::Ret::Code::NotSupported);
 }
 
+muse::RetVal<muse::ProgressPtr> Au3AudioComServiceStub::updateAudioPreview(au::project::IAudacityProjectPtr)
+{
+    return muse::RetVal<muse::ProgressPtr>::make_ret(muse::Ret::Code::NotSupported);
+}
+
 muse::RetVal<muse::ProgressPtr> Au3AudioComServiceStub::shareAudio(const std::string&)
 {
     return muse::RetVal<muse::ProgressPtr>::make_ret(muse::Ret::Code::NotSupported);

--- a/src/stubs/au3cloud/au3audiocomservicestub.h
+++ b/src/stubs/au3cloud/au3audiocomservicestub.h
@@ -26,6 +26,7 @@ public:
     muse::RetVal<muse::ProgressPtr> uploadProject(au::project::IAudacityProjectPtr project, const std::string& name,
                                                   std::function<bool()> projectSaveCallback = nullptr,
                                                   UploadMode uploadMode = UploadMode::NormalUpdate) override;
+    muse::RetVal<muse::ProgressPtr> updateAudioPreview(au::project::IAudacityProjectPtr project) override;
     muse::RetVal<muse::ProgressPtr> shareAudio(const std::string& title) override;
     muse::RetVal<muse::ProgressPtr> downloadAudioFile(const std::string& audioId) override;
 


### PR DESCRIPTION
Resolves: #11497 

Implements update audio preview

The user should be able to update the preview using the File->Update cloud audio preview or using audio.com web site. It is also possible to perform the action using the recent project and cloud project context menu.
The solution considers multiple projects and also should work ok even if the project is closed.
For close app it still depends on the framework fix for https://github.com/audacity/audacity/issues/10966

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [x] Use the file menu and check if it is disabled for local projects and enabled for cloud projects.
- [x] Use "Update audio preview" on the audio.com project page with the same project in the active window
- [x] Use "Update audio preview" on the audio.com project page with the project in a not active window
- [x] Use "update audio preview" on context menus
- [ ] Testflow test cases have been run
