### PR TITLE
Make welcome carousel dots clickable

### DIFF
--- a/src/appshell/qml/Audacity/AppShell/WelcomeDialog.qml
+++ b/src/appshell/qml/Audacity/AppShell/WelcomeDialog.qml
@@ -230,9 +230,16 @@ StyledDialogView {
 
                 indicatorSize: 12
                 spacing: 12
+                interactive: true
 
                 count: model.count
                 currentIndex: model.currentIndex
+
+                onCurrentIndexChanged: {
+                    if (currentIndex !== model.currentIndex) {
+                        model.setCurrentIndex(currentIndex)
+                    }
+                }
             }
         }
     }

--- a/src/appshell/qml/Audacity/AppShell/welcomedialogmodel.cpp
+++ b/src/appshell/qml/Audacity/AppShell/welcomedialogmodel.cpp
@@ -146,6 +146,23 @@ void WelcomeDialogModel::activateCurrentItem()
     }
 }
 
+void WelcomeDialogModel::setCurrentIndex(int index)
+{
+    if (index < 0 || index >= count()) {
+        return;
+    }
+
+    const size_t newIndex = static_cast<size_t>(index);
+    if (newIndex == m_currentIndex) {
+        return;
+    }
+
+    m_currentIndex = newIndex;
+    configuration()->setWelcomeDialogLastShownIndex(index);
+
+    emit currentItemChanged();
+}
+
 void WelcomeDialogModel::nextItem()
 {
     IF_ASSERT_FAILED(!m_items.empty()) {

--- a/src/appshell/qml/Audacity/AppShell/welcomedialogmodel.cpp
+++ b/src/appshell/qml/Audacity/AppShell/welcomedialogmodel.cpp
@@ -148,6 +148,23 @@ void WelcomeDialogModel::activateCurrentItem()
     }
 }
 
+void WelcomeDialogModel::setCurrentIndex(int index)
+{
+    if (index < 0 || index >= count()) {
+        return;
+    }
+
+    const size_t newIndex = static_cast<size_t>(index);
+    if (newIndex == m_currentIndex) {
+        return;
+    }
+
+    m_currentIndex = newIndex;
+    configuration()->setWelcomeDialogLastShownIndex(index);
+
+    emit currentItemChanged();
+}
+
 void WelcomeDialogModel::nextItem()
 {
     IF_ASSERT_FAILED(!m_items.empty()) {

--- a/src/appshell/qml/Audacity/AppShell/welcomedialogmodel.h
+++ b/src/appshell/qml/Audacity/AppShell/welcomedialogmodel.h
@@ -65,6 +65,7 @@ public:
     QVariantMap currentItem() const;
     int currentIndex() const { return static_cast<int>(m_currentIndex); }
 
+    Q_INVOKABLE void setCurrentIndex(int index);
     Q_INVOKABLE void nextItem();
     Q_INVOKABLE void prevItem();
 


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/11247

Made the carousel dots on the Welcome screen clickable. Clicking a dot now selects the corresponding carousel item, while keeping the selected dot synchronized with the existing previous and next arrow navigation.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
- [x] Clicking a carousel dot displays the corresponding Welcome screen item
- [x] Previous and next arrow buttons still change carousel items
- [x] The highlighted dot stays synchronized with the currently displayed item