### PR TITLE
Playback always starts from the beginning of the loop region #11074

### DIFF
--- a/src/playback/internal/au3/au3player.cpp
+++ b/src/playback/internal/au3/au3player.cpp
@@ -218,6 +218,20 @@ void Au3Player::play(std::optional<muse::secs_t> startTime)
     }
 }
 
+void Au3Player::playRange(const PlaybackRegion& range)
+{
+    IF_ASSERT_FAILED(range.isValid()) {
+        return;
+    }
+
+    //! NOTE: a non-default policy plays the exact range once,
+    //! regardless of the play region and loop region
+    PlayTracksOptions opts;
+    opts.isDefaultPolicy = false;
+
+    playTracks(Au3TrackList::Get(projectRef()), range.start.to_double(), range.end.to_double(), opts);
+}
+
 muse::Ret Au3Player::playTracks(TrackList& trackList, double startTime, double endTime, const PlayTracksOptions& options)
 {
     muse::Ret ret = doPlayTracks(trackList, startTime, endTime, options);

--- a/src/playback/internal/au3/au3player.cpp
+++ b/src/playback/internal/au3/au3player.cpp
@@ -534,8 +534,14 @@ void Au3Player::updateStreamState()
     bool isActive = AudioIO::Get()->IsStreamActive(token);
 
     if (!isActive) {
-        if (playbackStatus() == PlaybackStatus::Running
-            || playbackStatus() == PlaybackStatus::Paused) {
+        if (playbackStatus() == PlaybackStatus::Running) {
+            //! NOTE: the stream ended on its own (e.g. an explicit range played to its
+            //! end) — do a full stop so the audio engine releases the stream token;
+            //! otherwise isBusy() stays true and no new playback can ever start
+            stop();
+        } else if (playbackStatus() == PlaybackStatus::Paused) {
+            //! NOTE: e.g. a device change tore the stream down while paused; the
+            //! stream lifecycle is handled by that flow — only update the status
             m_playbackStatus.set(PlaybackStatus::Stopped);
         } else if (m_timer.isActive()) {
             // Stream ended (playback or recording finished)

--- a/src/playback/internal/au3/au3player.h
+++ b/src/playback/internal/au3/au3player.h
@@ -36,6 +36,7 @@ public:
     bool isBusy() const override;
 
     void play(std::optional<muse::secs_t> startTime = std::nullopt) override;
+    void playRange(const PlaybackRegion& range) override;
     void seek(const muse::secs_t newPosition, bool applyIfPlaying = false) override;
     void rewind() override;
     void stop() override;

--- a/src/playback/internal/playbackcontroller.cpp
+++ b/src/playback/internal/playbackcontroller.cpp
@@ -201,8 +201,15 @@ PlaybackRegion PlaybackController::selectionPlaybackRegion() const
     return PlaybackRegion();
 }
 
-bool PlaybackController::isSelectionPlaybackRegionChanged() const
+bool PlaybackController::isPlaybackRegionChanged() const
 {
+    if (isLoopRegionActive()) {
+        //! NOTE: with an active loop region the player's play region is the loop region,
+        //! not the last requested playback region — the comparison below would always
+        //! report a change and resuming from pause would restart playback instead
+        return false;
+    }
+
     return m_lastPlaybackRegion.isValid() && m_lastPlaybackRegion != player()->playbackRegion();
 }
 
@@ -347,7 +354,7 @@ void PlaybackController::togglePlay(TogglePlayMode mode)
     }
 
     if (isPaused()) {
-        if (isSelectionPlaybackRegionChanged()) {
+        if (isPlaybackRegionChanged()) {
             //! NOTE: just stop, without seek
             player()->stop();
             doPlay(false);
@@ -417,7 +424,14 @@ void PlaybackController::doPlay(bool clearPlaybackRegion)
         return;
     }
 
-    player()->play();
+    if (isStopped()) {
+        //! NOTE: pass the start explicitly: when a loop region is active the play region
+        //! cannot be updated, and playback must still start from the playhead, not from
+        //! the loop region start
+        player()->play(lastPlaybackSeekTime());
+    } else {
+        player()->play();
+    }
 }
 
 void PlaybackController::playSelectionAction()

--- a/src/playback/internal/playbackcontroller.cpp
+++ b/src/playback/internal/playbackcontroller.cpp
@@ -457,7 +457,13 @@ void PlaybackController::playSelectionAction()
         return;
     }
 
-    player()->play();
+    if (isLoopRegionActive()) {
+        //! NOTE: the play region cannot be updated while a loop region is active —
+        //! play the selected range directly so the selection is played, not the loop region
+        player()->playRange(selection);
+    } else {
+        player()->play();
+    }
 }
 
 void PlaybackController::playTracksAction(const muse::actions::ActionQuery&)

--- a/src/playback/internal/playbackcontroller.h
+++ b/src/playback/internal/playbackcontroller.h
@@ -109,7 +109,7 @@ private:
     bool loopBoundariesSet() const;
 
     PlaybackRegion selectionPlaybackRegion() const;
-    bool isSelectionPlaybackRegionChanged() const;
+    bool isPlaybackRegionChanged() const;
     void updatePlaybackRegion();
 
     void onProjectChanged();

--- a/src/playback/iplayer.h
+++ b/src/playback/iplayer.h
@@ -21,6 +21,8 @@ public:
 
     //! `startTime` does not change the current playback region.
     virtual void play(std::optional<muse::secs_t> startTime = std::nullopt) = 0;
+    //! Plays the given time range once, regardless of the play region and loop region.
+    virtual void playRange(const PlaybackRegion& range) = 0;
     virtual void seek(const muse::secs_t newPosition, bool applyIfPlaying = false) = 0;
     virtual void rewind() = 0;
     virtual void stop() = 0;

--- a/src/playback/tests/mocks/playermock.h
+++ b/src/playback/tests/mocks/playermock.h
@@ -13,6 +13,7 @@ class PlayerMock : public IPlayer
 public:
     MOCK_METHOD(bool, isBusy, (), (const, override));
     MOCK_METHOD(void, play, (std::optional<muse::secs_t>), (override));
+    MOCK_METHOD(void, playRange, (const PlaybackRegion&), (override));
     MOCK_METHOD(void, seek, (const muse::secs_t, bool), (override));
     MOCK_METHOD(void, rewind, (), (override));
     MOCK_METHOD(void, stop, (), (override));

--- a/src/playback/tests/playbackcontroller_tests.cpp
+++ b/src/playback/tests/playbackcontroller_tests.cpp
@@ -266,6 +266,36 @@ TEST_F(PlaybackControllerTests, TogglePlay_WhenStopped)
 }
 
 /**
+ * @brief Toggle play passes the playhead position to the player
+ * @details With an active loop region the play region cannot be updated, so the
+ *          explicit start time is what makes playback start from the playhead
+ *          instead of the loop region start (issue #11074)
+ */
+TEST_F(PlaybackControllerTests, TogglePlay_WhenStopped_PassesPlayheadToPlayer)
+{
+    //! [GIVEN] Playback is stopped
+    ON_CALL(*m_player, playbackStatus())
+    .WillByDefault(Return(PlaybackStatus::Stopped));
+
+    //! [GIVEN] Playhead is at 5 secs
+    const secs_t playheadPosition = 5.0;
+    EXPECT_CALL(*m_player, seek(playheadPosition, false))
+    .Times(1);
+    seek(playheadPosition);
+
+    //! [GIVEN] A loop region is active
+    ON_CALL(*m_player, isLoopRegionActive())
+    .WillByDefault(Return(true));
+
+    //! [THEN] Player starts playing from the playhead position, not the loop start
+    EXPECT_CALL(*m_player, play(std::optional<muse::secs_t>(playheadPosition)))
+    .Times(1);
+
+    //! [WHEN] Toggle play
+    togglePlayStop();
+}
+
+/**
  * @brief Toggle play when stopped on the end of project
  * @details User clicked play after the previous playback reached the end of project
  *          Playback should be started from start of project (0.0 time)
@@ -532,6 +562,42 @@ TEST_F(PlaybackControllerTests, TogglePlay_WhenPaused)
     //! [THEN] Player should resume playing
     EXPECT_CALL(*m_player, resume())
     .Times(1);
+
+    //! [WHEN] Toggle play
+    togglePlayStop();
+}
+
+/**
+ * @brief Toggle play when paused with an active loop region resumes
+ * @details With a loop region active the player's play region (the loop region) never
+ *          matches the last requested playback region; that mismatch must not be
+ *          mistaken for a playback region change — play after pause must resume from the
+ *          paused position, not restart
+ */
+TEST_F(PlaybackControllerTests, TogglePlay_WhenPaused_WithActiveLoop_Resumes)
+{
+    //! [GIVEN] Playback started while stopped, giving a valid last playback region
+    ON_CALL(*m_player, playbackStatus())
+    .WillByDefault(Return(PlaybackStatus::Stopped));
+    changePlaybackRegion(0.0, 100.0);
+
+    //! [GIVEN] A loop region is active; the player's play region is the loop region
+    ON_CALL(*m_player, isLoopRegionActive())
+    .WillByDefault(Return(true));
+    ON_CALL(*m_player, playbackRegion())
+    .WillByDefault(Return(PlaybackRegion { secs_t(10.0), secs_t(20.0) }));
+
+    //! [GIVEN] Playback is paused
+    ON_CALL(*m_player, playbackStatus())
+    .WillByDefault(Return(PlaybackStatus::Paused));
+
+    //! [THEN] Playback resumes from the paused position — no stop, no restart
+    EXPECT_CALL(*m_player, resume())
+    .Times(1);
+    EXPECT_CALL(*m_player, stop())
+    .Times(0);
+    EXPECT_CALL(*m_player, play(_))
+    .Times(0);
 
     //! [WHEN] Toggle play
     togglePlayStop();

--- a/src/playback/tests/playbackcontroller_tests.cpp
+++ b/src/playback/tests/playbackcontroller_tests.cpp
@@ -1057,6 +1057,40 @@ TEST_F(PlaybackControllerTests, PlaySelection_WithSelection)
 }
 
 /**
+ * @brief Play selection with an active loop region plays the selection, not the loop
+ * @details The play region cannot be updated while a loop region is active, so the
+ *          selection must be played as an explicit range (issue #9393)
+ */
+TEST_F(PlaybackControllerTests, PlaySelection_WithActiveLoop_PlaysSelectionRange)
+{
+    //! [GIVEN] Playback is stopped
+    ON_CALL(*m_player, playbackStatus())
+    .WillByDefault(Return(PlaybackStatus::Stopped));
+
+    //! [GIVEN] A loop region is active
+    ON_CALL(*m_player, isLoopRegionActive())
+    .WillByDefault(Return(true));
+
+    //! [GIVEN] There is selection from 5 to 7 secs
+    PlaybackRegion selectionRegion = { secs_t(5.0), secs_t(7.0) };
+    ON_CALL(*m_selectionController, timeSelectionIsEmpty())
+    .WillByDefault(Return(false));
+    ON_CALL(*m_selectionController, dataSelectedStartTime())
+    .WillByDefault(Return(selectionRegion.start));
+    ON_CALL(*m_selectionController, dataSelectedEndTime())
+    .WillByDefault(Return(selectionRegion.end));
+
+    //! [THEN] The selection is played as an explicit range, not via the play region
+    EXPECT_CALL(*m_player, playRange(selectionRegion))
+    .Times(1);
+    EXPECT_CALL(*m_player, play(_))
+    .Times(0);
+
+    //! [WHEN] Play selection
+    playSelection();
+}
+
+/**
  * @brief Play selection does nothing without a time selection
  */
 TEST_F(PlaybackControllerTests, PlaySelection_WithoutSelection_DoesNothing)

