### PR TITLE
11498 Add join and split at silence on context menus

### DIFF
--- a/src/projectscene/view/tracksitemsview/clipcontextmenumodel.cpp
+++ b/src/projectscene/view/tracksitemsview/clipcontextmenumodel.cpp
@@ -84,7 +84,7 @@ void ClipContextMenuModel::load()
         makeMenu(muse::TranslatableString("clip", "Delete and…"), deleteAndItems, "menu-delete-and"),
         makeSeparator(),
         makeItemWithArg("split"),
-        makeItemWithArg("clip-export"),
+        makeItemWithArg("disjoin", muse::TranslatableString("clip", "Split at silences")),
         makeSeparator(),
         enableStretchItem,
         makeItemWithArg("clip-pitch-speed-open"),

--- a/src/projectscene/view/tracksitemsview/multiclipcontextmenumodel.cpp
+++ b/src/projectscene/view/tracksitemsview/multiclipcontextmenumodel.cpp
@@ -47,6 +47,9 @@ MenuItemList MultiClipContextMenuModel::makeItems()
         makeMenu(muse::TranslatableString("multiclip", "Cut and…"), cutAndItems, "menu-cut-and"),
         makeMenu(muse::TranslatableString("multiclip", "Delete and…"), deleteAndItems, "menu-delete-and"),
         makeSeparator(),
+        makeMenuItem("join",
+                     muse::TranslatableString("multiclip", "Join")),
+        makeSeparator(),
         makeMenuItem("group-clips"),
         makeMenuItem("ungroup-clips"),
     };

--- a/src/projectscene/view/tracksitemsview/selectioncontextmenumodel.cpp
+++ b/src/projectscene/view/tracksitemsview/selectioncontextmenumodel.cpp
@@ -63,7 +63,11 @@ MenuItemList SelectionContextMenuModel::makeItems()
         makeMenu(muse::TranslatableString("selection", "Paste and…"), pasteAndItems, "menu-paste-and"),
         makeMenu(muse::TranslatableString("selection", "Delete and…"), deleteAndItems, "menu-delete-and"),
         makeSeparator(),
-        makeMenuItem("split")
+        makeMenuItem("split"),
+        makeMenuItem("disjoin",
+                     muse::TranslatableString("selection", "Split at silences")),
+        makeMenuItem("join",
+                     muse::TranslatableString("selection", "Join"))
     };
 
     return items;

--- a/src/trackedit/internal/trackeditactionscontroller.cpp
+++ b/src/trackedit/internal/trackeditactionscontroller.cpp
@@ -2,8 +2,9 @@
 * Audacity: A Digital Audio Editor
 */
 #include "trackeditactionscontroller.h"
-#include "project/internal/audacityproject.h"
-#include "trackediterrors.h"
+
+#include <algorithm>
+#include <limits>
 
 #include "global/translation.h"
 #include "global/defer.h"
@@ -341,6 +342,11 @@ void TrackeditActionsController::init()
     selectionController()->clipsSelected().onReceive(this, [this](const trackedit::ClipKeyList&) {
         notifyActionEnabledChanged(GROUP_CLIPS_CODE);
         notifyActionEnabledChanged(UNGROUP_CLIPS_CODE);
+        notifyActionEnabledChanged(JOIN_CODE);
+    });
+
+    selectionController()->clipsIntersectingRangeSelectionChanged().onReceive(this, [this](const trackedit::ClipKeyList&) {
+        notifyActionEnabledChanged(JOIN_CODE);
     });
 }
 
