### PR TITLE
Clip styling improvements

### DIFF
--- a/src/app/configs/dark.cfg
+++ b/src/app/configs/dark.cfg
@@ -33,9 +33,17 @@
 
     "item_opacity_disabled": 0.3,
 
-    "classic_clip_header_color": "#D0D6F2",
-    "classic_clip_header_hover_color": "#B0B6D8",
-    "classic_clip_background_color": "#F0F3FF",
+    "classic_clip_header_color": "#3C4968",
+    "classic_clip_header_hover_color": "#4E5A84",
+    "classic_clip_header_text_color": "#FFFFFF",
+    "classic_clip_header_selection_color": "#6F8EB5",
+    "classic_clip_background_color": "#343A4F",
+    "classic_clip_background_selected_color": "#42579E",
+    "classic_clip_samples_color": "#6464C0",
+    "classic_clip_samples_selected_color": "#7273E5",
+    "classic_clip_rms_color": "#9898ED",
+    "classic_clip_clipping_color": "#EF476F",
+    "classic_clip_sample_emphasis_color": "#FFFFFF",
 
     "focus_state_color": "#7EB1FF",
     "selection_highlight_color": "#ABE7FF",

--- a/src/app/configs/dark.cfg
+++ b/src/app/configs/dark.cfg
@@ -112,6 +112,16 @@
     "clip_selected_color_8": "#5EFFF7",
     "clip_selected_color_9": "#7CFFFF",
 
+    "clip_header_hover_color_1": "#4794EC",
+    "clip_header_hover_color_2": "#8B86EC",
+    "clip_header_hover_color_3": "#D578BD",
+    "clip_header_hover_color_4": "#E86B6D",
+    "clip_header_hover_color_5": "#EC8A4B",
+    "clip_header_hover_color_6": "#D9AE33",
+    "clip_header_hover_color_7": "#52AA42",
+    "clip_header_hover_color_8": "#0DA180",
+    "clip_header_hover_color_9": "#16AEBE",
+
     "audio_envelope_line": "#B7FF01",
     "audio_envelope_point": "#B7FF01",
     "audio_envelope_point_centre": "#FFFFFF"

--- a/src/app/configs/high_contrast_black.cfg
+++ b/src/app/configs/high_contrast_black.cfg
@@ -35,7 +35,15 @@
 
     "classic_clip_header_color": "#D0D6F2",
     "classic_clip_header_hover_color": "#B0B6D8",
+    "classic_clip_header_text_color": "#000000",
+    "classic_clip_header_selection_color": "#7E9FE0",
     "classic_clip_background_color": "#F0F3FF",
+    "classic_clip_background_selected_color": "#AAC3F2",
+    "classic_clip_samples_color": "#6464D3",
+    "classic_clip_samples_selected_color": "#677CE4",
+    "classic_clip_rms_color": "#9797FD",
+    "classic_clip_clipping_color": "#EF476F",
+    "classic_clip_sample_emphasis_color": "#000000",
 
     "focus_state_color": "#7EB1FF",
     "selection_highlight_color": "#ABE7FF",

--- a/src/app/configs/high_contrast_black.cfg
+++ b/src/app/configs/high_contrast_black.cfg
@@ -112,6 +112,16 @@
     "clip_selected_color_8": "#5EFFF7",
     "clip_selected_color_9": "#7CFFFF",
 
+    "clip_header_hover_color_1": "#4794EC",
+    "clip_header_hover_color_2": "#8B86EC",
+    "clip_header_hover_color_3": "#D578BD",
+    "clip_header_hover_color_4": "#E86B6D",
+    "clip_header_hover_color_5": "#EC8A4B",
+    "clip_header_hover_color_6": "#D9AE33",
+    "clip_header_hover_color_7": "#52AA42",
+    "clip_header_hover_color_8": "#0DA180",
+    "clip_header_hover_color_9": "#16AEBE",
+
     "audio_envelope_line": "#B7FF01",
     "audio_envelope_point": "#B7FF01",
     "audio_envelope_point_centre": "#FFFFFF"

--- a/src/app/configs/high_contrast_white.cfg
+++ b/src/app/configs/high_contrast_white.cfg
@@ -35,7 +35,15 @@
 
     "classic_clip_header_color": "#D0D6F2",
     "classic_clip_header_hover_color": "#B0B6D8",
+    "classic_clip_header_text_color": "#000000",
+    "classic_clip_header_selection_color": "#7E9FE0",
     "classic_clip_background_color": "#F0F3FF",
+    "classic_clip_background_selected_color": "#AAC3F2",
+    "classic_clip_samples_color": "#6464D3",
+    "classic_clip_samples_selected_color": "#677CE4",
+    "classic_clip_rms_color": "#9797FD",
+    "classic_clip_clipping_color": "#EF476F",
+    "classic_clip_sample_emphasis_color": "#000000",
 
     "focus_state_color": "#7EB1FF",
     "selection_highlight_color": "#ABE7FF",

--- a/src/app/configs/high_contrast_white.cfg
+++ b/src/app/configs/high_contrast_white.cfg
@@ -112,6 +112,16 @@
     "clip_selected_color_8": "#5EFFF7",
     "clip_selected_color_9": "#7CFFFF",
 
