### PR TITLE
11516 Fix clip/label resize

### DIFF
--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TracksItemsView.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TracksItemsView.qml
@@ -733,7 +733,7 @@ Rectangle {
             target: timeline.context
 
             function onFrameTimeChanged() {
-                if (emptyAreaGuidelineHandler.hovered && !mainMouseArea.pressed && root.interactionState === TracksItemsView.State.Idle) {
+                if (emptyAreaGuidelineHandler.hovered && !mainMouseArea.pressed && !tracksViewState.isItemEditInProgress()) {
                     emptyAreaGuidelineHandler.processHover()
                 }
             }

--- a/src/projectscene/view/common/tracksviewstatemodel.cpp
+++ b/src/projectscene/view/common/tracksviewstatemodel.cpp
@@ -77,6 +77,15 @@ bool TracksViewStateModel::snapEnabled() const
     return false;
 }
 
+bool TracksViewStateModel::isItemEditInProgress() const
+{
+    IProjectViewStatePtr vs = viewState();
+    if (vs) {
+        return !muse::RealIsEqual(vs->itemEditStartTimeOffset(), -1.0);
+    }
+    return false;
+}
+
 au::trackedit::TrackId TracksViewStateModel::trackAtPosition(double x, double y) const
 {
     UNUSED(x);

--- a/src/projectscene/view/common/tracksviewstatemodel.h
+++ b/src/projectscene/view/common/tracksviewstatemodel.h
@@ -51,6 +51,7 @@ public:
     Q_INVOKABLE void requestVerticalScrollUnlock();
 
     Q_INVOKABLE bool snapEnabled() const;
+    Q_INVOKABLE bool isItemEditInProgress() const;
     Q_INVOKABLE trackedit::TrackId trackAtPosition(double x, double y) const;
 
     Q_INVOKABLE int trackHeight(trackedit::TrackId trackId) const;


### PR DESCRIPTION
Resolves: #11516 

The frame-time refresh wrote mousePositionTime from a hover point that is frozen while a trim/stretch handle holds the mouse grab.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [ ] I signed [CLA](https://www.audacityteam.org/cla/)
- [ ] The title of the pull request describes an issue it addresses
- [ ] If changes are extensive, then there is a sequence of easily reviewable commits
- [ ] Each commit's message describes its purpose and effects
- [ ] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [ ] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
- [x] Check clip/label trimming/stretching/moving (including at auto-scroll area)
- [x] Check cancelling above with Esc key mid-drag
- [x] Verify timelineruler guideline still updates whenever you hover over clip/label/empty track/empty canvas under the tracks