@@ -828,12 +834,82 @@ void TrackeditActionsController::doGlobalSplitIntoNewTrack()
 
 void TrackeditActionsController::doGlobalJoin()
 {
-    auto selectedTracks = selectionController()->selectedTracks();
-    secs_t selectedStartTime = selectionController()->dataSelectedStartTime();
-    secs_t selectedEndTime = selectionController()->dataSelectedEndTime();
+    if (!selectionController()->timeSelectionIsEmpty()) {
+        auto selectedTracks = selectionController()->selectedTracks();
+        secs_t selectedStartTime = selectionController()->dataSelectedStartTime();
+        secs_t selectedEndTime = selectionController()->dataSelectedEndTime();
+
+        dispatcher()->dispatch(MERGE_SELECTED_ON_TRACK,
+                               ActionData::make_arg3<TrackIdList, secs_t, secs_t>(selectedTracks, selectedStartTime, selectedEndTime));
+        return;
+    }
+
+    const std::optional<ContiguousClipsSpan> span = contiguousSelectedClipsSpan();
+    if (!span) {
+        return;
+    }
 
     dispatcher()->dispatch(MERGE_SELECTED_ON_TRACK,
-                           ActionData::make_arg3<TrackIdList, secs_t, secs_t>(selectedTracks, selectedStartTime, selectedEndTime));
+                           ActionData::make_arg3<TrackIdList, secs_t, secs_t>(TrackIdList { span->trackId }, span->begin, span->end));
+}
+
+std::optional<TrackeditActionsController::ContiguousClipsSpan> TrackeditActionsController::contiguousSelectedClipsSpan() const
+{
+    const ClipKeyList clipKeys = selectionController()->selectedClips();
+    if (clipKeys.size() < 2) {
+        return std::nullopt;
+    }
+
+    const ITrackeditProjectPtr prj = globalContext()->currentTrackeditProject();
+    if (!prj) {
+        return std::nullopt;
+    }
+
+    const TrackId trackId = clipKeys.front().trackId;
+    for (const ClipKey& key : clipKeys) {
+        if (key.trackId != trackId) {
+            return std::nullopt;
+        }
+    }
+
+    const muse::async::NotifyList<Clip> trackClips = prj->clipList(trackId);
+
+    size_t selectedCount = 0;
+    double begin = std::numeric_limits<double>::max();
+    double end = std::numeric_limits<double>::lowest();
+    for (const Clip& clip : trackClips) {
+        if (muse::contains(clipKeys, clip.key)) {
+            ++selectedCount;
+            begin = std::min(begin, clip.startTime);
+            end = std::max(end, clip.endTime);
+        }
+    }
+
+    if (selectedCount != clipKeys.size()) {
+        return std::nullopt;
+    }
+
+    for (const Clip& clip : trackClips) {
+        if (!muse::contains(clipKeys, clip.key) && clip.startTime < end && clip.endTime > begin) {
+            return std::nullopt;
+        }
+    }
+
+    return ContiguousClipsSpan { trackId, begin, end };
+}
+
+bool TrackeditActionsController::rangeSelectionCoversMultipleClips() const
+{
+    ClipKeyList clips = selectionController()->clipsIntersectingRangeSelection();
+    std::sort(clips.begin(), clips.end());
+
+    for (size_t i = 1; i < clips.size(); ++i) {
+        if (clips[i].trackId == clips[i - 1].trackId) {
+            return true;
+        }
+    }
+
+    return false;
 }
 
 void TrackeditActionsController::doGlobalDisjoin()
@@ -2122,6 +2198,11 @@ bool TrackeditActionsController::canReceiveAction(const ActionCode& actionCode) 
         return clipsForInteraction().size() > 1 && !selectionController()->isSelectionGrouped();
     } else if (actionCode == UNGROUP_CLIPS_CODE) {
         return clipsForInteraction().size() > 1 && selectionController()->selectionContainsGroup();
+    } else if (actionCode == JOIN_CODE) {
+        if (!selectionController()->timeSelectionIsEmpty()) {
+            return rangeSelectionCoversMultipleClips();
+        }
+        return contiguousSelectedClipsSpan().has_value();
     }
 
     return true;

--- a/src/trackedit/internal/trackeditactionscontroller.h
+++ b/src/trackedit/internal/trackeditactionscontroller.h
@@ -3,6 +3,8 @@
 */
 #pragma once
 
+#include <optional>
+
 #include "framework/global/async/asyncable.h"
 #include "framework/actions/actionable.h"
 
@@ -64,6 +66,14 @@ private:
 
     bool isFocusedItemClip() const;
     ClipKeyList clipsForInteraction() const;
+
+    struct ContiguousClipsSpan {
+        TrackId trackId = INVALID_TRACK;
+        secs_t begin = 0.0;
+        secs_t end = 0.0;
+    };
+    std::optional<ContiguousClipsSpan> contiguousSelectedClipsSpan() const;
+    bool rangeSelectionCoversMultipleClips() const;
 
     bool isFocusedItemLabel() const;
     LabelKeyList labelsForInteraction() const;


### PR DESCRIPTION
Resolves: #11498

Add join and disjoin operations on clip, multi clip and selection menu.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Time selection
- [ ] Clip and multi-clip selection
- [ ] Testflow test cases have been run