+    "clip_header_hover_color_1": "#4794EC",
+    "clip_header_hover_color_2": "#8B86EC",
+    "clip_header_hover_color_3": "#D578BD",
+    "clip_header_hover_color_4": "#E86B6D",
+    "clip_header_hover_color_5": "#EC8A4B",
+    "clip_header_hover_color_6": "#D9AE33",
+    "clip_header_hover_color_7": "#52AA42",
+    "clip_header_hover_color_8": "#0DA180",
+    "clip_header_hover_color_9": "#16AEBE",
+
     "audio_envelope_line": "#B7FF01",
     "audio_envelope_point": "#B7FF01",
     "audio_envelope_point_centre": "#FFFFFF"

--- a/src/app/configs/light.cfg
+++ b/src/app/configs/light.cfg
@@ -35,7 +35,15 @@
 
     "classic_clip_header_color": "#D0D6F2",
     "classic_clip_header_hover_color": "#B0B6D8",
+    "classic_clip_header_text_color": "#000000",
+    "classic_clip_header_selection_color": "#7E9FE0",
     "classic_clip_background_color": "#F0F3FF",
+    "classic_clip_background_selected_color": "#AAC3F2",
+    "classic_clip_samples_color": "#6464D3",
+    "classic_clip_samples_selected_color": "#677CE4",
+    "classic_clip_rms_color": "#9797FD",
+    "classic_clip_clipping_color": "#EF476F",
+    "classic_clip_sample_emphasis_color": "#000000",
 
     "focus_state_color": "#7EB1FF",
     "selection_highlight_color": "#ABE7FF",

--- a/src/app/configs/light.cfg
+++ b/src/app/configs/light.cfg
@@ -112,6 +112,16 @@
     "clip_selected_color_8": "#5EFFF7",
     "clip_selected_color_9": "#7CFFFF",
 
+    "clip_header_hover_color_1": "#4794EC",
+    "clip_header_hover_color_2": "#8B86EC",
+    "clip_header_hover_color_3": "#D578BD",
+    "clip_header_hover_color_4": "#E86B6D",
+    "clip_header_hover_color_5": "#EC8A4B",
+    "clip_header_hover_color_6": "#D9AE33",
+    "clip_header_hover_color_7": "#52AA42",
+    "clip_header_hover_color_8": "#0DA180",
+    "clip_header_hover_color_9": "#16AEBE",
+
     "audio_envelope_line": "#B7FF01",
     "audio_envelope_point": "#B7FF01",
     "audio_envelope_point_centre": "#FFFFFF"

--- a/src/projectscene/internal/projectsceneconfiguration.cpp
+++ b/src/projectscene/internal/projectsceneconfiguration.cpp
@@ -228,6 +228,16 @@ muse::Color ProjectSceneConfiguration::clipSelectedColor(trackedit::ClipColorInd
     return muse::Color::fromQColor(color);
 }
 
