### PR TITLE
Track View. Navigation improvement. Step 1

### DIFF
--- a/src/app/configs/data/shortcuts.xml
+++ b/src/app/configs/data/shortcuts.xml
@@ -136,14 +136,6 @@
     </SC>
 
     <SC>
-        <key>track-view-next-item</key>
-        <seq>Right</seq>
-    </SC>
-    <SC>
-        <key>track-view-prev-item</key>
-        <seq>Left</seq>
-    </SC>
-    <SC>
         <key>track-view-item-context-menu</key>
         <seq>Shift+F10</seq>
         <seq>Ctrl+Shift+F10</seq>

--- a/src/appshell/internal/applicationactioncontroller.cpp
+++ b/src/appshell/internal/applicationactioncontroller.cpp
@@ -516,18 +516,20 @@ void ApplicationActionController::doGlobalCancel()
 {
     if (isProjectOpenedAndFocused()) {
         dispatcher()->dispatch("action://trackedit/cancel");
+        return;
     }
 
-    dispatcher()->dispatch("nav-escape");
+    commandDispatcher()->dispatch(muse::ui::ESCAPE_COMMAND);
 }
 
 void ApplicationActionController::doGlobalTrigger()
 {
     if (isProjectOpened()) {
         dispatcher()->dispatch("action://playback/toggle-play-stop");
-    } else {
-        commandDispatcher()->dispatch(muse::ui::TRIGGER_CONTROL_COMMAND);
+        return;
     }
+
+    commandDispatcher()->dispatch(muse::ui::TRIGGER_CONTROL_COMMAND);
 }
 
 void ApplicationActionController::doGlobalEnter()

--- a/src/appshell/internal/applicationactioncontroller.cpp
+++ b/src/appshell/internal/applicationactioncontroller.cpp
@@ -519,7 +519,6 @@ void ApplicationActionController::doGlobalCancel()
     }
 
     dispatcher()->dispatch("nav-escape");
-    commandDispatcher()->dispatch(muse::ui::ESCAPE_COMMAND);
 }
 
 void ApplicationActionController::doGlobalTrigger()

--- a/src/appshell/qml/Audacity/AppShell/ProjectPage/ProjectPage.qml
+++ b/src/appshell/qml/Audacity/AppShell/ProjectPage/ProjectPage.qml
@@ -333,7 +333,8 @@ DockPage {
                     width: parent.width
                     height: parent.height - trackstitleBarItem.height
 
-                    navPanels: tracksNavModel.trackItemPanels
+                    navigationPanels: tracksNavModel.trackItemPanels
+                    headerNavigationPanels: tracksNavModel.trackHeaderPanels
                     effectColumnNavigationPanel: trackstitleBarItem.closeEffectsNavigation
                     effectsSectionWidth: tracksPanel.effectsSectionWidth
 

--- a/src/context/internal/uicontextresolver.cpp
+++ b/src/context/internal/uicontextresolver.cpp
@@ -92,8 +92,12 @@ muse::ui::UiContext UiContextResolver::resolveUiContext() const
         }
 
         INavigationSection* activeSection = navigationController()->activeSection();