--- a/src/playback/tests/playbackcontroller_tests.cpp
+++ b/src/playback/tests/playbackcontroller_tests.cpp
@@ -257,8 +257,8 @@ TEST_F(PlaybackControllerTests, TogglePlay_WhenStopped)
     EXPECT_CALL(*m_player, setPlaybackRegion(PlaybackRegion { secs_t(0.0), secs_t(100.0) }))
     .Times(1);
 
-    //! [THEN] Player should start playing from current position
-    EXPECT_CALL(*m_player, play(_))
+    //! [THEN] Player should start playing from the seek anchor (0.0, no prior seek)
+    EXPECT_CALL(*m_player, play(std::optional<muse::secs_t>(secs_t(0.0))))
     .Times(1);
 
     //! [WHEN] Toggle play
@@ -393,8 +393,8 @@ TEST_F(PlaybackControllerTests, TogglePlay_WithSelection_PlaysFromPlayheadThroug
     EXPECT_CALL(*m_player, setPlaybackRegion(PlaybackRegion { playheadPosition, secs_t(100.0) }))
     .Times(1);
 
-    //! [THEN] Player should start playing
-    EXPECT_CALL(*m_player, play(_))
+    //! [THEN] Player should start playing from the playhead, not the selection start
+    EXPECT_CALL(*m_player, play(std::optional<muse::secs_t>(playheadPosition)))
     .Times(1);
 
     //! [WHEN] Toggle play
@@ -625,8 +625,9 @@ TEST_F(PlaybackControllerTests, TogglePlay_WhenPaused_WithIgnoreSelection)
     EXPECT_CALL(*m_selectionController, timeSelectionIsEmpty())
     .Times(0);
 
-    //! [THEN] Player should start playing
-    EXPECT_CALL(*m_player, play(_))
+    //! [THEN] Player should start playing without an explicit start time —
+    //! the player asserts that no start time is passed when resuming from pause
+    EXPECT_CALL(*m_player, play(std::optional<muse::secs_t>(std::nullopt)))
     .Times(1);
 
     //! [WHEN] Toggle play
@@ -1081,6 +1082,42 @@ TEST_F(PlaybackControllerTests, PlaySelection_WithActiveLoop_PlaysSelectionRange
     .WillByDefault(Return(selectionRegion.end));
 
     //! [THEN] The selection is played as an explicit range, not via the play region
+    EXPECT_CALL(*m_player, playRange(selectionRegion))
+    .Times(1);
+    EXPECT_CALL(*m_player, play(_))
+    .Times(0);
+
+    //! [WHEN] Play selection
+    playSelection();
+}
+
+/**
+ * @brief Play selection while playing with an active loop restarts with the selection range
+ * @details Active playback is stopped first, then the selection is played as an
+ *          explicit range because the loop region blocks play region updates
+ */
+TEST_F(PlaybackControllerTests, PlaySelection_WhilePlaying_WithActiveLoop_Restarts)
+{
+    //! [GIVEN] Playback is running
+    ON_CALL(*m_player, playbackStatus())
+    .WillByDefault(Return(PlaybackStatus::Running));
+
+    //! [GIVEN] A loop region is active
+    ON_CALL(*m_player, isLoopRegionActive())
+    .WillByDefault(Return(true));
+
+    //! [GIVEN] There is selection from 5 to 7 secs
+    PlaybackRegion selectionRegion = { secs_t(5.0), secs_t(7.0) };
+    ON_CALL(*m_selectionController, timeSelectionIsEmpty())
+    .WillByDefault(Return(false));
+    ON_CALL(*m_selectionController, dataSelectedStartTime())
+    .WillByDefault(Return(selectionRegion.start));
+    ON_CALL(*m_selectionController, dataSelectedEndTime())
+    .WillByDefault(Return(selectionRegion.end));
+
+    //! [THEN] Player is stopped, then the selection is played as an explicit range
+    EXPECT_CALL(*m_player, stop())
+    .Times(1);
     EXPECT_CALL(*m_player, playRange(selectionRegion))
     .Times(1);
     EXPECT_CALL(*m_player, play(_))


### PR DESCRIPTION
Resolves: 
Playback always starts from the beginning of the loop region https://github.com/audacity/audacity/issues/11074
Playback with looping and a range selection starts from a wrong position https://github.com/audacity/audacity/issues/9393
<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
