### PR TITLE
Add project, preferences and native libraries extension API

### DIFF
--- a/share/testflowscripts/steps/TestUtils.js
+++ b/share/testflowscripts/steps/TestUtils.js
@@ -4,7 +4,7 @@
  * Common utilities for testflow scripts.
  */
 
-var Project = require("MuseApi.Project")
+var Project = require("Audacity.Project")
 
 var EPSILON = 0.001
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -47,6 +47,7 @@ add_subdirectory(spectrogram)
 
 add_subdirectory(automation)
 
+add_subdirectory(extensions/native)
 add_subdirectory(trackedit)
 
 if (AU_BUILD_PLAYBACK_MODULE)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -50,6 +50,10 @@ add_subdirectory(automation)
 add_subdirectory(extensions/native)
 add_subdirectory(trackedit)
 
+if (MUSE_MODULE_EXTENSIONS)
+    add_subdirectory(extensions)
+endif()
+
 if (AU_BUILD_PLAYBACK_MODULE)
     add_subdirectory(au3audio)
     add_subdirectory(playback)

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -130,6 +130,7 @@ add_to_link_if_exists(muse::uicomponents)
 add_to_link_if_exists(muse::workspace)
 
 add_to_link_if_exists(appshell)
+add_to_link_if_exists(audacity_extensions)
 add_to_link_if_exists(au3audio)
 add_to_link_if_exists(au3wrap)
 add_to_link_if_exists(au3cloud)

--- a/src/app/appfactory.cpp
+++ b/src/app/appfactory.cpp
@@ -92,8 +92,10 @@
 
 #ifdef MUSE_MODULE_EXTENSIONS
 #include "framework/extensions/extensionsmodule.h"
+#include "extensions/audacityextensionsmodule.h"
 #else
 #include "framework/stubs/extensions/extensionsstubmodule.h"
+#include "stubs/extensions/audacityextensionsstubmodule.h"
 #endif
 
 #include "au3wrap/au3wrapmodule.h"
