### PR TITLE
Shift following clips when effect output length differs from selection

### DIFF
--- a/au3/libraries/au3-wave-track/WaveTrack.cpp
+++ b/au3/libraries/au3-wave-track/WaveTrack.cpp
@@ -1470,6 +1470,11 @@ void WaveTrack::ClearAndPasteAtSameTempo(
     // Now, clear the selection
     track.HandleClear(t0, t1, addCutLines, split, moveClips, clearByTrimming);
 
+    const auto pasteDelta = srcEndTime - (t1 - t0);
+    if (std::abs(pasteDelta) >= LongSamplesToTime(1)) {
+        track.ShiftBy(t1, pasteDelta);
+    }
+
     // And paste in the new data
     track.PasteWaveTrackAtSameTempo(t0, src, merge, moveClips);
 


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/11145

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
- [ ] Paulstretch should now behave same as in AU3
- [ ] Check a few effects just to make sure there are no regressions, generators, undo/redo, ripple editing, re-check #10465 
