### PR TITLE
Do not enforce local universal builds by default

### DIFF
--- a/.github/workflows/au4_build_macos.yml
+++ b/.github/workflows/au4_build_macos.yml
@@ -62,7 +62,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { arch: universal, osx_arch: '' }
+          - { arch: universal, osx_arch: 'x86_64;arm64' }
           - { arch: arm64,     osx_arch: arm64 }
           - { arch: x86_64,    osx_arch: x86_64 }
     runs-on: macos-26

--- a/.github/workflows/au4_deps_matrix.yml
+++ b/.github/workflows/au4_deps_matrix.yml
@@ -37,8 +37,8 @@ jobs:
           - { os: windows, mode: source,   arch: x86_64,  runner: windows-2022,     qt_host: windows,       qt_arch: win64_msvc2022_64 }
           - { os: windows, mode: prebuilt, arch: aarch64, runner: windows-11-arm,   qt_host: windows_arm64, qt_arch: win64_msvc2022_arm64 }
           - { os: windows, mode: source,   arch: aarch64, runner: windows-11-arm,   qt_host: windows_arm64, qt_arch: win64_msvc2022_arm64 }
-          - { os: macos,   mode: prebuilt, runner: macos-26, arch: universal, osx_arch: '',     qt_host: mac, qt_arch: clang_64 }
-          - { os: macos,   mode: source,   runner: macos-26, arch: universal, osx_arch: '',     qt_host: mac, qt_arch: clang_64 }
+          - { os: macos,   mode: prebuilt, runner: macos-26, arch: universal, osx_arch: 'x86_64;arm64', qt_host: mac, qt_arch: clang_64 }
+          - { os: macos,   mode: source,   runner: macos-26, arch: universal, osx_arch: 'x86_64;arm64', qt_host: mac, qt_arch: clang_64 }
           - { os: macos,   mode: prebuilt, runner: macos-26, arch: arm64,     osx_arch: arm64,  qt_host: mac, qt_arch: clang_64 }
           - { os: macos,   mode: source,   runner: macos-26, arch: arm64,     osx_arch: arm64,  qt_host: mac, qt_arch: clang_64 }
           - { os: macos,   mode: prebuilt, runner: macos-26, arch: x86_64,    osx_arch: x86_64, qt_host: mac, qt_arch: clang_64 }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,12 +15,6 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
-if(APPLE)
-    if(NOT CMAKE_OSX_ARCHITECTURES)
-        set(CMAKE_OSX_ARCHITECTURES "x86_64;arm64" CACHE STRING "macOS build architectures" FORCE)
-    endif()
-endif()
-
 ###########################################
 # Muse Framework
 ###########################################

--- a/ci_build.cmake
+++ b/ci_build.cmake
@@ -75,7 +75,8 @@ macro(do_build build_type build_dir)
 
     # Allow macos architecture override with env OSX_ARCHITECTURES
     if (DEFINED ENV{OSX_ARCHITECTURES} AND NOT "$ENV{OSX_ARCHITECTURES}" STREQUAL "")
-        list(APPEND CONFIGURE_ARGS "-DCMAKE_OSX_ARCHITECTURES=$ENV{OSX_ARCHITECTURES}")
+        string(REPLACE ";" "\\;" _osx_architectures "$ENV{OSX_ARCHITECTURES}")
+        list(APPEND CONFIGURE_ARGS "-DCMAKE_OSX_ARCHITECTURES=${_osx_architectures}")
     endif()
 
     message(STATUS "========= Begin configure =========")

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -17,7 +17,7 @@ if (OS_IS_WIN)
     set(APP_OUTPUT_NAME ${MUSE_APP_NAME}${MUSE_APP_VERSION_MAJOR})
 
     include(GetCompilerInfo)
-    
+
     set(WINDOWS_VERSION_RC ${PROJECT_BINARY_DIR}/windows_version.rc)
     configure_file(
         ${CMAKE_CURRENT_SOURCE_DIR}/windows_version.rc.in
@@ -246,6 +246,11 @@ if (OS_IS_MAC)
         PROPERTIES
         SKIP_UNITY_BUILD_INCLUSION ON
         SKIP_PRECOMPILE_HEADERS ON
+    )
+
+    add_custom_command(TARGET audacity POST_BUILD
+        COMMAND codesign --force --sign - "$<TARGET_BUNDLE_DIR:audacity>"
+        VERBATIM
     )
 endif (OS_IS_MAC)
 


### PR DESCRIPTION
- Makes local builds use the default osx architecture without falling back to universal
- ad-hoc sign the build to prevent infinite permission requests

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [ ] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