@@ -157,6 +159,7 @@ std::shared_ptr<muse::IApplication> AppFactory::newGuiApp(const std::shared_ptr<
     app->addModule(new au::usageinfo::UsageInfoModule());
     app->addModule(new au::preferences::PreferencesModule());
     app->addModule(new au::uicomponents::UiComponentsModule());
+    app->addModule(new au::extensions::AudacityExtensionsModule());
     app->addModule(new au::effects::AudioUnitEffectsModule());
     app->addModule(new au::effects::Lv2EffectsModule());
     app->addModule(new au::effects::VstEffectsModule());

--- a/src/extensions/CMakeLists.txt
+++ b/src/extensions/CMakeLists.txt
@@ -1,0 +1,23 @@
+#
+# Audacity: A Digital Audio Editor
+#
+
+declare_module(audacity_extensions)
+
+set(MODULE_SRC
+    ${CMAKE_CURRENT_LIST_DIR}/audacityextensionsmodule.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/audacityextensionsmodule.h
+    ${CMAKE_CURRENT_LIST_DIR}/extensionpreferences.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/extensionpreferences.h
+    ${CMAKE_CURRENT_LIST_DIR}/api/audiotransformapi.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/api/audiotransformapi.h
+    ${CMAKE_CURRENT_LIST_DIR}/api/nativeapi.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/api/nativeapi.h
+    ${CMAKE_CURRENT_LIST_DIR}/api/preferencesapi.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/api/preferencesapi.h
+)
+
+set(MODULE_LINK trackedit extension_native muse::extensions)
+set(MODULE_USE_UNITY OFF)
+
+setup_module()

--- a/src/extensions/api/audiotransformapi.cpp
+++ b/src/extensions/api/audiotransformapi.cpp
@@ -1,0 +1,77 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ */
+#include "audiotransformapi.h"
+
+#include <cstdint>
+#include <utility>
+#include <vector>
+
+#include "extensions/native/nativeextension.h"
+#include "extensions/native/nativelibrary.h"
+#include "trackedit/api/audiotransform.h"
+
+namespace au::extensions {
+namespace {
+class NativeAudioTransform final : public trackedit::api::AudioTransform
+{
+public:
+    NativeAudioTransform(muse::extensions::NativeLibrary& library, QByteArray operation, std::vector<void*> contexts)
+        : AudioTransform(&library), m_library(library), m_operation(std::move(operation)), m_contexts(std::move(contexts))
+    {
+    }
+
+    bool apply(float* const channels[], uint32_t channelCount, uint64_t sampleCount) override
+    {
+        if (!channels || (!m_contexts.empty() && m_contexts.size() != channelCount)) {
+            return false;
+        }
+        for (uint32_t channel = 0; channel < channelCount; ++channel) {
+            ext_value arguments[2]{};
+            if (!m_contexts.empty()) {
+                arguments[0].type = EXT_VALUE_OBJECT;
+                arguments[0].as_object = m_contexts[channel];
+            }
+            arguments[1].type = EXT_VALUE_BUFFER;
+            arguments[1].as_buffer.data = channels[channel];
+            arguments[1].as_buffer.size = sampleCount * sizeof(float);
+            ext_value result{};
+            if (m_library.dispatch(m_operation, arguments, 2, &result) != EXT_STATUS_OK) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+private:
+    muse::extensions::NativeLibrary& m_library;
+    QByteArray m_operation;
+    std::vector<void*> m_contexts;
+};
+} // namespace
+
+AudioTransformApi::AudioTransformApi(muse::api::IApiEngine* engine)
+    : ApiObject(engine)
+{
+}
+
+QObject* AudioTransformApi::create(QObject* declaredLibrary, const QString& operation, const QJSValue& declaredContexts)
+{
+    auto* library = qobject_cast<muse::extensions::NativeLibrary*>(declaredLibrary);
+    if (!library || operation.isEmpty() || !declaredContexts.isArray()) {
+        return nullptr;
+    }
+    const quint32 count = declaredContexts.property(QStringLiteral("length")).toUInt();
+    std::vector<void*> contexts;
+    contexts.reserve(count);
+    for (quint32 index = 0; index < count; ++index) {
+        auto* handle = qobject_cast<muse::extensions::NativeHandle*>(declaredContexts.property(index).toQObject());
+        if (!handle) {
+            return nullptr;
+        }
+        contexts.push_back(handle->value());
+    }
+    return new NativeAudioTransform(*library, operation.toUtf8(), std::move(contexts));
+}
+} // namespace au::extensions

--- a/src/extensions/api/audiotransformapi.h
+++ b/src/extensions/api/audiotransformapi.h
@@ -1,0 +1,23 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ */
+#pragma once
+
+#include <QJSValue>
+#include <QObject>
+#include <QString>
+
+#include "framework/global/api/apiobject.h"
+
+namespace au::extensions {
+class AudioTransformApi final : public muse::api::ApiObject
+{
+    Q_OBJECT
+
+public:
+    explicit AudioTransformApi(muse::api::IApiEngine* engine);
+
+    Q_INVOKABLE QObject* create(QObject* library, const QString& operation, const QJSValue& contexts);
+};
+} // namespace au::extensions

--- a/src/extensions/api/nativeapi.cpp
+++ b/src/extensions/api/nativeapi.cpp
@@ -1,0 +1,112 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ */
+#include "nativeapi.h"
+
+#include <limits>
+
+#include <QStringList>
+
+#include "extensions/native/bytebuffer.h"
+#include "extensions/native/nativelibrary.h"
+#include "framework/extensions/extensionbundle.h"
+#include "log.h"
+
+namespace au::extensions {
+namespace {
+constexpr auto EXTENSION_DISPATCH_SYMBOL = "extension_dispatch_v0";
+
+QString platformName()
+{
+#if defined(Q_OS_MACOS)
+    return QStringLiteral("macos");
+#elif defined(Q_OS_WIN)
+    return QStringLiteral("windows");
+#elif defined(Q_OS_LINUX)
+    return QStringLiteral("linux");
+#else
+    return {};
+#endif
+}
+
+QString architectureName()
+{
+#if defined(Q_PROCESSOR_ARM_64)
+    return QStringLiteral("arm64");
+#elif defined(Q_PROCESSOR_X86_64)
+    return QStringLiteral("x86_64");
+#else
+    return {};
+#endif
+}
+
+QString librarySuffix()
+{
+#if defined(Q_OS_MACOS)
+    return QStringLiteral(".dylib");
+#elif defined(Q_OS_WIN)
+    return QStringLiteral(".dll");
+#elif defined(Q_OS_LINUX)
+    return QStringLiteral(".so");
+#else
+    return {};
+#endif
+}
+
+QString resolveLibrary(muse::api::IApiEngine* engine, const QString& name)
+{
+    const muse::io::path_t bundlePath = engine ? engine->apiContext().bundlePath : muse::io::path_t{};
+    if (bundlePath.empty() || name.isEmpty()) {
+        return {};
+    }
+
+    const QString platform = platformName();
+    const QString architecture = architectureName();
+    const QString suffix = librarySuffix();
+    if (platform.isEmpty() || architecture.isEmpty() || suffix.isEmpty()) {
+        return {};
+    }
+
+    QStringList architectures{ architecture };
+#if defined(Q_OS_MACOS)
+    architectures.push_back(QStringLiteral("universal"));
+#endif
+    for (const QString& candidateArchitecture : architectures) {
+        const QString relative = QStringLiteral("platform/%1/%2/%3%4").arg(platform, candidateArchitecture, name, suffix);
+        if (const auto path = muse::extensions::resolveBundleFile(bundlePath, muse::io::path_t(relative))) {
+            return path->toQString();
+        }
+    }
+    return {};
+}
+} // namespace
+
+NativeApi::NativeApi(muse::api::IApiEngine* engine)
+    : ApiObject(engine)
+{
+}
+
+QObject* NativeApi::open(const QString& name)
+{
+    const QString path = resolveLibrary(engine(), name);
+    if (path.isEmpty()) {
+        return nullptr;
+    }
+    auto* library = new muse::extensions::NativeLibrary(path, EXTENSION_DISPATCH_SYMBOL, this);
+    if (!library->isLoaded()) {
+        LOGE() << "failed to load native extension library: " << path << ", error: " << library->errorString();
+        delete library;
+        return nullptr;
+    }
+    return library;
+}
+
+QObject* NativeApi::createBuffer(qulonglong byteLength)
+{
+    if (byteLength > static_cast<qulonglong>(std::numeric_limits<qsizetype>::max())) {
+        return nullptr;
+    }
+    return new muse::extensions::ByteBuffer(static_cast<size_t>(byteLength), this);
+}
+} // namespace au::extensions

--- a/src/extensions/api/nativeapi.h
+++ b/src/extensions/api/nativeapi.h
@@ -1,0 +1,23 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ */
+#pragma once
+
+#include <QObject>
+#include <QString>
+
+#include "framework/global/api/apiobject.h"
+
+namespace au::extensions {
+class NativeApi final : public muse::api::ApiObject
+{
+    Q_OBJECT
+
+public:
+    explicit NativeApi(muse::api::IApiEngine* engine);
+
+    Q_INVOKABLE QObject* open(const QString& name);
+    Q_INVOKABLE QObject* createBuffer(qulonglong byteLength);
+};
+} // namespace au::extensions

--- a/src/extensions/api/preferencesapi.cpp
+++ b/src/extensions/api/preferencesapi.cpp
@@ -1,0 +1,27 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ */
+#include "preferencesapi.h"
+
+#include "framework/global/settings.h"
+
+#include "../extensionpreferences.h"
+
+namespace au::extensions {
+PreferencesApi::PreferencesApi(muse::api::IApiEngine* engine)
+    : ApiObject(engine)
+{
+}
+
+QVariant PreferencesApi::value(const QString& name, const QVariant& defaultValue) const
+{
+    const std::string scopeId = engine()->apiContext().scopeId;
+    if (scopeId.empty()) {
+        return defaultValue;
+    }
+
+    const muse::Val& stored = muse::settings()->value(extensionPreferenceKey(muse::Uri(scopeId), name.toStdString()));
+    return stored.isNull() ? defaultValue : stored.toQVariant();
+}
+} // namespace au::extensions

--- a/src/extensions/api/preferencesapi.h
+++ b/src/extensions/api/preferencesapi.h
@@ -1,0 +1,22 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ */
+#pragma once
+
+#include <QString>
+#include <QVariant>
+
+#include "framework/global/api/apiobject.h"
+
+namespace au::extensions {
+class PreferencesApi final : public muse::api::ApiObject
+{
+    Q_OBJECT
+
+public:
+    explicit PreferencesApi(muse::api::IApiEngine* engine);
+
+    Q_INVOKABLE QVariant value(const QString& name, const QVariant& defaultValue = {}) const;
+};
+} // namespace au::extensions

--- a/src/extensions/audacityextensionsmodule.cpp
+++ b/src/extensions/audacityextensionsmodule.cpp
@@ -1,0 +1,63 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+#include "audacityextensionsmodule.h"
+
+#include "framework/global/api/iapiregister.h"
+
+#include "api/audiotransformapi.h"
+#include "api/nativeapi.h"
+#include "api/preferencesapi.h"
+#include "extensionpreferences.h"
+
+namespace au::extensions {
+namespace {
+const std::string mname = "audacity_extensions";
+}
+
+std::string AudacityExtensionsModule::moduleName() const
+{
+    return mname;
+}
+
+void AudacityExtensionsModule::registerApi()
+{
+    auto registry = muse::modularity::globalIoc()->resolve<muse::api::IApiRegister>(mname);
+    if (registry) {
+        registry->regApiCreator(mname, "MuseApi.Native", new muse::api::ApiCreator<NativeApi>());
+        registry->regApiCreator(mname, "Audacity.AudioTransform", new muse::api::ApiCreator<AudioTransformApi>());
+        registry->regApiCreator(mname, "Audacity.Preferences", new muse::api::ApiCreator<PreferencesApi>());
+    }
+}
+
+muse::modularity::IContextSetup* AudacityExtensionsModule::newContext(const muse::modularity::ContextPtr& context) const
+{
+    return new AudacityExtensionsContext(context);
+}
+
+AudacityExtensionsContext::AudacityExtensionsContext(const muse::modularity::ContextPtr& context)
+    : IContextSetup(context)
+{
+}
+
+void AudacityExtensionsContext::onInit(const muse::IApplication::RunMode&)
+{
+    m_extensions = ioc()->resolve<muse::extensions::IExtensionsProvider>(mname);
+    registerPreferenceDefaults();
+    if (m_extensions) {
+        m_extensions->manifestListChanged().onNotify(this, [this] {
+            registerPreferenceDefaults();
+        });
+    }
+}
+
+void AudacityExtensionsContext::registerPreferenceDefaults() const
+{
+    if (!m_extensions) {
+        return;
+    }
+    for (const auto& manifest : m_extensions->manifestList()) {
+        registerExtensionPreferenceDefaults(manifest);
+    }
+}
+} // namespace au::extensions

--- a/src/extensions/audacityextensionsmodule.h
+++ b/src/extensions/audacityextensionsmodule.h
@@ -1,0 +1,33 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+#pragma once
+
+#include <memory>
+
+#include "framework/extensions/iextensionsprovider.h"
+#include "framework/global/async/asyncable.h"
+#include "framework/global/modularity/imodulesetup.h"
+
+namespace au::extensions {
+class AudacityExtensionsModule final : public muse::modularity::IModuleSetup
+{
+public:
+    std::string moduleName() const override;
+    void registerApi() override;
+    muse::modularity::IContextSetup* newContext(const muse::modularity::ContextPtr& context) const override;
+};
+
+class AudacityExtensionsContext final : public muse::modularity::IContextSetup, public muse::async::Asyncable
+{
+public:
+    explicit AudacityExtensionsContext(const muse::modularity::ContextPtr& context);
+
+    void onInit(const muse::IApplication::RunMode& mode) override;
+
+private:
+    void registerPreferenceDefaults() const;
+
+    std::shared_ptr<muse::extensions::IExtensionsProvider> m_extensions;
+};
+} // namespace au::extensions

--- a/src/extensions/extensionpreferences.cpp
+++ b/src/extensions/extensionpreferences.cpp
@@ -1,0 +1,67 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+#include "extensionpreferences.h"
+
+#include <QByteArray>
+#include <QDir>
+
+#include "framework/global/iglobalconfiguration.h"
+#include "framework/global/modularity/ioc.h"
+#include "framework/extensions/extensionstypes.h"
+
+#include "framework/global/containers.h"
+
+namespace au::extensions {
+muse::Settings::Key extensionPreferenceKey(const muse::Uri& uri, const std::string& key)
+{
+    const std::string id = QByteArray::fromStdString(uri.toString()).toHex().toStdString();
+    return { "extensions", "preferences/" + id + "/" + key };
+}
+
+QVariant extensionPreferenceDefault(const muse::ValMap& preference)
+{
+    const muse::Val value = muse::value(preference, "default");
+    switch (value.type()) {
+    case muse::Val::Type::Bool:
+    case muse::Val::Type::Int:
+    case muse::Val::Type::Int64:
+    case muse::Val::Type::Double:
+        return value.toQVariant();
+    case muse::Val::Type::String:
+        break;
+    default:
+        return {};
+    }
+
+    QString result = value.toQVariant().toString();
+    static const QString genericDataToken = QStringLiteral("${GENERIC_DATA}");
+    if (!result.startsWith(genericDataToken)) {
+        return result;
+    }
+
+    static muse::GlobalInject<muse::IGlobalConfiguration> configuration;
+    if (!configuration()) {
+        return {};
+    }
+    result.replace(0, genericDataToken.size(), configuration()->genericDataPath().toQString());
+    return QDir::cleanPath(result);
+}
+
+void registerExtensionPreferenceDefaults(const muse::extensions::Manifest& manifest)
+{
+    const auto contribution = manifest.contributes.find("audacity.preferences");
+    if (contribution == manifest.contributes.end()) {
+        return;
+    }
+
+    for (const muse::ValMap& preference : contribution->second) {
+        const muse::Val id = muse::value(preference, "id");
+        const QVariant value = extensionPreferenceDefault(preference);
+        if (id.type() != muse::Val::Type::String || !value.isValid()) {
+            continue;
+        }
+        muse::settings()->setDefaultValue(extensionPreferenceKey(manifest.uri, id.toString()), muse::Val::fromQVariant(value));
+    }
+}
+} // namespace au::extensions

--- a/src/extensions/extensionpreferences.h
+++ b/src/extensions/extensionpreferences.h
@@ -1,0 +1,23 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+#pragma once
+
+#include <string>
+
+#include <QVariant>
+
+#include "framework/global/types/val.h"
+#include "framework/global/settings.h"
+#include "framework/global/types/uri.h"
+
+namespace muse::extensions {
+struct Manifest;
+}
+
+namespace au::extensions {
+muse::Settings::Key extensionPreferenceKey(const muse::Uri& uri, const std::string& key);
+
+QVariant extensionPreferenceDefault(const muse::ValMap& preference);
+void registerExtensionPreferenceDefaults(const muse::extensions::Manifest& manifest);
+} // namespace au::extensions

--- a/src/extensions/native/CMakeLists.txt
+++ b/src/extensions/native/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_library(extension_native STATIC
+    bytebuffer.cpp
+    bytebuffer.h
+)
+
+target_include_directories(extension_native PUBLIC ${PROJECT_SOURCE_DIR}/src)
+target_link_libraries(extension_native PUBLIC Qt::Core Qt::Qml)

--- a/src/extensions/native/CMakeLists.txt
+++ b/src/extensions/native/CMakeLists.txt
@@ -1,7 +1,15 @@
-add_library(extension_native STATIC
-    bytebuffer.cpp
-    bytebuffer.h
+declare_module(extension_native)
+
+set(MODULE_SRC
+    ${CMAKE_CURRENT_LIST_DIR}/bytebuffer.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/bytebuffer.h
+    ${CMAKE_CURRENT_LIST_DIR}/nativeextension.h
+    ${CMAKE_CURRENT_LIST_DIR}/nativelibrary.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/nativelibrary.h
 )
 
-target_include_directories(extension_native PUBLIC ${PROJECT_SOURCE_DIR}/src)
-target_link_libraries(extension_native PUBLIC Qt::Core Qt::Qml)
+set(MODULE_INCLUDE ${PROJECT_SOURCE_DIR}/src)
+set(MODULE_LINK_PUBLIC Qt::Core Qt::Qml)
+set(MODULE_USE_UNITY OFF)
+
+setup_module()

--- a/src/extensions/native/bytebuffer.cpp
+++ b/src/extensions/native/bytebuffer.cpp
@@ -15,10 +15,17 @@ void throwSizeError(const QObject* object)
         engine->throwError(QJSValue::RangeError, QStringLiteral("Buffer size does not match"));
     }
 }
+
+void throwInUseError(const QObject* object)
+{
+    if (auto* engine = qjsEngine(object)) {
+        engine->throwError(QStringLiteral("Buffer is in use by a native call"));
+    }
+}
 } // namespace
 
 ByteBuffer::ByteBuffer(size_t byteLength, QObject* parent)
-    : QObject(parent), m_data(std::make_shared<QByteArray>(static_cast<qsizetype>(byteLength), Qt::Uninitialized))
+    : QObject(parent), m_data(std::make_shared<QByteArray>(static_cast<qsizetype>(byteLength), '\0'))
 {
 }
 
@@ -29,6 +36,10 @@ qulonglong ByteBuffer::byteLength() const
 
 QByteArray ByteBuffer::copyToArrayBuffer() const
 {
+    if (!isExclusive()) {
+        throwInUseError(this);
+        return {};
+    }
     return *m_data;
 }
 
@@ -36,6 +47,10 @@ void ByteBuffer::copyFromArrayBuffer(const QByteArray& buffer)
 {
     if (buffer.size() != m_data->size()) {
         throwSizeError(this);
+        return;
+    }
+    if (!isExclusive()) {
+        throwInUseError(this);
         return;
     }
     *m_data = buffer;

--- a/src/extensions/native/bytebuffer.cpp
+++ b/src/extensions/native/bytebuffer.cpp
@@ -1,0 +1,62 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ */
+#include "bytebuffer.h"
+
+#include <QJSEngine>
+
+using namespace muse::extensions;
+
+namespace {
+void throwSizeError(const QObject* object)
+{
+    if (auto* engine = qjsEngine(object)) {
+        engine->throwError(QJSValue::RangeError, QStringLiteral("Buffer size does not match"));
+    }
+}
+} // namespace
+
+ByteBuffer::ByteBuffer(size_t byteLength, QObject* parent)
+    : QObject(parent), m_data(std::make_shared<QByteArray>(static_cast<qsizetype>(byteLength), Qt::Uninitialized))
+{
+}
+
+qulonglong ByteBuffer::byteLength() const
+{
+    return static_cast<qulonglong>(m_data->size());
+}
+
+QByteArray ByteBuffer::copyToArrayBuffer() const
+{
+    return *m_data;
+}
+
+void ByteBuffer::copyFromArrayBuffer(const QByteArray& buffer)
+{
+    if (buffer.size() != m_data->size()) {
+        throwSizeError(this);
+        return;
+    }
+    *m_data = buffer;
+}
+
+void* ByteBuffer::data()
+{
+    return m_data->data();
+}
+
+const void* ByteBuffer::data() const
+{
+    return m_data->constData();
+}
+
+std::shared_ptr<QByteArray> ByteBuffer::storage() const
+{
+    return m_data;
+}
+
+bool ByteBuffer::isExclusive() const
+{
+    return m_data.use_count() == 1;
+}

--- a/src/extensions/native/bytebuffer.h
+++ b/src/extensions/native/bytebuffer.h
@@ -1,0 +1,32 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ */
+#pragma once
+
+#include <memory>
+
+#include <QByteArray>
+#include <QObject>
+
+namespace muse::extensions {
+class ByteBuffer final : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(qulonglong byteLength READ byteLength CONSTANT)
+
+public:
+    explicit ByteBuffer(size_t byteLength, QObject* parent = nullptr);
+
+    qulonglong byteLength() const;
+    Q_INVOKABLE QByteArray copyToArrayBuffer() const;
+    Q_INVOKABLE void copyFromArrayBuffer(const QByteArray& buffer);
+    void* data();
+    const void* data() const;
+    std::shared_ptr<QByteArray> storage() const;
+    bool isExclusive() const;
+
+private:
+    std::shared_ptr<QByteArray> m_data;
+};
+} // namespace muse::extensions

--- a/src/extensions/native/nativeextension.h
+++ b/src/extensions/native/nativeextension.h
@@ -1,0 +1,61 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ */
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#define EXT_STATUS_OK ((int32_t)0)
+#define EXT_STATUS_ERROR ((int32_t)1)
+#define EXT_STATUS_UNKNOWN_CALL ((int32_t)2)
+#define EXT_STATUS_INVALID_ARGUMENT ((int32_t)3)
+
+#define EXT_VALUE_NONE ((uint32_t)0)
+#define EXT_VALUE_BOOL ((uint32_t)1)
+#define EXT_VALUE_NUMBER ((uint32_t)2)
+#define EXT_VALUE_STRING ((uint32_t)3)
+#define EXT_VALUE_OBJECT ((uint32_t)4)
+#define EXT_VALUE_BUFFER ((uint32_t)5)
+
+#if defined(_WIN32)
+#define EXT_EXPORT __declspec(dllexport)
+#else
+#define EXT_EXPORT __attribute__((visibility("default")))
+#endif
+
+#pragma pack(push, 8)
+
+typedef struct ext_buffer {
+    void* data;
+    // Bytes
+    uint64_t size;
+} ext_buffer;
+
+typedef struct ext_value {
+    uint32_t type;
+    union {
+        bool as_bool;
+        double as_number;
+        const char* as_string;
+        void* as_object;
+        ext_buffer as_buffer;
+    };
+} ext_value;
+
+#pragma pack(pop)
+
+// Input strings and buffers live for the call
+// Returned strings live until the next call on this thread
+typedef int32_t (* ext_dispatch_fn)(const char* call, const ext_value* args, uint32_t arg_count, ext_value* result);
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+EXT_EXPORT int32_t extension_dispatch_v0(const char* call, const ext_value* args, uint32_t arg_count, ext_value* result);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/extensions/native/nativelibrary.cpp
+++ b/src/extensions/native/nativelibrary.cpp
@@ -1,0 +1,316 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ */
+#include "nativelibrary.h"
+
+#include <chrono>
+#include <utility>
+
+#include "bytebuffer.h"
+
+using namespace muse::extensions;
+
+namespace {
+QJSValue boundFunction(QJSEngine* engine, QObject* library, const QString& name, const char* method)
+{
+    const QString source = QStringLiteral(
+        "(function(library, name, method) { return function() { "
+        "return library[method](name, Array.prototype.slice.call(arguments)); }; })");
+    return engine->evaluate(source).call({ engine->newQObject(library), name, QString::fromUtf8(method) });
+}
+
+QString statusText(const NativeCallData& call)
+{
+    if (!call.returnedString.isEmpty()) {
+        return QString::fromUtf8(call.returnedString);
+    }
+    switch (call.status) {
+    case EXT_STATUS_UNKNOWN_CALL:
+        return QStringLiteral("Unknown native call");
+    case EXT_STATUS_INVALID_ARGUMENT:
+        return QStringLiteral("Invalid native call arguments");
+    default:
+        return QStringLiteral("Native call failed");
+    }
+}
+
+int32_t dispatchCall(ext_dispatch_fn dispatch, const QByteArray& name, const ext_value* arguments, uint32_t argumentCount,
+                     ext_value* result)
+{
+    if (!dispatch || !result) {
+        return EXT_STATUS_ERROR;
+    }
+    try {
+        return dispatch(name.constData(), arguments, argumentCount, result);
+    } catch (...) {
+        return EXT_STATUS_ERROR;
+    }
+}
+
+void executeCall(ext_dispatch_fn dispatch, const QByteArray& name, NativeCallData& call)
+{
+    call.result = {};
+    call.status
+        = dispatchCall(dispatch, name, call.arguments.empty() ? nullptr : call.arguments.data(),
+                       static_cast<uint32_t>(call.arguments.size()), &call.result);
+    if (call.result.type == EXT_VALUE_STRING && call.result.as_string) {
+        call.returnedString = call.result.as_string;
+    }
+}
+} // namespace
+
+void NativeCallData::releaseBuffers()
+{
+    for (auto& argument : storage) {
+        argument.buffer.reset();
+    }
+}
+
+NativeLibrary::NativeLibrary(const QString& path, const QByteArray& dispatchSymbol, QObject* parent)
+    : QObject(parent), m_library(path)
+{
+    m_library.setLoadHints(QLibrary::ResolveAllSymbolsHint | QLibrary::PreventUnloadHint);
+    if (m_library.load()) {
+        m_dispatch = reinterpret_cast<ext_dispatch_fn>(m_library.resolve(dispatchSymbol.constData()));
+    }
+}
+
+NativeLibrary::~NativeLibrary()
+{
+    for (NativeCall* call : findChildren<NativeCall*>()) {
+        if (call->inFlight()) {
+            call->orphan();
+        } else {
+            delete call;
+        }
+    }
+}
+
+bool NativeLibrary::isLoaded() const
+{
+    return m_dispatch != nullptr;
+}
+
+QString NativeLibrary::errorString() const
+{
+    return m_library.isLoaded() && !m_dispatch ? QStringLiteral("The native library has no dispatcher") : m_library.errorString();
+}
+
+int32_t NativeLibrary::dispatch(const QByteArray& name, const ext_value* arguments, uint32_t argumentCount, ext_value* result) const
+{
+    return dispatchCall(m_dispatch, name, arguments, argumentCount, result);
+}
+
+QJSValue NativeLibrary::bind(const QString& name)
+{
+    return bind(name, "dispatch");
+}
+
+QJSValue NativeLibrary::bindWorker(const QString& name)
+{
+    return bind(name, "dispatchWorker");
+}
+
+QJSValue NativeLibrary::bind(const QString& name, const char* method)
+{
+    QJSEngine* engine = qjsEngine(this);
+    if (!engine || name.isEmpty()) {
+        return {};
+    }
+    return boundFunction(engine, this, name, method);
+}
+
+QJSValue NativeLibrary::dispatch(const QString& name, const QJSValue& arguments)
+{
+    NativeCallData call;
+    QJSEngine* engine = qjsEngine(this);
+    if (!engine || name.isEmpty() || !prepare(arguments, call)) {
+        if (engine) {
+            engine->throwError(QStringLiteral("Unsupported native call argument"));
+        }
+        return {};
+    }
+    execute(name.toUtf8(), call);
+    return resultValue(call);
+}
+
+QJSValue NativeLibrary::dispatchWorker(const QString& name, const QJSValue& arguments)
+{
+    NativeCallData call;
+    QJSEngine* engine = qjsEngine(this);
+    if (!engine || name.isEmpty() || !prepare(arguments, call)) {
+        if (engine) {
+            engine->throwError(QStringLiteral("Unsupported native call argument"));
+        }
+        return {};
+    }
+    return workerPromise(new NativeCall(*this, name.toUtf8(), std::move(call)));
+}
+
+bool NativeLibrary::prepare(const QJSValue& arguments, NativeCallData& call) const
+{
+    if (!arguments.isArray()) {
+        return false;
+    }
+    const quint32 count = arguments.property(QStringLiteral("length")).toUInt();
+    call.storage.resize(count);
+    call.arguments.resize(count);
+    for (quint32 index = 0; index < count; ++index) {
+        NativeArgument& stored = call.storage[index];
+        const QJSValue input = arguments.property(index);
+        if (input.isUndefined() || input.isNull()) {
+            stored.value.type = EXT_VALUE_NONE;
+        } else if (input.isBool()) {
+            stored.value.type = EXT_VALUE_BOOL;
+            stored.value.as_bool = input.toBool();
+        } else if (input.isString()) {
+            stored.string = input.toString().toUtf8();
+            stored.value.type = EXT_VALUE_STRING;
+            stored.value.as_string = stored.string.constData();
+        } else if (auto* object = input.toQObject()) {
+            if (auto* handle = qobject_cast<NativeHandle*>(object)) {
+                stored.value.type = EXT_VALUE_OBJECT;
+                stored.value.as_object = handle->value();
+            } else if (auto* buffer = qobject_cast<ByteBuffer*>(object)) {
+                if (!buffer->isExclusive()) {
+                    return false;
+                }
+                stored.buffer = buffer->storage();
+                stored.value.type = EXT_VALUE_BUFFER;
+                stored.value.as_buffer.data = stored.buffer->data();
+                stored.value.as_buffer.size = static_cast<uint64_t>(stored.buffer->size());
+            } else {
+                return false;
+            }
+        } else if (input.isNumber()) {
+            stored.value.type = EXT_VALUE_NUMBER;
+            stored.value.as_number = input.toNumber();
+        } else {
+            return false;
+        }
+        call.arguments[index] = stored.value;
+    }
+    return true;
+}
+
+void NativeLibrary::execute(const QByteArray& name, NativeCallData& call) const
+{
+    executeCall(m_dispatch, name, call);
+}
+
+QJSValue NativeLibrary::resultValue(const NativeCallData& call)
+{
+    QJSEngine* engine = qjsEngine(this);
+    if (!engine) {
+        return {};
+    }
+    if (call.status != EXT_STATUS_OK) {
+        engine->throwError(statusText(call));
+        return {};
+    }
+    switch (call.result.type) {
+    case EXT_VALUE_NONE:
+        return QJSValue(QJSValue::UndefinedValue);
+    case EXT_VALUE_BOOL:
+        return QJSValue(call.result.as_bool);
+    case EXT_VALUE_NUMBER:
+        return QJSValue(call.result.as_number);
+    case EXT_VALUE_STRING:
+        return QJSValue(QString::fromUtf8(call.returnedString));
+    case EXT_VALUE_OBJECT:
+        if (!call.result.as_object) {
+            return QJSValue(QJSValue::NullValue);
+        }
+        return engine->newQObject(new NativeHandle(call.result.as_object, this));
+    case EXT_VALUE_BUFFER:
+    default:
+        engine->throwError(QStringLiteral("Unsupported native result"));
+        return {};
+    }
+}
+
+QJSValue NativeLibrary::workerPromise(NativeCall* call)
+{
+    QJSEngine* engine = qjsEngine(this);
+    if (!engine || !call) {
+        delete call;
+        return {};
+    }
+    if (!m_workerPromiseFactory.isCallable()) {
+        m_workerPromiseFactory
+            = engine->evaluate(QStringLiteral(
+                                   "(function(call) { return new Promise(function(resolve, reject) { "
+                                   "call.start(resolve, reject); }); })"));
+    }
+    return m_workerPromiseFactory.call({ engine->newQObject(call) });
+}
+
+NativeCall::NativeCall(NativeLibrary& library, QByteArray name, NativeCallData call)
+    : QObject(&library), m_library(&library), m_dispatch(library.m_dispatch), m_name(std::move(name)), m_call(std::move(call))
+{
+}
+
+NativeCall::~NativeCall()
+{
+    if (m_future.valid()) {
+        m_future.wait();
+    }
+}
+
+bool NativeCall::inFlight() const
+{
+    return m_future.valid() && m_future.wait_for(std::chrono::seconds(0)) != std::future_status::ready;
+}
+
+void NativeCall::orphan()
+{
+    m_library = nullptr;
+    m_resolve = QJSValue();
+    m_reject = QJSValue();
+    setParent(nullptr);
+}
+
+void NativeCall::start(const QJSValue& resolve, const QJSValue& reject)
+{
+    if (m_started) {
+        return;
+    }
+    m_started = true;
+    m_resolve = resolve;
+    m_reject = reject;
+    m_future = std::async(std::launch::async, [this] {
+        executeCall(m_dispatch, m_name, m_call);
+        QMetaObject::invokeMethod(
+            this,
+            [this] {
+            complete();
+        },
+            Qt::QueuedConnection);
+    });
+}
+
+void NativeCall::complete()
+{
+    m_call.releaseBuffers();
+    if (!m_library) {
+        deleteLater();
+        return;
+    }
+    if (m_call.status == EXT_STATUS_OK && m_resolve.isCallable()) {
+        m_resolve.call({ m_library->resultValue(m_call) });
+    } else if (m_reject.isCallable()) {
+        m_reject.call({ QJSValue(statusText(m_call)) });
+    }
+    deleteLater();
+}
+
+NativeHandle::NativeHandle(void* value, QObject* parent)
+    : QObject(parent), m_value(value)
+{
+}
+
+void* NativeHandle::value() const
+{
+    return m_value;
+}

--- a/src/extensions/native/nativelibrary.h
+++ b/src/extensions/native/nativelibrary.h
@@ -1,0 +1,108 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-only
+ * MuseScore-CLA-applies
+ */
+#pragma once
+
+#include <cstdint>
+#include <future>
+#include <memory>
+#include <vector>
+
+#include <QByteArray>
+#include <QJSEngine>
+#include <QJSValue>
+#include <QLibrary>
+#include <QObject>
+#include <QString>
+
+#include "nativeextension.h"
+
+namespace muse::extensions {
+struct NativeArgument {
+    ext_value value{};
+    QByteArray string;
+    std::shared_ptr<QByteArray> buffer;
+};
+
+struct NativeCallData {
+    std::vector<NativeArgument> storage;
+    std::vector<ext_value> arguments;
+    ext_value result{};
+    QByteArray returnedString;
+    int32_t status = EXT_STATUS_ERROR;
+
+    void releaseBuffers();
+};
+
+class NativeLibrary;
+
+class NativeCall final : public QObject
+{
+    Q_OBJECT
+
+public:
+    NativeCall(NativeLibrary& library, QByteArray name, NativeCallData call);
+    ~NativeCall() override;
+
+    Q_INVOKABLE void start(const QJSValue& resolve, const QJSValue& reject);
+
+    bool inFlight() const;
+    void orphan();
+
+private:
+    void complete();
+
+    NativeLibrary* m_library = nullptr;
+    ext_dispatch_fn m_dispatch = nullptr;
+    QByteArray m_name;
+    NativeCallData m_call;
+    QJSValue m_resolve;
+    QJSValue m_reject;
+    std::future<void> m_future;
+    bool m_started = false;
+};
+
+class NativeLibrary : public QObject
+{
+    Q_OBJECT
+
+public:
+    NativeLibrary(const QString& path, const QByteArray& dispatchSymbol, QObject* parent);
+    ~NativeLibrary() override;
+
+    bool isLoaded() const;
+    QString errorString() const;
+    int32_t dispatch(const QByteArray& name, const ext_value* arguments, uint32_t argumentCount, ext_value* result) const;
+
+    Q_INVOKABLE QJSValue dispatch(const QString& name, const QJSValue& arguments);
+    Q_INVOKABLE QJSValue dispatchWorker(const QString& name, const QJSValue& arguments);
+    Q_INVOKABLE QJSValue bind(const QString& name);
+    Q_INVOKABLE QJSValue bindWorker(const QString& name);
+
+private:
+    QJSValue bind(const QString& name, const char* method);
+    bool prepare(const QJSValue& arguments, NativeCallData& call) const;
+    void execute(const QByteArray& name, NativeCallData& call) const;
+    QJSValue resultValue(const NativeCallData& call);
+    QJSValue workerPromise(NativeCall* call);
+
+    friend class NativeCall;
+
+    QLibrary m_library;
+    ext_dispatch_fn m_dispatch = nullptr;
+    QJSValue m_workerPromiseFactory;
+};
+
+class NativeHandle final : public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit NativeHandle(void* value, QObject* parent = nullptr);
+    void* value() const;
+
+private:
+    void* m_value = nullptr;
+};
+} // namespace muse::extensions