-        if (activeSection) {
-            if (activeSection->name() == DEFAULT_NAVIGATION_SECTION) {
+        if (activeSection && activeSection->name() == DEFAULT_NAVIGATION_SECTION) {
+            //! NOTE: the project focus is bound to the track panel and the clips/labels panel.
+            //! The track header controls panel is navigated as a usual panel (general navigation),
+            //! so it is ignored here and treated as merely project-opened, letting the general
+            //! navigation shortcuts (arrows between the controls, ...) work on it
+            if (!trackNavigationController()->isNavigationEnabled()) {
                 return context::UiCtxProjectFocused;
             }
         }

--- a/src/projectscene/qml/Audacity/ProjectScene/trackspanel/LabelTrackItem.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/trackspanel/LabelTrackItem.qml
@@ -27,7 +27,7 @@ TrackItem {
                 }
             }
 
-            navigation.panel: root.navigation.panel
+            navigation.panel: root.headerNavigationPanel
             navigation.order: root.extraControlsNavigationStart
             navigation.enabled: !root.collapsed
 

--- a/src/projectscene/qml/Audacity/ProjectScene/trackspanel/TrackItem.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/trackspanel/TrackItem.qml
@@ -20,6 +20,10 @@ ListItemBlank {
 
     property bool isFocused: false
 
+    //! NOTE: the track itself is a control of its own panel (root.navigation),
+    //! all the header controls live in the next panel, so Tab goes: track -> header controls -> clips/labels
+    property NavigationPanel headerNavigationPanel: null
+
     property alias headerTrailingControlsComponent: headerTrailingControls.sourceComponent
     property int headerTrailingControlsNavigationStart: collapsed ? title.navigation.order + 1 : extraControlsNavigationEnd + 1
     property int headerTrailingControlsNavigationEnd: 0
@@ -179,7 +183,7 @@ ListItemBlank {
 
                     text: Boolean(root.item) ? root.item.title : ""
 
-                    navigation.panel: root.navigation.panel
+                    navigation.panel: root.headerNavigationPanel
                     navigation.order: root.navigation.order + 1
 
                     onTextEdited: function (text) {
@@ -199,7 +203,7 @@ ListItemBlank {
 
                     menuModel: contextMenuModel
 
-                    navigation.panel: root.navigation.panel
+                    navigation.panel: root.headerNavigationPanel
                     navigation.order: root.collapsed ? root.headerTrailingControlsNavigationEnd + 1 : title.navigation.order + 1
                     navigation.accessible.name: qsTrc("projectscene", "Track menu")
 

--- a/src/projectscene/qml/Audacity/ProjectScene/trackspanel/TrackItem.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/trackspanel/TrackItem.qml
@@ -93,6 +93,10 @@ ListItemBlank {
         trackId: root.item ? root.item.trackId : -1
 
         onTrackRenameRequested: title.edit()
+
+        onOpenRequested: {
+            menuButton.toggleMenu(menuButton)
+        }
     }
 
     function init() {

--- a/src/projectscene/qml/Audacity/ProjectScene/trackspanel/TracksPanel.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/trackspanel/TracksPanel.qml
@@ -13,20 +13,22 @@ import Audacity.ProjectScene
 Item {
     id: root
 
-    property var navPanels: null
     property alias tracksModel: tracksModel
-    property NavigationPanel effectColumnNavigationPanel: null
-
-    signal openEffectsRequested
-    signal panelActive(var trackId)
-
-    property NavigationSection trackEffectsNavigationSection: null
-    property NavigationSection masterEffectsNavigationSection: null
 
     // property alias contextMenuModel: contextMenuModel
     property int effectsSectionWidth: 240 // TODO: can this be set as a constant that can be imported?
     property alias showEffectsSection: effectSectionModel.showEffectsSection
     property int selectedTrackIndex: -1
+
+    property var navigationPanels: null
+    property var headerNavigationPanels: null
+    property NavigationPanel effectColumnNavigationPanel: null
+
+    property NavigationSection trackEffectsNavigationSection: null
+    property NavigationSection masterEffectsNavigationSection: null
+
+    signal openEffectsRequested
+    signal panelActive(var trackId)
 
     PanelTracksListModel {
         id: tracksModel
@@ -230,8 +232,9 @@ Item {
                             container: view
 
                             navigation.name: Boolean(item) ? item.title + item.index : ""
-                            navigation.panel: root.navPanels && root.navPanels[index] ? root.navPanels[index] : null
+                            navigation.panel: root.navigationPanels && root.navigationPanels[index] ? root.navigationPanels[index] : null
                             navigation.order: 0
+                            headerNavigationPanel: root.headerNavigationPanels && root.headerNavigationPanels[index] ? root.headerNavigationPanels[index] : null
                             navigation.accessible.name: Boolean(item) ? (isSelected ? qsTrc("projectscene", "Track %1: %2, audio track, selected").arg(index + 1).arg(item.title) : qsTrc("projectscene", "Track %1: %2, audio track").arg(index + 1).arg(item.title)) : ""
                             navigation.accessible.description: qsTrc("projectscene", "Press Enter to select or deselect")
                             navigation.accessible.role: MUAccessible.Group
@@ -294,8 +297,9 @@ Item {
                             container: view
 
                             navigation.name: Boolean(item) ? item.title + item.index : ""
-                            navigation.panel: root.navPanels && root.navPanels[index] ? root.navPanels[index] : null
+                            navigation.panel: root.navigationPanels && root.navigationPanels[index] ? root.navigationPanels[index] : null
                             navigation.order: 0
+                            headerNavigationPanel: root.headerNavigationPanels && root.headerNavigationPanels[index] ? root.headerNavigationPanels[index] : null
                             navigation.accessible.name: Boolean(item) ? (isSelected ? qsTrc("projectscene", "Track %1: %2, label track, selected").arg(index + 1).arg(item.title) : qsTrc("projectscene", "Track %1: %2, label track").arg(index + 1).arg(item.title)) : ""
                             navigation.accessible.description: qsTrc("projectscene", "Press Enter to select or deselect")
                             navigation.accessible.role: MUAccessible.Group

--- a/src/projectscene/qml/Audacity/ProjectScene/trackspanel/WaveTrackItem.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/trackspanel/WaveTrackItem.qml
@@ -56,7 +56,7 @@ TrackItem {
 
                     value: Boolean(root.item) ? root.item.pan : 0
 
-                    navigation.panel: root.navigation.panel
+                    navigation.panel: root.headerNavigationPanel
                     navigation.order: root.extraControlsNavigationStart
                     navigation.enabled: !root.collapsed
                     navigation.accessible.name: qsTrc("projectscene", "Pan")
@@ -73,7 +73,7 @@ TrackItem {
 
                     value: Boolean(root.item) ? root.item.volumeLevel : 0
 
-                    navigation.panel: root.navigation.panel
+                    navigation.panel: root.headerNavigationPanel
                     navigation.order: panKnob.navigation.order + 1
                     navigation.enabled: !root.collapsed
                     navigation.accessible.name: qsTrc("projectscene", "Track volume")
@@ -111,7 +111,7 @@ TrackItem {
                     }
                 }
 
-                navigation.panel: root.navigation.panel
+                navigation.panel: root.headerNavigationPanel
                 navigation.order: root.headerTrailingControlsNavigationEnd + 1
                 navigation.enabled: topRow.visible
 
@@ -244,7 +244,7 @@ TrackItem {
                 icon: IconCode.MUTE
                 checked: Boolean(root.item) ? root.item.muted : false
 
-                navigation.panel: root.navigation.panel
+                navigation.panel: root.headerNavigationPanel
                 navigation.order: root.headerTrailingControlsNavigationStart
                 navigation.accessible.name: qsTrc("projectscene", "Mute")
                 navigation.accessible.role: MUAccessible.CheckBox
@@ -265,7 +265,7 @@ TrackItem {
                 icon: IconCode.SOLO
                 checked: Boolean(root.item) ? root.item.solo : false
 
-                navigation.panel: root.navigation.panel
+                navigation.panel: root.headerNavigationPanel
                 navigation.order: muteButton.navigation.order + 1
                 navigation.accessible.name: qsTrc("projectscene", "Solo")
                 navigation.accessible.role: MUAccessible.CheckBox

--- a/src/projectscene/view/playcursor/playpositionactioncontroller.cpp
+++ b/src/projectscene/view/playcursor/playpositionactioncontroller.cpp
@@ -44,8 +44,8 @@ au::projectscene::PlayPositionActionController::PlayPositionActionController(QOb
 
 void PlayPositionActionController::init()
 {
-    // dispatcher()->reg(this, PLAY_POSITION_DECREASE, this, &PlayPositionActionController::playPositionDecrease);
-    // dispatcher()->reg(this, PLAY_POSITION_INCREASE, this, &PlayPositionActionController::playPositionIncrease);
+    dispatcher()->reg(this, PLAY_POSITION_DECREASE, this, &PlayPositionActionController::playPositionDecrease);
+    dispatcher()->reg(this, PLAY_POSITION_INCREASE, this, &PlayPositionActionController::playPositionIncrease);
     dispatcher()->reg(this, SEL_EXT_LEFT, this, &PlayPositionActionController::selectionExtendLeft);
     dispatcher()->reg(this, SEL_EXT_RIGHT, this, &PlayPositionActionController::selectionExtendRight);
     dispatcher()->reg(this, SEL_CNTR_LEFT, this, &PlayPositionActionController::selectionContractLeft);

--- a/src/projectscene/view/playcursor/playpositionactioncontroller.cpp
+++ b/src/projectscene/view/playcursor/playpositionactioncontroller.cpp
@@ -44,8 +44,8 @@ au::projectscene::PlayPositionActionController::PlayPositionActionController(QOb
 
 void PlayPositionActionController::init()
 {
-    dispatcher()->reg(this, PLAY_POSITION_DECREASE, this, &PlayPositionActionController::playPositionDecrease);
-    dispatcher()->reg(this, PLAY_POSITION_INCREASE, this, &PlayPositionActionController::playPositionIncrease);
+    // dispatcher()->reg(this, PLAY_POSITION_DECREASE, this, &PlayPositionActionController::playPositionDecrease);
+    // dispatcher()->reg(this, PLAY_POSITION_INCREASE, this, &PlayPositionActionController::playPositionIncrease);
     dispatcher()->reg(this, SEL_EXT_LEFT, this, &PlayPositionActionController::selectionExtendLeft);
     dispatcher()->reg(this, SEL_EXT_RIGHT, this, &PlayPositionActionController::selectionExtendRight);
     dispatcher()->reg(this, SEL_CNTR_LEFT, this, &PlayPositionActionController::selectionContractLeft);

--- a/src/projectscene/view/trackspanel/trackcontextmenumodel.cpp
+++ b/src/projectscene/view/trackspanel/trackcontextmenumodel.cpp
@@ -130,6 +130,12 @@ void TrackContextMenuModel::load()
         updateTrackMonoState();
     }, muse::async::Asyncable::Mode::SetReplace);
 
+    trackNavigationController()->openContextMenuRequested().onReceive(this, [this](const trackedit::TrackItemKey& key) {
+        if (key.trackId == m_trackId && key.itemId == trackedit::INVALID_TRACK_ITEM) {
+            emit openRequested();
+        }
+    }, muse::async::Asyncable::Mode::SetReplace);
+
     trackedit::ITrackeditProjectPtr prj = globalContext()->currentTrackeditProject();
     auto track = prj->track(m_trackId);
     if (!track.has_value()) {

--- a/src/projectscene/view/trackspanel/trackcontextmenumodel.h
+++ b/src/projectscene/view/trackspanel/trackcontextmenumodel.h
@@ -10,6 +10,7 @@
 #include "iprojectsceneconfiguration.h"
 #include "trackedit/iprojecthistory.h"
 #include "trackedit/iselectioncontroller.h"
+#include "trackedit/internal/itracknavigationcontroller.h"
 
 namespace au::projectscene {
 class TrackContextMenuModel : public muse::uicomponents::AbstractMenuModel
@@ -22,6 +23,7 @@ class TrackContextMenuModel : public muse::uicomponents::AbstractMenuModel
     muse::ContextInject<context::IGlobalContext> globalContext{ this };
     muse::ContextInject<trackedit::IProjectHistory> projectHistory{ this };
     muse::ContextInject<trackedit::ISelectionController> selectionController{ this };
+    muse::ContextInject<trackedit::ITrackNavigationController> trackNavigationController{ this };
 
     Q_PROPERTY(trackedit::TrackId trackId READ trackId WRITE setTrackId NOTIFY trackIdChanged FINAL)
 
@@ -37,6 +39,7 @@ public:
 signals:
     void trackIdChanged();
     void trackRenameRequested();
+    void openRequested();
 
 private:
     void onActionsStateChanges(const muse::actions::ActionCodeList& codes) override;

--- a/src/trackedit/internal/itracknavigationcontroller.h
+++ b/src/trackedit/internal/itracknavigationcontroller.h
@@ -31,6 +31,8 @@ public:
 
     virtual TrackItemKeyList itemKeysInRange(const TrackItemKey& anchor, const TrackItemKey& target) const = 0;
 
+    virtual void resetNavigation() = 0;
+
     virtual muse::async::Channel<TrackItemKey> openContextMenuRequested() const = 0;
 };
 }

--- a/src/trackedit/internal/trackeditactionscontroller.cpp
+++ b/src/trackedit/internal/trackeditactionscontroller.cpp
@@ -687,7 +687,95 @@ void TrackeditActionsController::doGlobalDelete()
 void TrackeditActionsController::doGlobalCancel()
 {
     trackeditInteraction()->notifyAboutCancelDragEdit();
-    trackNavigationController()->resetNavigation();
+
+    const TrackItemKey focusedItem = trackNavigationController()->focusedItem();
+    const ClipKeyList selectedClips = selectionController()->selectedClips();
+    const LabelKeyList selectedLabels = selectionController()->selectedLabels();
+
+    const TrackId currentTrack = currentFocusedOrSelectedTrack();
+
+    //! [Stage 1] A clip/label is focused: drop the navigation focus, then step out of the current
+    //! item: onto the selection if the focus is not part of it, otherwise back onto the track.
+    if (focusedItem.isValid()) {
+        trackNavigationController()->resetNavigation();
+
+        if (stepFocusOutOfSelection(selectedClips, focusedItem, currentTrack,
+                                    [this]() { selectionController()->resetSelectedClips(); })) {
+            return;
+        }
+        if (stepFocusOutOfSelection(selectedLabels, focusedItem, currentTrack,
+                                    [this]() { selectionController()->resetSelectedLabels(); })) {
+            return;
+        }
+
+        focusTrack(currentTrack);
+        return;
+    }
+
+    //! [Stage 2] No item is focused: reset the active selection and move the focus back to the track.
+    if (!selectedClips.empty()) {
+        selectionController()->resetSelectedClips();
+    } else if (!selectedLabels.empty()) {
+        selectionController()->resetSelectedLabels();
+    } else if (!selectionController()->timeSelectionIsEmpty()) {
+        selectionController()->resetTimeSelection();
+    } else {
+        return;
+    }
+
+    focusTrack(currentTrack);
+}
+
+void TrackeditActionsController::focusTrack(const TrackId& trackId)
+{
+    if (trackId != INVALID_TRACK) {
+        trackNavigationController()->setFocusedTrack(trackId, false /*highlight*/);
+    }
+}
+
+bool TrackeditActionsController::stepFocusOutOfSelection(const TrackItemKeyList& selectedItems,
+                                                         const TrackItemKey& focusedItem, const TrackId& currentTrack,
+                                                         const std::function<void()>& resetSelection)
+{
+    if (selectedItems.empty()) {
+        return false;
+    }
+
+    //! NOTE: if the focus sits on one of the selected items, cancel that selection and fall back to
+    //! the track; otherwise step the focus onto the selection
+    if (muse::contains(selectedItems, focusedItem)) {
+        resetSelection();
+        focusTrack(currentTrack);
+    } else {
+        trackNavigationController()->setFocusedItem(selectedItems.front(), false /*highlight*/);
+    }
+
+    return true;
+}
+
+TrackId TrackeditActionsController::currentFocusedOrSelectedTrack() const
+{
+    const TrackId focusedTrack = trackNavigationController()->focusedItem().trackId;
+    if (focusedTrack != INVALID_TRACK) {
+        return focusedTrack;
+    }
+
+    const TrackIdList selectedTracks = selectionController()->selectedTracks();
+    if (!selectedTracks.empty()) {
+        return selectedTracks.front();
+    }
+
+    const ClipKeyList selectedClips = selectionController()->selectedClipsInTrackOrder();
+    if (!selectedClips.empty()) {
+        return selectedClips.front().trackId;
+    }
+
+    const LabelKeyList selectedLabels = selectionController()->selectedLabelsInTrackOrder();
+    if (!selectedLabels.empty()) {
+        return selectedLabels.front().trackId;
+    }
+
+    return INVALID_TRACK;
 }
 
 void TrackeditActionsController::doGlobalDeleteLeaveGap()

--- a/src/trackedit/internal/trackeditactionscontroller.cpp
+++ b/src/trackedit/internal/trackeditactionscontroller.cpp
@@ -2232,6 +2232,16 @@ void TrackeditActionsController::moveFocusedItemDown()
 
 void TrackeditActionsController::moveFocusedItem(secs_t timePositionOffset, int trackPositionOffset)
 {
+    const TrackItemKey focusedItem = trackNavigationController()->focusedItem();
+    const bool trackFocused = focusedItem.trackId != INVALID_TRACK && focusedItem.itemId == INVALID_TRACK_ITEM;
+    if (trackFocused) {
+        if (trackPositionOffset != 0) {
+            const TrackMoveDirection direction = trackPositionOffset < 0 ? TrackMoveDirection::Up : TrackMoveDirection::Down;
+            trackeditInteraction()->moveTracks({ focusedItem.trackId }, direction);
+        }
+        return;
+    }
+
     constexpr bool completed = false;
 
     if (!labelsForInteraction().empty()) {

--- a/src/trackedit/internal/trackeditactionscontroller.cpp
+++ b/src/trackedit/internal/trackeditactionscontroller.cpp
@@ -687,7 +687,7 @@ void TrackeditActionsController::doGlobalDelete()
 void TrackeditActionsController::doGlobalCancel()
 {
     trackeditInteraction()->notifyAboutCancelDragEdit();
-    trackNavigationController()->setIsNavigationActive(false);
+    navigationController()->setIsHighlight(false);
 }
 
 void TrackeditActionsController::doGlobalDeleteLeaveGap()

--- a/src/trackedit/internal/trackeditactionscontroller.cpp
+++ b/src/trackedit/internal/trackeditactionscontroller.cpp
@@ -687,7 +687,7 @@ void TrackeditActionsController::doGlobalDelete()
 void TrackeditActionsController::doGlobalCancel()
 {
     trackeditInteraction()->notifyAboutCancelDragEdit();
-    navigationController()->setIsHighlight(false);
+    trackNavigationController()->resetNavigation();
 }
 
 void TrackeditActionsController::doGlobalDeleteLeaveGap()

--- a/src/trackedit/internal/trackeditactionscontroller.cpp
+++ b/src/trackedit/internal/trackeditactionscontroller.cpp
@@ -2317,73 +2317,61 @@ void TrackeditActionsController::completeFocusedItemMove()
 
 void TrackeditActionsController::extendFocusedItemBoundaryLeft()
 {
-    if (!navigationController()->isHighlight()) {
-        dispatcher()->dispatch("sel-ext-left");
-        return;
-    }
-
     const double stepSize = calculateStepSize();
     static bool completed = true;
 
     if (!labelsForInteraction().empty()) {
         trackeditInteraction()->stretchLabelsLeft(labelsForInteraction(), -stepSize, completed);
-    } else {
+    } else if (!clipsForInteraction().empty()) {
         double minClipDuration = MIN_CLIP_WIDTH / zoomLevel();
         trackeditInteraction()->trimClipsLeft(clipsForInteraction(), -stepSize, minClipDuration, completed, UndoPushType::CONSOLIDATE);
+    } else {
+        dispatcher()->dispatch("sel-ext-left");
     }
 }
 
 void TrackeditActionsController::extendFocusedItemBoundaryRight()
 {
-    if (!navigationController()->isHighlight()) {
-        dispatcher()->dispatch("sel-ext-right");
-        return;
-    }
-
     const double stepSize = calculateStepSize();
     static bool completed = true;
 
     if (!labelsForInteraction().empty()) {
         trackeditInteraction()->stretchLabelsRight(labelsForInteraction(), stepSize, completed);
-    } else {
+    } else if (!clipsForInteraction().empty()) {
         double minClipDuration = MIN_CLIP_WIDTH / zoomLevel();
         trackeditInteraction()->trimClipsRight(clipsForInteraction(), -stepSize, minClipDuration, completed, UndoPushType::CONSOLIDATE);
+    } else {
+        dispatcher()->dispatch("sel-ext-right");
     }
 }
 
 void TrackeditActionsController::reduceFocusedItemBoundaryLeft()
 {
-    if (!navigationController()->isHighlight()) {
-        dispatcher()->dispatch("sel-cntr-right");
-        return;
-    }
-
     const double stepSize = calculateStepSize();
     static bool completed = true;
 
     if (!labelsForInteraction().empty()) {
         trackeditInteraction()->stretchLabelsRight(labelsForInteraction(), -stepSize, completed);
-    } else {
+    } else if (!clipsForInteraction().empty()) {
         double minClipDuration = MIN_CLIP_WIDTH / zoomLevel();
         trackeditInteraction()->trimClipsRight(clipsForInteraction(), stepSize, minClipDuration, completed, UndoPushType::CONSOLIDATE);
+    } else {
+        dispatcher()->dispatch("sel-cntr-right");
     }
 }
 
 void TrackeditActionsController::reduceFocusedItemBoundaryRight()
 {
-    if (!navigationController()->isHighlight()) {
-        dispatcher()->dispatch("sel-cntr-left");
-        return;
-    }
-
     const double stepSize = calculateStepSize();
     static bool completed = true;
 
     if (!labelsForInteraction().empty()) {
         trackeditInteraction()->stretchLabelsLeft(labelsForInteraction(), stepSize, completed);
-    } else {
+    } else if (!clipsForInteraction().empty()) {
         double minClipDuration = MIN_CLIP_WIDTH / zoomLevel();
         trackeditInteraction()->trimClipsLeft(clipsForInteraction(), stepSize, minClipDuration, completed, UndoPushType::CONSOLIDATE);
+    } else {
+        dispatcher()->dispatch("sel-cntr-left");
     }
 }
 

--- a/src/trackedit/internal/trackeditactionscontroller.h
+++ b/src/trackedit/internal/trackeditactionscontroller.h
@@ -3,6 +3,7 @@
 */
 #pragma once
 
+#include <functional>
 #include <optional>
 
 #include "framework/global/async/asyncable.h"
@@ -11,17 +12,18 @@
 #include "framework/global/modularity/ioc.h"
 #include "framework/interactive/iinteractive.h"
 #include "framework/actions/iactionsdispatcher.h"
+#include "framework/ui/inavigationcontroller.h"
 
 #include "audio/driver/iaudiodrivercontroller.h"
 #include "context/iglobalcontext.h"
 #include "projectscene/iprojectsceneconfiguration.h"
 #include "spectrogram/ifrequencyselectioncontroller.h"
 #include "spectrogram/ispectraleffectsregister.h"
-#include "iprojecthistory.h"
-#include "iselectioncontroller.h"
-#include "itrackeditconfiguration.h"
-#include "itrackeditinteraction.h"
-#include "internal/itracknavigationcontroller.h"
+#include "../iprojecthistory.h"
+#include "../iselectioncontroller.h"
+#include "../itrackeditconfiguration.h"
+#include "../itrackeditinteraction.h"
+#include "itracknavigationcontroller.h"
 
 #include "deletebehavioronboardingscenario.h"
 
@@ -43,6 +45,7 @@ class TrackeditActionsController : public ITrackeditActionsController, public mu
     muse::ContextInject<trackedit::ISelectionController> selectionController { this };
     muse::ContextInject<trackedit::ITrackeditInteraction> trackeditInteraction { this };
     muse::ContextInject<trackedit::ITrackNavigationController> trackNavigationController { this };
+    muse::ContextInject<muse::ui::INavigationController> navigationController { this };
     muse::ContextInject<spectrogram::IFrequencySelectionController> frequencySelectionController { this };
 
 public:
@@ -59,6 +62,8 @@ public:
     bool canReceiveAction(const muse::actions::ActionCode& actionCode) const override;
 
 private:
+    friend class TrackeditActionsControllerTests;
+
     void notifyActionEnabledChanged(const muse::actions::ActionCode& actionCode);
     void notifyActionCheckedChanged(const muse::actions::ActionCode& actionCode);
 
@@ -75,6 +80,11 @@ private:
 
     bool isFocusedItemLabel() const;
     LabelKeyList labelsForInteraction() const;
+
+    TrackId currentFocusedOrSelectedTrack() const;
+    void focusTrack(const TrackId& trackId);
+    bool stepFocusOutOfSelection(const TrackItemKeyList& selectedItems, const TrackItemKey& focusedItem, const TrackId& currentTrack,
+                                 const std::function<void()>& resetSelection);
 
     void undo();
     void redo();

--- a/src/trackedit/internal/trackeditactionscontroller.h
+++ b/src/trackedit/internal/trackeditactionscontroller.h
@@ -11,7 +11,6 @@
 #include "framework/global/modularity/ioc.h"
 #include "framework/interactive/iinteractive.h"
 #include "framework/actions/iactionsdispatcher.h"
-#include "framework/ui/inavigationcontroller.h"
 
 #include "audio/driver/iaudiodrivercontroller.h"
 #include "context/iglobalcontext.h"
@@ -44,7 +43,6 @@ class TrackeditActionsController : public ITrackeditActionsController, public mu
     muse::ContextInject<trackedit::ISelectionController> selectionController { this };
     muse::ContextInject<trackedit::ITrackeditInteraction> trackeditInteraction { this };
     muse::ContextInject<trackedit::ITrackNavigationController> trackNavigationController { this };
-    muse::ContextInject<muse::ui::INavigationController> navigationController { this };
     muse::ContextInject<spectrogram::IFrequencySelectionController> frequencySelectionController { this };
 
 public:

--- a/src/trackedit/internal/trackedituiactions.cpp
+++ b/src/trackedit/internal/trackedituiactions.cpp
@@ -441,19 +441,6 @@ UiActionList STATIC_ACTIONS = {
              TranslatableString("action", "Previous panel")
              ),
 
-    UiAction("track-view-next-item",
-             au::context::UiCtxProjectFocused,
-             au::context::CTX_PROJECT_FOCUSED,
-             TranslatableString("action", "Next item"),
-             TranslatableString("action", "Next item")
-             ),
-    UiAction("track-view-prev-item",
-             au::context::UiCtxProjectFocused,
-             au::context::CTX_PROJECT_FOCUSED,
-             TranslatableString("action", "Previous item"),
-             TranslatableString("action", "Previous item")
-             ),
-
     UiAction("track-view-above-item",
              au::context::UiCtxProjectFocused,
              au::context::CTX_PROJECT_FOCUSED,

--- a/src/trackedit/internal/tracknavigationcontroller.cpp
+++ b/src/trackedit/internal/tracknavigationcontroller.cpp
@@ -30,8 +30,6 @@ static const muse::actions::ActionCode TRACK_VIEW_RANGE_SELECTION_CODE("track-vi
 static const muse::actions::ActionCode TRACK_VIEW_TRACK_SELECTION_PREV_CODE("track-view-extend-track-selection-prev");
 static const muse::actions::ActionCode TRACK_VIEW_TRACK_SELECTION_NEXT_CODE("track-view-extend-track-selection-next");
 
-static const muse::actions::ActionCode TRACK_VIEW_NEXT_ITEM_CODE("track-view-next-item");
-static const muse::actions::ActionCode TRACK_VIEW_PREV_ITEM_CODE("track-view-prev-item");
 static const muse::actions::ActionCode TRACK_VIEW_ABOVE_ITEM_CODE("track-view-above-item");
 static const muse::actions::ActionCode TRACK_VIEW_BELOW_ITEM_CODE("track-view-below-item");
 
@@ -47,8 +45,6 @@ void TrackNavigationController::init()
     dispatcher()->reg(this, TRACK_VIEW_FIRST_TRACK_CODE, this, &TrackNavigationController::navigateToFirstTrack);
     dispatcher()->reg(this, TRACK_VIEW_LAST_TRACK_CODE, this, &TrackNavigationController::navigateToLastTrack);
 
-    dispatcher()->reg(this, TRACK_VIEW_NEXT_ITEM_CODE, this, &TrackNavigationController::navigateToNextItem);
-    dispatcher()->reg(this, TRACK_VIEW_PREV_ITEM_CODE, this, &TrackNavigationController::navigateToPrevItem);
     dispatcher()->reg(this, TRACK_VIEW_ABOVE_ITEM_CODE, this, &TrackNavigationController::navigateToAboveItem);
     dispatcher()->reg(this, TRACK_VIEW_BELOW_ITEM_CODE, this, &TrackNavigationController::navigateToBelowItem);
 
@@ -435,52 +431,6 @@ void TrackNavigationController::navigateToLastTrack()
     if (!trackList.empty()) {
         setFocusedTrack(trackList.back().id, true /*highlight*/);
     }
-}
-
-void TrackNavigationController::navigateToNextItem()
-{
-    if (m_focusedItemKey.itemId == INVALID_TRACK_ITEM) {
-        // dispatcher()->dispatch("play-position-increase");
-        return;
-    }
-
-    TrackItemKeyList itemsKeys = sortedItemsKeys(m_focusedItemKey.trackId);
-
-    for (size_t i = 0; i < itemsKeys.size(); ++i) {
-        if (itemsKeys[i].itemId == m_focusedItemKey.itemId) {
-            if (++i >= itemsKeys.size()) {
-                setFocusedItem(itemsKeys.front(), true /*highlight*/);
-            } else {
-                setFocusedItem(itemsKeys[i], true /*highlight*/);
-            }
-            break;
-        }
-    }
-
-    m_savedItemStartTime = std::nullopt;
-}
-
-void TrackNavigationController::navigateToPrevItem()
-{
-    if (m_focusedItemKey.itemId == INVALID_TRACK_ITEM) {
-        // dispatcher()->dispatch("play-position-decrease");
-        return;
-    }
-
-    TrackItemKeyList itemsKeys = sortedItemsKeys(m_focusedItemKey.trackId);
-
-    for (size_t i = 0; i < itemsKeys.size(); ++i) {
-        if (itemsKeys[i].itemId == m_focusedItemKey.itemId) {
-            if (i == 0) {
-                setFocusedItem(itemsKeys.back(), true /*highlight*/);
-            } else {
-                setFocusedItem(itemsKeys.at(i - 1), true /*highlight*/);
-            }
-            break;
-        }
-    }
-
-    m_savedItemStartTime = std::nullopt;
 }
 
 double TrackNavigationController::itemStartTime(const TrackItemKey& key) const

--- a/src/trackedit/internal/tracknavigationcontroller.cpp
+++ b/src/trackedit/internal/tracknavigationcontroller.cpp
@@ -270,6 +270,12 @@ TrackItemKeyList TrackNavigationController::itemKeysInRange(const TrackItemKey& 
     return range;
 }
 
+void TrackNavigationController::resetNavigation()
+{
+    m_savedItemStartTime = std::nullopt;
+    navigationController()->setIsHighlight(false);
+}
+
 bool TrackNavigationController::isTrackItemsEmpty(const TrackId& trackId) const
 {
     TrackItemKeyList itemsKeys = sortedItemsKeys(trackId);

--- a/src/trackedit/internal/tracknavigationcontroller.cpp
+++ b/src/trackedit/internal/tracknavigationcontroller.cpp
@@ -317,46 +317,52 @@ bool TrackNavigationController::isLastTrack(const TrackId& trackId) const
 
 void TrackNavigationController::navigateToNextPanel()
 {
-    bool isTrackPanel = m_focusedItemKey.itemId == INVALID_TRACK_ITEM;
-
-    if (isTrackPanel) {
-        if (isTrackItemsEmpty(m_focusedItemKey.trackId)) {
-            commandDispatcher()->dispatch(muse::ui::NEXT_PANEL_COMMAND);
-        } else {
-            navigateToFirstItem();
-        }
+    if (navigateToAdjacentItem(true /*next*/)) {
         return;
     }
 
-    if (isLastTrack(m_focusedItemKey.trackId)) {
-        commandDispatcher()->dispatch(muse::ui::NEXT_PANEL_COMMAND);
-        return;
-    }
-
-    navigateToNextTrack();
+    commandDispatcher()->dispatch(muse::ui::NEXT_PANEL_COMMAND);
 }
 
 void TrackNavigationController::navigateToPrevPanel()
 {
-    bool isTrackPanel = m_focusedItemKey.itemId == INVALID_TRACK_ITEM;
-
-    if (!isTrackPanel) {
-        setFocusedTrack(m_focusedItemKey.trackId, true /*highlight*/);
+    if (navigateToAdjacentItem(false /*next*/)) {
         return;
     }
 
-    m_focusedItemKey.itemId = INVALID_TRACK_ITEM;
+    commandDispatcher()->dispatch(muse::ui::PREV_PANEL_COMMAND);
+}
 
-    if (isFirstTrack(m_focusedItemKey.trackId)) {
-        commandDispatcher()->dispatch(muse::ui::PREV_PANEL_COMMAND);
-        return;
+bool TrackNavigationController::navigateToAdjacentItem(bool next)
+{
+    if (m_focusedItemKey.itemId == INVALID_TRACK_ITEM) {
+        return false;
     }
 
-    navigateToPrevTrack();
+    const TrackItemKeyList itemsKeys = sortedItemsKeys(m_focusedItemKey.trackId);
 
-    if (!isTrackItemsEmpty(m_focusedItemKey.trackId)) {
-        navigateToLastItem();
+    for (size_t i = 0; i < itemsKeys.size(); ++i) {
+        if (itemsKeys.at(i).itemId != m_focusedItemKey.itemId) {
+            continue;
+        }
+
+        if (next) {
+            if (i + 1 >= itemsKeys.size()) {
+                return false;
+            }
+            setFocusedItem(itemsKeys.at(i + 1), true /*highlight*/);
+        } else {
+            if (i == 0) {
+                return false;
+            }
+            setFocusedItem(itemsKeys.at(i - 1), true /*highlight*/);
+        }
+
+        m_savedItemStartTime = std::nullopt;
+        return true;
     }
+
+    return false;
 }
 
 void TrackNavigationController::navigateToPrevTrack()

--- a/src/trackedit/internal/tracknavigationcontroller.cpp
+++ b/src/trackedit/internal/tracknavigationcontroller.cpp
@@ -433,17 +433,12 @@ void TrackNavigationController::navigateToLastTrack()
 
 void TrackNavigationController::navigateToNextItem()
 {
-    if (!navigationController()->isHighlight()) {
-        dispatcher()->dispatch("play-position-increase");
+    if (m_focusedItemKey.itemId == INVALID_TRACK_ITEM) {
+        // dispatcher()->dispatch("play-position-increase");
         return;
     }
 
     TrackItemKeyList itemsKeys = sortedItemsKeys(m_focusedItemKey.trackId);
-
-    if (m_focusedItemKey.itemId == INVALID_TRACK_ITEM) {
-        commandDispatcher()->dispatch(muse::ui::RIGHT_COMMAND);
-        return;
-    }
 
     for (size_t i = 0; i < itemsKeys.size(); ++i) {
         if (itemsKeys[i].itemId == m_focusedItemKey.itemId) {
@@ -461,17 +456,12 @@ void TrackNavigationController::navigateToNextItem()
 
 void TrackNavigationController::navigateToPrevItem()
 {
-    if (!navigationController()->isHighlight()) {
-        dispatcher()->dispatch("play-position-decrease");
+    if (m_focusedItemKey.itemId == INVALID_TRACK_ITEM) {
+        // dispatcher()->dispatch("play-position-decrease");
         return;
     }
 
     TrackItemKeyList itemsKeys = sortedItemsKeys(m_focusedItemKey.trackId);
-
-    if (m_focusedItemKey.itemId == INVALID_TRACK_ITEM) {
-        commandDispatcher()->dispatch(muse::ui::LEFT_COMMAND);
-        return;
-    }
 
     for (size_t i = 0; i < itemsKeys.size(); ++i) {
         if (itemsKeys[i].itemId == m_focusedItemKey.itemId) {

--- a/src/trackedit/internal/tracknavigationcontroller.cpp
+++ b/src/trackedit/internal/tracknavigationcontroller.cpp
@@ -61,11 +61,6 @@ void TrackNavigationController::init()
         m_selectionStart = std::nullopt;
     });
 
-    dispatcher()->reg(this, "nav-escape", [this] {
-        m_savedItemStartTime = std::nullopt;
-        navigationController()->setIsHighlight(false);
-    });
-
     selectionController()->tracksSelected().onReceive(this, [this](const trackedit::TrackIdList& trackIds) {
         if (trackIds.size() == 1) {
             // The idea here is that range selection also supports the base track to be selected using the mouse.

--- a/src/trackedit/internal/tracknavigationcontroller.cpp
+++ b/src/trackedit/internal/tracknavigationcontroller.cpp
@@ -780,7 +780,7 @@ void TrackNavigationController::updateTrackSelection(TrackIdList& selectedTracks
 
 void TrackNavigationController::openContextMenuForFocusedItem()
 {
-    if (!isFocusedItemValid()) {
+    if (m_focusedItemKey.trackId == INVALID_TRACK) {
         return;
     }
 

--- a/src/trackedit/internal/tracknavigationcontroller.h
+++ b/src/trackedit/internal/tracknavigationcontroller.h
@@ -10,7 +10,6 @@
 #include "framework/global/modularity/ioc.h"
 #include "framework/actions/iactionsdispatcher.h"
 #include "framework/rcommand/icommanddispatcher.h"
-#include "framework/ui/inavigationcontroller.h"
 #include "trackedit/iselectioncontroller.h"
 #include "context/iglobalcontext.h"
 #include "trackedit/itrackeditinteraction.h"
@@ -28,7 +27,6 @@ class TrackNavigationController : public ITrackNavigationController, public muse
 {
     muse::ContextInject<muse::actions::IActionsDispatcher> dispatcher{ this };
     muse::ContextInject<muse::rcommand::ICommandDispatcher> commandDispatcher{ this };
-    muse::ContextInject<muse::ui::INavigationController> navigationController{ this };
     muse::ContextInject<au::context::IGlobalContext> globalContext{ this };
     muse::ContextInject<au::trackedit::ISelectionController> selectionController{ this };
     muse::ContextInject<au::trackedit::ITrackeditInteraction> trackeditInteraction{ this };

--- a/src/trackedit/internal/tracknavigationcontroller.h
+++ b/src/trackedit/internal/tracknavigationcontroller.h
@@ -71,6 +71,8 @@ private:
     void navigateToNextPanel();
     void navigateToPrevPanel();
 
+    bool navigateToAdjacentItem(bool next);
+
     void navigateToPrevTrack();
     void navigateToNextTrack();
     void navigateToFirstTrack();

--- a/src/trackedit/internal/tracknavigationcontroller.h
+++ b/src/trackedit/internal/tracknavigationcontroller.h
@@ -78,8 +78,6 @@ private:
     void navigateToFirstTrack();
     void navigateToLastTrack();
 
-    void navigateToNextItem();
-    void navigateToPrevItem();
     void navigateToAboveItem();
     void navigateToBelowItem();
     void navigateToFirstItem();

--- a/src/trackedit/internal/tracknavigationcontroller.h
+++ b/src/trackedit/internal/tracknavigationcontroller.h
@@ -10,6 +10,7 @@
 #include "framework/global/modularity/ioc.h"
 #include "framework/actions/iactionsdispatcher.h"
 #include "framework/rcommand/icommanddispatcher.h"
+#include "framework/ui/inavigationcontroller.h"
 #include "trackedit/iselectioncontroller.h"
 #include "context/iglobalcontext.h"
 #include "trackedit/itrackeditinteraction.h"
@@ -27,6 +28,7 @@ class TrackNavigationController : public ITrackNavigationController, public muse
 {
     muse::ContextInject<muse::actions::IActionsDispatcher> dispatcher{ this };
     muse::ContextInject<muse::rcommand::ICommandDispatcher> commandDispatcher{ this };
+    muse::ContextInject<muse::ui::INavigationController> navigationController{ this };
     muse::ContextInject<au::context::IGlobalContext> globalContext{ this };
     muse::ContextInject<au::trackedit::ISelectionController> selectionController{ this };
     muse::ContextInject<au::trackedit::ITrackeditInteraction> trackeditInteraction{ this };
@@ -50,6 +52,8 @@ public:
     muse::async::Channel<TrackItemKey, bool /*highlight*/> focusedItemChanged() const override;
 
     TrackItemKeyList itemKeysInRange(const TrackItemKey& anchor, const TrackItemKey& target) const override;
+
+    void resetNavigation() override;
 
     muse::async::Channel<TrackItemKey> openContextMenuRequested() const override;
 

--- a/src/trackedit/tests/CMakeLists.txt
+++ b/src/trackedit/tests/CMakeLists.txt
@@ -17,6 +17,7 @@ set(MODULE_TEST_SRC
     ${CMAKE_CURRENT_LIST_DIR}/mocks/navigationcontrollermock.h
 
     ${CMAKE_CURRENT_LIST_DIR}/tracknavigationcontroller_tests.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/tracknavigationmodel_tests.cpp
     ${CMAKE_CURRENT_LIST_DIR}/au3tracksinteraction_tests.cpp
     ${CMAKE_CURRENT_LIST_DIR}/au3clipsinteraction_tests.cpp
     ${CMAKE_CURRENT_LIST_DIR}/au3labelsinteractions_tests.cpp
@@ -30,6 +31,9 @@ set(MODULE_TEST_LINK
     au3wrap
 
     muse::ui
+    muse::ui_qml
+
+    Qt::Quick
     )
 
 set(MODULE_TEST_DATA_ROOT ${CMAKE_CURRENT_LIST_DIR})

--- a/src/trackedit/tests/CMakeLists.txt
+++ b/src/trackedit/tests/CMakeLists.txt
@@ -15,7 +15,9 @@ set(MODULE_TEST_SRC
     ${CMAKE_CURRENT_LIST_DIR}/mocks/projecthistorymock.h
     ${CMAKE_CURRENT_LIST_DIR}/mocks/tracknavigationcontrollermock.h
     ${CMAKE_CURRENT_LIST_DIR}/mocks/navigationcontrollermock.h
+    ${CMAKE_CURRENT_LIST_DIR}/mocks/trackeditinteractionmock.h
 
+    ${CMAKE_CURRENT_LIST_DIR}/trackeditactionscontroller_tests.cpp
     ${CMAKE_CURRENT_LIST_DIR}/tracknavigationcontroller_tests.cpp
     ${CMAKE_CURRENT_LIST_DIR}/tracknavigationmodel_tests.cpp
     ${CMAKE_CURRENT_LIST_DIR}/au3tracksinteraction_tests.cpp
@@ -28,6 +30,7 @@ set(MODULE_TEST_SRC
 
 set(MODULE_TEST_LINK
     trackedit
+    spectrogram
     au3wrap
 
     muse::ui

--- a/src/trackedit/tests/mocks/tracknavigationcontrollermock.h
+++ b/src/trackedit/tests/mocks/tracknavigationcontrollermock.h
@@ -25,6 +25,8 @@ public:
 
     MOCK_METHOD(TrackItemKeyList, itemKeysInRange, (const TrackItemKey& anchor, const TrackItemKey& target), (const, override));
 
+    MOCK_METHOD(void, resetNavigation, (), (override));
+
     MOCK_METHOD(muse::async::Channel<TrackItemKey>, openContextMenuRequested, (), (const, override));
 };
 }

--- a/src/trackedit/tests/trackeditactionscontroller_tests.cpp
+++ b/src/trackedit/tests/trackeditactionscontroller_tests.cpp
@@ -1,0 +1,293 @@
+/*
+* Audacity: A Digital Audio Editor
+*/
+#include <gtest/gtest.h>
+
+#include "trackedit/internal/trackeditactionscontroller.h"
+
+#include "mocks/selectioncontrollermock.h"
+#include "mocks/tracknavigationcontrollermock.h"
+#include "mocks/trackeditinteractionmock.h"
+
+using ::testing::NiceMock;
+using ::testing::Return;
+
+namespace au::trackedit {
+class TrackeditActionsControllerTests : public ::testing::Test
+{
+public:
+    void SetUp() override
+    {
+        m_selectionController = std::make_shared<NiceMock<SelectionControllerMock> >();
+        m_trackNavigationController = std::make_shared<NiceMock<TrackNavigationControllerMock> >();
+        m_trackeditInteraction = std::make_shared<NiceMock<TrackeditInteractionMock> >();
+
+        m_testCtx = std::make_shared<muse::modularity::Context>(999);
+        m_controller = std::make_shared<TrackeditActionsController>(m_testCtx);
+
+        m_controller->selectionController.set(m_selectionController);
+        m_controller->trackNavigationController.set(m_trackNavigationController);
+        m_controller->trackeditInteraction.set(m_trackeditInteraction);
+
+        ON_CALL(*m_trackNavigationController, focusedItem())
+        .WillByDefault(Return(TrackItemKey { INVALID_TRACK, INVALID_TRACK_ITEM }));
+
+        ON_CALL(*m_selectionController, selectedClips())
+        .WillByDefault(Return(ClipKeyList {}));
+        ON_CALL(*m_selectionController, selectedClipsInTrackOrder())
+        .WillByDefault(Return(ClipKeyList {}));
+        ON_CALL(*m_selectionController, selectedLabels())
+        .WillByDefault(Return(LabelKeyList {}));
+        ON_CALL(*m_selectionController, selectedLabelsInTrackOrder())
+        .WillByDefault(Return(LabelKeyList {}));
+        ON_CALL(*m_selectionController, selectedTracks())
+        .WillByDefault(Return(TrackIdList {}));
+        ON_CALL(*m_selectionController, timeSelectionIsEmpty())
+        .WillByDefault(Return(true));
+    }
+
+    void TearDown() override
+    {
+        m_controller.reset();
+        muse::modularity::removeIoC(m_testCtx);
+    }
+
+    void cancel()
+    {
+        m_controller->doGlobalCancel();
+    }
+
+    std::shared_ptr<muse::modularity::Context> m_testCtx;
+    std::shared_ptr<TrackeditActionsController> m_controller;
+
+    std::shared_ptr<SelectionControllerMock> m_selectionController;
+    std::shared_ptr<TrackNavigationControllerMock> m_trackNavigationController;
+    std::shared_ptr<TrackeditInteractionMock> m_trackeditInteraction;
+};
+
+/**
+ * Cancel always notifies about the in-progress drag edit being cancelled.
+ */
+TEST_F(TrackeditActionsControllerTests, AlwaysNotifiesCancelDragEdit)
+{
+    EXPECT_CALL(*m_trackeditInteraction, notifyAboutCancelDragEdit()).Times(1);
+
+    cancel();
+}
+
+/**
+ * [Stage 1] A clip is focused with no selection: the focus is dropped and moved onto the
+ * clip's own track.
+ */
+TEST_F(TrackeditActionsControllerTests, ClipFocusNoSelection_DropsFocusAndFocusesTrack)
+{
+    //! [GIVEN] A clip is focused on track 1, nothing is selected
+    ON_CALL(*m_trackNavigationController, focusedItem())
+    .WillByDefault(Return(TrackItemKey { 1, 100 }));
+
+    //! [EXPECT] The focus is dropped and moved to the focused clip's track (no item focus)
+    EXPECT_CALL(*m_trackNavigationController, resetNavigation()).Times(1);
+    EXPECT_CALL(*m_trackNavigationController, setFocusedTrack(1, false)).Times(1);
+    EXPECT_CALL(*m_trackNavigationController, setFocusedItem(::testing::_, ::testing::_)).Times(0);
+
+    cancel();
+}
+
+/**
+ * [Stage 1] A clip is focused while clips are selected: the focus is dropped and moved onto
+ * the first selected clip.
+ */
+TEST_F(TrackeditActionsControllerTests, ClipFocusWithClipSelection_MovesFocusToSelectedClip)
+{
+    //! [GIVEN] A clip is focused, and clip {2, 200} is selected
+    ON_CALL(*m_trackNavigationController, focusedItem())
+    .WillByDefault(Return(TrackItemKey { 1, 100 }));
+    ON_CALL(*m_selectionController, selectedClips())
+    .WillByDefault(Return(ClipKeyList { { 2, 200 } }));
+
+    //! [EXPECT] The focus is dropped and moved onto the selected clip
+    EXPECT_CALL(*m_trackNavigationController, resetNavigation()).Times(1);
+    EXPECT_CALL(*m_trackNavigationController, setFocusedItem(TrackItemKey { 2, 200 }, false)).Times(1);
+    EXPECT_CALL(*m_trackNavigationController, setFocusedTrack(::testing::_, ::testing::_)).Times(0);
+    EXPECT_CALL(*m_selectionController, resetSelectedClips()).Times(0);
+
+    cancel();
+}
+
+/**
+ * [Stage 1] A clip is focused while only labels are selected: the focus is dropped and moved
+ * onto the first selected label.
+ */
+TEST_F(TrackeditActionsControllerTests, ClipFocusWithLabelSelection_MovesFocusToSelectedLabel)
+{
+    //! [GIVEN] A clip is focused, no clips selected, label {3, 300} is selected
+    ON_CALL(*m_trackNavigationController, focusedItem())
+    .WillByDefault(Return(TrackItemKey { 1, 100 }));
+    ON_CALL(*m_selectionController, selectedLabels())
+    .WillByDefault(Return(LabelKeyList { { 3, 300 } }));
+
+    //! [EXPECT] The focus is dropped and moved onto the selected label
+    EXPECT_CALL(*m_trackNavigationController, resetNavigation()).Times(1);
+    EXPECT_CALL(*m_trackNavigationController, setFocusedItem(TrackItemKey { 3, 300 }, false)).Times(1);
+    EXPECT_CALL(*m_trackNavigationController, setFocusedTrack(::testing::_, ::testing::_)).Times(0);
+
+    cancel();
+}
+
+/**
+ * [Stage 1] The focused clip is itself part of the clip selection: the focus is dropped, the clip
+ * selection is cleared and the focus falls back to the current track.
+ */
+TEST_F(TrackeditActionsControllerTests, ClipFocusOnSelectedClip_DeselectsAndFocusesTrack)
+{
+    //! [GIVEN] Clip {2, 200} is focused and is part of the clip selection
+    ON_CALL(*m_trackNavigationController, focusedItem())
+    .WillByDefault(Return(TrackItemKey { 2, 200 }));
+    ON_CALL(*m_selectionController, selectedClips())
+    .WillByDefault(Return(ClipKeyList { { 2, 200 } }));
+
+    //! [EXPECT] The focus is dropped, the clip selection cleared and the clip's track focused
+    EXPECT_CALL(*m_trackNavigationController, resetNavigation()).Times(1);
+    EXPECT_CALL(*m_selectionController, resetSelectedClips()).Times(1);
+    EXPECT_CALL(*m_trackNavigationController, setFocusedTrack(2, false)).Times(1);
+    EXPECT_CALL(*m_trackNavigationController, setFocusedItem(::testing::_, ::testing::_)).Times(0);
+
+    cancel();
+}
+
+/**
+ * [Stage 1] The focused label is itself part of the label selection: the focus is dropped, the
+ * label selection is cleared and the focus falls back to the current track.
+ */
+TEST_F(TrackeditActionsControllerTests, LabelFocusOnSelectedLabel_DeselectsAndFocusesTrack)
+{
+    //! [GIVEN] Label {3, 300} is focused and is part of the label selection (no clips selected)
+    ON_CALL(*m_trackNavigationController, focusedItem())
+    .WillByDefault(Return(TrackItemKey { 3, 300 }));
+    ON_CALL(*m_selectionController, selectedLabels())
+    .WillByDefault(Return(LabelKeyList { { 3, 300 } }));
+
+    //! [EXPECT] The focus is dropped, the label selection cleared and the label's track focused
+    EXPECT_CALL(*m_trackNavigationController, resetNavigation()).Times(1);
+    EXPECT_CALL(*m_selectionController, resetSelectedLabels()).Times(1);
+    EXPECT_CALL(*m_trackNavigationController, setFocusedTrack(3, false)).Times(1);
+    EXPECT_CALL(*m_trackNavigationController, setFocusedItem(::testing::_, ::testing::_)).Times(0);
+
+    cancel();
+}
+
+/**
+ * A track (no item) is focused with no selection: Escape only cancels the drag edit; there is
+ * no item focus to drop and no selection to reset.
+ */
+TEST_F(TrackeditActionsControllerTests, TrackFocusNoSelection_OnlyCancelsDragEdit)
+{
+    //! [GIVEN] A track (no item) is focused, nothing is selected
+    ON_CALL(*m_trackNavigationController, focusedItem())
+    .WillByDefault(Return(TrackItemKey { 1, INVALID_TRACK_ITEM }));
+
+    //! [EXPECT] Only the drag edit is cancelled
+    EXPECT_CALL(*m_trackeditInteraction, notifyAboutCancelDragEdit()).Times(1);
+    EXPECT_CALL(*m_trackNavigationController, resetNavigation()).Times(0);
+    EXPECT_CALL(*m_trackNavigationController, setFocusedItem(::testing::_, ::testing::_)).Times(0);
+    EXPECT_CALL(*m_trackNavigationController, setFocusedTrack(::testing::_, ::testing::_)).Times(0);
+
+    cancel();
+}
+
+/**
+ * [Stage 2] A track is focused while clips are selected: the clip selection is reset and the
+ * focus stays on the current track.
+ */
+TEST_F(TrackeditActionsControllerTests, TrackFocusWithClipSelection_ResetsSelectionAndFocusesTrack)
+{
+    //! [GIVEN] Track 1 is focused (no item), and clip {2, 200} is selected
+    ON_CALL(*m_trackNavigationController, focusedItem())
+    .WillByDefault(Return(TrackItemKey { 1, INVALID_TRACK_ITEM }));
+    ON_CALL(*m_selectionController, selectedClips())
+    .WillByDefault(Return(ClipKeyList { { 2, 200 } }));
+
+    //! [EXPECT] The clip selection is reset and the current (focused) track is focused
+    EXPECT_CALL(*m_selectionController, resetSelectedClips()).Times(1);
+    EXPECT_CALL(*m_trackNavigationController, setFocusedTrack(1, false)).Times(1);
+    EXPECT_CALL(*m_trackNavigationController, resetNavigation()).Times(0);
+
+    cancel();
+}
+
+/**
+ * [Stage 2] Clips are selected with nothing focused: the clip selection is reset and the focus
+ * moves to the selected clip's track.
+ */
+TEST_F(TrackeditActionsControllerTests, ClipSelectionNoFocus_ResetsSelectionAndFocusesClipTrack)
+{
+    //! [GIVEN] Nothing focused, clip {2, 200} selected, no track selected
+    ON_CALL(*m_selectionController, selectedClips())
+    .WillByDefault(Return(ClipKeyList { { 2, 200 } }));
+    ON_CALL(*m_selectionController, selectedClipsInTrackOrder())
+    .WillByDefault(Return(ClipKeyList { { 2, 200 } }));
+
+    //! [EXPECT] The clip selection is reset and the clip's track is focused
+    EXPECT_CALL(*m_selectionController, resetSelectedClips()).Times(1);
+    EXPECT_CALL(*m_trackNavigationController, setFocusedTrack(2, false)).Times(1);
+    EXPECT_CALL(*m_trackNavigationController, resetNavigation()).Times(0);
+
+    cancel();
+}
+
+/**
+ * [Stage 2] Labels are selected with nothing focused: the label selection is reset and the focus
+ * moves to the selected label's track.
+ */
+TEST_F(TrackeditActionsControllerTests, LabelSelectionNoFocus_ResetsSelectionAndFocusesLabelTrack)
+{
+    //! [GIVEN] Nothing focused, no clips selected, label {3, 300} selected
+    ON_CALL(*m_selectionController, selectedLabels())
+    .WillByDefault(Return(LabelKeyList { { 3, 300 } }));
+    ON_CALL(*m_selectionController, selectedLabelsInTrackOrder())
+    .WillByDefault(Return(LabelKeyList { { 3, 300 } }));
+
+    //! [EXPECT] The label selection is reset and the label's track is focused
+    EXPECT_CALL(*m_selectionController, resetSelectedLabels()).Times(1);
+    EXPECT_CALL(*m_trackNavigationController, setFocusedTrack(3, false)).Times(1);
+    EXPECT_CALL(*m_selectionController, resetSelectedClips()).Times(0);
+
+    cancel();
+}
+
+/**
+ * [Stage 2] A data range (time) selection with nothing focused: the time selection is reset and
+ * the focus moves to the selected track.
+ */
+TEST_F(TrackeditActionsControllerTests, TimeSelectionNoFocus_ResetsTimeSelectionAndFocusesTrack)
+{
+    //! [GIVEN] Nothing focused, no clips/labels, a time selection on track 5
+    ON_CALL(*m_selectionController, timeSelectionIsEmpty())
+    .WillByDefault(Return(false));
+    ON_CALL(*m_selectionController, selectedTracks())
+    .WillByDefault(Return(TrackIdList { 5 }));
+
+    //! [EXPECT] The time selection is reset and the selected track is focused
+    EXPECT_CALL(*m_selectionController, resetTimeSelection()).Times(1);
+    EXPECT_CALL(*m_trackNavigationController, setFocusedTrack(5, false)).Times(1);
+    EXPECT_CALL(*m_selectionController, resetSelectedClips()).Times(0);
+    EXPECT_CALL(*m_selectionController, resetSelectedLabels()).Times(0);
+
+    cancel();
+}
+
+/**
+ * Nothing is focused and nothing is selected: Escape only cancels the drag edit.
+ */
+TEST_F(TrackeditActionsControllerTests, NoFocusNoSelection_OnlyCancelsDragEdit)
+{
+    //! [EXPECT] Only the drag edit is cancelled, nothing else changes
+    EXPECT_CALL(*m_trackeditInteraction, notifyAboutCancelDragEdit()).Times(1);
+    EXPECT_CALL(*m_trackNavigationController, resetNavigation()).Times(0);
+    EXPECT_CALL(*m_trackNavigationController, setFocusedTrack(::testing::_, ::testing::_)).Times(0);
+    EXPECT_CALL(*m_trackNavigationController, setFocusedItem(::testing::_, ::testing::_)).Times(0);
+    EXPECT_CALL(*m_selectionController, resetTimeSelection()).Times(0);
+
+    cancel();
+}
+}

--- a/src/trackedit/tests/tracknavigationcontroller_tests.cpp
+++ b/src/trackedit/tests/tracknavigationcontroller_tests.cpp
@@ -9,7 +9,6 @@
 #include "framework/ui/navigationcommands.h"
 #include "mocks/commanddispatchermock.h"
 #include "context/tests/mocks/globalcontextmock.h"
-#include "mocks/navigationcontrollermock.h"
 #include "mocks/selectioncontrollermock.h"
 #include "mocks/trackeditinteractionmock.h"
 #include "mocks/trackeditprojectmock.h"
@@ -24,10 +23,10 @@ namespace au::trackedit {
 /*******************************************************************************
  * TRACK NAVIGATION CONTROLLER TESTS
  *
- * Verifies arrow key behavior based on navigation highlight state:
- * - When highlight is off (default): arrows move the playhead
- * - When highlight is on (after Tab): arrows navigate clips
- * - Escape dismisses highlight, returning arrows to playhead movement
+ * Verifies the Tab / Shift+Tab panel navigation of the track view:
+ * - on a clip it steps to the adjacent clip of the same track
+ * - on the edge clip (or a track without a focused clip) it hands over to the
+ *   framework panel navigation (NEXT_PANEL_COMMAND / PREV_PANEL_COMMAND)
  ******************************************************************************/
 
 class TrackNavigationControllerTests : public ::testing::Test
@@ -37,7 +36,6 @@ public:
     {
         m_dispatcher = std::make_shared<NiceMock<muse::actions::ActionsDispatcherMock> >();
         m_commandDispatcher = std::make_shared<NiceMock<muse::rcommand::CommandDispatcherMock> >();
-        m_navigationController = std::make_shared<NiceMock<muse::ui::NavigationControllerMock> >();
         m_globalContext = std::make_shared<NiceMock<context::GlobalContextMock> >();
         m_selectionController = std::make_shared<NiceMock<SelectionControllerMock> >();
         m_trackeditInteraction = std::make_shared<NiceMock<TrackeditInteractionMock> >();
@@ -56,7 +54,6 @@ public:
                 return resolve(muse::rcommand::make_response(request, muse::make_ok()));
             });
         });
-        m_controller->navigationController.set(m_navigationController);
         m_controller->globalContext.set(m_globalContext);
         m_controller->selectionController.set(m_selectionController);
         m_controller->trackeditInteraction.set(m_trackeditInteraction);
@@ -99,11 +96,44 @@ public:
         it->second(code, muse::actions::ActionData());
     }
 
+    static Clip makeClip(const TrackId& trackId, const TrackItemId& itemId, double startTime)
+    {
+        Clip clip;
+        clip.key = { trackId, itemId };
+        clip.startTime = startTime;
+        return clip;
+    }
+
+    void setupTrackWithClips(const TrackId& trackId, const std::vector<Clip>& clips)
+    {
+        Track track;
+        track.id = trackId;
+        track.type = TrackType::Mono;
+
+        ON_CALL(*m_trackeditProject, track(trackId))
+        .WillByDefault(Return(track));
+        ON_CALL(*m_trackeditProject, clipList(trackId))
+        .WillByDefault([clips](const TrackId&) {
+            muse::async::NotifyList<Clip> list;
+            for (const Clip& clip : clips) {
+                list.push_back(clip);
+            }
+            return list;
+        });
+    }
+
+    //! NOTE Matcher for a framework panel-navigation command dispatch
+    static auto isPanelCommand(const muse::rcommand::Command& command)
+    {
+        return ::testing::Truly([command](const muse::rcommand::Request& request) {
+            return request.query.uri() == command;
+        });
+    }
+
     std::shared_ptr<muse::modularity::Context> m_testCtx;
     std::shared_ptr<TrackNavigationController> m_controller;
     std::shared_ptr<muse::actions::ActionsDispatcherMock> m_dispatcher;
     std::shared_ptr<muse::rcommand::CommandDispatcherMock> m_commandDispatcher;
-    std::shared_ptr<muse::ui::NavigationControllerMock> m_navigationController;
     std::shared_ptr<context::GlobalContextMock> m_globalContext;
     std::shared_ptr<SelectionControllerMock> m_selectionController;
     std::shared_ptr<TrackeditInteractionMock> m_trackeditInteraction;
@@ -113,141 +143,109 @@ public:
 };
 
 /**
- * Test 1: When project just opened (no highlight), right arrow should move playhead
+ * Tab, while a clip is focused, steps to the next clip of the same track without
+ * handing over to framework panel navigation.
  */
-TEST_F(TrackNavigationControllerTests, RightArrowMovesPlayheadWhenNoHighlight)
+TEST_F(TrackNavigationControllerTests, TabOnClipStepsToNextClip)
 {
-    //! [GIVEN] Navigation highlight is off (default after opening project)
-    ON_CALL(*m_navigationController, isHighlight())
-    .WillByDefault(Return(false));
+    //! [GIVEN] A track with two clips, focus on the first clip
+    setupTrackWithClips(1, { makeClip(1, 100, 0.0), makeClip(1, 200, 2.0) });
 
-    //! [GIVEN] Controller is initialized
     initController();
+    m_controller->setFocusedItem({ 1, 100 });
 
-    //! [EXPECT] Playhead move action is dispatched
-    EXPECT_CALL(*m_dispatcher, dispatch(muse::actions::ActionCode("play-position-increase"))).Times(1);
+    //! [EXPECT] Framework panel navigation is NOT dispatched
+    EXPECT_CALL(*m_commandDispatcher, dispatch(isPanelCommand(muse::ui::NEXT_PANEL_COMMAND))).Times(0);
 
-    //! [WHEN] Right arrow is pressed (track-view-next-item is dispatched by shortcut system)
-    invokeAction("track-view-next-item");
+    //! [WHEN] Tab is pressed
+    invokeAction("track-view-next-panel");
+
+    //! [THEN] Focus moves to the next clip
+    EXPECT_EQ(m_controller->focusedItem(), (TrackItemKey { 1, 200 }));
 }
 
 /**
- * Test 2: When project just opened (no highlight), left arrow should move playhead
+ * Tab, while the last clip of a track is focused, hands over to the framework
+ * panel navigation and leaves the focus untouched.
  */
-TEST_F(TrackNavigationControllerTests, LeftArrowMovesPlayheadWhenNoHighlight)
+TEST_F(TrackNavigationControllerTests, TabOnLastClipHandsOverToNextPanel)
 {
-    //! [GIVEN] Navigation highlight is off
-    ON_CALL(*m_navigationController, isHighlight())
-    .WillByDefault(Return(false));
+    //! [GIVEN] A track with two clips, focus on the last clip
+    setupTrackWithClips(1, { makeClip(1, 100, 0.0), makeClip(1, 200, 2.0) });
 
-    //! [GIVEN] Controller is initialized
     initController();
+    m_controller->setFocusedItem({ 1, 200 });
 
-    //! [EXPECT] Playhead move action is dispatched
-    EXPECT_CALL(*m_dispatcher, dispatch(muse::actions::ActionCode("play-position-decrease"))).Times(1);
+    //! [EXPECT] Framework panel navigation is dispatched
+    EXPECT_CALL(*m_commandDispatcher, dispatch(isPanelCommand(muse::ui::NEXT_PANEL_COMMAND))).Times(1);
 
-    //! [WHEN] Left arrow is pressed
-    invokeAction("track-view-prev-item");
+    //! [WHEN] Tab is pressed
+    invokeAction("track-view-next-panel");
+
+    //! [THEN] Focus stays on the last clip
+    EXPECT_EQ(m_controller->focusedItem(), (TrackItemKey { 1, 200 }));
 }
 
 /**
- * Test 3: When navigation is highlighted, right arrow should navigate to next clip (not move playhead)
- */
-TEST_F(TrackNavigationControllerTests, RightArrowNavigatesClipsWhenHighlighted)
-{
-    //! [GIVEN] Navigation highlight is on (user pressed Tab)
-    ON_CALL(*m_navigationController, isHighlight())
-    .WillByDefault(Return(true));
-
-    //! [GIVEN] There is a track with two clips, focus is on the first clip
-    Track track;
-    track.id = 1;
-    track.type = TrackType::Mono;
-
-    Clip clip1;
-    clip1.key = { 1, 100 };
-    clip1.startTime = 0.0;
-    Clip clip2;
-    clip2.key = { 1, 200 };
-    clip2.startTime = 2.0;
-
-    ON_CALL(*m_trackeditProject, track(1))
-    .WillByDefault(Return(track));
-    ON_CALL(*m_trackeditProject, clipList(1))
-    .WillByDefault([clip1, clip2](const TrackId&) {
-        muse::async::NotifyList<Clip> list;
-        list.push_back(clip1);
-        list.push_back(clip2);
-        return list;
-    });
-
-    //! [GIVEN] Controller is initialized with focus on the first clip
-    initController();
-    m_controller->setFocusedItem(clip1.key);
-
-    //! [EXPECT] Playhead move is NOT dispatched
-    EXPECT_CALL(*m_dispatcher, dispatch(muse::actions::ActionCode("play-position-increase"))).Times(0);
-
-    //! [WHEN] Right arrow is pressed
-    invokeAction("track-view-next-item");
-}
-
-/**
- * Test 4: When project just opened, Tab should trigger panel navigation
+ * Tab, while a track (no clip) is focused, hands over to the framework panel
+ * navigation.
  */
 TEST_F(TrackNavigationControllerTests, TabNavigatesToNextPanelWhenNoItems)
 {
-    //! [GIVEN] There is one track with no clips
-    Track track;
-    track.id = 1;
-    track.type = TrackType::Mono;
+    //! [GIVEN] One track with no clips, focus on the track (no item)
+    setupTrackWithClips(1, {});
 
-    ON_CALL(*m_trackeditProject, trackList())
-    .WillByDefault(Return(std::vector<Track>({ track })));
-    ON_CALL(*m_trackeditProject, track(1))
-    .WillByDefault(Return(track));
-    ON_CALL(*m_trackeditProject, clipList(1))
-    .WillByDefault(Return(muse::async::NotifyList<Clip> {}));
-
-    //! [GIVEN] Controller is initialized with focus on the track (no item)
     initController();
     m_controller->setFocusedTrack(1);
 
     //! [EXPECT] Framework panel navigation is dispatched
-    EXPECT_CALL(*m_commandDispatcher, dispatch(::testing::Truly([](const muse::rcommand::Request& request) {
-        return request.query.uri() == muse::ui::NEXT_PANEL_COMMAND;
-    }))).Times(1);
+    EXPECT_CALL(*m_commandDispatcher, dispatch(isPanelCommand(muse::ui::NEXT_PANEL_COMMAND))).Times(1);
 
-    //! [WHEN] Tab is pressed (track-view-next-panel is dispatched by shortcut system)
+    //! [WHEN] Tab is pressed
     invokeAction("track-view-next-panel");
 }
 
 /**
- * Test 5: Pressing Escape dismisses highlight, then arrow moves playhead
+ * Shift+Tab, while a clip is focused, steps to the previous clip of the same
+ * track without handing over to framework panel navigation.
  */
-TEST_F(TrackNavigationControllerTests, EscapeDismissesHighlightThenArrowMovesPlayhead)
+TEST_F(TrackNavigationControllerTests, ShiftTabOnClipStepsToPrevClip)
 {
-    //! [GIVEN] Navigation highlight is initially on
-    bool isHighlighted = true;
-    ON_CALL(*m_navigationController, isHighlight())
-    .WillByDefault([&isHighlighted]() { return isHighlighted; });
+    //! [GIVEN] A track with two clips, focus on the last clip
+    setupTrackWithClips(1, { makeClip(1, 100, 0.0), makeClip(1, 200, 2.0) });
 
-    //! [GIVEN] Controller is initialized
     initController();
+    m_controller->setFocusedItem({ 1, 200 });
 
-    //! [EXPECT] Escape sets highlight to false
-    EXPECT_CALL(*m_navigationController, setIsHighlight(false)).Times(1);
+    //! [EXPECT] Framework panel navigation is NOT dispatched
+    EXPECT_CALL(*m_commandDispatcher, dispatch(isPanelCommand(muse::ui::PREV_PANEL_COMMAND))).Times(0);
 
-    //! [WHEN] Escape is pressed (nav-escape is dispatched)
-    invokeAction("nav-escape");
+    //! [WHEN] Shift+Tab is pressed
+    invokeAction("track-view-prev-panel");
 
-    //! [THEN] Simulate highlight being turned off
-    isHighlighted = false;
+    //! [THEN] Focus moves to the previous clip
+    EXPECT_EQ(m_controller->focusedItem(), (TrackItemKey { 1, 100 }));
+}
 
-    //! [EXPECT] Now arrow dispatches playhead move
-    EXPECT_CALL(*m_dispatcher, dispatch(muse::actions::ActionCode("play-position-increase"))).Times(1);
+/**
+ * Shift+Tab, while the first clip of a track is focused, hands over to the
+ * framework panel navigation and leaves the focus untouched.
+ */
+TEST_F(TrackNavigationControllerTests, ShiftTabOnFirstClipHandsOverToPrevPanel)
+{
+    //! [GIVEN] A track with two clips, focus on the first clip
+    setupTrackWithClips(1, { makeClip(1, 100, 0.0), makeClip(1, 200, 2.0) });
 
-    //! [WHEN] Right arrow is pressed after Escape
-    invokeAction("track-view-next-item");
+    initController();
+    m_controller->setFocusedItem({ 1, 100 });
+
+    //! [EXPECT] Framework panel navigation is dispatched
+    EXPECT_CALL(*m_commandDispatcher, dispatch(isPanelCommand(muse::ui::PREV_PANEL_COMMAND))).Times(1);
+
+    //! [WHEN] Shift+Tab is pressed
+    invokeAction("track-view-prev-panel");
+
+    //! [THEN] Focus stays on the first clip
+    EXPECT_EQ(m_controller->focusedItem(), (TrackItemKey { 1, 100 }));
 }
 }

--- a/src/trackedit/tests/tracknavigationcontroller_tests.cpp
+++ b/src/trackedit/tests/tracknavigationcontroller_tests.cpp
@@ -9,6 +9,7 @@
 #include "framework/ui/navigationcommands.h"
 #include "mocks/commanddispatchermock.h"
 #include "context/tests/mocks/globalcontextmock.h"
+#include "mocks/navigationcontrollermock.h"
 #include "mocks/selectioncontrollermock.h"
 #include "mocks/trackeditinteractionmock.h"
 #include "mocks/trackeditprojectmock.h"
@@ -36,6 +37,7 @@ public:
     {
         m_dispatcher = std::make_shared<NiceMock<muse::actions::ActionsDispatcherMock> >();
         m_commandDispatcher = std::make_shared<NiceMock<muse::rcommand::CommandDispatcherMock> >();
+        m_navigationController = std::make_shared<NiceMock<muse::ui::NavigationControllerMock> >();
         m_globalContext = std::make_shared<NiceMock<context::GlobalContextMock> >();
         m_selectionController = std::make_shared<NiceMock<SelectionControllerMock> >();
         m_trackeditInteraction = std::make_shared<NiceMock<TrackeditInteractionMock> >();
@@ -47,6 +49,7 @@ public:
         //! NOTE Inject mock dependencies directly via friend access
         m_controller->dispatcher.set(m_dispatcher);
         m_controller->commandDispatcher.set(m_commandDispatcher);
+        m_controller->navigationController.set(m_navigationController);
 
         ON_CALL(*m_commandDispatcher, dispatch(_))
         .WillByDefault([](const muse::rcommand::Request& request) {
@@ -122,6 +125,47 @@ public:
         });
     }
 
+    struct TrackSpec
+    {
+        TrackId id = INVALID_TRACK;
+        std::vector<Clip> clips;
+    };
+
+    //! NOTE Set up a project with several mono tracks, each with its own clips.
+    //! Wires trackList(), per-track track()/clipList() and a clip(key) lookup so
+    //! the start-time based navigation (above/below item) can be exercised.
+    void setupTracks(const std::vector<TrackSpec>& specs)
+    {
+        std::vector<Track> trackList;
+        std::vector<Clip> allClips;
+
+        for (const TrackSpec& spec : specs) {
+            setupTrackWithClips(spec.id, spec.clips);
+
+            Track track;
+            track.id = spec.id;
+            track.type = TrackType::Mono;
+            trackList.push_back(track);
+
+            for (const Clip& clip : spec.clips) {
+                allClips.push_back(clip);
+            }
+        }
+
+        ON_CALL(*m_trackeditProject, trackList())
+        .WillByDefault(Return(trackList));
+
+        ON_CALL(*m_trackeditProject, clip(_))
+        .WillByDefault([allClips](const ClipKey& key) {
+            for (const Clip& clip : allClips) {
+                if (clip.key.trackId == key.trackId && clip.key.itemId == key.itemId) {
+                    return clip;
+                }
+            }
+            return Clip {};
+        });
+    }
+
     //! NOTE Matcher for a framework panel-navigation command dispatch
     static auto isPanelCommand(const muse::rcommand::Command& command)
     {
@@ -134,6 +178,7 @@ public:
     std::shared_ptr<TrackNavigationController> m_controller;
     std::shared_ptr<muse::actions::ActionsDispatcherMock> m_dispatcher;
     std::shared_ptr<muse::rcommand::CommandDispatcherMock> m_commandDispatcher;
+    std::shared_ptr<muse::ui::NavigationControllerMock> m_navigationController;
     std::shared_ptr<context::GlobalContextMock> m_globalContext;
     std::shared_ptr<SelectionControllerMock> m_selectionController;
     std::shared_ptr<TrackeditInteractionMock> m_trackeditInteraction;
@@ -247,5 +292,177 @@ TEST_F(TrackNavigationControllerTests, ShiftTabOnFirstClipHandsOverToPrevPanel)
 
     //! [THEN] Focus stays on the first clip
     EXPECT_EQ(m_controller->focusedItem(), (TrackItemKey { 1, 100 }));
+}
+
+/**
+ * Down (track-view-below-item), while a track (no clip) is focused, moves the
+ * focus to the next track.
+ */
+TEST_F(TrackNavigationControllerTests, DownFromTrackFocusesNextTrack)
+{
+    //! [GIVEN] Two tracks, focus on the first track (no item)
+    setupTracks({ { 1, {} }, { 2, {} } });
+
+    initController();
+    m_controller->setFocusedTrack(1);
+
+    //! [WHEN] Down is pressed
+    invokeAction("track-view-below-item");
+
+    //! [THEN] The next track is focused
+    EXPECT_EQ(m_controller->focusedTrack(), 2);
+}
+
+/**
+ * Up (track-view-above-item), while a track (no clip) is focused, moves the
+ * focus to the previous track.
+ */
+TEST_F(TrackNavigationControllerTests, UpFromTrackFocusesPrevTrack)
+{
+    //! [GIVEN] Two tracks, focus on the second track (no item)
+    setupTracks({ { 1, {} }, { 2, {} } });
+
+    initController();
+    m_controller->setFocusedTrack(2);
+
+    //! [WHEN] Up is pressed
+    invokeAction("track-view-above-item");
+
+    //! [THEN] The previous track is focused
+    EXPECT_EQ(m_controller->focusedTrack(), 1);
+}
+
+/**
+ * Down (track-view-below-item), while a clip is focused, moves the focus to the
+ * clip closest in start time on the next non-empty track.
+ */
+TEST_F(TrackNavigationControllerTests, DownFromClipFocusesClosestClipBelow)
+{
+    //! [GIVEN] Two tracks with clips, focus on the first clip of the first track
+    setupTracks({
+            { 1, { makeClip(1, 100, 0.0), makeClip(1, 200, 2.0) } },
+            { 2, { makeClip(2, 300, 0.1), makeClip(2, 400, 2.5) } }
+        });
+
+    initController();
+    m_controller->setFocusedItem({ 1, 100 }); //!< start time 0.0
+
+    //! [WHEN] Down is pressed
+    invokeAction("track-view-below-item");
+
+    //! [THEN] The clip closest to 0.0 on track 2 is focused (clip 300 at 0.1)
+    EXPECT_EQ(m_controller->focusedItem(), (TrackItemKey { 2, 300 }));
+}
+
+/**
+ * Up (track-view-above-item), while a clip is focused, moves the focus to the
+ * clip closest in start time on the previous non-empty track.
+ */
+TEST_F(TrackNavigationControllerTests, UpFromClipFocusesClosestClipAbove)
+{
+    //! [GIVEN] Two tracks with clips, focus on the last clip of the second track
+    setupTracks({
+            { 1, { makeClip(1, 100, 0.0), makeClip(1, 200, 2.0) } },
+            { 2, { makeClip(2, 300, 0.1), makeClip(2, 400, 2.5) } }
+        });
+
+    initController();
+    m_controller->setFocusedItem({ 2, 400 }); //!< start time 2.5
+
+    //! [WHEN] Up is pressed
+    invokeAction("track-view-above-item");
+
+    //! [THEN] The clip closest to 2.5 on track 1 is focused (clip 200 at 2.0)
+    EXPECT_EQ(m_controller->focusedItem(), (TrackItemKey { 1, 200 }));
+}
+
+/**
+ * Shift+F10 (track-view-item-context-menu), while a track is focused, requests
+ * the context menu for the focused track (no item).
+ */
+TEST_F(TrackNavigationControllerTests, ContextMenuRequestedForFocusedTrack)
+{
+    //! [GIVEN] One track, focus on the track (no item)
+    setupTracks({ { 1, {} } });
+
+    initController();
+    m_controller->setFocusedTrack(1);
+
+    //! [GIVEN] A listener on the context-menu request channel
+    TrackItemKey requested { INVALID_TRACK, INVALID_TRACK_ITEM };
+    bool called = false;
+    muse::async::Channel<TrackItemKey> channel = m_controller->openContextMenuRequested();
+    channel.onReceive(m_controller.get(), [&requested, &called](const TrackItemKey& key) {
+        requested = key;
+        called = true;
+    });
+
+    //! [WHEN] Shift+F10 is pressed
+    invokeAction("track-view-item-context-menu");
+
+    //! [THEN] The context menu is requested for the focused track
+    EXPECT_TRUE(called);
+    EXPECT_EQ(requested, (TrackItemKey { 1, INVALID_TRACK_ITEM }));
+}
+
+/**
+ * Shift+F10 (track-view-item-context-menu) is a no-op when nothing is focused.
+ */
+TEST_F(TrackNavigationControllerTests, ContextMenuNotRequestedWithoutFocus)
+{
+    //! [GIVEN] A project with one track, but nothing is focused
+    setupTracks({ { 1, {} } });
+
+    initController();
+
+    bool called = false;
+    muse::async::Channel<TrackItemKey> channel = m_controller->openContextMenuRequested();
+    channel.onReceive(m_controller.get(), [&called](const TrackItemKey&) {
+        called = true;
+    });
+
+    //! [WHEN] Shift+F10 is pressed
+    invokeAction("track-view-item-context-menu");
+
+    //! [THEN] Nothing is requested
+    EXPECT_FALSE(called);
+}
+
+/**
+ * resetNavigation() drops the navigation highlight and clears the vertical-navigation
+ * reference time, so the next Up/Down step recalculates it from the focused item instead
+ * of a stale value. This is what the cancel/escape path relies on.
+ */
+TEST_F(TrackNavigationControllerTests, ResetNavigationRecomputesVerticalReference)
+{
+    //! [GIVEN] Three tracks; track 3 has a clip near t=1 and another near t=9
+    setupTracks({
+            { 1, { makeClip(1, 100, 0.0) } },
+            { 2, { makeClip(2, 200, 0.0), makeClip(2, 210, 10.0) } },
+            { 3, { makeClip(3, 300, 1.0), makeClip(3, 310, 9.0) } },
+        });
+
+    initController();
+
+    //! [GIVEN] A vertical anchor established at t=0 by moving down from the first track
+    m_controller->setFocusedItem({ 1, 100 });
+    invokeAction("track-view-below-item");
+    ASSERT_EQ(m_controller->focusedItem(), (TrackItemKey { 2, 200 }));
+
+    //! [GIVEN] The focus is moved to an item at t=10 (the anchor is now stale at t=0)
+    m_controller->setFocusedItem({ 2, 210 });
+
+    //! [EXPECT] Resetting the navigation also drops the highlight
+    EXPECT_CALL(*m_navigationController, setIsHighlight(false)).Times(1);
+
+    //! [WHEN] The navigation is reset (as the cancel/escape path does)
+    m_controller->resetNavigation();
+
+    //! [AND] Down is pressed
+    invokeAction("track-view-below-item");
+
+    //! [THEN] The reference is recomputed from t=10, so the closest clip on track 3 is 310 (t=9),
+    //! not the stale-anchor clip 300 (t=1)
+    EXPECT_EQ(m_controller->focusedItem(), (TrackItemKey { 3, 310 }));
 }
 }

--- a/src/trackedit/tests/tracknavigationmodel_tests.cpp
+++ b/src/trackedit/tests/tracknavigationmodel_tests.cpp
@@ -167,8 +167,8 @@ public:
         m_navigationChanged.notify();
     }
 
-    //! NOTE Send the AboutActive event muse sends before it activates a panel, and return
-    //! the control name the model asked to activate (empty when it leaves muse's default)
+    //! NOTE Send the AboutActive event navigation system sends before it activates a panel, and return
+    //! the control name the model asked to activate (empty when it leaves navigation system's default)
     static QString requestedControlName(muse::ui::NavigationPanel* panel)
     {
         auto event = muse::ui::INavigation::Event::make(muse::ui::INavigation::Event::AboutActive);
@@ -375,7 +375,7 @@ TEST_F(TrackNavigationModelTests, NavigationOnTrackPanelFocusesTrackWithoutItem)
 
 /**
  * Entering the clips/labels panel while navigating backwards (Shift+Tab, i.e. from a
- * higher panel) asks muse to activate the last item instead of its default first one.
+ * higher panel) asks navigation system to activate the last item instead of its default first one.
  */
 TEST_F(TrackNavigationModelTests, BackwardsIntoItemsPanelRequestsLastItem)
 {
@@ -411,7 +411,7 @@ TEST_F(TrackNavigationModelTests, ForwardsIntoItemsPanelKeepsFirstItem)
     fireNavigationChanged(m_model->trackHeaderPanels().at(0), nullptr);
 
     //! [WHEN] The navigation enters the clips panel (Tab)
-    //! [THEN] The model does not override the control, muse keeps its first-item default
+    //! [THEN] The model does not override the control, navigation system keeps its first-item default
     EXPECT_TRUE(requestedControlName(itemsPanel).isEmpty());
 }
 }

--- a/src/trackedit/tests/tracknavigationmodel_tests.cpp
+++ b/src/trackedit/tests/tracknavigationmodel_tests.cpp
@@ -176,6 +176,13 @@ public:
         return event->data.value("controlName").toString();
     }
 
+    //! NOTE Deliver a navigation event (e.g. Escape) to a panel, as navigation system would
+    static void sendPanelEvent(muse::ui::NavigationPanel* panel, muse::ui::INavigation::Event::Type type)
+    {
+        auto event = muse::ui::INavigation::Event::make(type);
+        panel->onEvent(event);
+    }
+
     QQmlEngine m_engine;
     muse::QmlIoCContext* m_qmlIoc = nullptr;
 
@@ -413,5 +420,29 @@ TEST_F(TrackNavigationModelTests, ForwardsIntoItemsPanelKeepsFirstItem)
     //! [WHEN] The navigation enters the clips panel (Tab)
     //! [THEN] The model does not override the control, navigation system keeps its first-item default
     EXPECT_TRUE(requestedControlName(itemsPanel).isEmpty());
+}
+
+/**
+ * Escape from a control of a track's header panel returns the navigation focus
+ * to that track's container panel (with the highlight kept on).
+ */
+TEST_F(TrackNavigationModelTests, EscapeFromHeaderReturnsFocusToTrack)
+{
+    //! [GIVEN] A project with one track
+    loadWithTracks({ makeTrack(10) });
+
+    muse::ui::NavigationPanel* trackPanel = m_model->trackItemPanels().at(0);
+    muse::ui::NavigationPanel* headerPanel = m_model->trackHeaderPanels().at(0);
+
+    //! [AND] The track container panel has an enabled control to land on
+    addItemControl(trackPanel, "track-10", 0);
+
+    //! [EXPECT] The model keeps the highlight and activates the track container control
+    EXPECT_CALL(*m_navigationController, setIsHighlight(true)).Times(1);
+    EXPECT_CALL(*m_navigationController, requestActivateByName(
+                    std::string(SECTION_NAME), trackPanelName(10).toStdString(), std::string("track-10"))).Times(1);
+
+    //! [WHEN] Escape is pressed on the header panel
+    sendPanelEvent(headerPanel, muse::ui::INavigation::Event::Escape);
 }
 }

--- a/src/trackedit/tests/tracknavigationmodel_tests.cpp
+++ b/src/trackedit/tests/tracknavigationmodel_tests.cpp
@@ -1,0 +1,417 @@
+/*
+* Audacity: A Digital Audio Editor
+*/
+#include <gtest/gtest.h>
+
+#include <QQmlEngine>
+#include <QQmlContext>
+
+#include "../view/tracknavigationmodel.h"
+
+#include "global/modularity/ioc.h"
+#include "global/async/channel.h"
+#include "global/async/notification.h"
+#include "ui/inavigation.h"
+#include "ui/qml/Muse/Ui/navigationsection.h"
+#include "ui/qml/Muse/Ui/navigationcontrol.h"
+
+#include "actions/tests/mocks/actionsdispatchermock.h"
+#include "context/tests/mocks/globalcontextmock.h"
+#include "mocks/navigationcontrollermock.h"
+#include "mocks/tracknavigationcontrollermock.h"
+#include "mocks/trackeditprojectmock.h"
+
+using ::testing::NiceMock;
+using ::testing::Return;
+using ::testing::ReturnRef;
+using ::testing::_;
+
+namespace au::trackedit {
+static constexpr const char* SECTION_NAME = "TrackViewSection";
+
+class TrackNavigationModelTests : public ::testing::Test
+{
+public:
+    void SetUp() override
+    {
+        m_globalContext = std::make_shared<NiceMock<context::GlobalContextMock> >();
+        m_navigationController = std::make_shared<NiceMock<muse::ui::NavigationControllerMock> >();
+        m_tracksNavigationController = std::make_shared<NiceMock<TrackNavigationControllerMock> >();
+        m_dispatcher = std::make_shared<NiceMock<muse::actions::ActionsDispatcherMock> >();
+        m_trackeditProject = std::make_shared<NiceMock<TrackeditProjectMock> >();
+
+        //! NOTE The context the model and its panels resolve their dependencies from
+        m_testCtx = std::make_shared<muse::modularity::Context>(999);
+
+        auto ioc = muse::modularity::ioc(m_testCtx);
+        ioc->registerExportNoDelete<context::IGlobalContext>("utests", m_globalContext.get());
+        ioc->registerExportNoDelete<muse::ui::INavigationController>("utests", m_navigationController.get());
+        ioc->registerExportNoDelete<ITrackNavigationController>("utests", m_tracksNavigationController.get());
+        ioc->registerExportNoDelete<muse::actions::IActionsDispatcher>("utests", m_dispatcher.get());
+
+        //! NOTE Wire the test IoC context into the QML root context, so that objects
+        //! created with the QObject constructor resolve their dependencies from it
+        m_qmlIoc = new muse::QmlIoCContext(&m_engine);
+        m_qmlIoc->ctx = m_testCtx;
+        m_engine.rootContext()->setContextProperty("ioc_context", QVariant::fromValue(m_qmlIoc));
+
+        //! NOTE The project channels the model subscribes to
+        ON_CALL(*m_globalContext, currentTrackeditProject())
+        .WillByDefault(Return(m_trackeditProject));
+        ON_CALL(*m_globalContext, currentTrackeditProjectChanged())
+        .WillByDefault(Return(m_projectChanged));
+
+        ON_CALL(*m_trackeditProject, tracksChanged())
+        .WillByDefault(Return(m_tracksChanged));
+        ON_CALL(*m_trackeditProject, trackAdded())
+        .WillByDefault(Return(m_trackAdded));
+        ON_CALL(*m_trackeditProject, trackRemoved())
+        .WillByDefault(Return(m_trackRemoved));
+        ON_CALL(*m_trackeditProject, trackInserted())
+        .WillByDefault(Return(m_trackInserted));
+        ON_CALL(*m_trackeditProject, trackMoved())
+        .WillByDefault(Return(m_trackMoved));
+
+        //! NOTE The navigation controller channels the model subscribes to
+        ON_CALL(*m_navigationController, navigationChanged())
+        .WillByDefault(Return(m_navigationChanged));
+        ON_CALL(*m_navigationController, isHighlight())
+        .WillByDefault(Return(false));
+
+        //! NOTE The tracks navigation controller channels the model subscribes to
+        ON_CALL(*m_tracksNavigationController, focusedTrackChanged())
+        .WillByDefault(Return(m_focusedTrackChanged));
+        ON_CALL(*m_tracksNavigationController, focusedItemChanged())
+        .WillByDefault(Return(m_focusedItemChanged));
+        ON_CALL(*m_tracksNavigationController, focusedTrack())
+        .WillByDefault(Return(INVALID_TRACK));
+
+        //! NOTE The section is created with the test context directly
+        m_section = new muse::ui::NavigationSection(m_testCtx);
+        m_section->setName(SECTION_NAME);
+        m_section->setOrder(1);
+        m_section->componentComplete();
+
+        m_model = new TrackNavigationModel();
+        QQmlEngine::setContextForObject(m_model, m_engine.rootContext());
+    }
+
+    void TearDown() override
+    {
+        //! NOTE The controls reference the panels owned by the model, delete them first
+        for (muse::ui::NavigationControl* control : m_controls) {
+            delete control;
+        }
+        m_controls.clear();
+
+        delete m_model;
+        m_model = nullptr;
+
+        delete m_section;
+        m_section = nullptr;
+
+        auto ioc = muse::modularity::ioc(m_testCtx);
+        ioc->unregister<context::IGlobalContext>("utests");
+        ioc->unregister<muse::ui::INavigationController>("utests");
+        ioc->unregister<ITrackNavigationController>("utests");
+        ioc->unregister<muse::actions::IActionsDispatcher>("utests");
+
+        muse::modularity::removeIoC(m_testCtx);
+    }
+
+    //! NOTE Initialize the model and load the given tracks as the initial track list
+    void loadWithTracks(const std::vector<Track>& tracks)
+    {
+        ON_CALL(*m_trackeditProject, trackList())
+        .WillByDefault(Return(tracks));
+
+        m_model->init(m_section);
+
+        //! NOTE Triggers cleanup() + load(), which subscribes to the project and
+        //! creates the panels for the initial track list
+        m_projectChanged.notify();
+    }
+
+    static Track makeTrack(TrackId id, TrackType type = TrackType::Mono)
+    {
+        Track track;
+        track.id = id;
+        track.type = type;
+        return track;
+    }
+
+    static QString trackPanelName(TrackId id) { return QString("Track %1 Panel").arg(id); }
+    static QString headerPanelName(TrackId id) { return QString("Track %1 Header Panel").arg(id); }
+    static QString itemsPanelName(TrackId id) { return QString("Track %1 Items Panel").arg(id); }
+
+    //! NOTE Add an item control (a clip/label) to a panel, ordered by column, as QML does
+    muse::ui::NavigationControl* addItemControl(muse::ui::NavigationPanel* panel, const QString& name, int column)
+    {
+        auto* control = new muse::ui::NavigationControl(m_testCtx);
+        control->setName(name);
+        control->setColumn(column);
+        control->setEnabled(true);
+        control->setPanel(panel);
+        m_controls.push_back(control);
+        return control;
+    }
+
+    //! NOTE Simulate the navigation controller landing on a given panel/control
+    void fireNavigationChanged(muse::ui::NavigationPanel* panel, muse::ui::NavigationControl* control)
+    {
+        ON_CALL(*m_navigationController, activePanel())
+        .WillByDefault(Return(panel));
+        ON_CALL(*m_navigationController, activeControl())
+        .WillByDefault(Return(control));
+
+        m_navigationChanged.notify();
+    }
+
+    //! NOTE Send the AboutActive event muse sends before it activates a panel, and return
+    //! the control name the model asked to activate (empty when it leaves muse's default)
+    static QString requestedControlName(muse::ui::NavigationPanel* panel)
+    {
+        auto event = muse::ui::INavigation::Event::make(muse::ui::INavigation::Event::AboutActive);
+        panel->onEvent(event);
+        return event->data.value("controlName").toString();
+    }
+
+    QQmlEngine m_engine;
+    muse::QmlIoCContext* m_qmlIoc = nullptr;
+
+    std::shared_ptr<muse::modularity::Context> m_testCtx;
+    muse::ui::NavigationSection* m_section = nullptr;
+    TrackNavigationModel* m_model = nullptr;
+
+    std::shared_ptr<context::GlobalContextMock> m_globalContext;
+    std::shared_ptr<muse::ui::NavigationControllerMock> m_navigationController;
+    std::shared_ptr<TrackNavigationControllerMock> m_tracksNavigationController;
+    std::shared_ptr<muse::actions::ActionsDispatcherMock> m_dispatcher;
+    std::shared_ptr<TrackeditProjectMock> m_trackeditProject;
+
+    muse::async::Notification m_projectChanged;
+    muse::async::Notification m_navigationChanged;
+    muse::async::Channel<std::vector<Track> > m_tracksChanged;
+    muse::async::Channel<Track> m_trackAdded;
+    muse::async::Channel<Track> m_trackRemoved;
+    muse::async::Channel<Track, int> m_trackInserted;
+    muse::async::Channel<Track, int> m_trackMoved;
+    muse::async::Channel<TrackId, bool> m_focusedTrackChanged;
+    muse::async::Channel<TrackItemKey, bool> m_focusedItemChanged;
+
+    std::vector<muse::ui::NavigationControl*> m_controls;
+};
+
+/**
+ * Every track exposes three panels (track, header, clips/labels), the lists are
+ * kept per track and the panel orders are laid out in blocks after the reserved
+ * order 0 of the empty-project default panel.
+ */
+TEST_F(TrackNavigationModelTests, InitialLoadCreatesThreePanelsPerTrack)
+{
+    //! [GIVEN] A project with two tracks
+    //! [WHEN] The model is loaded
+    loadWithTracks({ makeTrack(10), makeTrack(20) });
+
+    //! [THEN] There are three panel lists, one panel per track in each
+    ASSERT_EQ(m_model->trackItemPanels().size(), 2);
+    ASSERT_EQ(m_model->trackHeaderPanels().size(), 2);
+    ASSERT_EQ(m_model->viewItemPanels().size(), 2);
+
+    //! [AND] The panels are named after their tracks
+    EXPECT_EQ(m_model->trackItemPanels().at(0)->name(), trackPanelName(10));
+    EXPECT_EQ(m_model->trackHeaderPanels().at(0)->name(), headerPanelName(10));
+    EXPECT_EQ(m_model->viewItemPanels().at(0)->name(), itemsPanelName(10));
+
+    EXPECT_EQ(m_model->trackItemPanels().at(1)->name(), trackPanelName(20));
+
+    //! [AND] The panel orders are laid out in blocks: base = 1 + 4 * pos
+    EXPECT_EQ(m_model->trackItemPanels().at(0)->order(), 1);
+    EXPECT_EQ(m_model->trackHeaderPanels().at(0)->order(), 2);
+    EXPECT_EQ(m_model->viewItemPanels().at(0)->order(), 3);
+
+    EXPECT_EQ(m_model->trackItemPanels().at(1)->order(), 5);
+    EXPECT_EQ(m_model->trackHeaderPanels().at(1)->order(), 6);
+    EXPECT_EQ(m_model->viewItemPanels().at(1)->order(), 7);
+}
+
+/**
+ * Adding a track appends its three panels after the existing ones.
+ */
+TEST_F(TrackNavigationModelTests, TrackAddedAppendsPanels)
+{
+    //! [GIVEN] A project with one track
+    loadWithTracks({ makeTrack(10) });
+    ASSERT_EQ(m_model->trackItemPanels().size(), 1);
+
+    //! [WHEN] A second track is added
+    m_trackAdded.send(makeTrack(20));
+
+    //! [THEN] Its panels are appended after the first track
+    ASSERT_EQ(m_model->trackItemPanels().size(), 2);
+    EXPECT_EQ(m_model->trackItemPanels().at(1)->name(), trackPanelName(20));
+    EXPECT_EQ(m_model->trackItemPanels().at(1)->order(), 5);
+    EXPECT_EQ(m_model->viewItemPanels().at(1)->order(), 7);
+}
+
+/**
+ * Inserting a track places its panels at the position, the orders follow the
+ * (new) track order rather than the insertion history.
+ */
+TEST_F(TrackNavigationModelTests, TrackInsertedPlacesPanelsAtPosition)
+{
+    //! [GIVEN] A project with two tracks
+    loadWithTracks({ makeTrack(10), makeTrack(20) });
+
+    //! [WHEN] A track is inserted between them
+    m_trackInserted.send(makeTrack(15), 1);
+
+    //! [THEN] The middle position holds the inserted track's panels
+    ASSERT_EQ(m_model->trackItemPanels().size(), 3);
+    EXPECT_EQ(m_model->trackItemPanels().at(0)->name(), trackPanelName(10));
+    EXPECT_EQ(m_model->trackItemPanels().at(1)->name(), trackPanelName(15));
+    EXPECT_EQ(m_model->trackItemPanels().at(2)->name(), trackPanelName(20));
+
+    //! [AND] The orders are reassigned by position
+    EXPECT_EQ(m_model->trackItemPanels().at(1)->order(), 5);
+    EXPECT_EQ(m_model->trackItemPanels().at(2)->order(), 9);
+}
+
+/**
+ * Removing a track drops its three panels and reorders the rest.
+ */
+TEST_F(TrackNavigationModelTests, TrackRemovedRemovesTrackPanels)
+{
+    //! [GIVEN] A project with three tracks
+    loadWithTracks({ makeTrack(10), makeTrack(20), makeTrack(30) });
+
+    //! [WHEN] The middle track is removed
+    m_trackRemoved.send(makeTrack(20));
+
+    //! [THEN] Only the remaining tracks keep their panels
+    ASSERT_EQ(m_model->trackItemPanels().size(), 2);
+    ASSERT_EQ(m_model->viewItemPanels().size(), 2);
+    EXPECT_EQ(m_model->trackItemPanels().at(0)->name(), trackPanelName(10));
+    EXPECT_EQ(m_model->trackItemPanels().at(1)->name(), trackPanelName(30));
+
+    //! [AND] The orders are compacted by the new positions
+    EXPECT_EQ(m_model->trackItemPanels().at(1)->order(), 5);
+}
+
+/**
+ * Moving a track moves its panels and reorders all of them by the new positions.
+ */
+TEST_F(TrackNavigationModelTests, TrackMovedReordersPanels)
+{
+    //! [GIVEN] A project with three tracks
+    loadWithTracks({ makeTrack(10), makeTrack(20), makeTrack(30) });
+
+    //! [WHEN] The first track is moved to the last position
+    m_trackMoved.send(makeTrack(10), 2);
+
+    //! [THEN] The panel lists follow the new track order
+    ASSERT_EQ(m_model->trackItemPanels().size(), 3);
+    EXPECT_EQ(m_model->trackItemPanels().at(0)->name(), trackPanelName(20));
+    EXPECT_EQ(m_model->trackItemPanels().at(1)->name(), trackPanelName(30));
+    EXPECT_EQ(m_model->trackItemPanels().at(2)->name(), trackPanelName(10));
+
+    //! [AND] The moved track takes the last order block
+    EXPECT_EQ(m_model->trackItemPanels().at(2)->order(), 9);
+}
+
+/**
+ * When the navigation lands on a clips/labels panel (e.g. via Tab or mouse), the
+ * model reflects the active item back into the tracks navigation controller.
+ */
+TEST_F(TrackNavigationModelTests, NavigationOnItemsPanelFocusesItem)
+{
+    //! [GIVEN] A project with one track
+    loadWithTracks({ makeTrack(10) });
+
+    muse::ui::NavigationPanel* itemsPanel = m_model->viewItemPanels().at(0);
+
+    //! [AND] An active clip control on the track's clips panel
+    auto* clipControl = new muse::ui::NavigationControl(m_testCtx);
+    clipControl->setName("200");
+    clipControl->setPanel(itemsPanel);
+    clipControl->setEnabled(true);
+
+    ON_CALL(*m_navigationController, activePanel())
+    .WillByDefault(Return(itemsPanel));
+    ON_CALL(*m_navigationController, activeControl())
+    .WillByDefault(Return(clipControl));
+
+    //! [EXPECT] The focused item is set to that clip on that track
+    EXPECT_CALL(*m_tracksNavigationController, setFocusedItem(TrackItemKey { 10, 200 }, _)).Times(1);
+
+    //! [WHEN] The navigation changes
+    m_navigationChanged.notify();
+
+    delete clipControl;
+}
+
+/**
+ * When the navigation lands on a track or header panel, the model focuses the
+ * track with no item.
+ */
+TEST_F(TrackNavigationModelTests, NavigationOnTrackPanelFocusesTrackWithoutItem)
+{
+    //! [GIVEN] A project with one track
+    loadWithTracks({ makeTrack(10) });
+
+    muse::ui::NavigationPanel* trackPanel = m_model->trackItemPanels().at(0);
+
+    ON_CALL(*m_navigationController, activePanel())
+    .WillByDefault(Return(trackPanel));
+    ON_CALL(*m_navigationController, activeControl())
+    .WillByDefault(Return(nullptr));
+
+    //! [EXPECT] The track is focused, without an item
+    EXPECT_CALL(*m_tracksNavigationController, setFocusedItem(TrackItemKey { 10, INVALID_TRACK_ITEM }, _)).Times(1);
+
+    //! [WHEN] The navigation changes
+    m_navigationChanged.notify();
+}
+
+/**
+ * Entering the clips/labels panel while navigating backwards (Shift+Tab, i.e. from a
+ * higher panel) asks muse to activate the last item instead of its default first one.
+ */
+TEST_F(TrackNavigationModelTests, BackwardsIntoItemsPanelRequestsLastItem)
+{
+    //! [GIVEN] A project with two tracks, the first track's clips panel has two clips
+    loadWithTracks({ makeTrack(10), makeTrack(20) });
+
+    muse::ui::NavigationPanel* itemsPanel = m_model->viewItemPanels().at(0);
+    addItemControl(itemsPanel, "100", 0);
+    addItemControl(itemsPanel, "200", 4);
+
+    //! [AND] The navigation currently sits on the second track (a higher panel order)
+    fireNavigationChanged(m_model->trackItemPanels().at(1), nullptr);
+
+    //! [WHEN] The navigation enters the first track's clips panel (Shift+Tab)
+    //! [THEN] The model asks to activate the last clip
+    EXPECT_EQ(requestedControlName(itemsPanel), QString("200"));
+}
+
+/**
+ * Entering the clips/labels panel while navigating forwards (Tab, i.e. from a lower
+ * panel) leaves muse's default, which activates the first item.
+ */
+TEST_F(TrackNavigationModelTests, ForwardsIntoItemsPanelKeepsFirstItem)
+{
+    //! [GIVEN] A project with one track whose clips panel has two clips
+    loadWithTracks({ makeTrack(10) });
+
+    muse::ui::NavigationPanel* itemsPanel = m_model->viewItemPanels().at(0);
+    addItemControl(itemsPanel, "100", 0);
+    addItemControl(itemsPanel, "200", 4);
+
+    //! [AND] The navigation currently sits on the same track's header (a lower panel order)
+    fireNavigationChanged(m_model->trackHeaderPanels().at(0), nullptr);
+
+    //! [WHEN] The navigation enters the clips panel (Tab)
+    //! [THEN] The model does not override the control, muse keeps its first-item default
+    EXPECT_TRUE(requestedControlName(itemsPanel).isEmpty());
+}
+}

--- a/src/trackedit/view/tracknavigationmodel.cpp
+++ b/src/trackedit/view/tracknavigationmodel.cpp
@@ -9,9 +9,25 @@ static const QString makeTrackPanelName(const TrackId& trackId)
     return QString("Track %1 Panel").arg(trackId);
 }
 
+static const QString makeTrackHeaderPanelName(const TrackId& trackId)
+{
+    return QString("Track %1 Header Panel").arg(trackId);
+}
+
 static const QString makeTrackItemsPanelName(const TrackId& trackId)
 {
     return QString("Track %1 Items Panel").arg(trackId);
+}
+
+//! NOTE: the default (no tracks) panel takes the order 0, tracks start right after it.
+//! Every track takes a block of orders: the track itself, its header controls,
+//! its clips/labels and one slot reserved for the per-track vertical ruler
+static constexpr int TRACK_PANELS_ORDER_START = 1;
+static constexpr int TRACK_PANELS_ORDER_STRIDE = 4;
+
+static int trackPanelsOrderBase(int pos)
+{
+    return TRACK_PANELS_ORDER_START + TRACK_PANELS_ORDER_STRIDE * pos;
 }
 
 static const muse::ui::INavigationControl* findFirstEnabledControl(const muse::ui::INavigationPanel* panel)
@@ -31,6 +47,25 @@ static const muse::ui::INavigationControl* findFirstEnabledControl(const muse::u
     }
 
     return firstControl;
+}
+
+static const muse::ui::INavigationControl* findLastEnabledControl(const muse::ui::INavigationPanel* panel)
+{
+    int maxIndex = std::numeric_limits<int>::min();
+    const muse::ui::INavigationControl* lastControl = nullptr;
+    for (muse::ui::INavigationControl* control : panel->controls()) {
+        if (!control || !control->enabled()) {
+            continue;
+        }
+
+        int index = control->index().order();
+        if (maxIndex < index) {
+            lastControl = control;
+            maxIndex = index;
+        }
+    }
+
+    return lastControl;
 }
 
 TrackNavigationModel::TrackNavigationModel(QObject* parent)
@@ -55,10 +90,15 @@ void TrackNavigationModel::init(muse::ui::NavigationSection* section)
         const muse::ui::INavigationPanel* activePanel = navigationController()->activePanel();
         const muse::ui::INavigationControl* activeControl = navigationController()->activeControl();
 
-        if (m_trackItemPanels.contains(activePanel)) {
-            const muse::ui::INavigationControl* firstControl = findFirstEnabledControl(activePanel);
-            tracksNavigationController()->setIsNavigationActive(firstControl == activeControl);
+        for (const TrackPanels& panels : m_panels) {
+            if (panels.track == activePanel) {
+                const muse::ui::INavigationControl* firstControl = findFirstEnabledControl(activePanel);
+                tracksNavigationController()->setIsNavigationActive(firstControl == activeControl);
+                break;
+            }
         }
+
+        syncFocusedItem(activePanel, activeControl);
     });
 }
 
@@ -84,44 +124,25 @@ void TrackNavigationModel::load()
     });
 
     prj->trackAdded().onReceive(this, [this](const Track& track) {
-        if (m_trackItemPanels.isEmpty()) {
+        if (m_panels.isEmpty()) {
             disableDefaultNavigation();
         }
-        const int pos = m_trackItemPanels.size();
-        addPanels(track.id, pos);
+        addPanels(track.id, m_panels.size());
         resetPanelOrder();
     });
 
     prj->trackRemoved().onReceive(this, [this](const Track& track) {
-        QString trackPanelName = makeTrackPanelName(track.id);
-        for (int i = 0; i < m_trackItemPanels.size(); ++i) {
-            if (m_trackItemPanels.at(i)->name() == trackPanelName) {
-                muse::ui::NavigationPanel* trackPanel = m_trackItemPanels.takeAt(i);
-                trackPanel->setSection(nullptr);
-                trackPanel->deleteLater();
-                break;
-            }
-        }
-
-        QString trackItemsPanelName = makeTrackItemsPanelName(track.id);
-        for (int i = 0; i < m_viewItemPanels.size(); ++i) {
-            if (m_viewItemPanels.at(i)->name() == trackItemsPanelName) {
-                muse::ui::NavigationPanel* itemsPanel = m_viewItemPanels.takeAt(i);
-                itemsPanel->setSection(nullptr);
-                itemsPanel->deleteLater();
-                break;
-            }
-        }
+        removePanels(track.id);
 
         resetPanelOrder();
 
-        if (m_trackItemPanels.isEmpty()) {
+        if (m_panels.isEmpty()) {
             addDefaultNavigation();
         }
     });
 
     prj->trackInserted().onReceive(this, [this](const Track& track, int pos) {
-        if (m_trackItemPanels.isEmpty()) {
+        if (m_panels.isEmpty()) {
             disableDefaultNavigation();
         }
         addPanels(track.id, pos);
@@ -129,30 +150,19 @@ void TrackNavigationModel::load()
     });
 
     prj->trackMoved().onReceive(this, [this](const Track& track, int pos) {
-        for (int i = 0; i < m_trackItemPanels.size(); ++i) {
-            if (m_trackItemPanels.at(i)->name() == makeTrackPanelName(track.id)) {
-                auto trackPanel = m_trackItemPanels.takeAt(i);
-                m_trackItemPanels.insert(pos, trackPanel);
-                break;
-            }
+        const int from = indexOfTrack(track.id);
+        if (from < 0 || from == pos) {
+            return;
         }
 
-        QString trackItemsPanelName = makeTrackItemsPanelName(track.id);
-        for (int i = 0; i < m_viewItemPanels.size(); ++i) {
-            if (m_viewItemPanels.at(i)->name() == trackItemsPanelName) {
-                auto itemsPanel = m_viewItemPanels.takeAt(i);
-                m_viewItemPanels.insert(pos, itemsPanel);
-                break;
-            }
-        }
+        m_panels.move(from, pos);
 
         resetPanelOrder();
     });
 
     const auto trackList = prj->trackList();
     for (const auto& track : trackList) {
-        const int pos = m_trackItemPanels.size();
-        addPanels(track.id, pos);
+        addPanels(track.id, m_panels.size());
     }
 
     if (trackList.empty()) {
@@ -160,6 +170,10 @@ void TrackNavigationModel::load()
     }
 
     tracksNavigationController()->focusedTrackChanged().onReceive(this, [this](const TrackId& trackId, bool highlight) {
+        if (tracksNavigationController()->focusedItem().itemId != INVALID_TRACK_ITEM) {
+            return;
+        }
+
         QTimer::singleShot(10, [this, trackId, highlight](){
             activateNavigation(trackId, highlight);
         });
@@ -174,12 +188,9 @@ void TrackNavigationModel::load()
 
 void TrackNavigationModel::addPanels(const TrackId& trackId, int pos)
 {
-    muse::ui::NavigationPanel* trackPanel = new muse::ui::NavigationPanel(this);
-    trackPanel->setName(makeTrackPanelName(trackId));
-    trackPanel->setIndex({ 2 * pos, 0 });
-    trackPanel->setOrder(2 * pos);
-    trackPanel->setSection(m_section);
-    trackPanel->componentComplete();
+    const int orderBase = trackPanelsOrderBase(pos);
+
+    muse::ui::NavigationPanel* trackPanel = makePanel(makeTrackPanelName(trackId), orderBase);
 
     connect(trackPanel, &muse::ui::NavigationPanel::navigationEvent, this,
             [this, trackId](muse::ui::NavigationEvent* event) {
@@ -193,37 +204,68 @@ void TrackNavigationModel::addPanels(const TrackId& trackId, int pos)
         // handleArrowKeyFallback(event);
     });
 
-    muse::ui::NavigationPanel* itemsPanel = new muse::ui::NavigationPanel(this);
-    itemsPanel->setName(makeTrackItemsPanelName(trackId));
-    itemsPanel->setIndex({ 2 * pos + 1, 0 });
-    itemsPanel->setOrder(2 * pos + 1);
-    itemsPanel->setSection(m_section);
-    itemsPanel->componentComplete();
+    muse::ui::NavigationPanel* headerPanel = makePanel(makeTrackHeaderPanelName(trackId), orderBase + 1);
+
+    muse::ui::NavigationPanel* itemsPanel = makePanel(makeTrackItemsPanelName(trackId), orderBase + 2);
 
     connect(itemsPanel, &muse::ui::NavigationPanel::navigationEvent, this,
-            [this](muse::ui::NavigationEvent* event) {
+            [this, itemsPanel](muse::ui::NavigationEvent* event) {
+        if (event->type() == muse::ui::NavigationEvent::AboutActive) {
+            //! NOTE: muse activates the first control of a panel it enters. When the clips/labels
+            //! panel is entered while navigating backwards (Shift+Tab), the navigation should
+            //! instead land on the last item, so ask muse to activate it explicitly
+            const bool backwards = itemsPanel->index().order() < m_lastActivePanelOrder;
+            if (backwards) {
+                if (const muse::ui::INavigationControl* last = findLastEnabledControl(itemsPanel)) {
+                    event->setData("controlName", last->name());
+                }
+            }
+            return;
+        }
+
         // handleArrowKeyFallback(event);
     });
 
-    m_trackItemPanels.append(trackPanel);
-    m_viewItemPanels.append(itemsPanel);
+    m_panels.insert(pos, { trackId, trackPanel, headerPanel, itemsPanel });
 
-    emit trackItemPanelsChanged();
-    emit viewItemPanelsChanged();
+    emit panelsChanged();
+}
+
+muse::ui::NavigationPanel* TrackNavigationModel::makePanel(const QString& name, int order)
+{
+    muse::ui::NavigationPanel* panel = new muse::ui::NavigationPanel(this);
+    panel->setName(name);
+    panel->setIndex({ order, 0 });
+    panel->setOrder(order);
+    panel->setSection(m_section);
+    panel->componentComplete();
+
+    return panel;
 }
 
 void TrackNavigationModel::resetPanelOrder()
 {
-    for (int i = 0; i < m_trackItemPanels.size(); ++i) {
-        m_trackItemPanels.at(i)->setOrder(2 * i);
+    for (int i = 0; i < m_panels.size(); ++i) {
+        const TrackPanels& panels = m_panels.at(i);
+        const int orderBase = trackPanelsOrderBase(i);
+
+        panels.track->setOrder(orderBase);
+        panels.header->setOrder(orderBase + 1);
+        panels.items->setOrder(orderBase + 2);
     }
 
-    for (int i = 0; i < m_viewItemPanels.size(); ++i) {
-        m_viewItemPanels.at(i)->setOrder(2 * i + 1);
+    emit panelsChanged();
+}
+
+int TrackNavigationModel::indexOfTrack(const TrackId& trackId) const
+{
+    for (int i = 0; i < m_panels.size(); ++i) {
+        if (m_panels.at(i).trackId == trackId) {
+            return i;
+        }
     }
 
-    emit trackItemPanelsChanged();
-    emit viewItemPanelsChanged();
+    return -1;
 }
 
 void TrackNavigationModel::addDefaultNavigation()
@@ -272,6 +314,31 @@ void TrackNavigationModel::disableDefaultNavigation()
     m_defaultControl->setEnabled(false);
 }
 
+void TrackNavigationModel::syncFocusedItem(const muse::ui::INavigationPanel* activePanel,
+                                           const muse::ui::INavigationControl* activeControl)
+{
+    //! NOTE: the navigation may be moved by the navigation controller itself (Tab, mouse),
+    //! so the focused item of the tracks controller is taken from the active panel/control.
+    //! Setting an item of the already focused track sends the item notification only,
+    //! so this doesn't fight with the activation done on focus changes
+    for (const TrackPanels& panels : m_panels) {
+        if (panels.items == activePanel) {
+            m_lastActivePanelOrder = activePanel->index().order();
+
+            const TrackItemId itemId = activeControl ? activeControl->name().toLongLong() : INVALID_TRACK_ITEM;
+            tracksNavigationController()->setFocusedItem({ panels.trackId, itemId });
+            return;
+        }
+
+        if (panels.track == activePanel || panels.header == activePanel) {
+            m_lastActivePanelOrder = activePanel->index().order();
+
+            tracksNavigationController()->setFocusedItem({ panels.trackId, INVALID_TRACK_ITEM });
+            return;
+        }
+    }
+}
+
 void TrackNavigationModel::handleArrowKeyFallback(muse::ui::NavigationEvent* event)
 {
     if (!tracksNavigationController()->isNavigationEnabled()) {
@@ -299,27 +366,60 @@ void TrackNavigationModel::cleanup()
 
 void TrackNavigationModel::clearPanels()
 {
-    for (auto& panel : m_trackItemPanels) {
-        panel->setSection(nullptr);
-        panel->deleteLater();
+    for (const TrackPanels& panels : m_panels) {
+        deletePanels(panels);
     }
-    m_trackItemPanels.clear();
 
-    for (auto& panel : m_viewItemPanels) {
+    m_panels.clear();
+
+    emit panelsChanged();
+}
+
+void TrackNavigationModel::removePanels(const TrackId& trackId)
+{
+    const int pos = indexOfTrack(trackId);
+    if (pos < 0) {
+        return;
+    }
+
+    deletePanels(m_panels.takeAt(pos));
+
+    emit panelsChanged();
+}
+
+void TrackNavigationModel::deletePanels(const TrackPanels& panels)
+{
+    for (muse::ui::NavigationPanel* panel : { panels.track, panels.header, panels.items }) {
         panel->setSection(nullptr);
         panel->deleteLater();
     }
-    m_viewItemPanels.clear();
 }
 
 QList<muse::ui::NavigationPanel*> TrackNavigationModel::trackItemPanels() const
 {
-    return m_trackItemPanels;
+    return panelsList(&TrackPanels::track);
+}
+
+QList<muse::ui::NavigationPanel*> TrackNavigationModel::trackHeaderPanels() const
+{
+    return panelsList(&TrackPanels::header);
 }
 
 QList<muse::ui::NavigationPanel*> TrackNavigationModel::viewItemPanels() const
 {
-    return m_viewItemPanels;
+    return panelsList(&TrackPanels::items);
+}
+
+QList<muse::ui::NavigationPanel*> TrackNavigationModel::panelsList(muse::ui::NavigationPanel* TrackPanels::* panel) const
+{
+    QList<muse::ui::NavigationPanel*> result;
+    result.reserve(m_panels.size());
+
+    for (const TrackPanels& panels : m_panels) {
+        result.append(panels.*panel);
+    }
+
+    return result;
 }
 
 void TrackNavigationModel::activateNavigation(const TrackId& trackId, bool highlight)
@@ -332,19 +432,12 @@ void TrackNavigationModel::activateNavigation(const TrackId& trackId, bool highl
         return;
     }
 
-    QString panelName = makeTrackPanelName(trackId);
-
-    muse::ui::NavigationPanel* targetPanel = nullptr;
-    for (auto* panel : m_trackItemPanels) {
-        if (panel->name() == panelName) {
-            targetPanel = panel;
-            break;
-        }
-    }
-
-    if (!targetPanel) {
+    const int pos = indexOfTrack(trackId);
+    if (pos < 0) {
         return;
     }
+
+    const muse::ui::NavigationPanel* targetPanel = m_panels.at(pos).track;
 
     const muse::ui::INavigationControl* firstControl = findFirstEnabledControl(targetPanel);
     if (!firstControl) {
@@ -358,7 +451,7 @@ void TrackNavigationModel::activateNavigation(const TrackId& trackId, bool highl
     navigationController()->setIsHighlight(highlight);
     navigationController()->requestActivateByName(
         m_section->name().toStdString(),
-        panelName.toStdString(),
+        targetPanel->name().toStdString(),
         firstControl->name().toStdString()
         );
 }
@@ -373,19 +466,12 @@ void TrackNavigationModel::activateNavigation(const TrackItemKey& itemKey, bool 
         return;
     }
 
-    QString panelName = makeTrackItemsPanelName(itemKey.trackId);
-
-    muse::ui::NavigationPanel* targetPanel = nullptr;
-    for (auto* panel : m_viewItemPanels) {
-        if (panel->name() == panelName) {
-            targetPanel = panel;
-            break;
-        }
-    }
-
-    if (!targetPanel) {
+    const int pos = indexOfTrack(itemKey.trackId);
+    if (pos < 0) {
         return;
     }
+
+    const muse::ui::NavigationPanel* targetPanel = m_panels.at(pos).items;
 
     const auto controls = targetPanel->controls();
     for (auto* control : controls) {
@@ -397,7 +483,7 @@ void TrackNavigationModel::activateNavigation(const TrackItemKey& itemKey, bool 
             navigationController()->setIsHighlight(highlight);
             navigationController()->requestActivateByName(
                 m_section->name().toStdString(),
-                panelName.toStdString(),
+                targetPanel->name().toStdString(),
                 control->name().toStdString()
                 );
             return;

--- a/src/trackedit/view/tracknavigationmodel.cpp
+++ b/src/trackedit/view/tracknavigationmodel.cpp
@@ -90,13 +90,7 @@ void TrackNavigationModel::init(muse::ui::NavigationSection* section)
         const muse::ui::INavigationPanel* activePanel = navigationController()->activePanel();
         const muse::ui::INavigationControl* activeControl = navigationController()->activeControl();
 
-        for (const TrackPanels& panels : m_panels) {
-            if (panels.track == activePanel) {
-                const muse::ui::INavigationControl* firstControl = findFirstEnabledControl(activePanel);
-                tracksNavigationController()->setIsNavigationActive(firstControl == activeControl);
-                break;
-            }
-        }
+        updateNavigationActive(activePanel);
 
         syncFocusedItem(activePanel, activeControl);
     });
@@ -200,8 +194,6 @@ void TrackNavigationModel::addPanels(const TrackId& trackId, int pos)
             }
             return;
         }
-
-        // handleArrowKeyFallback(event);
     });
 
     muse::ui::NavigationPanel* headerPanel = makePanel(makeTrackHeaderPanelName(trackId), orderBase + 1);
@@ -222,8 +214,6 @@ void TrackNavigationModel::addPanels(const TrackId& trackId, int pos)
             }
             return;
         }
-
-        // handleArrowKeyFallback(event);
     });
 
     m_panels.insert(pos, { trackId, trackPanel, headerPanel, itemsPanel });
@@ -314,6 +304,28 @@ void TrackNavigationModel::disableDefaultNavigation()
     m_defaultControl->setEnabled(false);
 }
 
+void TrackNavigationModel::updateNavigationActive(const muse::ui::INavigationPanel* activePanel)
+{
+    //! NOTE: only the header controls panel is navigated as a usual panel (general navigation):
+    //! Left/Right move between the controls and the trigger (Space) presses the focused control.
+    //! The track panel and the clips/labels panel belong to the project: Left/Right move the play
+    //! cursor, Up/Down navigate the tracks, the trigger starts the playback.
+    bool navigationActive = false;
+    for (const TrackPanels& panels : m_panels) {
+        if (panels.header == activePanel) {
+            navigationActive = true;
+            break;
+        }
+
+        if (panels.track == activePanel || panels.items == activePanel) {
+            navigationActive = false;
+            break;
+        }
+    }
+
+    tracksNavigationController()->setIsNavigationActive(navigationActive);
+}
+
 void TrackNavigationModel::syncFocusedItem(const muse::ui::INavigationPanel* activePanel,
                                            const muse::ui::INavigationControl* activeControl)
 {
@@ -335,19 +347,6 @@ void TrackNavigationModel::syncFocusedItem(const muse::ui::INavigationPanel* act
 
             tracksNavigationController()->setFocusedItem({ panels.trackId, INVALID_TRACK_ITEM });
             return;
-        }
-    }
-}
-
-void TrackNavigationModel::handleArrowKeyFallback(muse::ui::NavigationEvent* event)
-{
-    if (!tracksNavigationController()->isNavigationEnabled()) {
-        if (event->type() == muse::ui::NavigationEvent::Right) {
-            event->setAccepted(true);
-            dispatcher()->dispatch("play-position-increase");
-        } else if (event->type() == muse::ui::NavigationEvent::Left) {
-            event->setAccepted(true);
-            dispatcher()->dispatch("play-position-decrease");
         }
     }
 }

--- a/src/trackedit/view/tracknavigationmodel.cpp
+++ b/src/trackedit/view/tracknavigationmodel.cpp
@@ -198,6 +198,15 @@ void TrackNavigationModel::addPanels(const TrackId& trackId, int pos)
 
     muse::ui::NavigationPanel* headerPanel = makePanel(makeTrackHeaderPanelName(trackId), orderBase + 1);
 
+    connect(headerPanel, &muse::ui::NavigationPanel::navigationEvent, this,
+            [this, trackId](muse::ui::NavigationEvent* event) {
+        if (event->type() == muse::ui::NavigationEvent::Escape) {
+            //! NOTE: Escape from a track header control returns the focus to the track container
+            event->setAccepted(true);
+            activateNavigation(trackId, true /*highlight*/);
+        }
+    });
+
     muse::ui::NavigationPanel* itemsPanel = makePanel(makeTrackItemsPanelName(trackId), orderBase + 2);
 
     connect(itemsPanel, &muse::ui::NavigationPanel::navigationEvent, this,

--- a/src/trackedit/view/tracknavigationmodel.cpp
+++ b/src/trackedit/view/tracknavigationmodel.cpp
@@ -212,9 +212,9 @@ void TrackNavigationModel::addPanels(const TrackId& trackId, int pos)
     connect(itemsPanel, &muse::ui::NavigationPanel::navigationEvent, this,
             [this, itemsPanel](muse::ui::NavigationEvent* event) {
         if (event->type() == muse::ui::NavigationEvent::AboutActive) {
-            //! NOTE: muse activates the first control of a panel it enters. When the clips/labels
+            //! NOTE: navigation system activates the first control of a panel it enters. When the clips/labels
             //! panel is entered while navigating backwards (Shift+Tab), the navigation should
-            //! instead land on the last item, so ask muse to activate it explicitly
+            //! instead land on the last item, so ask navigation system to activate it explicitly
             const bool backwards = itemsPanel->index().order() < m_lastActivePanelOrder;
             if (backwards) {
                 if (const muse::ui::INavigationControl* last = findLastEnabledControl(itemsPanel)) {

--- a/src/trackedit/view/tracknavigationmodel.cpp
+++ b/src/trackedit/view/tracknavigationmodel.cpp
@@ -190,7 +190,7 @@ void TrackNavigationModel::addPanels(const TrackId& trackId, int pos)
             return;
         }
 
-        handleArrowKeyFallback(event);
+        // handleArrowKeyFallback(event);
     });
 
     muse::ui::NavigationPanel* itemsPanel = new muse::ui::NavigationPanel(this);
@@ -202,7 +202,7 @@ void TrackNavigationModel::addPanels(const TrackId& trackId, int pos)
 
     connect(itemsPanel, &muse::ui::NavigationPanel::navigationEvent, this,
             [this](muse::ui::NavigationEvent* event) {
-        handleArrowKeyFallback(event);
+        // handleArrowKeyFallback(event);
     });
 
     m_trackItemPanels.append(trackPanel);

--- a/src/trackedit/view/tracknavigationmodel.h
+++ b/src/trackedit/view/tracknavigationmodel.h
@@ -62,12 +62,11 @@ private:
     void deletePanels(const TrackPanels& panels);
     int indexOfTrack(const TrackId& trackId) const;
     QList<muse::ui::NavigationPanel*> panelsList(muse::ui::NavigationPanel* TrackPanels::* panel) const;
+    void updateNavigationActive(const muse::ui::INavigationPanel* activePanel);
     void syncFocusedItem(const muse::ui::INavigationPanel* activePanel, const muse::ui::INavigationControl* activeControl);
 
     void addDefaultNavigation();
     void disableDefaultNavigation();
-
-    void handleArrowKeyFallback(muse::ui::NavigationEvent* event);
 
     void activateNavigation(const TrackId& trackId, bool highlight = false);
     void activateNavigation(const TrackItemKey& itemKey, bool highlight = false);

--- a/src/trackedit/view/tracknavigationmodel.h
+++ b/src/trackedit/view/tracknavigationmodel.h
@@ -21,8 +21,11 @@ class TrackNavigationModel : public QObject, public muse::async::Asyncable, publ
     muse::ContextInject<muse::ui::INavigationController> navigationController{ this };
     muse::ContextInject<ITrackNavigationController> tracksNavigationController{ this };
 
-    Q_PROPERTY(QList<muse::ui::NavigationPanel*> trackItemPanels READ trackItemPanels NOTIFY trackItemPanelsChanged)
-    Q_PROPERTY(QList<muse::ui::NavigationPanel*> viewItemPanels READ viewItemPanels NOTIFY viewItemPanelsChanged)
+    //! NOTE: three panels per track, in the tab order:
+    //! the track itself, the controls of its header, its clips/labels
+    Q_PROPERTY(QList<muse::ui::NavigationPanel*> trackItemPanels READ trackItemPanels NOTIFY panelsChanged)
+    Q_PROPERTY(QList<muse::ui::NavigationPanel*> trackHeaderPanels READ trackHeaderPanels NOTIFY panelsChanged)
+    Q_PROPERTY(QList<muse::ui::NavigationPanel*> viewItemPanels READ viewItemPanels NOTIFY panelsChanged)
 
 public:
     explicit TrackNavigationModel(QObject* parent = nullptr);
@@ -32,21 +35,38 @@ public:
     Q_INVOKABLE void moveFocusTo(const QVariant& trackId);
 
     QList<muse::ui::NavigationPanel*> trackItemPanels() const;
+    QList<muse::ui::NavigationPanel*> trackHeaderPanels() const;
     QList<muse::ui::NavigationPanel*> viewItemPanels() const;
 
 signals:
-    void trackItemPanelsChanged();
-    void viewItemPanelsChanged();
+    void panelsChanged();
 
 private:
+    struct TrackPanels
+    {
+        TrackId trackId = INVALID_TRACK;
+
+        muse::ui::NavigationPanel* track = nullptr;
+        muse::ui::NavigationPanel* header = nullptr;
+        muse::ui::NavigationPanel* items = nullptr;
+    };
+
     void load();
     void cleanup();
     void clearPanels();
 
+    muse::ui::NavigationPanel* makePanel(const QString& name, int order);
     void addPanels(const TrackId& trackId, int pos);
+    void removePanels(const TrackId& trackId);
     void resetPanelOrder();
+    void deletePanels(const TrackPanels& panels);
+    int indexOfTrack(const TrackId& trackId) const;
+    QList<muse::ui::NavigationPanel*> panelsList(muse::ui::NavigationPanel* TrackPanels::* panel) const;
+    void syncFocusedItem(const muse::ui::INavigationPanel* activePanel, const muse::ui::INavigationControl* activeControl);
+
     void addDefaultNavigation();
     void disableDefaultNavigation();
+
     void handleArrowKeyFallback(muse::ui::NavigationEvent* event);
 
     void activateNavigation(const TrackId& trackId, bool highlight = false);
@@ -57,7 +77,8 @@ private:
     muse::ui::NavigationPanel* m_defaultPanel = nullptr;
     muse::ui::NavigationControl* m_defaultControl = nullptr;
 
-    QList<muse::ui::NavigationPanel*> m_trackItemPanels;
-    QList<muse::ui::NavigationPanel*> m_viewItemPanels;
+    QList<TrackPanels> m_panels;
+
+    int m_lastActivePanelOrder = -1;
 };
 }


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/11180
Resolves: https://github.com/audacity/audacity/issues/11292

Track View navigation now works using Tab/Shift+Tab. To make this possible, I split the Track View into three panels: the Track panel, the Track Controls panel, and the Track Items panel (clips, labels).
Added reordering tracks with Cmd+Up/Down.
Added opening the context menu for a track with Shift+F10.

I've solved the problem with navigation in the Track Controls panel in a slightly different way. Now, when we're in this panel, we disable track view navigation and enable standard navigation (see UiContextResolver). So Up/Down/Left/Right/Enter/Space work only with this panel and do not affect the Track Items panel.

Full navigation description here https://release-audacity-4--audacityteam.netlify.app/manual/accessibility/track-view. 


QA:
- [x] Tab from a track container to its header controls (title → mute/solo/pan/volume/menu), then to clips/labels, then to the next track container.
- [x] Shift+Tab cycles through the same panels in reverse order.
- [x] For a collapsed track, header controls that are hidden are skipped when Tabbing.

- [x] When on a clip, Tab moves to the next clip on the same track (not to the playhead, not directly to the next panel).
- [x] When on the last clip, Tab moves to the next panel/track.
- [x] When on a clip, Shift+Tab moves to the previous clip.
- [x] When on the first clip, Shift+Tab returns to the previous panel (track controls).

- [x] On the track container and in the clip panel, Left/Right move the playhead (play-position decrease/increase). On the track container - this is not a requirement!!! This needs to be discussed, it is a technical limitation for now.
- [x] On the controls panel, Left/Right switch focus between controls (general navigation), rather than moving the playhead.

- [x] On a track container, Up/Down transitions between tracks.
- [x] On the clip/cue panel, Up/Down transitions to the closest element above/below in time.

- [x] When a project is open, Space/Enter on the track container or on the clip → play/pause (not "clicking" the element).
- [x] On the header control (mute/solo/menu button), Space/Enter activates the control itself (toggle mute/solo, open the menu), rather than starting playback.

- [x] Esc, while on the track header control, returns focus to the container of this track (with highlighting).
- [x] Esc when dragging/editing a clip cancels the gesture - the clip returns to its original state.
- [x] Esc when a clip/label has focus and nothing is selected clears the focus ring and moves focus to that element's track.
- [x] Esc when an element has focus and another element is selected jumps focus to the selection; the selection is preserved.
- [x] Esc when the focus is on the selected element deselects the selection and moves focus to the track.
- [x] Esc when there is a selection (clip/label/range) but no focus deselects the selection and moves focus to the track.
- [x] Esc when there is neither focus nor selection does anything (except cancel drag).

- [x] When a track is focused (focus on a container, not a clip), Ctrl+Up/Ctrl+Down move that track up/down (specifically the focused track, not the selection).
- [x] When a clip/label is focused, Ctrl+Up/Ctrl+Down work as before for the element (regression is not broken).
- [x] Moving the first track up/the last track down is a no-op, no dropouts.

- [x] Shift+F10 on a focused track (without a clip) opens the track's context menu and sets focus to the first item.

- [x] Test https://github.com/audacity/audacity/issues/11292

