### PR TITLE
Track Panel. Track hover no longer blocks the controls inside it

### DIFF
--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/ClipItem.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/ClipItem.qml
@@ -820,6 +820,9 @@ Rectangle {
 
                     menuModel: (root.multiClipsSelected || root.isGrouped) ? multiClipContextMenuModel : singleClipContextMenuModel
 
+                    accentColor: root.clipColor
+                    hoverHitColor: root.clipSelectedColor
+
                     visible: header.width > (60 + menuBtn.implicitWidth)
 
                     navigation.name: "ClipMenuBtn"

--- a/src/projectscene/qml/Audacity/ProjectScene/trackspanel/TrackItem.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/trackspanel/TrackItem.qml
@@ -249,12 +249,8 @@ ListItemBlank {
         }
     }
 
-    Item {
-        anchors.fill: parent
-
-        HoverHandler {
-            id: hoverHandler
-        }
+    HoverHandler {
+        id: hoverHandler
     }
 
     MouseArea {


### PR DESCRIPTION
HoverHandler was attached to a transparent full-size Item declared after the content, so it covered the header as a sibling on top of it. The handler makes its parent item accept hover events, and the hover walk stops at the first item that takes it — the overlay consumed the hover and the controls underneath (title, menu button and the rest) never became hovered.

Moved the handler to the track item itself: as the parent of the content it does not compete with it — the children keep their own hover, while the handler still reports the pointer being anywhere inside the track.

https://github.com/user-attachments/assets/5168bb32-4b9f-4fb4-bd6b-790a2ad32209


QA:

- [x] hover state for all track controls and for entire track