--- a/src/preferences/qml/Audacity/Preferences/CMakeLists.txt
+++ b/src/preferences/qml/Audacity/Preferences/CMakeLists.txt
@@ -54,6 +54,7 @@ qt_add_qml_module(preferences_qml
         internal/DeleteBehaviorSection.qml
         internal/EffectBehaviorSection.qml
         internal/EffectOptionsSection.qml
+        internal/ExtensionPreferencesSection.qml
         internal/FFmpegLibrarySection.qml
         internal/FoldersSection.qml
         internal/FreeSpaceSection.qml
@@ -107,8 +108,9 @@ qt_add_qml_module(preferences_qml
     IMPORTS
         TARGET muse_ui_qml
         TARGET muse_uicomponents_qml
-        TARGET muse_extensions_qml
         TARGET muse_shortcuts_qml
 )
 
 fixup_qml_module_dependencies(preferences_qml)
+
+target_link_libraries(preferences_qml PRIVATE audacity_extensions)

--- a/src/preferences/qml/Audacity/Preferences/PluginPreferencesPage.qml
+++ b/src/preferences/qml/Audacity/Preferences/PluginPreferencesPage.qml
@@ -12,14 +12,15 @@ PreferencesPage {
     id: root
 
     PluginPreferencesModel {
-        id: pluginPreferencesModel
+        id: preferencesModel
     }
 
     Component.onCompleted: {
-        pluginPreferencesModel.init()
+        preferencesModel.init()
     }
 
     Column {
+        id: sectionsColumn
 
         width: parent.width
         spacing: root.sectionsSpacing
@@ -27,7 +28,7 @@ PreferencesPage {
         EffectOptionsSection {
             id: effectBehaviorSection
 
-            pluginPreferencesModel: pluginPreferencesModel
+            pluginPreferencesModel: preferencesModel
 
             navigation.section: root.navigationSection
             navigation.order: root.navigationOrderStart
@@ -46,25 +47,25 @@ PreferencesPage {
         PluginLocationsSection {
             id: lv2Section
 
-            visible: pluginPreferencesModel.lv2Supported
+            visible: preferencesModel.lv2Supported
 
             title: qsTrc("preferences", "Custom LV2 plugins location")
             dialogTitle: qsTrc("preferences", "Choose custom LV2 plugins location")
 
-            paths: pluginPreferencesModel.lv2CustomPaths
+            paths: preferencesModel.lv2CustomPaths
             pathValidator: function (p) {
-                return pluginPreferencesModel.pathExists(p)
+                return preferencesModel.pathExists(p)
             }
 
             navigation.section: root.navigationSection
             navigation.order: effectBehaviorSection.navigation.order + 1
 
-            onAddPathRequested: pluginPreferencesModel.addLv2Path()
+            onAddPathRequested: preferencesModel.addLv2Path()
             onPathChanged: function (index, newPath) {
-                pluginPreferencesModel.setLv2Path(index, newPath)
+                preferencesModel.setLv2Path(index, newPath)
             }
             onRemovePathRequested: function (index) {
-                pluginPreferencesModel.removeLv2Path(index)
+                preferencesModel.removeLv2Path(index)
             }
 
             onFocusChanged: {
@@ -81,30 +82,66 @@ PreferencesPage {
         PluginLocationsSection {
             id: vst3Section
 
-            visible: pluginPreferencesModel.vst3Supported
+            visible: preferencesModel.vst3Supported
 
             title: qsTrc("preferences", "Custom VST3 plugins location")
             dialogTitle: qsTrc("preferences", "Choose custom VST3 plugins location")
 
-            paths: pluginPreferencesModel.vst3CustomPaths
+            paths: preferencesModel.vst3CustomPaths
             pathValidator: function (p) {
-                return pluginPreferencesModel.pathExists(p)
+                return preferencesModel.pathExists(p)
             }
 
             navigation.section: root.navigationSection
             navigation.order: lv2Section.navigation.order + 1
 
-            onAddPathRequested: pluginPreferencesModel.addVst3Path()
+            onAddPathRequested: preferencesModel.addVst3Path()
             onPathChanged: function (index, newPath) {
-                pluginPreferencesModel.setVst3Path(index, newPath)
+                preferencesModel.setVst3Path(index, newPath)
             }
             onRemovePathRequested: function (index) {
-                pluginPreferencesModel.removeVst3Path(index)
+                preferencesModel.removeVst3Path(index)
             }
 
             onFocusChanged: {
                 if (activeFocus) {
                     root.ensureContentVisibleRequested(Qt.rect(x, y, width, height))
+                }
+            }
+        }
+
+        Repeater {
+            model: preferencesModel.extensionPreferences
+
+            delegate: Column {
+                id: extensionPreferences
+
+                required property var modelData
+                required property int index
+
+                width: parent.width
+                spacing: root.sectionsSpacing
+
+                SeparatorLine {
+                    width: parent.width
+                }
+
+                ExtensionPreferencesSection {
+                    id: extensionSection
+
+                    width: parent.width
+                    preferenceGroup: extensionPreferences.modelData
+                    pluginPreferencesModel: preferencesModel
+
+                    navigation.section: root.navigationSection
+                    navigation.order: vst3Section.navigation.order + 1 + extensionPreferences.index
+
+                    onFocusChanged: {
+                        if (activeFocus) {
+                            const position = extensionSection.mapToItem(sectionsColumn, 0, 0)
+                            root.ensureContentVisibleRequested(Qt.rect(position.x, position.y, width, height))
+                        }
+                    }
                 }
             }
         }

--- a/src/preferences/qml/Audacity/Preferences/internal/ExtensionPreferencesSection.qml
+++ b/src/preferences/qml/Audacity/Preferences/internal/ExtensionPreferencesSection.qml
@@ -1,0 +1,150 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+import QtQuick
+
+import Muse.Ui
+import Muse.UiComponents
+
+import Audacity.UiComponents 1.0
+
+BaseSection {
+    id: root
+
+    required property var preferenceGroup
+    required property var pluginPreferencesModel
+
+    title: preferenceGroup.title
+
+    navigation.direction: NavigationPanel.Both
+
+    Repeater {
+        model: root.preferenceGroup.items
+
+        delegate: Column {
+            id: preferenceRow
+
+            required property var modelData
+            required property int index
+
+            width: parent.width
+            spacing: 6
+
+            StyledTextLabel {
+                width: parent.width
+                text: preferenceRow.modelData.title
+                horizontalAlignment: Text.AlignLeading
+                wrapMode: Text.WordWrap
+            }
+
+            Loader {
+                id: editor
+
+                width: 360
+                sourceComponent: preferenceRow.modelData.type === "bool" ? booleanEditor : preferenceRow.modelData.type === "enum" ? enumEditor : preferenceRow.modelData.type === "directory" ? directoryEditor : textEditor
+
+                property var preference: preferenceRow.modelData
+                property int row: preferenceRow.index
+                property var section: root
+            }
+
+            StyledTextLabel {
+                width: parent.width
+                visible: text.length > 0
+                text: preferenceRow.modelData.description
+                horizontalAlignment: Text.AlignLeading
+                wrapMode: Text.WordWrap
+                color: ui.theme.fontSecondaryColor
+            }
+        }
+    }
+
+    Component {
+        id: booleanEditor
+
+        CheckBox {
+            id: checkBox
+
+            readonly property var preference: parent.preference
+            readonly property var section: parent.section
+
+            checked: preference.value
+            navigation.name: section.preferenceGroup.extensionId + "." + preference.id
+            navigation.panel: section.navigation
+            navigation.row: parent.row
+            navigation.column: 0
+            onClicked: {
+                checked = !checked
+                section.pluginPreferencesModel.setExtensionPreference(section.preferenceGroup.extensionId, preference.id, checked)
+            }
+        }
+    }
+
+    Component {
+        id: enumEditor
+
+        StyledDropdown {
+            id: dropdown
+
+            readonly property var preference: parent.preference
+            readonly property var section: parent.section
+
+            width: 280
+            model: preference.choices
+            textRole: "text"
+            valueRole: "value"
+            currentIndex: indexOfValue(preference.value)
+            navigation.name: section.preferenceGroup.extensionId + "." + preference.id
+            navigation.panel: section.navigation
+            navigation.row: parent.row
+            navigation.column: 0
+            onActivated: function (index, value) {
+                currentIndex = index
+                section.pluginPreferencesModel.setExtensionPreference(section.preferenceGroup.extensionId, preference.id, value)
+            }
+        }
+    }
+
+    Component {
+        id: textEditor
+
+        TextInputField {
+            id: textInput
+
+            readonly property var preference: parent.preference
+            readonly property var section: parent.section
+
+            width: 360
+            currentText: preference.value ?? ""
+            navigation.name: section.preferenceGroup.extensionId + "." + preference.id
+            navigation.panel: section.navigation
+            navigation.row: parent.row
+            navigation.column: 0
+            onTextEditingFinished: function (value) {
+                section.pluginPreferencesModel.setExtensionPreference(section.preferenceGroup.extensionId, preference.id, value)
+            }
+        }
+    }
+
+    Component {
+        id: directoryEditor
+
+        FilePicker {
+            readonly property var preference: parent.preference
+            readonly property var section: parent.section
+
+            width: 360
+            pickerType: FilePicker.PickerType.Directory
+            path: preference.value ?? ""
+            pathFieldTitle: preference.title
+            dialogTitle: preference.title
+            navigation: section.navigation
+            navigationRowOrderStart: parent.row
+
+            onPathEdited: function (value) {
+                path = value
+                section.pluginPreferencesModel.setExtensionPreference(section.preferenceGroup.extensionId, preference.id, value)
+            }
+        }
+    }
+}

--- a/src/preferences/qml/Audacity/Preferences/pluginpreferencesmodel.cpp
+++ b/src/preferences/qml/Audacity/Preferences/pluginpreferencesmodel.cpp
@@ -3,9 +3,27 @@
  */
 #include "pluginpreferencesmodel.h"
 
+#include <QTimer>
+
 #include "io/dir.h"
+#include "extensions/extensionpreferences.h"
+#include "framework/global/containers.h"
 
 namespace au::appshell {
+static QVariant preferenceValue(const muse::Val& value)
+{
+    switch (value.type()) {
+    case muse::Val::Type::Bool:
+    case muse::Val::Type::Int:
+    case muse::Val::Type::Int64:
+    case muse::Val::Type::Double:
+    case muse::Val::Type::String:
+        return value.toQVariant();
+    default:
+        return {};
+    }
+}
+
 static QStringList toQStringList(const muse::io::paths_t& paths)
 {
     QStringList result;
@@ -27,7 +45,7 @@ static muse::io::paths_t toPathsT(const QStringList& paths)
 }
 
 PluginPreferencesModel::PluginPreferencesModel(QObject* parent)
-    : QObject(parent)
+    : QObject(parent), muse::Contextable(muse::iocCtxForQmlObject(this))
 {
 }
 
@@ -43,6 +61,17 @@ void PluginPreferencesModel::init()
 
     effectsConfiguration()->vst3CustomPathsChanged().onNotify(this, [this] {
         emit vst3CustomPathsChanged();
+    });
+
+    reloadExtensionPreferences();
+    extensionsProvider()->manifestListChanged().onNotify(this, [this] {
+        reloadExtensionPreferences();
+    });
+
+    appshellConfiguration()->aboutToRevertToFactorySettings().onNotify(this, [this] {
+        QTimer::singleShot(0, this, [this] {
+            reloadExtensionPreferences();
+        });
     });
 }
 
@@ -151,5 +180,91 @@ bool PluginPreferencesModel::lv2Supported() const
 bool PluginPreferencesModel::vst3Supported() const
 {
     return effectsProvider()->hasEffectFamily(effects::EffectFamily::VST3);
+}
+
+QVariantList PluginPreferencesModel::extensionPreferences() const
+{
+    return m_extensionPreferences;
+}
+
+bool PluginPreferencesModel::setExtensionPreference(const QString& extensionId, const QString& key, const QVariant& value)
+{
+    const muse::Uri uri(extensionId.toStdString());
+    if (!uri.isValid() || key.isEmpty() || !value.isValid()) {
+        return false;
+    }
+    muse::settings()->setSharedValue(au::extensions::extensionPreferenceKey(uri, key.toStdString()), muse::Val::fromQVariant(value));
+    return true;
+}
+
+void PluginPreferencesModel::reloadExtensionPreferences()
+{
+    QVariantList groups;
+    for (const auto& manifest : extensionsProvider()->manifestList()) {
+        const auto found = manifest.contributes.find("audacity.preferences");
+        if (found == manifest.contributes.end() || found->second.empty()) {
+            continue;
+        }
+
+        QVariantList items;
+        for (const muse::ValMap& item : found->second) {
+            const muse::Val idValue = muse::value(item, "id");
+            const muse::Val titleValue = muse::value(item, "title");
+            if (idValue.type() != muse::Val::Type::String || titleValue.type() != muse::Val::Type::String) {
+                continue;
+            }
+
+            const QString key = QString::fromStdString(idValue.toString());
+            const QString title = QString::fromStdString(titleValue.toString());
+            const muse::Val typeValue = muse::value(item, "type");
+            const QString type = typeValue.type()
+                                 == muse::Val::Type::String ? QString::fromStdString(typeValue.toString()) : QStringLiteral("string");
+            if (key.isEmpty() || title.isEmpty()) {
+                continue;
+            }
+
+            const auto setting = au::extensions::extensionPreferenceKey(manifest.uri, key.toStdString());
+
+            const muse::Val descriptionValue = muse::value(item, "description");
+            QVariantMap mapped{
+                { QStringLiteral("id"), key }, { QStringLiteral("title"), title },
+                { QStringLiteral("description"), descriptionValue.type() == muse::Val::Type::String ? QString::fromStdString(
+                      descriptionValue.toString()) : QString() }, { QStringLiteral("type"), type },
+                { QStringLiteral("value"), muse::settings()->value(setting).toQVariant() },
+            };
+            QVariantList choices;
+            const muse::Val choiceValue = muse::value(item, "choices");
+            if (choiceValue.type() == muse::Val::Type::List) {
+                for (const muse::Val& declaredChoice : choiceValue.toList()) {
+                    if (declaredChoice.type() != muse::Val::Type::Map) {
+                        continue;
+                    }
+
+                    const muse::ValMap entry = declaredChoice.toMap();
+                    const muse::Val choiceTitle = muse::value(entry, "title");
+                    const QVariant value = preferenceValue(muse::value(entry, "value"));
+                    if (choiceTitle.type() != muse::Val::Type::String || !value.isValid()) {
+                        continue;
+                    }
+                    choices.push_back(QVariantMap {
+                            { QStringLiteral("value"), value },
+                            { QStringLiteral("text"), QString::fromStdString(choiceTitle.toString()) },
+                        });
+                }
+            }
+            mapped.insert(QStringLiteral("choices"), choices);
+            items.push_back(mapped);
+        }
+        if (items.empty()) {
+            continue;
+        }
+        groups.push_back(QVariantMap {
+                { QStringLiteral("extensionId"), QString::fromStdString(manifest.uri.toString()) },
+                { QStringLiteral("title"), manifest.title.toQString() },
+                { QStringLiteral("items"), items },
+            });
+    }
+    m_extensionPreferences = std::move(groups);
+    emit extensionPreferencesChanged();
 }
 }

--- a/src/preferences/qml/Audacity/Preferences/pluginpreferencesmodel.h
+++ b/src/preferences/qml/Audacity/Preferences/pluginpreferencesmodel.h
@@ -9,13 +9,15 @@
 #include "effects/effects_base/effectstypes.h"
 #include "effects/effects_base/ieffectsconfiguration.h"
 #include "effects/effects_base/ieffectsprovider.h"
+#include "appshell/iappshellconfiguration.h"
+#include "framework/extensions/iextensionsprovider.h"
 #include "async/asyncable.h"
 #include "modularity/ioc.h"
 
 #include <QObject>
 
 namespace au::appshell {
-class PluginPreferencesModel : public QObject, public muse::async::Asyncable
+class PluginPreferencesModel : public QObject, public muse::Contextable, public muse::async::Asyncable
 {
     Q_OBJECT
     QML_ELEMENT
@@ -27,9 +29,13 @@ class PluginPreferencesModel : public QObject, public muse::async::Asyncable
 
     Q_PROPERTY(bool lv2Supported READ lv2Supported CONSTANT)
     Q_PROPERTY(bool vst3Supported READ vst3Supported CONSTANT)
+    Q_PROPERTY(QVariantList extensionPreferences READ extensionPreferences NOTIFY extensionPreferencesChanged)
 
     muse::GlobalInject<effects::IEffectsConfiguration> effectsConfiguration;
     muse::GlobalInject<effects::IEffectsProvider> effectsProvider;
+    muse::GlobalInject<IAppShellConfiguration> appshellConfiguration;
+
+    muse::ContextInject<muse::extensions::IExtensionsProvider> extensionsProvider{ this };
 
 public:
     explicit PluginPreferencesModel(QObject* parent = nullptr);
@@ -42,6 +48,8 @@ public:
 
     bool lv2Supported() const;
     bool vst3Supported() const;
+    QVariantList extensionPreferences() const;
+    Q_INVOKABLE bool setExtensionPreference(const QString& extensionId, const QString& key, const QVariant& value);
 
     Q_INVOKABLE void addLv2Path();
     Q_INVOKABLE void setLv2Path(int index, const QString& path);
@@ -59,5 +67,11 @@ signals:
     void effectMenuOrganizationChanged();
     void lv2CustomPathsChanged();
     void vst3CustomPathsChanged();
+    void extensionPreferencesChanged();
+
+private:
+    void reloadExtensionPreferences();
+
+    QVariantList m_extensionPreferences;
 };
 }

--- a/src/stubs/CMakeLists.txt
+++ b/src/stubs/CMakeLists.txt
@@ -17,3 +17,7 @@ endif()
 if (NOT AU_BUILD_USAGEINFO_MODULE)
     add_subdirectory(usageinfo)
 endif()
+
+if (NOT MUSE_MODULE_EXTENSIONS)
+    add_subdirectory(extensions)
+endif()

--- a/src/stubs/extensions/CMakeLists.txt
+++ b/src/stubs/extensions/CMakeLists.txt
@@ -1,0 +1,12 @@
+declare_module(audacity_extensions)
+
+set(MODULE_IS_STUB ON)
+set(MODULE_SRC
+    ${CMAKE_CURRENT_LIST_DIR}/audacityextensionsstubmodule.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/audacityextensionsstubmodule.h
+    ${CMAKE_CURRENT_LIST_DIR}/../../extensions/extensionpreferences.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/../../extensions/extensionpreferences.h
+)
+set(MODULE_LINK muse::extensions)
+
+setup_module()

--- a/src/stubs/extensions/audacityextensionsstubmodule.cpp
+++ b/src/stubs/extensions/audacityextensionsstubmodule.cpp
@@ -1,0 +1,11 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+#include "audacityextensionsstubmodule.h"
+
+namespace au::extensions {
+std::string AudacityExtensionsModule::moduleName() const
+{
+    return "audacity_extensions";
+}
+} // namespace au::extensions

--- a/src/stubs/extensions/audacityextensionsstubmodule.h
+++ b/src/stubs/extensions/audacityextensionsstubmodule.h
@@ -1,0 +1,14 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+#pragma once
+
+#include "modularity/imodulesetup.h"
+
+namespace au::extensions {
+class AudacityExtensionsModule final : public muse::modularity::IModuleSetup
+{
+public:
+    std::string moduleName() const override;
+};
+} // namespace au::extensions

--- a/src/trackedit/CMakeLists.txt
+++ b/src/trackedit/CMakeLists.txt
@@ -85,6 +85,16 @@ set(MODULE_SRC
 
     ${CMAKE_CURRENT_LIST_DIR}/api/projectapi.cpp
     ${CMAKE_CURRENT_LIST_DIR}/api/projectapi.h
+    ${CMAKE_CURRENT_LIST_DIR}/api/projectaudio.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/api/projectaudio.h
+    ${CMAKE_CURRENT_LIST_DIR}/api/projectedit.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/api/projectedit.h
+    ${CMAKE_CURRENT_LIST_DIR}/api/projecteditobject.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/api/projecteditobject.h
+    ${CMAKE_CURRENT_LIST_DIR}/api/projectlabels.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/api/projectlabels.h
+    ${CMAKE_CURRENT_LIST_DIR}/api/internal/projecteditstate.h
+    ${CMAKE_CURRENT_LIST_DIR}/api/audiotransform.h
 
     ${CMAKE_CURRENT_LIST_DIR}/view/deletebehaviorpanelmodel.cpp
     ${CMAKE_CURRENT_LIST_DIR}/view/deletebehaviorpanelmodel.h
@@ -100,7 +110,7 @@ include(${CMAKE_CURRENT_LIST_DIR}/../au3wrap/au3wrapDefs.cmake)
 
 set(MODULE_INCLUDE ${AU3_INCLUDE})
 set(MODULE_DEF ${AU3_DEF})
-set(MODULE_LINK au3wrap)
+set(MODULE_LINK au3wrap extension_native)
 
 set(MODULE_LINK
     ${MODULE_LINK}

--- a/src/trackedit/api/audiotransform.h
+++ b/src/trackedit/api/audiotransform.h
@@ -1,0 +1,29 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+#pragma once
+
+#include <cstdint>
+
+#include <QObject>
+#include <QString>
+
+namespace au::trackedit::api {
+class AudioTransformTask
+{
+public:
+    virtual ~AudioTransformTask() = default;
+
+    virtual bool cancelled() const = 0;
+    virtual bool report(double fraction, const QString& message) = 0;
+};
+
+class AudioTransform : public QObject
+{
+public:
+    using QObject::QObject;
+    ~AudioTransform() override = default;
+
+    virtual bool apply(float* const channels[], uint32_t channelCount, uint64_t sampleCount) = 0;
+};
+} // namespace au::trackedit::api

--- a/src/trackedit/api/internal/projecteditstate.h
+++ b/src/trackedit/api/internal/projecteditstate.h
@@ -1,0 +1,140 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include <QObject>
+#include <QVariantMap>
+
+#include "trackedit/api/projectedit.h"
+
+class LabelTrack;
+class Track;
+class TrackList;
+class TransactionScope;
+class WaveTrack;
+
+namespace au::trackedit::api::detail {
+constexpr size_t AUDIO_CHUNK_SAMPLES = 65536;
+
+struct AudioFormat {
+    uint32_t channelCount = 0;
+    double sampleRate = 0.0;
+};
+
+struct Replacement {
+    std::shared_ptr<WaveTrack> destination;
+    std::shared_ptr<WaveTrack> audio;
+    double start = 0.0;
+    double end = 0.0;
+    std::string name;
+    bool wholeTrack = false;
+};
+
+struct AddedAudio {
+    std::string name;
+    double start = 0.0;
+    std::shared_ptr<WaveTrack> audio;
+};
+
+struct LabelChange {
+    size_t trackIndex = 0;
+    std::optional<int64_t> nativeId;
+    bool remove = false;
+    double start = 0.0;
+    double end = 0.0;
+    std::string text;
+};
+
+struct AddedLabelTrack {
+    std::string name;
+    std::vector<ProjectLabel> labels;
+};
+
+struct PreparedChanges {
+    std::shared_ptr<TrackList> audioReplacements;
+    std::vector<std::shared_ptr<WaveTrack> > audioDestinations;
+    std::shared_ptr<TrackList> labelReplacements;
+    std::vector<std::shared_ptr<LabelTrack> > labelDestinations;
+    std::shared_ptr<TrackList> additions;
+};
+
+struct AppliedChanges {
+    struct ReplacedTrack {
+        std::shared_ptr<Track> original;
+        std::shared_ptr<Track> replacement;
+    };
+
+    std::vector<ReplacedTrack> replacements;
+    std::vector<std::shared_ptr<Track> > additions;
+};
+
+struct EditState {
+    ~EditState();
+
+    bool acquire();
+    void release();
+    bool usable() const;
+    bool writable() const;
+    bool available() const;
+
+    std::shared_ptr<AudacityProject> project;
+    std::function<bool()> projectAvailable;
+    std::function<void(double, double, const std::vector<int64_t>&)> setSelection;
+    IProjectHistoryPtr history;
+    TrackList* tracks = nullptr;
+    WaveTrackFactory* factory = nullptr;
+    std::shared_ptr<TrackList> sourceTracks;
+    std::vector<ProjectAudioTrack> audioTracks;
+    std::vector<ProjectLabelTrack> labelTracks;
+    std::shared_ptr<WaveTrack> preferredAudioDestination;
+    double selectionStart = 0.0;
+    double selectionEnd = 0.0;
+    bool deferredCommit = false;
+    bool active = true;
+    bool editStarted = false;
+    bool committed = false;
+    bool selectionChanged = false;
+    std::vector<int64_t> selectedTrackIds;
+    bool lockHeld = false;
+    size_t writers = 0;
+    size_t routedWriters = 0;
+    std::string undoName;
+    std::string error;
+    std::unique_ptr<TransactionScope> transaction;
+    std::vector<Replacement> replacements;
+    std::vector<AddedAudio> addedAudio;
+    std::vector<LabelChange> labelChanges;
+    std::vector<AddedLabelTrack> addedLabelTracks;
+    std::unique_ptr<PreparedChanges> prepared;
+};
+
+std::optional<AudioFormat> audioFormat(const QVariantMap& value);
+bool validTimes(double start, double end);
+bool isCurrentTrack(const EditState& state, const std::shared_ptr<Track>& track);
+
+QObject* makeAudioTrack(std::shared_ptr<EditState> state, size_t index, QObject* parent);
+QObject* makeAudioWriter(std::shared_ptr<EditState> state, AudioFormat format, std::shared_ptr<WaveTrack> audio, QObject* parent);
+bool transformAudio(const std::shared_ptr<EditState>& state, QObject* track, const QVariantMap& options, QObject* processor, QObject* task,
+                    QObject* errorContext);
+
+QObject* makeLabelTrack(std::shared_ptr<EditState> state, size_t index, bool intersectingLabelsOnly, QObject* parent);
+std::optional<size_t> audioTrackIndex(const std::shared_ptr<EditState>& state, QObject* object);
+std::optional<size_t> labelTrackIndex(const std::shared_ptr<EditState>& state, QObject* object);
+QObject* makeAddedLabelTrack(std::shared_ptr<EditState> state, size_t index, QObject* parent);
+
+QObject* makeProjectSelection(std::shared_ptr<EditState> state, QObject* parent);
+QObject* makeProjectEdit(std::shared_ptr<EditState> state, QObject* parent);
+
+bool prepareChanges(EditState& state, PreparedChanges& prepared, std::string& error);
+bool applyChanges(EditState& state, std::string& error, AppliedChanges* applied = nullptr);
+bool rollbackChanges(EditState& state, AppliedChanges& applied, std::string& error);
+} // namespace au::trackedit::api::detail

--- a/src/trackedit/api/projectapi.cpp
+++ b/src/trackedit/api/projectapi.cpp
@@ -6,8 +6,13 @@
 #include <algorithm>
 #include <limits>
 
+#include <QJSEngine>
+
+#include "au3-project-rate/ProjectRate.h"
+#include "au3-project/Project.h"
 #include "log.h"
-#include "trackedit/itrackeditproject.h"
+
+#include "projectedit.h"
 
 using namespace au::trackedit;
 using namespace au::trackedit::api;
@@ -19,6 +24,24 @@ constexpr double INVALID_TIME = std::numeric_limits<double>::quiet_NaN();
 ProjectApi::ProjectApi(muse::api::IApiEngine* e)
     : ApiObject(e)
 {
+}
+
+AudacityProject* ProjectApi::project() const
+{
+    const auto current = globalContext() ? globalContext()->currentProject() : nullptr;
+    return current ? reinterpret_cast<AudacityProject*>(current->au3ProjectPtr()) : nullptr;
+}
+
+QObject* ProjectApi::selection()
+{
+    auto* current = project();
+    if (!current || !selectionController()) {
+        return nullptr;
+    }
+    auto* result = makeCurrentProjectSelection(current, selectionController()->dataSelectedStartTime(),
+                                               selectionController()->dataSelectedEndTime(), nullptr);
+    QJSEngine::setObjectOwnership(result, QJSEngine::JavaScriptOwnership);
+    return result;
 }
 
 ITrackeditProjectPtr ProjectApi::trackeditProject() const
@@ -56,26 +79,6 @@ int ProjectApi::clipCount(int trackIndex) const
     return static_cast<int>(sortedClips(trackIndex).size());
 }
 
-double ProjectApi::clipStartTime(int trackIndex, int clipIndex) const
-{
-    auto clips = sortedClips(trackIndex);
-    if (clipIndex < 0 || clipIndex >= static_cast<int>(clips.size())) {
-        LOGE() << "clipIndex out of range: " << clipIndex << " on track " << trackIndex;
-        return INVALID_TIME;
-    }
-    return clips[clipIndex].startTime;
-}
-
-double ProjectApi::clipEndTime(int trackIndex, int clipIndex) const
-{
-    auto clips = sortedClips(trackIndex);
-    if (clipIndex < 0 || clipIndex >= static_cast<int>(clips.size())) {
-        LOGE() << "clipIndex out of range: " << clipIndex << " on track " << trackIndex;
-        return INVALID_TIME;
-    }
-    return clips[clipIndex].endTime;
-}
-
 QJSValue ProjectApi::clipsOnTrack(int trackIndex) const
 {
     const auto clips = sortedClips(trackIndex);
@@ -98,26 +101,59 @@ double ProjectApi::totalTime() const
     return static_cast<double>(prj->totalTime());
 }
 
-double ProjectApi::selectionStart() const
+double ProjectApi::defaultSampleRate() const
 {
-    if (!trackeditProject() || !selectionController()) {
-        return INVALID_TIME;
-    }
-    return static_cast<double>(selectionController()->dataSelectedStartTime());
+    const auto* current = project();
+    return current ? ProjectRate::Get(*current).GetRate() : INVALID_TIME;
 }
 
-double ProjectApi::selectionEnd() const
+QObject* ProjectApi::beginEdit(const QString& name, QObject* context)
 {
-    if (!trackeditProject() || !selectionController()) {
-        return INVALID_TIME;
+    if (projectApiScopeActive()) {
+        auto* editContext = dynamic_cast<ProjectEditSession*>(context);
+        if (!editContext || editContext != currentProjectEditContext()) {
+            throwProjectError(this, QStringLiteral("Project edits are not available in this callback"));
+            return nullptr;
+        }
+        return editContext->beginEdit(this);
     }
-    return static_cast<double>(selectionController()->dataSelectedEndTime());
-}
 
-bool ProjectApi::hasSelection() const
-{
-    if (!trackeditProject() || !selectionController()) {
-        return false;
+    if (context) {
+        throwProjectError(this, QStringLiteral("The project edit context is no longer active"));
+        return nullptr;
     }
-    return !selectionController()->timeSelectionIsEmpty();
+
+    auto* current = project();
+    if (!current || !selectionController()) {
+        throwProjectError(this, QStringLiteral("No project is active"));
+        return nullptr;
+    }
+    if (name.isEmpty()) {
+        throwProjectError(this, QStringLiteral("An undo description is required"));
+        return nullptr;
+    }
+    if (recordController() && recordController()->isRecording()) {
+        throwProjectError(this, QStringLiteral("Project edits are not available while recording"));
+        return nullptr;
+    }
+    if (playbackController()) {
+        playbackController()->stop();
+    }
+    const auto appContext = globalContext();
+    const auto selection = selectionController();
+    const auto target = appContext->currentProject();
+    return beginRootProjectEdit(
+        current, selectionController()->dataSelectedStartTime(), selectionController()->dataSelectedEndTime(), name, projectHistory(),
+        [appContext, target, current] {
+        const auto active = appContext->currentProject();
+        return active == target && active && reinterpret_cast<AudacityProject*>(active->au3ProjectPtr()) == current;
+    },
+        [selection](double start, double end, const std::vector<int64_t>& tracks) {
+        selection->resetSelectedClips();
+        selection->resetSelectedLabels();
+        selection->setSelectedTracks(tracks, true);
+        selection->setDataSelectedStartTime(start, true);
+        selection->setDataSelectedEndTime(end, true);
+    },
+        this);
 }

--- a/src/trackedit/api/projectapi.h
+++ b/src/trackedit/api/projectapi.h
@@ -6,41 +6,49 @@
 #include <QJSValue>
 
 #include "api/apiobject.h"
-#include "modularity/ioc.h"
 #include "context/iglobalcontext.h"
-#include "trackedit/itrackeditproject.h"
+#include "modularity/ioc.h"
+#include "playback/iplaybackcontroller.h"
+#include "record/irecordcontroller.h"
 #include "trackedit/dom/clip.h"
 #include "trackedit/iselectioncontroller.h"
+#include "trackedit/iprojecthistory.h"
+#include "trackedit/itrackeditproject.h"
+
+class AudacityProject;
 
 namespace au::trackedit::api {
 class ProjectApi : public muse::api::ApiObject
 {
     Q_OBJECT
+    Q_PROPERTY(QObject * selection READ selection)
+    Q_PROPERTY(double defaultSampleRate READ defaultSampleRate)
 
     muse::ContextInject<context::IGlobalContext> globalContext = { this };
     muse::ContextInject<ISelectionController> selectionController = { this };
+    muse::ContextInject<IProjectHistory> projectHistory = { this };
+    muse::ContextInject<record::IRecordController> recordController = { this };
+    muse::ContextInject<playback::IPlaybackController> playbackController = { this };
 
 public:
     explicit ProjectApi(muse::api::IApiEngine* e);
+
+    QObject* selection();
+    double defaultSampleRate() const;
 
     // Tracks
     Q_INVOKABLE int trackCount() const;
 
     // Clips
     Q_INVOKABLE int clipCount(int trackIndex) const;
-    Q_INVOKABLE double clipStartTime(int trackIndex, int clipIndex) const;
-    Q_INVOKABLE double clipEndTime(int trackIndex, int clipIndex) const;
     Q_INVOKABLE QJSValue clipsOnTrack(int trackIndex) const;
 
     // Project
     Q_INVOKABLE double totalTime() const;
-
-    // Selection
-    Q_INVOKABLE double selectionStart() const;
-    Q_INVOKABLE double selectionEnd() const;
-    Q_INVOKABLE bool hasSelection() const;
+    Q_INVOKABLE QObject* beginEdit(const QString& name, QObject* context = nullptr);
 
 private:
+    AudacityProject* project() const;
     ITrackeditProjectPtr trackeditProject() const;
     Clips sortedClips(int trackIndex) const;
 };

--- a/src/trackedit/api/projectaudio.cpp
+++ b/src/trackedit/api/projectaudio.cpp
@@ -1,0 +1,560 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+#include "internal/projecteditstate.h"
+#include "projectaudio.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+#include <utility>
+
+#include <QVariantList>
+
+#include "au3-audio-graph/AudioGraphBuffers.h"
+#include "au3-audio-graph/AudioGraphSource.h"
+#include "au3-audio-graph/AudioGraphTask.h"
+#include "au3-math/SampleFormat.h"
+#include "au3-mixer/Mix.h"
+#include "au3-mixer/WideSampleSource.h"
+#include "au3-stretching-sequence/StretchingSequence.h"
+#include "au3-track/Track.h"
+#include "au3-wave-track/TimeStretching.h"
+#include "au3-wave-track/WaveClip.h"
+#include "au3-wave-track/WaveTrack.h"
+#include "au3-wave-track/WaveTrackSink.h"
+
+#include "audiotransform.h"
+#include "extensions/native/bytebuffer.h"
+
+namespace au::trackedit::api::detail {
+std::optional<AudioFormat> audioFormat(const QVariantMap& value)
+{
+    AudioFormat result{
+        value.value(QStringLiteral("channelCount")).toUInt(),
+        value.value(QStringLiteral("sampleRate")).toDouble(),
+    };
+    constexpr double maxSampleRate = 384000.0;
+    if ((result.channelCount != 1 && result.channelCount != 2) || !std::isfinite(result.sampleRate) || result.sampleRate < 1.0
+        || result.sampleRate > maxSampleRate || result.sampleRate != std::floor(result.sampleRate)) {
+        return std::nullopt;
+    }
+    return result;
+}
+
+class TransformSource final : public AudioGraph::Source
+{
+public:
+    TransformSource(AudioGraph::Source& source, AudioTransform& transform, uint32_t channelCount)
+        : m_source(source), m_transform(transform), m_channelCount(channelCount)
+    {
+    }
+
+    bool AcceptsBuffers(const Buffers& buffers) const override
+    {
+        return buffers.Channels() == m_channelCount && m_source.AcceptsBuffers(buffers);
+    }
+
+    bool AcceptsBlockSize(size_t blockSize) const override
+    {
+        return m_source.AcceptsBlockSize(blockSize);
+    }
+
+    std::optional<size_t> Acquire(Buffers& buffers, size_t bound) override
+    {
+        const auto count = m_source.Acquire(buffers, bound);
+        if (!count || *count == 0) {
+            return count;
+        }
+        float* channels[2]{};
+        for (uint32_t channel = 0; channel < m_channelCount; ++channel) {
+            channels[channel] = &buffers.GetWritePosition(channel);
+        }
+        return m_transform.apply(channels, m_channelCount, *count) ? count : std::nullopt;
+    }
+
+    sampleCount Remaining() const override
+    {
+        return m_source.Remaining();
+    }
+
+    bool Release() override
+    {
+        return m_source.Release();
+    }
+
+private:
+    AudioGraph::Source& m_source;
+    AudioTransform& m_transform;
+    uint32_t m_channelCount = 0;
+};
+
+bool reportProgress(AudioTransformTask* task, double fraction)
+{
+    return !task || task->report(fraction, {});
+}
+
+AudioChunkObject::AudioChunkObject(AudioFormat format, size_t samples, QObject* parent)
+    : QObject(parent), m_format(format), m_samples(samples)
+{
+    const size_t bytes = samples * sizeof(float);
+    for (uint32_t channel = 0; channel < format.channelCount; ++channel) {
+        auto* buffer = new muse::extensions::ByteBuffer(bytes, this);
+        m_buffers.push_back(buffer);
+        m_channels.push_back(QVariant::fromValue<QObject*>(buffer));
+    }
+}
+
+uint AudioChunkObject::channelCount() const
+{
+    return m_format.channelCount;
+}
+
+qulonglong AudioChunkObject::sampleCount() const
+{
+    return m_samples;
+}
+
+double AudioChunkObject::sampleRate() const
+{
+    return m_format.sampleRate;
+}
+
+QVariantList AudioChunkObject::channels() const
+{
+    return m_channels;
+}
+
+const AudioFormat& AudioChunkObject::format() const
+{
+    return m_format;
+}
+
+muse::extensions::ByteBuffer* AudioChunkObject::buffer(size_t channel) const
+{
+    return m_buffers.at(channel);
+}
+
+bool AudioChunkObject::released() const
+{
+    return m_released;
+}
+
+bool AudioChunkObject::reusable() const
+{
+    return std::all_of(m_buffers.begin(), m_buffers.end(), [](const muse::extensions::ByteBuffer* buffer) {
+        return buffer->isExclusive();
+    });
+}
+
+void AudioChunkObject::reuse()
+{
+    m_released = false;
+}
+
+void AudioChunkObject::release()
+{
+    m_released = true;
+}
+
+AudioReaderObject::AudioReaderObject(std::shared_ptr<EditState> state, std::shared_ptr<WaveTrack> source, AudioFormat format, double start,
+                                     double end, QObject* parent)
+    : QObject(parent), m_state(std::move(state)), m_source(std::move(source)), m_format(format)
+{
+    const bool matchingFormat = m_format.channelCount == m_source->NChannels() && m_format.sampleRate == m_source->GetRate();
+    const bool stretched = TimeStretching::HasPitchOrSpeed(*m_source, start, end);
+    if (matchingFormat && !stretched) {
+        m_position = m_source->TimeToLongSamples(start);
+        m_end = m_source->TimeToLongSamples(end);
+    } else {
+        Mixer::Inputs inputs;
+        inputs.emplace_back(StretchingSequence::Create(*m_source, m_source->GetClipInterfaces()), Mixer::Stages {});
+        m_mixer = std::make_unique<Mixer>(
+            std::move(inputs), std::nullopt, true, Mixer::WarpOptions { m_state->project.get() }, start, end, format.channelCount,
+            AUDIO_CHUNK_SAMPLES, false, format.sampleRate, floatSample, true, nullptr, Mixer::ApplyVolume::Mixdown);
+    }
+}
+
+AudioReaderObject::~AudioReaderObject() = default;
+
+uint AudioReaderObject::channelCount() const
+{
+    return m_format.channelCount;
+}
+
+double AudioReaderObject::sampleRate() const
+{
+    return m_format.sampleRate;
+}
+
+QObject* AudioReaderObject::read()
+{
+    return read(AUDIO_CHUNK_SAMPLES);
+}
+
+QObject* AudioReaderObject::read(qulonglong requested)
+{
+    if (!m_state->usable()) {
+        throwProjectError(this, QStringLiteral("The project edit is no longer active"));
+        return nullptr;
+    }
+    if (requested == 0) {
+        throwProjectError(this, QStringLiteral("Audio reads must request at least one sample"));
+        return nullptr;
+    }
+    if (m_chunk && !m_chunk->released()) {
+        throwProjectError(this, QStringLiteral("Release the previous audio chunk before reading again"));
+        return nullptr;
+    }
+
+    try {
+        const size_t limit = static_cast<size_t>(std::min<qulonglong>(requested, AUDIO_CHUNK_SAMPLES));
+        size_t count = 0;
+        if (m_mixer) {
+            count = m_mixer->Process(limit);
+        } else {
+            count = limitSampleBufferSize(limit, m_end - m_position);
+        }
+        if (count == 0) {
+            return nullptr;
+        }
+        if (!m_chunk || m_chunk->sampleCount() != count || !m_chunk->reusable()) {
+            delete m_chunk;
+            m_chunk = nullptr;
+            m_chunk = new AudioChunkObject(m_format, count, this);
+        } else {
+            m_chunk->reuse();
+        }
+        if (m_mixer) {
+            for (uint32_t channel = 0; channel < m_format.channelCount; ++channel) {
+                std::memcpy(m_chunk->buffer(channel)->data(), m_mixer->GetBuffer(channel), count * sizeof(float));
+            }
+        } else {
+            float* buffers[2]{};
+            for (uint32_t channel = 0; channel < m_format.channelCount; ++channel) {
+                buffers[channel] = static_cast<float*>(m_chunk->buffer(channel)->data());
+            }
+            m_source->GetFloats(0, m_format.channelCount, buffers, m_position, count);
+            m_position += count;
+        }
+        return m_chunk;
+    } catch (const std::exception& exception) {
+        throwProjectError(this, QString::fromUtf8(exception.what()));
+    } catch (...) {
+        throwProjectError(this, QStringLiteral("Could not read project audio"));
+    }
+    return nullptr;
+}
+
+AudioTrackObject::AudioTrackObject(std::shared_ptr<EditState> state, size_t index, QObject* parent)
+    : QObject(parent), m_state(std::move(state)), m_index(index)
+{
+}
+
+QString AudioTrackObject::name() const
+{
+    return QString::fromStdString(input().name);
+}
+
+uint AudioTrackObject::channelCount() const
+{
+    return static_cast<uint>(input().source->NChannels());
+}
+
+double AudioTrackObject::sampleRate() const
+{
+    return input().source->GetRate();
+}
+
+double AudioTrackObject::start() const
+{
+    return input().source->GetStartTime();
+}
+
+double AudioTrackObject::end() const
+{
+    return input().source->GetEndTime();
+}
+
+size_t AudioTrackObject::index() const
+{
+    return m_index;
+}
+
+const std::shared_ptr<EditState>& AudioTrackObject::state() const
+{
+    return m_state;
+}
+
+QObject* AudioTrackObject::openReader(const QVariantMap& options)
+{
+    if (!m_state->usable()) {
+        throwProjectError(this, QStringLiteral("The project edit is no longer active"));
+        return nullptr;
+    }
+    const auto format = audioFormat(options);
+    const double rangeStart = options.value(QStringLiteral("start")).toDouble();
+    const double rangeEnd = options.value(QStringLiteral("end")).toDouble();
+    if (!format || !validTimes(rangeStart, rangeEnd)) {
+        throwProjectError(this, QStringLiteral("Invalid audio reader options"));
+        return nullptr;
+    }
+    try {
+        return new AudioReaderObject(m_state, input().source, *format, rangeStart, rangeEnd, this);
+    } catch (const std::exception& exception) {
+        throwProjectError(this, QString::fromUtf8(exception.what()));
+    } catch (...) {
+        throwProjectError(this, QStringLiteral("Could not open the audio reader"));
+    }
+    return nullptr;
+}
+
+const ProjectAudioTrack& AudioTrackObject::input() const
+{
+    return m_state->audioTracks.at(m_index);
+}
+
+AudioWriterObject::AudioWriterObject(std::shared_ptr<EditState> state, AudioFormat format, std::shared_ptr<WaveTrack> audio,
+                                     QObject* parent)
+    : QObject(parent), m_state(std::move(state)), m_format(format), m_audio(std::move(audio))
+{
+}
+
+uint AudioWriterObject::channelCount() const
+{
+    return m_format.channelCount;
+}
+
+double AudioWriterObject::sampleRate() const
+{
+    return m_format.sampleRate;
+}
+
+QObject* AudioWriterObject::createChunk(qulonglong samples)
+{
+    if (!m_state->writable() || samples > AUDIO_CHUNK_SAMPLES) {
+        throwProjectError(this, QStringLiteral("Invalid audio chunk size"));
+        return nullptr;
+    }
+    try {
+        return new AudioChunkObject(m_format, static_cast<size_t>(samples), this);
+    } catch (...) {
+        throwProjectError(this, QStringLiteral("Could not allocate the audio chunk"));
+        return nullptr;
+    }
+}
+
+bool AudioWriterObject::write(QObject* object)
+{
+    auto* chunk = qobject_cast<AudioChunkObject*>(object);
+    if (!m_state->writable() || m_routed || !chunk || chunk->released() || chunk->format().channelCount != m_format.channelCount
+        || chunk->format().sampleRate != m_format.sampleRate) {
+        throwProjectError(this, QStringLiteral("Invalid audio write"));
+        return false;
+    }
+    if (chunk->sampleCount() == 0) {
+        return true;
+    }
+
+    for (uint32_t channel = 0; channel < m_format.channelCount; ++channel) {
+        const auto* samples = static_cast<const float*>(chunk->buffer(channel)->data());
+        if (!std::all_of(samples, samples + chunk->sampleCount(), [](float sample) {
+            return std::isfinite(sample);
+        })) {
+            throwProjectError(this, QStringLiteral("Audio contains non-finite samples"));
+            return false;
+        }
+    }
+
+    try {
+        constSamplePtr buffers[2]{};
+        for (uint32_t channel = 0; channel < m_format.channelCount; ++channel) {
+            buffers[channel] = reinterpret_cast<constSamplePtr>(chunk->buffer(channel)->data());
+        }
+        m_audio->RightmostOrNewClip()->Append(buffers, floatSample, static_cast<size_t>(chunk->sampleCount()), 1, floatSample);
+        return true;
+    } catch (...) {
+        throwProjectError(this, QStringLiteral("Could not write project audio"));
+        return false;
+    }
+}
+
+bool AudioWriterObject::replace(QObject* object, double start, double end)
+{
+    auto* input = qobject_cast<AudioTrackObject*>(object);
+    if (!m_state->writable() || m_routed || !input || input->state() != m_state || !validTimes(start, end)) {
+        throwProjectError(this, QStringLiteral("Invalid audio replacement"));
+        return false;
+    }
+    const auto& destination = m_state->audioTracks.at(input->index()).destination;
+    if (!destination || destination->NChannels() != m_format.channelCount
+        || std::any_of(m_state->replacements.begin(), m_state->replacements.end(), [&](const Replacement& replacement) {
+        return replacement.destination == destination;
+    })) {
+        throwProjectError(this, QStringLiteral("The audio track cannot be replaced"));
+        return false;
+    }
+    try {
+        m_audio->Flush();
+        m_state->replacements.push_back({
+                destination,
+                m_audio,
+                start,
+                end,
+                {},
+                false,
+            });
+        route();
+        return true;
+    } catch (...) {
+        throwProjectError(this, QStringLiteral("Could not stage replacement audio"));
+        return false;
+    }
+}
+
+bool AudioWriterObject::addTrack(const QString& name, double start)
+{
+    if (!m_state->writable() || m_routed || !std::isfinite(start) || start < 0.0) {
+        throwProjectError(this, QStringLiteral("Invalid audio track"));
+        return false;
+    }
+    try {
+        m_audio->Flush();
+        const auto& destination = m_state->preferredAudioDestination;
+        const bool destinationUsed = destination
+                                     && std::any_of(m_state->replacements.begin(), m_state->replacements.end(),
+                                                    [&](const Replacement& replacement) {
+            return replacement.destination == destination;
+        });
+        if (destination && !destinationUsed) {
+            m_state->replacements.push_back({
+                    destination,
+                    m_audio,
+                    start,
+                    start,
+                    name.toStdString(),
+                    true,
+                });
+        } else {
+            m_state->addedAudio.push_back({
+                    name.toStdString(),
+                    start,
+                    m_audio,
+                });
+        }
+        route();
+        return true;
+    } catch (...) {
+        throwProjectError(this, QStringLiteral("Could not stage the audio track"));
+        return false;
+    }
+}
+
+void AudioWriterObject::route()
+{
+    m_routed = true;
+    ++m_state->routedWriters;
+}
+
+QObject* makeAudioTrack(std::shared_ptr<EditState> state, size_t index, QObject* parent)
+{
+    return new AudioTrackObject(std::move(state), index, parent);
+}
+
+std::optional<size_t> audioTrackIndex(const std::shared_ptr<EditState>& state, QObject* object)
+{
+    auto* track = qobject_cast<AudioTrackObject*>(object);
+    return track && track->state() == state ? std::optional<size_t> { track->index() } : std::nullopt;
+}
+
+QObject* makeAudioWriter(std::shared_ptr<EditState> state, AudioFormat format, std::shared_ptr<WaveTrack> audio, QObject* parent)
+{
+    return new AudioWriterObject(std::move(state), format, std::move(audio), parent);
+}
+
+bool transformAudio(const std::shared_ptr<EditState>& state, QObject* object, const QVariantMap& options, QObject* processor, QObject* task,
+                    QObject* errorContext)
+{
+    auto* track = qobject_cast<AudioTrackObject*>(object);
+    auto* transform = dynamic_cast<AudioTransform*>(processor);
+    const double start = options.value(QStringLiteral("start")).toDouble();
+    const double end = options.value(QStringLiteral("end")).toDouble();
+    const double progressStart = options.value(QStringLiteral("progressStart"), 0.0).toDouble();
+    const double progressEnd = options.value(QStringLiteral("progressEnd"), 1.0).toDouble();
+    if (!state->writable() || !track || track->state() != state || !transform
+        || !validTimes(start,
+                       end) || !std::isfinite(progressStart) || !std::isfinite(progressEnd) || progressStart < 0.0
+        || progressEnd < progressStart
+        || progressEnd > 1.0) {
+        throwProjectError(errorContext, QStringLiteral("Invalid audio transform"));
+        return false;
+    }
+
+    auto* progressTask = dynamic_cast<AudioTransformTask*>(task);
+    if (task && !progressTask) {
+        throwProjectError(errorContext, QStringLiteral("Invalid progress task"));
+        return false;
+    }
+
+    const auto& input = state->audioTracks.at(track->index());
+    const auto& destination = input.destination;
+    if (!destination || input.source->NChannels() > 2
+        || std::any_of(state->replacements.begin(), state->replacements.end(), [&](const Replacement& replacement) {
+        return replacement.destination == destination;
+    })) {
+        throwProjectError(errorContext, QStringLiteral("The audio track cannot be transformed"));
+        return false;
+    }
+
+    try {
+        auto output = std::static_pointer_cast<WaveTrack>(input.source->Duplicate(Track::DuplicateOptions {}.Backup()));
+        const double rangeStart = std::max(start, output->GetStartTime());
+        const double rangeEnd = std::min(end, output->GetEndTime());
+        if (rangeEnd > rangeStart) {
+            const sampleCount first = output->TimeToLongSamples(rangeStart);
+            const sampleCount last = output->TimeToLongSamples(rangeEnd);
+            const sampleCount length = last - first;
+            const uint32_t channelCount = static_cast<uint32_t>(output->NChannels());
+            const size_t blockSize = std::max<size_t>(1, output->GetMaxBlockSize() * 2);
+            AudioGraph::Buffers buffers(channelCount, blockSize, 1);
+            WideSampleSource source(*output, channelCount, first, length, [&](sampleCount position) {
+                const double fraction = length > 0 ? (position - first).as_double() / length.as_double() : 1.0;
+                return reportProgress(progressTask, progressStart + std::clamp(fraction, 0.0, 1.0) * (progressEnd - progressStart));
+            });
+            TransformSource transformed(source, *transform, channelCount);
+            const auto channels = output->Channels();
+            WaveTrackSink sink(**channels.begin(), channelCount == 2 ? (*channels.rbegin()).get() : nullptr, nullptr, first, true,
+                               widestSampleFormat);
+            AudioGraph::Task graph(transformed, buffers, sink);
+            if (!graph.RunLoop()) {
+                if (progressTask && progressTask->cancelled()) {
+                    return false;
+                }
+                throwProjectError(errorContext, QStringLiteral("Could not transform project audio"));
+                return false;
+            }
+            sink.Flush(buffers);
+            if (!sink.IsOk()) {
+                throwProjectError(errorContext, QStringLiteral("Could not write transformed audio"));
+                return false;
+            }
+        } else if (!reportProgress(progressTask, progressEnd)) {
+            return false;
+        }
+        state->replacements.push_back({
+                destination,
+                std::move(output),
+                0.0,
+                0.0,
+                {},
+                true,
+            });
+        return true;
+    } catch (const std::exception& exception) {
+        throwProjectError(errorContext, QString::fromUtf8(exception.what()));
+    } catch (...) {
+        throwProjectError(errorContext, QStringLiteral("Could not transform project audio"));
+    }
+    return false;
+}
+} // namespace au::trackedit::api::detail

--- a/src/trackedit/api/projectaudio.cpp
+++ b/src/trackedit/api/projectaudio.cpp
@@ -352,6 +352,12 @@ bool AudioWriterObject::write(QObject* object)
         throwProjectError(this, QStringLiteral("Invalid audio write"));
         return false;
     }
+    for (uint32_t channel = 0; channel < m_format.channelCount; ++channel) {
+        if (!chunk->buffer(channel)->isExclusive()) {
+            throwProjectError(this, QStringLiteral("Audio is in use by a native call"));
+            return false;
+        }
+    }
     if (chunk->sampleCount() == 0) {
         return true;
     }

--- a/src/trackedit/api/projectaudio.h
+++ b/src/trackedit/api/projectaudio.h
@@ -1,0 +1,141 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include <QObject>
+#include <QVariantList>
+#include <QVariantMap>
+
+#include "au3-math/SampleCount.h"
+
+#include "internal/projecteditstate.h"
+
+class Mixer;
+class WaveTrack;
+
+namespace muse::extensions {
+class ByteBuffer;
+}
+
+namespace au::trackedit::api {
+namespace detail {
+class AudioChunkObject final : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(uint channelCount READ channelCount CONSTANT)
+    Q_PROPERTY(qulonglong sampleCount READ sampleCount CONSTANT)
+    Q_PROPERTY(double sampleRate READ sampleRate CONSTANT)
+    Q_PROPERTY(QVariantList channels READ channels CONSTANT)
+
+public:
+    AudioChunkObject(AudioFormat format, size_t samples, QObject* parent);
+
+    uint channelCount() const;
+    qulonglong sampleCount() const;
+    double sampleRate() const;
+    QVariantList channels() const;
+    const AudioFormat& format() const;
+    muse::extensions::ByteBuffer* buffer(size_t channel) const;
+    bool released() const;
+    bool reusable() const;
+    void reuse();
+
+    Q_INVOKABLE void release();
+
+private:
+    AudioFormat m_format;
+    size_t m_samples = 0;
+    std::vector<muse::extensions::ByteBuffer*> m_buffers;
+    QVariantList m_channels;
+    bool m_released = false;
+};
+
+class AudioReaderObject final : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(uint channelCount READ channelCount CONSTANT)
+    Q_PROPERTY(double sampleRate READ sampleRate CONSTANT)
+
+public:
+    AudioReaderObject(std::shared_ptr<EditState> state, std::shared_ptr<WaveTrack> source, AudioFormat format, double start, double end,
+                      QObject* parent);
+    ~AudioReaderObject() override;
+
+    uint channelCount() const;
+    double sampleRate() const;
+
+    Q_INVOKABLE QObject* read();
+    Q_INVOKABLE QObject* read(qulonglong requested);
+
+private:
+    std::shared_ptr<EditState> m_state;
+    std::shared_ptr<WaveTrack> m_source;
+    AudioFormat m_format;
+    sampleCount m_position{ 0 };
+    sampleCount m_end{ 0 };
+    std::unique_ptr<Mixer> m_mixer;
+    AudioChunkObject* m_chunk = nullptr;
+};
+
+class AudioTrackObject final : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(QString name READ name CONSTANT)
+    Q_PROPERTY(uint channelCount READ channelCount CONSTANT)
+    Q_PROPERTY(double sampleRate READ sampleRate CONSTANT)
+    Q_PROPERTY(double start READ start CONSTANT)
+    Q_PROPERTY(double end READ end CONSTANT)
+
+public:
+    AudioTrackObject(std::shared_ptr<EditState> state, size_t index, QObject* parent);
+
+    QString name() const;
+    uint channelCount() const;
+    double sampleRate() const;
+    double start() const;
+    double end() const;
+    size_t index() const;
+    const std::shared_ptr<EditState>& state() const;
+
+    Q_INVOKABLE QObject* openReader(const QVariantMap& options);
+
+private:
+    const ProjectAudioTrack& input() const;
+
+    std::shared_ptr<EditState> m_state;
+    size_t m_index = 0;
+};
+
+class AudioWriterObject final : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(uint channelCount READ channelCount CONSTANT)
+    Q_PROPERTY(double sampleRate READ sampleRate CONSTANT)
+
+public:
+    AudioWriterObject(std::shared_ptr<EditState> state, AudioFormat format, std::shared_ptr<WaveTrack> audio, QObject* parent);
+
+    uint channelCount() const;
+    double sampleRate() const;
+
+    Q_INVOKABLE QObject* createChunk(qulonglong samples);
+    Q_INVOKABLE bool write(QObject* object);
+    Q_INVOKABLE bool replace(QObject* object, double start, double end);
+    Q_INVOKABLE bool addTrack(const QString& name, double start);
+
+private:
+    void route();
+
+    std::shared_ptr<EditState> m_state;
+    AudioFormat m_format;
+    std::shared_ptr<WaveTrack> m_audio;
+    bool m_routed = false;
+};
+} // namespace detail
+} // namespace au::trackedit::api

--- a/src/trackedit/api/projectedit.cpp
+++ b/src/trackedit/api/projectedit.cpp
@@ -1,0 +1,553 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+#include "projectedit.h"
+
+#include <algorithm>
+#include <cassert>
+#include <cmath>
+#include <limits>
+#include <map>
+#include <set>
+#include <thread>
+#include <utility>
+
+#include <QJSEngine>
+
+#include "au3-label-track/LabelTrack.h"
+#include "au3-project/Project.h"
+#include "au3-time-frequency-selection/SelectedRegion.h"
+#include "au3-track/TimeWarper.h"
+#include "au3-track/Track.h"
+#include "au3-transactions/TransactionScope.h"
+#include "au3-wave-track/WaveClip.h"
+#include "au3-wave-track/WaveTrack.h"
+#include "au3wrap/internal/wxtypes_convert.h"
+#include "framework/global/runtime.h"
+#include "log.h"
+
+#include "internal/projecteditstate.h"
+
+namespace au::trackedit::api::detail {
+namespace {
+std::set<AudacityProject*> activeEdits;
+}
+
+EditState::~EditState()
+{
+    release();
+}
+
+bool EditState::acquire()
+{
+    if (std::this_thread::get_id() != muse::runtime::mainThreadId()) {
+        error = "Project edits must run on the main thread";
+        return false;
+    }
+    if (!available()) {
+        error = "No project is active";
+        return false;
+    }
+    if (activeEdits.find(project.get()) != activeEdits.end()) {
+        error = "Another project edit is already active";
+        return false;
+    }
+    activeEdits.insert(project.get());
+    lockHeld = true;
+    return true;
+}
+
+void EditState::release()
+{
+    if (lockHeld) {
+        assert(std::this_thread::get_id() == muse::runtime::mainThreadId());
+        activeEdits.erase(project.get());
+        lockHeld = false;
+    }
+}
+
+bool EditState::usable() const
+{
+    return active && !committed && available();
+}
+
+bool EditState::writable() const
+{
+    return usable() && editStarted;
+}
+
+bool EditState::available() const
+{
+    return project && (!projectAvailable || projectAvailable());
+}
+
+bool validTimes(double start, double end)
+{
+    return std::isfinite(start) && std::isfinite(end) && start >= 0.0 && end >= start;
+}
+
+bool isCurrentTrack(const EditState& state, const std::shared_ptr<Track>& track)
+{
+    return state.tracks && track && state.tracks->FindById(track->GetId()) == track.get();
+}
+
+bool prepareChanges(EditState& state, PreparedChanges& prepared, std::string& error)
+{
+    prepared.audioReplacements = TrackList::Temporary(state.tracks->GetOwner());
+    for (const auto& replacement : state.replacements) {
+        if (!isCurrentTrack(state, replacement.destination)) {
+            error = "An audio track changed while the edit was open";
+            return false;
+        }
+        if (replacement.wholeTrack) {
+            replacement.audio->SetName(replacement.name.empty() ? replacement.destination->GetName() : au3::wxFromStdString(
+                                           replacement.name));
+            replacement.audio->MoveTo(replacement.start);
+            prepared.audioReplacements->Add(replacement.audio);
+            prepared.audioDestinations.push_back(replacement.destination);
+            continue;
+        }
+
+        const auto isClipBoundary = [&](double time) {
+            const auto sample = replacement.destination->TimeToLongSamples(time);
+            const auto intervals = replacement.destination->Intervals();
+            return std::any_of(intervals.begin(), intervals.end(), [&](const auto& clip) {
+                return clip->GetPlayStartSample() == sample || clip->GetPlayEndSample() == sample;
+            });
+        };
+        const bool merge = !(isClipBoundary(replacement.start) && isClipBoundary(replacement.end));
+        auto duplicate = std::static_pointer_cast<WaveTrack>(replacement.destination->Duplicate(Track::DuplicateOptions {}.Backup()));
+        const double duration = replacement.audio->GetEndTime() - replacement.audio->GetStartTime();
+        PasteTimeWarper warper{
+            replacement.end,
+            replacement.start + duration,
+        };
+        duplicate->ClearAndPaste(replacement.start, replacement.end, *replacement.audio, true, merge, &warper);
+        prepared.audioReplacements->Add(duplicate);
+        prepared.audioDestinations.push_back(replacement.destination);
+    }
+
+    prepared.labelReplacements = TrackList::Temporary(state.tracks->GetOwner());
+    for (size_t trackIndex = 0; trackIndex < state.labelTracks.size(); ++trackIndex) {
+        const bool changed = std::any_of(state.labelChanges.begin(), state.labelChanges.end(), [&](const LabelChange& change) {
+            return change.trackIndex == trackIndex;
+        });
+        if (!changed) {
+            continue;
+        }
+
+        const auto& input = state.labelTracks[trackIndex];
+        if (!isCurrentTrack(state, input.track)) {
+            error = "A label track changed while the edit was open";
+            return false;
+        }
+        auto duplicate = std::static_pointer_cast<LabelTrack>(input.track->Duplicate(Track::DuplicateOptions {}.Backup()));
+        std::map<int64_t, int64_t> duplicateIds;
+        for (int index = 0; index < input.track->GetNumLabels(); ++index) {
+            const auto* original = input.track->GetLabel(index);
+            const auto* copy = duplicate->GetLabel(index);
+            if (original && copy) {
+                duplicateIds.emplace(original->GetId(), copy->GetId());
+            }
+        }
+        for (const auto& change : state.labelChanges) {
+            if (change.trackIndex != trackIndex) {
+                continue;
+            }
+            if (!change.nativeId) {
+                duplicate->AddLabel(SelectedRegion(change.start, change.end), au3::wxFromStdString(change.text));
+                continue;
+            }
+
+            const auto mapped = duplicateIds.find(*change.nativeId);
+            if (mapped == duplicateIds.end()) {
+                error = "A selected label no longer exists";
+                return false;
+            }
+            if (change.remove) {
+                duplicate->DeleteLabelById(mapped->second);
+                continue;
+            }
+            const int duplicateIndex = duplicate->GetLabelIndex(mapped->second);
+            if (duplicateIndex < 0) {
+                error = "A selected label no longer exists";
+                return false;
+            }
+            auto updated = *duplicate->GetLabel(duplicateIndex);
+            updated.selectedRegion.setTimes(change.start, change.end);
+            updated.title = au3::wxFromStdString(change.text);
+            duplicate->SetLabel(static_cast<size_t>(duplicateIndex), updated);
+        }
+        prepared.labelReplacements->Add(duplicate);
+        prepared.labelDestinations.push_back(input.track);
+    }
+
+    prepared.additions = TrackList::Temporary(state.tracks->GetOwner());
+    for (const auto& added : state.addedAudio) {
+        added.audio->SetName(au3::wxFromStdString(added.name));
+        added.audio->MoveTo(added.start);
+        prepared.additions->Add(added.audio);
+    }
+    for (const auto& added : state.addedLabelTracks) {
+        auto track = LabelTrack::CreatePtr(*state.tracks);
+        track->SetName(au3::wxFromStdString(added.name));
+        for (const auto& label : added.labels) {
+            track->AddLabel(SelectedRegion(label.start, label.end), au3::wxFromStdString(label.text));
+        }
+        prepared.additions->Add(track);
+    }
+    return true;
+}
+
+bool applyChanges(EditState& state, std::string& error, AppliedChanges* applied)
+{
+    if (!state.available() || !state.tracks || !state.factory) {
+        error = "The project edit target is unavailable";
+        return false;
+    }
+
+    state.selectedTrackIds.clear();
+    if (state.selectionChanged) {
+        for (const auto& track : state.audioTracks) {
+            if (track.selected) {
+                if (!isCurrentTrack(state, track.destination)) {
+                    error = "A selected audio track changed while the edit was open";
+                    return false;
+                }
+                state.selectedTrackIds.push_back(track.destination->GetId());
+            }
+        }
+        for (const auto& track : state.labelTracks) {
+            if (track.selected) {
+                if (!isCurrentTrack(state, track.track)) {
+                    error = "A selected label track changed while the edit was open";
+                    return false;
+                }
+                state.selectedTrackIds.push_back(track.track->GetId());
+            }
+        }
+    }
+
+    if (!state.prepared) {
+        state.prepared = std::make_unique<PreparedChanges>();
+    }
+    if (!state.committed && !prepareChanges(state, *state.prepared, error)) {
+        return false;
+    }
+
+    for (const auto& destination : state.prepared->audioDestinations) {
+        if (!isCurrentTrack(state, destination)) {
+            error = "An audio track changed while the edit was open";
+            return false;
+        }
+    }
+    for (const auto& destination : state.prepared->labelDestinations) {
+        if (!isCurrentTrack(state, destination)) {
+            error = "A label track changed while the edit was open";
+            return false;
+        }
+    }
+
+    if (applied) {
+        applied->replacements.clear();
+        applied->replacements.reserve(state.prepared->audioDestinations.size() + state.prepared->labelDestinations.size());
+        applied->additions.clear();
+        for (Track* addition : *state.prepared->additions) {
+            applied->additions.push_back(addition->shared_from_this());
+        }
+    }
+    for (const auto& destination : state.prepared->audioDestinations) {
+        const auto replacement = (*state.prepared->audioReplacements->begin())->shared_from_this();
+        auto original = state.tracks->ReplaceOne(*destination, std::move(*state.prepared->audioReplacements));
+        if (applied) {
+            applied->replacements.push_back({
+                    std::move(original),
+                    replacement,
+                });
+        }
+    }
+    for (const auto& destination : state.prepared->labelDestinations) {
+        const auto replacement = (*state.prepared->labelReplacements->begin())->shared_from_this();
+        auto original = state.tracks->ReplaceOne(*destination, std::move(*state.prepared->labelReplacements));
+        if (applied) {
+            applied->replacements.push_back({
+                    std::move(original),
+                    replacement,
+                });
+        }
+    }
+    state.tracks->Append(std::move(*state.prepared->additions));
+    return true;
+}
+
+bool rollbackChanges(EditState& state, AppliedChanges& applied, std::string& error)
+{
+    try {
+        for (auto iterator = applied.additions.rbegin(); iterator != applied.additions.rend(); ++iterator) {
+            if (isCurrentTrack(state, *iterator)) {
+                state.tracks->Remove(**iterator);
+            }
+        }
+        for (auto iterator = applied.replacements.rbegin(); iterator != applied.replacements.rend(); ++iterator) {
+            if (!isCurrentTrack(state, iterator->replacement)) {
+                error = "Could not restore a replaced project track";
+                return false;
+            }
+            auto original = TrackList::Temporary(state.tracks->GetOwner());
+            original->Add(iterator->original);
+            state.tracks->ReplaceOne(*iterator->replacement, std::move(*original));
+        }
+        applied = {};
+        return true;
+    } catch (const std::exception& exception) {
+        error = exception.what();
+    } catch (...) {
+        error = "Could not restore project tracks";
+    }
+    return false;
+}
+
+std::shared_ptr<EditState> currentState(AudacityProject* project, double start, double end, bool allTracks)
+{
+    auto state = std::make_shared<EditState>();
+    if (project) {
+        state->project = project->shared_from_this();
+    }
+    state->tracks = project ? &TrackList::Get(*project) : nullptr;
+    state->factory = project ? &WaveTrackFactory::Get(*project) : nullptr;
+    state->selectionStart = std::min(start, end);
+    state->selectionEnd = std::max(start, end);
+    if (!state->tracks) {
+        return state;
+    }
+
+    state->sourceTracks = TrackList::Temporary(state->project.get());
+    const auto addAudioTrack = [&](WaveTrack* track) {
+        if (track->NChannels() != 1 && track->NChannels() != 2) {
+            return;
+        }
+        auto destination = track->SharedPointer<WaveTrack>();
+        auto source = std::static_pointer_cast<WaveTrack>(track->Duplicate(Track::DuplicateOptions {}.Backup()));
+        state->sourceTracks->Add(source);
+        state->audioTracks.push_back({
+                std::move(source),
+                std::move(destination),
+                au3::wxToStdString(track->GetName()),
+                !allTracks || track->GetSelected(),
+            });
+    };
+    if (allTracks) {
+        for (auto* track : state->tracks->Any<WaveTrack>()) {
+            addAudioTrack(track);
+        }
+    } else {
+        for (auto* track : state->tracks->Selected<WaveTrack>()) {
+            addAudioTrack(track);
+        }
+    }
+
+    constexpr double infinity = std::numeric_limits<double>::infinity();
+    const auto addLabelTrack = [&](LabelTrack* track) {
+        auto selected = snapshotLabelTrack(*track, -infinity, infinity);
+        selected.selected = !allTracks || track->GetSelected();
+        state->labelTracks.push_back(std::move(selected));
+    };
+    if (allTracks) {
+        for (auto* track : state->tracks->Any<LabelTrack>()) {
+            addLabelTrack(track);
+        }
+    } else {
+        for (auto* track : state->tracks->Selected<LabelTrack>()) {
+            addLabelTrack(track);
+        }
+    }
+    return state;
+}
+} // namespace au::trackedit::api::detail
+
+namespace au::trackedit::api {
+thread_local bool apiScopeActive = false;
+thread_local ProjectEditSession* editContext = nullptr;
+
+ProjectEditSession::ProjectEditSession(ProjectEditWorkspace workspace, QObject* parent)
+    : QObject(parent)
+{
+    auto state = std::make_shared<detail::EditState>();
+    state->project = workspace.project;
+    state->tracks = workspace.tracks;
+    state->factory = workspace.factory;
+    state->audioTracks = std::move(workspace.audioTracks);
+    state->labelTracks = std::move(workspace.labelTracks);
+    state->preferredAudioDestination = std::move(workspace.preferredAudioDestination);
+    state->projectAvailable = std::move(workspace.projectAvailable);
+    state->selectionStart = std::min(workspace.selectionStart, workspace.selectionEnd);
+    state->selectionEnd = std::max(workspace.selectionStart, workspace.selectionEnd);
+    state->deferredCommit = true;
+    if (!state->tracks || !state->factory || !state->acquire()) {
+        state->active = false;
+    }
+    m_state = std::move(state);
+}
+
+ProjectEditSession::~ProjectEditSession()
+{
+    invalidate();
+}
+
+bool ProjectEditSession::finish(std::string& error)
+{
+    auto& state = *m_state;
+    if (!state.active) {
+        error = state.error.empty() ? "The project edit is no longer active" : state.error;
+        return false;
+    }
+    if (!state.editStarted) {
+        state.active = false;
+        state.release();
+        return true;
+    }
+    if (!state.committed) {
+        error = "The extension did not commit its project edit";
+        invalidate();
+        return false;
+    }
+    detail::AppliedChanges applied;
+    const auto rollback = [&] {
+        std::string rollbackError;
+        if (!detail::rollbackChanges(state, applied, rollbackError)) {
+            LOGE() << "failed to restore project edit: " << rollbackError;
+        }
+    };
+    try {
+        if (!detail::applyChanges(state, error, &applied)) {
+            rollback();
+            invalidate();
+            return false;
+        }
+        if (state.selectionChanged && state.setSelection) {
+            state.setSelection(state.selectionStart, state.selectionEnd, state.selectedTrackIds);
+        }
+        state.active = false;
+        state.release();
+        return true;
+    } catch (const std::exception& exception) {
+        error = exception.what();
+    } catch (...) {
+        error = "Could not commit project changes";
+    }
+    rollback();
+    invalidate();
+    return false;
+}
+
+void ProjectEditSession::invalidate()
+{
+    if (m_state) {
+        m_state->active = false;
+        m_state->release();
+    }
+}
+
+ProjectApiScope::ProjectApiScope(ProjectEditSession* context)
+    : m_previousContext(editContext), m_previousActive(apiScopeActive)
+{
+    apiScopeActive = true;
+    editContext = context;
+}
+
+ProjectApiScope::~ProjectApiScope()
+{
+    apiScopeActive = m_previousActive;
+    editContext = m_previousContext;
+}
+
+bool projectApiScopeActive()
+{
+    return apiScopeActive;
+}
+
+ProjectEditSession* currentProjectEditContext()
+{
+    return editContext;
+}
+
+ProjectLabelTrack snapshotLabelTrack(LabelTrack& track, double start, double end)
+{
+    ProjectLabelTrack result;
+    result.track = track.SharedPointer<LabelTrack>();
+    result.name = au3::wxToStdString(track.GetName());
+    for (int index = 0; index < track.GetNumLabels(); ++index) {
+        const auto* label = track.GetLabel(index);
+        if (!label || label->getT1() < start || label->getT0() > end) {
+            continue;
+        }
+        result.labels.push_back({
+                label->GetId(),
+                label->getT0(),
+                label->getT1(),
+                au3::wxToStdString(label->title),
+            });
+    }
+    return result;
+}
+
+void throwProjectError(QObject* object, const QString& message)
+{
+    if (auto* engine = qjsEngine(object)) {
+        engine->throwError(message);
+    }
+}
+
+QObject* makeCurrentProjectSelection(AudacityProject* project, double start, double end, QObject* parent)
+{
+    return detail::makeProjectSelection(detail::currentState(project, start, end, false), parent);
+}
+
+QObject* beginRootProjectEdit(
+    AudacityProject* project, double start, double end, const QString& name, IProjectHistoryPtr history,
+    std::function<bool()> projectAvailable, std::function<void(double, double, const std::vector<int64_t>&)> setSelection, QObject* parent)
+{
+    auto state = detail::currentState(project, start, end, true);
+    state->undoName = name.toStdString();
+    state->history = std::move(history);
+    state->projectAvailable = std::move(projectAvailable);
+    state->setSelection = std::move(setSelection);
+    state->editStarted = true;
+    try {
+        if (!state->history) {
+            throwProjectError(parent, QStringLiteral("Project history is unavailable"));
+            return nullptr;
+        }
+        if (!state->acquire()) {
+            throwProjectError(parent, QString::fromStdString(state->error));
+            return nullptr;
+        }
+        state->transaction = std::make_unique<TransactionScope>(*state->project, "JavaScript project edit");
+        auto* edit = detail::makeProjectEdit(std::move(state), nullptr);
+        QJSEngine::setObjectOwnership(edit, QJSEngine::JavaScriptOwnership);
+        return edit;
+    } catch (const std::exception& exception) {
+        throwProjectError(parent, QString::fromUtf8(exception.what()));
+    } catch (...) {
+        throwProjectError(parent, QStringLiteral("Could not begin the project edit"));
+    }
+    return nullptr;
+}
+
+QObject* ProjectEditSession::beginEdit(QObject* parent)
+{
+    auto state = m_state;
+    if (!state->active) {
+        throwProjectError(parent, QString::fromStdString(state->error.empty() ? "The project edit is no longer active" : state->error));
+        return nullptr;
+    }
+    if (state->editStarted) {
+        throwProjectError(parent, QStringLiteral("Only one project edit may be active"));
+        return nullptr;
+    }
+    state->editStarted = true;
+    auto* edit = detail::makeProjectEdit(std::move(state), nullptr);
+    QJSEngine::setObjectOwnership(edit, QJSEngine::JavaScriptOwnership);
+    return edit;
+}
+} // namespace au::trackedit::api

--- a/src/trackedit/api/projectedit.h
+++ b/src/trackedit/api/projectedit.h
@@ -1,0 +1,99 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <QObject>
+#include <QString>
+
+#include "trackedit/iprojecthistory.h"
+
+class AudacityProject;
+class LabelTrack;
+class TrackList;
+class WaveTrack;
+class WaveTrackFactory;
+
+namespace au::trackedit::api {
+struct ProjectAudioTrack {
+    std::shared_ptr<WaveTrack> source;
+    std::shared_ptr<WaveTrack> destination;
+    std::string name;
+    bool selected = true;
+};
+
+struct ProjectLabel {
+    int64_t nativeId = 0;
+    double start = 0.0;
+    double end = 0.0;
+    std::string text;
+};
+
+struct ProjectLabelTrack {
+    std::shared_ptr<LabelTrack> track;
+    std::string name;
+    std::vector<ProjectLabel> labels;
+    bool selected = true;
+};
+
+struct ProjectEditWorkspace {
+    std::shared_ptr<AudacityProject> project;
+    ::TrackList* tracks = nullptr;
+    WaveTrackFactory* factory = nullptr;
+    std::vector<ProjectAudioTrack> audioTracks;
+    std::vector<ProjectLabelTrack> labelTracks;
+    std::shared_ptr<WaveTrack> preferredAudioDestination;
+    std::function<bool()> projectAvailable;
+    double selectionStart = 0.0;
+    double selectionEnd = 0.0;
+};
+
+namespace detail {
+struct EditState;
+}
+
+class ProjectEditSession : public QObject
+{
+public:
+    explicit ProjectEditSession(ProjectEditWorkspace workspace, QObject* parent = nullptr);
+    ~ProjectEditSession() override;
+
+    QObject* beginEdit(QObject* parent);
+    bool finish(std::string& error);
+    void invalidate();
+
+private:
+    std::shared_ptr<detail::EditState> m_state;
+};
+
+class ProjectApiScope final
+{
+public:
+    explicit ProjectApiScope(ProjectEditSession* context = nullptr);
+    ~ProjectApiScope();
+
+    ProjectApiScope(const ProjectApiScope&) = delete;
+    ProjectApiScope& operator=(const ProjectApiScope&) = delete;
+
+private:
+    ProjectEditSession* m_previousContext = nullptr;
+    bool m_previousActive = false;
+
+    friend class ProjectApi;
+};
+
+bool projectApiScopeActive();
+ProjectEditSession* currentProjectEditContext();
+ProjectLabelTrack snapshotLabelTrack(LabelTrack& track, double start, double end);
+QObject* makeCurrentProjectSelection(AudacityProject* project, double start, double end, QObject* parent);
+QObject* beginRootProjectEdit(
+    AudacityProject* project, double start, double end, const QString& name, IProjectHistoryPtr history,
+    std::function<bool()> projectAvailable, std::function<void(double, double, const std::vector<int64_t>&)> setSelection, QObject* parent);
+void throwProjectError(QObject* object, const QString& message);
+} // namespace au::trackedit::api

--- a/src/trackedit/api/projecteditobject.cpp
+++ b/src/trackedit/api/projecteditobject.cpp
@@ -1,0 +1,281 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+#include "internal/projecteditstate.h"
+#include "projecteditobject.h"
+
+#include <utility>
+
+#include <QVariantList>
+
+#include "au3-math/SampleFormat.h"
+#include "au3-transactions/TransactionScope.h"
+#include "au3-wave-track/WaveTrack.h"
+#include "log.h"
+
+namespace au::trackedit::api::detail {
+ProjectSelectionObject::ProjectSelectionObject(std::shared_ptr<EditState> state, QObject* parent)
+    : QObject(parent), m_state(std::move(state))
+{
+    refresh();
+}
+
+void ProjectSelectionObject::refresh()
+{
+    m_audioTracks.clear();
+    m_labelTracks.clear();
+    for (size_t index = 0; index < m_state->audioTracks.size(); ++index) {
+        if (!m_state->audioTracks[index].selected) {
+            continue;
+        }
+        QObject*& wrapper = m_audioWrappers[index];
+        if (!wrapper) {
+            wrapper = makeAudioTrack(m_state, index, this);
+        }
+        m_audioTracks.push_back(QVariant::fromValue<QObject*>(wrapper));
+    }
+    for (size_t index = 0; index < m_state->labelTracks.size(); ++index) {
+        if (!m_state->labelTracks[index].selected) {
+            continue;
+        }
+        QObject*& wrapper = m_labelWrappers[index];
+        if (!wrapper) {
+            wrapper = makeLabelTrack(m_state, index, true, this);
+        }
+        m_labelTracks.push_back(QVariant::fromValue<QObject*>(wrapper));
+    }
+}
+
+double ProjectSelectionObject::start() const
+{
+    return m_state->selectionStart;
+}
+
+double ProjectSelectionObject::end() const
+{
+    return m_state->selectionEnd;
+}
+
+double ProjectSelectionObject::duration() const
+{
+    return m_state->selectionEnd - m_state->selectionStart;
+}
+
+QVariantList ProjectSelectionObject::audioTracks() const
+{
+    return m_audioTracks;
+}
+
+QVariantList ProjectSelectionObject::labelTracks() const
+{
+    return m_labelTracks;
+}
+
+ProjectEditObject::ProjectEditObject(std::shared_ptr<EditState> state, QObject* parent)
+    : QObject(parent), m_state(std::move(state)), m_selection(new ProjectSelectionObject(m_state, this))
+{
+    for (size_t index = 0; index < m_state->audioTracks.size(); ++index) {
+        m_audioTracks.push_back(QVariant::fromValue<QObject*>(makeAudioTrack(m_state, index, this)));
+    }
+    for (size_t index = 0; index < m_state->labelTracks.size(); ++index) {
+        m_labelTracks.push_back(QVariant::fromValue<QObject*>(makeLabelTrack(m_state, index, false, this)));
+    }
+}
+
+ProjectEditObject::~ProjectEditObject()
+{
+    if (m_state->active && !m_state->committed) {
+        abandon();
+    }
+}
+
+QObject* ProjectEditObject::selection() const
+{
+    return m_selection;
+}
+
+QVariantList ProjectEditObject::audioTracks() const
+{
+    return m_audioTracks;
+}
+
+QVariantList ProjectEditObject::labelTracks() const
+{
+    return m_labelTracks;
+}
+
+bool ProjectEditObject::setSelection(const QVariantMap& value)
+{
+    const double start = value.value(QStringLiteral("start")).toDouble();
+    const double end = value.value(QStringLiteral("end")).toDouble();
+    if (!m_state->writable() || !m_state->setSelection || !value.contains(QStringLiteral("start"))
+        || !value.contains(QStringLiteral("end")) || !value.contains(QStringLiteral("tracks")) || !validTimes(start, end)) {
+        throwProjectError(this, QStringLiteral("Invalid project selection"));
+        return false;
+    }
+
+    std::vector<size_t> audioTracks;
+    std::vector<size_t> labelTracks;
+    const QVariantList tracks = value.value(QStringLiteral("tracks")).toList();
+    for (const QVariant& value : tracks) {
+        QObject* object = value.value<QObject*>();
+        if (const auto index = audioTrackIndex(m_state, object)) {
+            audioTracks.push_back(*index);
+        } else if (const auto index = labelTrackIndex(m_state, object)) {
+            labelTracks.push_back(*index);
+        } else {
+            throwProjectError(this, QStringLiteral("Invalid project selection track"));
+            return false;
+        }
+    }
+
+    for (auto& track : m_state->audioTracks) {
+        track.selected = false;
+    }
+    for (auto& track : m_state->labelTracks) {
+        track.selected = false;
+    }
+    for (size_t index : audioTracks) {
+        m_state->audioTracks[index].selected = true;
+    }
+    for (size_t index : labelTracks) {
+        m_state->labelTracks[index].selected = true;
+    }
+    m_state->selectionStart = start;
+    m_state->selectionEnd = end;
+    m_state->selectionChanged = true;
+    m_selection->refresh();
+    return true;
+}
+
+QObject* ProjectEditObject::createAudioWriter(const QVariantMap& value)
+{
+    const auto format = audioFormat(value);
+    if (!m_state->writable() || !format) {
+        throwProjectError(this, QStringLiteral("Invalid audio writer format"));
+        return nullptr;
+    }
+    try {
+        auto audio = m_state->factory->Create(format->channelCount, floatSample, format->sampleRate);
+        ++m_state->writers;
+        return makeAudioWriter(m_state, *format, std::move(audio), this);
+    } catch (...) {
+        throwProjectError(this, QStringLiteral("Could not create the audio writer"));
+        return nullptr;
+    }
+}
+
+bool ProjectEditObject::transformAudio(QObject* track, const QVariantMap& options, QObject* processor, QObject* task)
+{
+    return detail::transformAudio(m_state, track, options, processor, task, this);
+}
+
+QObject* ProjectEditObject::createLabelTrack(const QString& name)
+{
+    if (!m_state->writable()) {
+        throwProjectError(this, QStringLiteral("The project edit is no longer active"));
+        return nullptr;
+    }
+    m_state->addedLabelTracks.push_back({ name.toStdString(), {} });
+    return makeAddedLabelTrack(m_state, m_state->addedLabelTracks.size() - 1, this);
+}
+
+void ProjectEditObject::commit()
+{
+    if (!m_state->writable()) {
+        throwProjectError(this, QStringLiteral("The project edit is no longer active"));
+        return;
+    }
+    if (m_state->writers != m_state->routedWriters) {
+        throwProjectError(this, QStringLiteral("An audio writer was not routed"));
+        return;
+    }
+    std::string error;
+    AppliedChanges applied;
+    bool storageCommitted = false;
+    const auto rollback = [&] {
+        std::string rollbackError;
+        if (!rollbackChanges(*m_state, applied, rollbackError)) {
+            LOGE() << "failed to restore project edit: " << rollbackError;
+        }
+    };
+    try {
+        m_state->prepared = std::make_unique<PreparedChanges>();
+        if (!prepareChanges(*m_state, *m_state->prepared, error)) {
+            throwProjectError(this, QString::fromStdString(error));
+            return;
+        }
+        m_state->committed = true;
+        if (m_state->deferredCommit) {
+            return;
+        }
+        if (!applyChanges(*m_state, error, &applied)) {
+            throwProjectError(this, QString::fromStdString(error));
+            rollback();
+            abandon();
+            return;
+        }
+        if (m_state->transaction && !m_state->transaction->Commit()) {
+            throwProjectError(this, QStringLiteral("Could not commit project storage"));
+            rollback();
+            abandon();
+            return;
+        }
+        storageCommitted = true;
+        m_state->active = false;
+        m_state->transaction.reset();
+        m_state->release();
+    } catch (const std::exception& exception) {
+        throwProjectError(this, QString::fromUtf8(exception.what()));
+        if (!storageCommitted) {
+            rollback();
+        }
+        abandon();
+        return;
+    } catch (...) {
+        throwProjectError(this, QStringLiteral("Could not commit project changes"));
+        if (!storageCommitted) {
+            rollback();
+        }
+        abandon();
+        return;
+    }
+
+    try {
+        if (m_state->selectionChanged && m_state->setSelection) {
+            m_state->setSelection(m_state->selectionStart, m_state->selectionEnd, m_state->selectedTrackIds);
+        }
+        m_state->history->pushHistoryState(m_state->undoName, m_state->undoName);
+    } catch (const std::exception& exception) {
+        LOGE() << "project edit was committed but finalization failed: " << exception.what();
+    } catch (...) {
+        LOGE() << "project edit was committed but finalization failed";
+    }
+}
+
+void ProjectEditObject::abort()
+{
+    if (!m_state->active || m_state->committed) {
+        throwProjectError(this, QStringLiteral("The project edit is no longer active"));
+        return;
+    }
+    abandon();
+}
+
+void ProjectEditObject::abandon()
+{
+    m_state->active = false;
+    m_state->transaction.reset();
+    m_state->release();
+}
+
+QObject* makeProjectSelection(std::shared_ptr<EditState> state, QObject* parent)
+{
+    return new ProjectSelectionObject(std::move(state), parent);
+}
+
+QObject* makeProjectEdit(std::shared_ptr<EditState> state, QObject* parent)
+{
+    return new ProjectEditObject(std::move(state), parent);
+}
+} // namespace au::trackedit::api::detail

--- a/src/trackedit/api/projecteditobject.h
+++ b/src/trackedit/api/projecteditobject.h
@@ -1,0 +1,74 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+#pragma once
+
+#include <map>
+#include <memory>
+
+#include <QObject>
+#include <QVariantList>
+#include <QVariantMap>
+
+namespace au::trackedit::api::detail {
+struct EditState;
+
+class ProjectSelectionObject final : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(double start READ start)
+    Q_PROPERTY(double end READ end)
+    Q_PROPERTY(double duration READ duration)
+    Q_PROPERTY(QVariantList audioTracks READ audioTracks)
+    Q_PROPERTY(QVariantList labelTracks READ labelTracks)
+
+public:
+    explicit ProjectSelectionObject(std::shared_ptr<EditState> state, QObject* parent);
+
+    void refresh();
+
+    double start() const;
+    double end() const;
+    double duration() const;
+    QVariantList audioTracks() const;
+    QVariantList labelTracks() const;
+
+private:
+    std::shared_ptr<EditState> m_state;
+    QVariantList m_audioTracks;
+    QVariantList m_labelTracks;
+    std::map<size_t, QObject*> m_audioWrappers;
+    std::map<size_t, QObject*> m_labelWrappers;
+};
+
+class ProjectEditObject final : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(QObject * selection READ selection CONSTANT)
+    Q_PROPERTY(QVariantList audioTracks READ audioTracks CONSTANT)
+    Q_PROPERTY(QVariantList labelTracks READ labelTracks CONSTANT)
+
+public:
+    ProjectEditObject(std::shared_ptr<EditState> state, QObject* parent);
+    ~ProjectEditObject() override;
+
+    QObject* selection() const;
+    QVariantList audioTracks() const;
+    QVariantList labelTracks() const;
+
+    Q_INVOKABLE bool setSelection(const QVariantMap& value);
+    Q_INVOKABLE QObject* createAudioWriter(const QVariantMap& value);
+    Q_INVOKABLE bool transformAudio(QObject* track, const QVariantMap& options, QObject* processor, QObject* task);
+    Q_INVOKABLE QObject* createLabelTrack(const QString& name);
+    Q_INVOKABLE void commit();
+    Q_INVOKABLE void abort();
+
+private:
+    void abandon();
+
+    std::shared_ptr<EditState> m_state;
+    ProjectSelectionObject* m_selection = nullptr;
+    QVariantList m_audioTracks;
+    QVariantList m_labelTracks;
+};
+} // namespace au::trackedit::api::detail

--- a/src/trackedit/api/projectlabels.cpp
+++ b/src/trackedit/api/projectlabels.cpp
@@ -1,0 +1,178 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+#include "projectlabels.h"
+
+#include <algorithm>
+#include <utility>
+
+#include "internal/projecteditstate.h"
+
+namespace au::trackedit::api::detail {
+LabelObject::LabelObject(std::shared_ptr<EditState> state, size_t trackIndex, size_t labelIndex, QObject* parent)
+    : QObject(parent), m_state(std::move(state)), m_trackIndex(trackIndex), m_labelIndex(labelIndex)
+{
+}
+
+double LabelObject::start() const
+{
+    return source().start;
+}
+
+double LabelObject::end() const
+{
+    return source().end;
+}
+
+QString LabelObject::text() const
+{
+    return QString::fromStdString(source().text);
+}
+
+bool LabelObject::update(double start, double end, const QString& text)
+{
+    if (!m_state->writable() || m_removed || !validTimes(start, end)) {
+        throwProjectError(this, QStringLiteral("Invalid label update"));
+        return false;
+    }
+    const auto matches = [&](const LabelChange& change) {
+        return change.trackIndex == m_trackIndex && change.nativeId == source().nativeId;
+    };
+    auto found = std::find_if(m_state->labelChanges.begin(), m_state->labelChanges.end(), matches);
+    if (found == m_state->labelChanges.end()) {
+        m_state->labelChanges.push_back({
+                m_trackIndex,
+                source().nativeId,
+                false,
+                start,
+                end,
+                text.toStdString(),
+            });
+    } else {
+        found->remove = false;
+        found->start = start;
+        found->end = end;
+        found->text = text.toStdString();
+    }
+    return true;
+}
+
+bool LabelObject::remove()
+{
+    if (!m_state->writable() || m_removed) {
+        throwProjectError(this, QStringLiteral("The label cannot be removed"));
+        return false;
+    }
+    const auto matches = [&](const LabelChange& change) {
+        return change.trackIndex == m_trackIndex && change.nativeId == source().nativeId;
+    };
+    m_state->labelChanges.erase(std::remove_if(m_state->labelChanges.begin(),
+                                               m_state->labelChanges.end(), matches), m_state->labelChanges.end());
+    m_state->labelChanges.push_back({
+            m_trackIndex,
+            source().nativeId,
+            true,
+            0.0,
+            0.0,
+            {},
+        });
+    m_removed = true;
+    return true;
+}
+
+const ProjectLabel& LabelObject::source() const
+{
+    return m_state->labelTracks.at(m_trackIndex).labels.at(m_labelIndex);
+}
+
+LabelTrackObject::LabelTrackObject(std::shared_ptr<EditState> state, size_t index, bool intersectingLabelsOnly, QObject* parent)
+    : QObject(parent), m_state(std::move(state)), m_index(index), m_intersectingOnly(intersectingLabelsOnly)
+{
+}
+
+QString LabelTrackObject::name() const
+{
+    return QString::fromStdString(m_state->labelTracks.at(m_index).name);
+}
+
+QVariantList LabelTrackObject::labels() const
+{
+    QVariantList result;
+    const auto& input = m_state->labelTracks.at(m_index);
+    for (size_t label = 0; label < input.labels.size(); ++label) {
+        if (m_intersectingOnly
+            && (input.labels[label].end < m_state->selectionStart || input.labels[label].start > m_state->selectionEnd)) {
+            continue;
+        }
+        QObject*& wrapper = m_labelWrappers[label];
+        if (!wrapper) {
+            wrapper = new LabelObject(m_state, m_index, label, const_cast<LabelTrackObject*>(this));
+        }
+        result.push_back(QVariant::fromValue<QObject*>(wrapper));
+    }
+    return result;
+}
+
+size_t LabelTrackObject::index() const
+{
+    return m_index;
+}
+
+const std::shared_ptr<EditState>& LabelTrackObject::state() const
+{
+    return m_state;
+}
+
+bool LabelTrackObject::addLabel(double start, double end, const QString& text)
+{
+    if (!m_state->writable() || !validTimes(start, end)) {
+        throwProjectError(this, QStringLiteral("Invalid label"));
+        return false;
+    }
+    m_state->labelChanges.push_back({
+            m_index,
+            std::nullopt,
+            false,
+            start,
+            end,
+            text.toStdString(),
+        });
+    return true;
+}
+
+AddedLabelTrackObject::AddedLabelTrackObject(std::shared_ptr<EditState> state, size_t index, QObject* parent)
+    : QObject(parent), m_state(std::move(state)), m_index(index)
+{
+}
+
+bool AddedLabelTrackObject::addLabel(double start, double end, const QString& text)
+{
+    if (!m_state->writable() || !validTimes(start, end)) {
+        throwProjectError(this, QStringLiteral("Invalid label"));
+        return false;
+    }
+    m_state->addedLabelTracks.at(m_index).labels.push_back({
+            0,
+            start,
+            end,
+            text.toStdString(),
+        });
+    return true;
+}
+
+QObject* makeLabelTrack(std::shared_ptr<EditState> state, size_t index, bool intersectingLabelsOnly, QObject* parent)
+{
+    return new LabelTrackObject(std::move(state), index, intersectingLabelsOnly, parent);
+}
+
+std::optional<size_t> labelTrackIndex(const std::shared_ptr<EditState>& state, QObject* object)
+{
+    auto* track = qobject_cast<LabelTrackObject*>(object);
+    return track && track->state() == state ? std::optional<size_t> { track->index() } : std::nullopt;
+}
+
+QObject* makeAddedLabelTrack(std::shared_ptr<EditState> state, size_t index, QObject* parent)
+{
+    return new AddedLabelTrackObject(std::move(state), index, parent);
+}
+} // namespace au::trackedit::api::detail

--- a/src/trackedit/api/projectlabels.h
+++ b/src/trackedit/api/projectlabels.h
@@ -1,0 +1,82 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+#pragma once
+
+#include <cstddef>
+#include <map>
+#include <memory>
+
+#include <QObject>
+#include <QVariantList>
+
+namespace au::trackedit::api {
+struct ProjectLabel;
+
+namespace detail {
+struct EditState;
+
+class LabelObject final : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(double start READ start CONSTANT)
+    Q_PROPERTY(double end READ end CONSTANT)
+    Q_PROPERTY(QString text READ text CONSTANT)
+
+public:
+    LabelObject(std::shared_ptr<EditState> state, size_t trackIndex, size_t labelIndex, QObject* parent);
+
+    double start() const;
+    double end() const;
+    QString text() const;
+
+    Q_INVOKABLE bool update(double start, double end, const QString& text);
+    Q_INVOKABLE bool remove();
+
+private:
+    const ProjectLabel& source() const;
+
+    std::shared_ptr<EditState> m_state;
+    size_t m_trackIndex = 0;
+    size_t m_labelIndex = 0;
+    bool m_removed = false;
+};
+
+class LabelTrackObject final : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(QString name READ name CONSTANT)
+    Q_PROPERTY(QVariantList labels READ labels CONSTANT)
+
+public:
+    LabelTrackObject(std::shared_ptr<EditState> state, size_t index, bool intersectingLabelsOnly, QObject* parent);
+
+    QString name() const;
+    QVariantList labels() const;
+    size_t index() const;
+    const std::shared_ptr<EditState>& state() const;
+
+    Q_INVOKABLE bool addLabel(double start, double end, const QString& text);
+
+private:
+    std::shared_ptr<EditState> m_state;
+    size_t m_index = 0;
+    bool m_intersectingOnly = false;
+    mutable std::map<size_t, QObject*> m_labelWrappers;
+};
+
+class AddedLabelTrackObject final : public QObject
+{
+    Q_OBJECT
+
+public:
+    AddedLabelTrackObject(std::shared_ptr<EditState> state, size_t index, QObject* parent);
+
+    Q_INVOKABLE bool addLabel(double start, double end, const QString& text);
+
+private:
+    std::shared_ptr<EditState> m_state;
+    size_t m_index = 0;
+};
+} // namespace detail
+} // namespace au::trackedit::api

--- a/src/trackedit/trackeditmodule.cpp
+++ b/src/trackedit/trackeditmodule.cpp
@@ -96,7 +96,7 @@ void TrackeditModule::resolveImports()
 {
     auto ar = globalIoc()->resolve<muse::api::IApiRegister>(mname);
     if (ar) {
-        ar->regApiCreator(mname, "MuseApi.Project", new muse::api::ApiCreator<api::ProjectApi>());
+        ar->regApiCreator(mname, "Audacity.Project", new muse::api::ApiCreator<api::ProjectApi>());
     }
 
     auto ir = globalIoc()->resolve<muse::interactive::IInteractiveUriRegister>(mname);


### PR DESCRIPTION
Adds project editing api for JS extensions:

  - Project editing for audio, labels, tracks, and selection
  - Native-library calls
  - Extension preferences API and Preferences UI integration
   

Examples:

Create a label track

```js
const project = require("Audacity.Project")

const edit = project.beginEdit("Add marker", context)
const track = edit.createLabelTrack("Markers")
track.addLabel(5.0, 5.0, "Beat")
edit.commit()
```

Call a native library

```js
const native = require("Audacity.Native")

const library = native.open("dsp")
const applyGain = library.bind("gain.process")
const gain = 1.1;
applyGain(buffer, gain);
```

Read preferences
```js
const preferences = require("Audacity.Preferences")
const modelRoot = preferences.value("modelRoot", "")
```

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