+muse::Color ProjectSceneConfiguration::clipHeaderHoverColor(trackedit::ClipColorIndex index) const
+{
+    QString key = QString("clip_header_hover_color_%1").arg(index);
+    QColor color = uiConfiguration()->currentTheme().extra[key].value<QColor>();
+    if (!color.isValid()) {
+        color = uiConfiguration()->currentTheme().extra["clip_header_hover_color_1"].value<QColor>();
+    }
+    return muse::Color::fromQColor(color);
+}
+
 ClipStyles::Style ProjectSceneConfiguration::clipStyle() const
 {
     return muse::settings()->value(CLIP_STYLE).toEnum<ClipStyles::Style>();

--- a/src/projectscene/internal/projectsceneconfiguration.cpp
+++ b/src/projectscene/internal/projectsceneconfiguration.cpp
@@ -238,6 +238,26 @@ muse::Color ProjectSceneConfiguration::clipHeaderHoverColor(trackedit::ClipColor
     return muse::Color::fromQColor(color);
 }
 
+ClassicClipColors ProjectSceneConfiguration::classicClipColors() const
+{
+    auto read = [this](const char* key, const QColor& fallback) {
+        QColor color = uiConfiguration()->currentTheme().extra[QString::fromLatin1(key)].value<QColor>();
+        return muse::Color::fromQColor(color.isValid() ? color : fallback);
+    };
+
+    //! NOTE Fallbacks are the AU3 light-theme values these colours originally came from
+    ClassicClipColors colors;
+    colors.background = read("classic_clip_background_color", QColor(240, 243, 255));
+    colors.backgroundSelected = read("classic_clip_background_selected_color", QColor(170, 195, 242));
+    colors.samples = read("classic_clip_samples_color", QColor(100, 100, 211));
+    colors.samplesSelected = read("classic_clip_samples_selected_color", QColor(103, 124, 228));
+    colors.rms = read("classic_clip_rms_color", QColor(151, 151, 253));
+    colors.clipping = read("classic_clip_clipping_color", QColor(239, 71, 111));
+    colors.sampleEmphasis = read("classic_clip_sample_emphasis_color", QColor(0, 0, 0));
+
+    return colors;
+}
+
 ClipStyles::Style ProjectSceneConfiguration::clipStyle() const
 {
     return muse::settings()->value(CLIP_STYLE).toEnum<ClipStyles::Style>();

--- a/src/projectscene/internal/projectsceneconfiguration.h
+++ b/src/projectscene/internal/projectsceneconfiguration.h
@@ -41,6 +41,7 @@ public:
     muse::Color clipColor(trackedit::ClipColorIndex index) const override;
     muse::Color clipSelectedColor(trackedit::ClipColorIndex index) const override;
     muse::Color clipHeaderHoverColor(trackedit::ClipColorIndex index) const override;
+    ClassicClipColors classicClipColors() const override;
 
     ClipStyles::Style clipStyle() const override;
     void setClipStyle(ClipStyles::Style style) override;

--- a/src/projectscene/internal/projectsceneconfiguration.h
+++ b/src/projectscene/internal/projectsceneconfiguration.h
@@ -40,6 +40,7 @@ public:
     const std::vector<ClipColorInfo>& clipColorInfos() const override;
     muse::Color clipColor(trackedit::ClipColorIndex index) const override;
     muse::Color clipSelectedColor(trackedit::ClipColorIndex index) const override;
+    muse::Color clipHeaderHoverColor(trackedit::ClipColorIndex index) const override;
 
     ClipStyles::Style clipStyle() const override;
     void setClipStyle(ClipStyles::Style style) override;

--- a/src/projectscene/iprojectsceneconfiguration.h
+++ b/src/projectscene/iprojectsceneconfiguration.h
@@ -45,6 +45,7 @@ public:
     virtual const std::vector<ClipColorInfo>& clipColorInfos() const = 0;
     virtual muse::Color clipColor(trackedit::ClipColorIndex index) const = 0;
     virtual muse::Color clipSelectedColor(trackedit::ClipColorIndex index) const = 0;
+    virtual muse::Color clipHeaderHoverColor(trackedit::ClipColorIndex index) const = 0;
 
     virtual ClipStyles::Style clipStyle() const = 0;
     virtual void setClipStyle(ClipStyles::Style style) = 0;

--- a/src/projectscene/iprojectsceneconfiguration.h
+++ b/src/projectscene/iprojectsceneconfiguration.h
@@ -15,6 +15,21 @@ struct ClipColorInfo {
     std::string name;
     trackedit::ClipColorIndex index = 0;
 };
+
+//! NOTE Colours for the Classic clip style. Unlike the Colorful style these
+//! do not derive from the clip's own colour, so they come straight from the theme.
+struct ClassicClipColors {
+    muse::Color background;
+    muse::Color backgroundSelected;
+    muse::Color samples;
+    muse::Color samplesSelected;
+    muse::Color rms;
+    muse::Color clipping;
+    //! NOTE Blend target used to emphasise samples inside a time selection. Colorful always
+    //! blends toward black because its clips are pale; Classic bodies follow the theme, so
+    //! this is black on light themes and white on dark ones.
+    muse::Color sampleEmphasis;
+};
 class IProjectSceneConfiguration : MODULE_GLOBAL_INTERFACE
 {
     INTERFACE_ID(IProjectSceneConfiguration)
@@ -46,6 +61,7 @@ public:
     virtual muse::Color clipColor(trackedit::ClipColorIndex index) const = 0;
     virtual muse::Color clipSelectedColor(trackedit::ClipColorIndex index) const = 0;
     virtual muse::Color clipHeaderHoverColor(trackedit::ClipColorIndex index) const = 0;
+    virtual ClassicClipColors classicClipColors() const = 0;
 
     virtual ClipStyles::Style clipStyle() const = 0;
     virtual void setClipStyle(ClipStyles::Style style) = 0;

--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/ClipItem.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/ClipItem.qml
@@ -31,9 +31,10 @@ Rectangle {
     required property int headerHeight
     property color clipColor: ui.theme.extra["clip_color_1"]
     property color clipSelectedColor: ui.theme.extra["clip_selected_color_1"]
+    property color clipHeaderHoverColor: ui.theme.extra["clip_header_hover_color_1"]
     property color normalHeaderColor: root.currentClipStyle == ClipStyle.COLORFUL ? root.clipColor : root.classicHeaderColor
     property color selectedHeaderColor: root.currentClipStyle == ClipStyle.COLORFUL ? ui.theme.extra["white_color"] : classicHeaderColor
-    property color normalHeaderHoveredColor: root.currentClipStyle == ClipStyle.COLORFUL ? ui.blendColors(ui.theme.extra["white_color"], root.clipColor, 0.8) : classicHeaderHoveredColor
+    property color normalHeaderHoveredColor: root.currentClipStyle == ClipStyle.COLORFUL ? root.clipHeaderHoverColor : classicHeaderHoveredColor
     property color selectedHeaderHoveredColor: root.currentClipStyle == ClipStyle.COLORFUL ? ui.theme.extra["white_color"] : classicHeaderHoveredColor
     readonly property color classicHeaderColor: ui.theme.extra["classic_clip_header_color"]
     readonly property color classicHeaderHoveredColor: ui.theme.extra["classic_clip_header_hover_color"]

--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/ClipItem.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/ClipItem.qml
@@ -32,9 +32,9 @@ Rectangle {
     property color clipColor: ui.theme.extra["clip_color_1"]
     property color clipSelectedColor: ui.theme.extra["clip_selected_color_1"]
     property color normalHeaderColor: root.currentClipStyle == ClipStyle.COLORFUL ? root.clipColor : root.classicHeaderColor
-    property color selectedHeaderColor: root.currentClipStyle == ClipStyle.COLORFUL ? ui.blendColors(ui.theme.extra["white_color"], root.clipColor, 0.3) : classicHeaderColor
+    property color selectedHeaderColor: root.currentClipStyle == ClipStyle.COLORFUL ? ui.theme.extra["white_color"] : classicHeaderColor
     property color normalHeaderHoveredColor: root.currentClipStyle == ClipStyle.COLORFUL ? ui.blendColors(ui.theme.extra["white_color"], root.clipColor, 0.8) : classicHeaderHoveredColor
-    property color selectedHeaderHoveredColor: root.currentClipStyle == ClipStyle.COLORFUL ? ui.blendColors(ui.theme.extra["white_color"], root.clipColor, 0.2) : classicHeaderHoveredColor
+    property color selectedHeaderHoveredColor: root.currentClipStyle == ClipStyle.COLORFUL ? ui.theme.extra["white_color"] : classicHeaderHoveredColor
     readonly property color classicHeaderColor: ui.theme.extra["classic_clip_header_color"]
     readonly property color classicHeaderHoveredColor: ui.theme.extra["classic_clip_header_hover_color"]
     property int currentClipStyle: ClipStyle.COLORFUL

--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/ClipItem.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/ClipItem.qml
@@ -35,9 +35,13 @@ Rectangle {
     property color normalHeaderColor: root.currentClipStyle == ClipStyle.COLORFUL ? root.clipColor : root.classicHeaderColor
     property color selectedHeaderColor: root.currentClipStyle == ClipStyle.COLORFUL ? ui.theme.extra["white_color"] : classicHeaderColor
     property color normalHeaderHoveredColor: root.currentClipStyle == ClipStyle.COLORFUL ? root.clipHeaderHoverColor : classicHeaderHoveredColor
-    property color selectedHeaderHoveredColor: root.currentClipStyle == ClipStyle.COLORFUL ? ui.theme.extra["white_color"] : classicHeaderHoveredColor
+    //! NOTE A selected header does not react to hover in either style - it keeps its selected colour.
+    property color selectedHeaderHoveredColor: root.currentClipStyle == ClipStyle.COLORFUL ? ui.theme.extra["white_color"] : classicHeaderColor
     readonly property color classicHeaderColor: ui.theme.extra["classic_clip_header_color"]
     readonly property color classicHeaderHoveredColor: ui.theme.extra["classic_clip_header_hover_color"]
+    //! NOTE Colorful headers are always light (clip colour or white), so their text stays black.
+    //! Classic headers follow the theme, so their text colour comes from the theme too.
+    readonly property color headerTextColor: root.currentClipStyle == ClipStyle.COLORFUL ? ui.theme.extra["black_color"] : ui.theme.extra["classic_clip_header_text_color"]
     property int currentClipStyle: ClipStyle.COLORFUL
     property bool isGrouped: false
     property bool clipSelected: false
@@ -594,8 +598,12 @@ Rectangle {
                 anchors.top: header.top
                 anchors.bottom: header.bottom
 
-                color: waveView.transformColor(clipColor)
-                visible: root.isDataSelected && currentClipStyle == ClipStyle.COLORFUL
+                //! NOTE Colorful derives the band from the clip's own colour. Classic has no
+                //! clip colour to derive from, so it takes the band straight from the theme.
+                color: root.currentClipStyle == ClipStyle.COLORFUL
+                       ? waveView.transformColor(root.clipColor)
+                       : ui.theme.extra["classic_clip_header_selection_color"]
+                visible: root.isDataSelected
             }
 
             MouseArea {
@@ -1205,21 +1213,21 @@ Rectangle {
             }
             PropertyChanges {
                 target: titleLabel
-                color: ui.theme.extra["black_color"]
+                color: root.headerTextColor
             }
             PropertyChanges {
                 target: pitchBtn
-                textColor: ui.theme.extra["black_color"]
-                iconColor: ui.theme.extra["black_color"]
+                textColor: root.headerTextColor
+                iconColor: root.headerTextColor
             }
             PropertyChanges {
                 target: speedBtn
-                textColor: ui.theme.extra["black_color"]
-                iconColor: ui.theme.extra["black_color"]
+                textColor: root.headerTextColor
+                iconColor: root.headerTextColor
             }
             PropertyChanges {
                 target: menuBtn
-                iconColor: ui.theme.extra["black_color"]
+                iconColor: root.headerTextColor
             }
         },
         State {
@@ -1231,21 +1239,21 @@ Rectangle {
             }
             PropertyChanges {
                 target: titleLabel
-                color: ui.theme.extra["black_color"]
+                color: root.headerTextColor
             }
             PropertyChanges {
                 target: pitchBtn
-                textColor: ui.theme.extra["black_color"]
-                iconColor: ui.theme.extra["black_color"]
+                textColor: root.headerTextColor
+                iconColor: root.headerTextColor
             }
             PropertyChanges {
                 target: speedBtn
-                textColor: ui.theme.extra["black_color"]
-                iconColor: ui.theme.extra["black_color"]
+                textColor: root.headerTextColor
+                iconColor: root.headerTextColor
             }
             PropertyChanges {
                 target: menuBtn
-                iconColor: ui.theme.extra["black_color"]
+                iconColor: root.headerTextColor
             }
         },
         State {
@@ -1257,21 +1265,21 @@ Rectangle {
             }
             PropertyChanges {
                 target: titleLabel
-                color: ui.theme.extra["black_color"]
+                color: root.headerTextColor
             }
             PropertyChanges {
                 target: pitchBtn
-                textColor: ui.theme.extra["black_color"]
-                iconColor: ui.theme.extra["black_color"]
+                textColor: root.headerTextColor
+                iconColor: root.headerTextColor
             }
             PropertyChanges {
                 target: speedBtn
-                textColor: ui.theme.extra["black_color"]
-                iconColor: ui.theme.extra["black_color"]
+                textColor: root.headerTextColor
+                iconColor: root.headerTextColor
             }
             PropertyChanges {
                 target: menuBtn
-                iconColor: ui.theme.extra["black_color"]
+                iconColor: root.headerTextColor
             }
         },
         State {
@@ -1283,21 +1291,21 @@ Rectangle {
             }
             PropertyChanges {
                 target: titleLabel
-                color: ui.theme.extra["black_color"]
+                color: root.headerTextColor
             }
             PropertyChanges {
                 target: pitchBtn
-                textColor: ui.theme.extra["black_color"]
-                iconColor: ui.theme.extra["black_color"]
+                textColor: root.headerTextColor
+                iconColor: root.headerTextColor
             }
             PropertyChanges {
                 target: speedBtn
-                textColor: ui.theme.extra["black_color"]
-                iconColor: ui.theme.extra["black_color"]
+                textColor: root.headerTextColor
+                iconColor: root.headerTextColor
             }
             PropertyChanges {
                 target: menuBtn
-                iconColor: ui.theme.extra["black_color"]
+                iconColor: root.headerTextColor
             }
         }
     ]

--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/ClipItem.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/ClipItem.qml
@@ -829,8 +829,11 @@ Rectangle {
 
                     menuModel: (root.multiClipsSelected || root.isGrouped) ? multiClipContextMenuModel : singleClipContextMenuModel
 
-                    accentColor: root.clipColor
-                    hoverHitColor: root.clipSelectedColor
+                    //! NOTE The Classic style does not use the clip colour palette, so the menu
+                    //! button falls back to the standard theme colours there rather than tinting
+                    //! itself with a colour the clip never shows.
+                    accentColor: root.currentClipStyle == ClipStyle.COLORFUL ? root.clipColor : ui.theme.accentColor
+                    hoverHitColor: root.currentClipStyle == ClipStyle.COLORFUL ? root.clipSelectedColor : ui.theme.buttonColor
 
                     visible: header.width > (60 + menuBtn.implicitWidth)
 

--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TrackClipsContainer.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TrackClipsContainer.qml
@@ -359,6 +359,7 @@ TrackItemsContainer {
                                 title: itemData.title
                                 clipColor: itemData.color
                                 clipSelectedColor: itemData.selectedColor
+                                clipHeaderHoverColor: itemData.headerHoverColor
                                 isGrouped: itemData.isGrouped
                                 clipKey: itemData.key
                                 clipTime: itemData.time

--- a/src/projectscene/tests/mocks/projectsceneconfigurationmock.h
+++ b/src/projectscene/tests/mocks/projectsceneconfigurationmock.h
@@ -36,6 +36,7 @@ public:
     MOCK_METHOD((const std::vector<ClipColorInfo>&), clipColorInfos, (), (const, override));
     MOCK_METHOD(muse::Color, clipColor, (trackedit::ClipColorIndex index), (const, override));
     MOCK_METHOD(muse::Color, clipSelectedColor, (trackedit::ClipColorIndex index), (const, override));
+    MOCK_METHOD(muse::Color, clipHeaderHoverColor, (trackedit::ClipColorIndex index), (const, override));
 
     MOCK_METHOD(ClipStyles::Style, clipStyle, (), (const, override));
     MOCK_METHOD(void, setClipStyle, (ClipStyles::Style style), (override));

--- a/src/projectscene/tests/mocks/projectsceneconfigurationmock.h
+++ b/src/projectscene/tests/mocks/projectsceneconfigurationmock.h
@@ -37,6 +37,7 @@ public:
     MOCK_METHOD(muse::Color, clipColor, (trackedit::ClipColorIndex index), (const, override));
     MOCK_METHOD(muse::Color, clipSelectedColor, (trackedit::ClipColorIndex index), (const, override));
     MOCK_METHOD(muse::Color, clipHeaderHoverColor, (trackedit::ClipColorIndex index), (const, override));
+    MOCK_METHOD(ClassicClipColors, classicClipColors, (), (const, override));
 
     MOCK_METHOD(ClipStyles::Style, clipStyle, (), (const, override));
     MOCK_METHOD(void, setClipStyle, (ClipStyles::Style style), (override));

--- a/src/projectscene/view/tracksitemsview/clipcontextmenumodel.cpp
+++ b/src/projectscene/view/tracksitemsview/clipcontextmenumodel.cpp
@@ -50,7 +50,16 @@ void ClipContextMenuModel::load()
     auto resetPitchSpeedItem = makeItemWithArg(RESET_PITCH_SPEED_CODE);
     updatePitchSpeedModifiedEnabledState(*resetPitchSpeedItem);
 
-    auto colorItems = makeClipColourItems();
+    //! NOTE The Classic style does not use the clip colour palette at all, so the colour
+    //! submenu is left out entirely rather than offered and ignored.
+    const bool clipColorsApply = projectSceneConfiguration()->clipStyle() == ClipStyles::Style::COLORFUL;
+
+    MenuItemList colorItems;
+    if (clipColorsApply) {
+        colorItems = makeClipColourItems();
+    } else {
+        m_colorChangeActionCodeList.clear();
+    }
 
     MenuItemList cutAndItems {
         makeMenuItem("cut-leave-gap",
@@ -73,7 +82,6 @@ void ClipContextMenuModel::load()
     MenuItemList items {
         makeItemWithArg("clip-properties"),
         makeItemWithArg("rename-item", muse::TranslatableString("clip", "Rename clip")),
-        makeMenu(muse::TranslatableString("clip", "Clip color"), colorItems, "colorMenu"),
         makeSeparator(),
         makeItemWithArg("action://trackedit/cut"),
         makeItemWithArg("action://trackedit/copy"),
@@ -119,10 +127,13 @@ void ClipContextMenuModel::load()
         }, muse::async::Asyncable::Mode::SetReplace);
     }
 
+    if (clipColorsApply) {
+        items.insert(2, makeMenu(muse::TranslatableString("clip", "Clip color"), colorItems, "colorMenu"));
+    }
+
     setItems(items);
 
     updateColorCheckedState();
-    updateColorMenu();
 }
 
 void ClipContextMenuModel::handleMenuItem(const QString& itemId)
@@ -211,6 +222,11 @@ void ClipContextMenuModel::updatePitchSpeedModifiedEnabledState(MenuItem& item)
 
 void ClipContextMenuModel::updateColorCheckedState()
 {
+    //! NOTE Empty in the Classic style, where the colour submenu is not built at all
+    if (m_colorChangeActionCodeList.empty()) {
+        return;
+    }
+
     project::IAudacityProjectPtr project = globalContext()->currentProject();
     if (!project) {
         return;
@@ -247,17 +263,6 @@ void ClipContextMenuModel::updateColorCheckedState()
     }
 }
 
-void ClipContextMenuModel::updateColorMenu()
-{
-    ClipStyles::Style clipStyle = projectSceneConfiguration()->clipStyle();
-    MenuItem& colorMenu = findMenu("colorMenu");
-
-    if (clipStyle == ClipStyles::Style::CLASSIC) {
-        colorMenu.setState(muse::ui::UiActionState::make_disabled());
-    } else {
-        colorMenu.setState(muse::ui::UiActionState::make_enabled());
-    }
-}
 
 MenuItemList ClipContextMenuModel::makeClipColourItems()
 {

--- a/src/projectscene/view/tracksitemsview/clipcontextmenumodel.h
+++ b/src/projectscene/view/tracksitemsview/clipcontextmenumodel.h
@@ -39,7 +39,6 @@ private:
 
     muse::uicomponents::MenuItemList makeClipColourItems();
     void updateColorCheckedState();
-    void updateColorMenu();
 
     ClipKey m_clipKey;
     muse::actions::ActionCodeList m_colorChangeActionCodeList;

--- a/src/projectscene/view/tracksitemsview/trackclipitem.cpp
+++ b/src/projectscene/view/tracksitemsview/trackclipitem.cpp
@@ -18,6 +18,7 @@ void TrackClipItem::setClip(const trackedit::Clip& clip)
     m_title = clip.title;
     m_color = configuration()->clipColor(clip.colorIndex).toQColor();
     m_selectedColor = configuration()->clipSelectedColor(clip.colorIndex).toQColor();
+    m_headerHoverColor = configuration()->clipHeaderHoverColor(clip.colorIndex).toQColor();
     m_groupId = clip.groupId;
     m_pitch = clip.pitch;
     m_speed = clip.speed;

--- a/src/projectscene/view/tracksitemsview/tracklabelitem.cpp
+++ b/src/projectscene/view/tracksitemsview/tracklabelitem.cpp
@@ -18,6 +18,7 @@ void TrackLabelItem::setLabel(const trackedit::Label& label)
     m_title = label.title;
     m_color = configuration()->clipColor(label.colorIndex).toQColor();
     m_selectedColor = configuration()->clipSelectedColor(label.colorIndex).toQColor();
+    m_headerHoverColor = configuration()->clipHeaderHoverColor(label.colorIndex).toQColor();
 
     emit titleChanged();
     emit colorChanged();

--- a/src/projectscene/view/tracksitemsview/viewtrackitem.cpp
+++ b/src/projectscene/view/tracksitemsview/viewtrackitem.cpp
@@ -44,6 +44,11 @@ QColor ViewTrackItem::selectedColor() const
     return m_selectedColor;
 }
 
+QColor ViewTrackItem::headerHoverColor() const
+{
+    return m_headerHoverColor;
+}
+
 double ViewTrackItem::x() const
 {
     return m_x;

--- a/src/projectscene/view/tracksitemsview/viewtrackitem.h
+++ b/src/projectscene/view/tracksitemsview/viewtrackitem.h
@@ -20,6 +20,7 @@ class ViewTrackItem : public QObject
     Q_PROPERTY(QString title READ title WRITE setTitle NOTIFY titleChanged FINAL)
     Q_PROPERTY(QColor color READ color NOTIFY colorChanged FINAL)
     Q_PROPERTY(QColor selectedColor READ selectedColor NOTIFY colorChanged FINAL)
+    Q_PROPERTY(QColor headerHoverColor READ headerHoverColor NOTIFY colorChanged FINAL)
     Q_PROPERTY(double x READ x WRITE setX NOTIFY xChanged FINAL)
     Q_PROPERTY(double width READ width WRITE setWidth NOTIFY widthChanged FINAL)
     Q_PROPERTY(double leftVisibleMargin READ leftVisibleMargin WRITE setLeftVisibleMargin NOTIFY leftVisibleMarginChanged FINAL)
@@ -39,6 +40,7 @@ public:
     void setTitle(const QString& newTitle);
     QColor color() const;
     QColor selectedColor() const;
+    QColor headerHoverColor() const;
 
     double x() const;
     void setX(double newX);
@@ -86,6 +88,7 @@ protected:
     QString m_title;
     QColor m_color;
     QColor m_selectedColor;
+    QColor m_headerHoverColor;
     double m_x = 0.0;
     double m_width = 0.0;
     bool m_selected = false;

--- a/src/projectscene/view/tracksitemsview/waveview.cpp
+++ b/src/projectscene/view/tracksitemsview/waveview.cpp
@@ -25,14 +25,8 @@ static const QColor CENTER_LINE_COLOR = QColor(0, 0, 0);
 static const QColor SAMPLE_HEAD_COLOR = QColor(0, 0, 0);
 static const QColor SAMPLE_STALK_COLOR = QColor(0, 0, 0);
 
-// AU3 colors from au3/libraries/au3-theme-resources/light/Components/Colors.txt
-static const QColor CLASSIC_BACKGROUND_COLOR = QColor(240, 243, 255);               // Unselected: #f0f3ff
-static const QColor CLASSIC_BACKGROUND_SELECTED_COLOR = QColor(170, 195, 242);      // Selected: #aac3f2
-static const QColor CLASSIC_SAMPLES_BASE_COLOR = QColor(100, 100, 211);             // Sample: #6464D3
-static const QColor CLASSIC_SAMPLES_BASE_SELECTED_COLOR = QColor(103, 124, 228);    // SelSample: #677ce4
-static const QColor CLASSIC_RMS_COLOR = QColor(151, 151, 253);                      // Rms: #9797FD
-static const QColor CLASSIC_RMS_SELECTED_COLOR = QColor(151, 151, 253);             // Rms: #9797FD // TODO: This need update
-static const QColor CLASSIC_CLIPPING_COLOR = QColor(239, 71, 111);                  // Clipped: #ef476f
+//! NOTE Classic style colours now come from the theme - see
+//! ProjectSceneConfiguration::classicClipColors() and the classic_clip_* theme keys.
 
 static const float SAMPLE_HEAD_DEFAULT_ALPHA= 0.6;
 static const float SAMPLE_HEAD_CLIP_SELECTED_ALPHA = 0.8;
@@ -161,27 +155,38 @@ void WaveView::applyColorfulStyle(IWavePainter::Params& params,
 
 void WaveView::applyClassicStyle(IWavePainter::Params& params, bool selected) const
 {
-    params.style.blankBrush = selected ? CLASSIC_BACKGROUND_SELECTED_COLOR : CLASSIC_BACKGROUND_COLOR;
+    const ClassicClipColors colors = configuration()->classicClipColors();
+    const QColor background = colors.background.toQColor();
+    const QColor backgroundSelected = colors.backgroundSelected.toQColor();
+    const QColor samples = colors.samples.toQColor();
+    const QColor samplesSelected = colors.samplesSelected.toQColor();
+    const QColor rms = colors.rms.toQColor();
+
+    params.style.blankBrush = selected ? backgroundSelected : background;
     params.style.normalBackground = params.style.blankBrush;
-    params.style.selectedBackground = selected ? transformColor(CLASSIC_BACKGROUND_SELECTED_COLOR) : CLASSIC_BACKGROUND_SELECTED_COLOR;
+    params.style.selectedBackground = selected ? transformColor(backgroundSelected) : backgroundSelected;
 
     params.style.envelopeBackground = params.style.blankBrush;
     params.style.selectedEnvelopeBackground
-        = selected ? transformColor(CLASSIC_BACKGROUND_SELECTED_COLOR) : CLASSIC_BACKGROUND_SELECTED_COLOR;
+        = selected ? transformColor(backgroundSelected) : backgroundSelected;
 
-    QColor baseSampleColor = selected ? CLASSIC_SAMPLES_BASE_SELECTED_COLOR : CLASSIC_SAMPLES_BASE_COLOR;
+    QColor baseSampleColor = selected ? samplesSelected : samples;
     params.style.samplePen = baseSampleColor;
-    params.style.selectedSamplePen = CLASSIC_SAMPLES_BASE_SELECTED_COLOR;
-    params.style.rmsPen = CLASSIC_RMS_COLOR;
-    params.style.rmsSelectedPen = muse::blendQColors(params.style.selectedSamplePen, CLASSIC_RMS_COLOR, 0.6); // TODO: use CLASSIC_RMS_SELECTED_COLOR
-    params.style.clippedPen = CLASSIC_CLIPPING_COLOR;
+    params.style.selectedSamplePen = samplesSelected;
+    params.style.rmsPen = rms;
+    params.style.rmsSelectedPen = muse::blendQColors(params.style.selectedSamplePen, rms, 0.6); // TODO: use a dedicated selected-RMS colour
+    params.style.clippedPen = colors.clipping.toQColor();
     params.style.centerLine = baseSampleColor;
     params.style.sampleHead = baseSampleColor;
     params.style.sampleStalk = baseSampleColor;
 
     if (!selected) {
-        params.style.sampleHeadSelection = baseSampleColor;
-        params.style.sampleStalkSelection = baseSampleColor;
+        //! NOTE Mirrors the Colorful style, which emphasises samples inside a time selection by
+        //! blending 0.3 further toward its base colour. Colorful can hardcode black for that;
+        //! Classic takes the target from the theme so it works on dark bodies too.
+        const QColor emphasis = colors.sampleEmphasis.toQColor();
+        params.style.sampleHeadSelection = muse::blendQColors(baseSampleColor, emphasis, 0.3);
+        params.style.sampleStalkSelection = muse::blendQColors(baseSampleColor, emphasis, 0.3);
     }
 }
 

--- a/src/projectscene/view/trackspanel/trackcontextmenumodel.cpp
+++ b/src/projectscene/view/trackspanel/trackcontextmenumodel.cpp
@@ -61,7 +61,6 @@ MenuItemList TrackContextMenuModel::makeStereoTrackItems()
         makeSeparator(),
         makeMenu(muse::TranslatableString(TRANSLATABLE_STRING_CONTEXT, "Move track"), makeTrackMoveItems()),
         makeMenu(muse::TranslatableString(TRANSLATABLE_STRING_CONTEXT, "Track visualization"), makeTrackVisualizationItems()),
-        makeMenu(muse::TranslatableString(TRANSLATABLE_STRING_CONTEXT, "Track color"), makeTrackColorItems(), TRACK_COLOR_MENU_ID),
         makeItemWithArg("toggle-vertical-rulers"),
         makeMenu(muse::TranslatableString(TRANSLATABLE_STRING_CONTEXT, "Meters && monitoring"), makeMeterMonitoringItems()),
         makeSeparator(),
@@ -73,6 +72,14 @@ MenuItemList TrackContextMenuModel::makeStereoTrackItems()
         makeMenu(muse::TranslatableString(TRANSLATABLE_STRING_CONTEXT, "Rate:"), makeTrackRateItems(), TRACK_RATE_MENU_ID),
         makeItemWithArg("track-resample"),
     };
+
+    //! NOTE Clips in the Classic style do not use the colour palette, so the track colour
+    //! submenu is left out there. Label tracks keep it unconditionally - labels use these
+    //! colours in both styles.
+    if (projectSceneConfiguration()->clipStyle() == ClipStyles::Style::COLORFUL) {
+        items.insert(6, makeMenu(muse::TranslatableString(TRANSLATABLE_STRING_CONTEXT, "Track color"),
+                                 makeTrackColorItems(), TRACK_COLOR_MENU_ID));
+    }
 
     return items;
 }
@@ -86,7 +93,6 @@ MenuItemList TrackContextMenuModel::makeMonoTrackItems()
         makeSeparator(),
         makeMenu(muse::TranslatableString(TRANSLATABLE_STRING_CONTEXT, "Move track"), makeTrackMoveItems()),
         makeMenu(muse::TranslatableString(TRANSLATABLE_STRING_CONTEXT, "Track visualization"), makeTrackVisualizationItems()),
-        makeMenu(muse::TranslatableString(TRANSLATABLE_STRING_CONTEXT, "Track color"), makeTrackColorItems(), TRACK_COLOR_MENU_ID),
         makeItemWithArg("toggle-vertical-rulers"),
         makeMenu(muse::TranslatableString(TRANSLATABLE_STRING_CONTEXT, "Meters && monitoring"), makeMeterMonitoringItems()),
         makeSeparator(),
@@ -96,6 +102,14 @@ MenuItemList TrackContextMenuModel::makeMonoTrackItems()
         makeMenu(muse::TranslatableString(TRANSLATABLE_STRING_CONTEXT, "Rate:"), makeTrackRateItems(), TRACK_RATE_MENU_ID),
         makeItemWithArg("track-resample"),
     };
+
+    //! NOTE Clips in the Classic style do not use the colour palette, so the track colour
+    //! submenu is left out there. Label tracks keep it unconditionally - labels use these
+    //! colours in both styles.
+    if (projectSceneConfiguration()->clipStyle() == ClipStyles::Style::COLORFUL) {
+        items.insert(6, makeMenu(muse::TranslatableString(TRANSLATABLE_STRING_CONTEXT, "Track color"),
+                                 makeTrackColorItems(), TRACK_COLOR_MENU_ID));
+    }
 
     return items;
 }


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/9750
Resolves: #11587 

Updated clip headers to match design documents, added dark themed clips for "classic" clip view, ensured menu button color doesn't follow track color when in classic theme, hid track color from track header menu when user has classic clips enabled.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
