### PR TITLE
Fix setting clip's project tempo after opening project

### DIFF
--- a/src/ProjectFileManager.cpp
+++ b/src/ProjectFileManager.cpp
@@ -1121,6 +1121,12 @@ AudacityProject *ProjectFileManager::OpenProjectFile(
    const bool err = results.trackError;
 
    if (bParseSuccess && !err) {
+      // Set clip's project tempo - this is a fix for issue #11337
+      const auto projectTempo = ProjectTimeSignature::Get(project).GetTempo();
+      const std::optional<double> oldTempo{};
+      for (auto track : tracks)
+         OnProjectTempoChange::Call(*track, oldTempo, projectTempo);
+
       Viewport::Get(project).ReinitScrollbars();
 
       ProjectHistory::Get( project ).InitialState();


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/11337

Problem:
After opening a project, clips can have the wrong tempo. The tempo of a clip is the clip's "RawAudioTempo" rather than the project tempo. So when these values are different, a clip has the wrong tempo.

This issue was caused by PR #10688, in which there was a change to publishing a TrackListEvent::ADDITION event immediately, rather than using CallAfter. When opening a project, ProjectTempoListener::ProjectTempoListener() responds to a TrackListEvent::ADDITION by calling DoProjectTempoChange(*track, tempo), which calls OnProjectTempoChange::Call(group, oldTempo, newTempo), where oldTempo is nullopt, and newTempo is the project tempo. This is an attached virtual function, and there are overrides for each type of track. For wavetracks, this function sets the clip's project tempo. However because of the change in timing of the publishing of the event, the clips have not yet been added to the track, and so their values of project tempo are not set. When the oldTempo is nullopt, the overrides for all the other track types do nothing, and so other tracks are not affected by the change in timing.

Fix:
Add another call to OnProjectTempoChange::Call(group, oldTempo, newTempo), after the clips have been added.


<!-- Use "x" to fill the checkboxes below like [x] -->

- [ x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x ] The title of the pull request describes an issue it addresses
- [x ] If changes are extensive, then there is a sequence of easily reviewable commits
- [ x] Each commit's message describes its purpose and effects
- [x ] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x ] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
