### PR TITLE
fixed #11412: Plugin Parameters are not retained in Non-GUI Mode

### DIFF
--- a/au3/libraries/au3-vst3/VST3ParameterExtraction.cpp
+++ b/au3/libraries/au3-vst3/VST3ParameterExtraction.cpp
@@ -182,7 +182,9 @@ std::vector<ParamInfo> VST3ParameterExtraction::extractParameters(EffectInstance
                 wrapper.FetchSettings(settings, false);
                 return nullptr;
             });
-            wrapper.lastFetchedSettingsCounter = currentCounter;
+
+            // Modify settings itself bumps the modification counter, re-read the counter.
+            wrapper.lastFetchedSettingsCounter = settingsAccess->modificationCounter();
         }
     }
 


### PR DESCRIPTION
Resolves: #11412