### PR TITLE
Update bug report template for Audacity versions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -42,8 +42,8 @@ body:
       label: Audacity Version
       description: What version of Audacity are you running?
       options:
+        - Audacity 4.0 beta 3
         - Audacity 4.0 beta 2
-        - Audacity 4.0 beta 1
         - Other
     validations:
       required: true


### PR DESCRIPTION
Added 'Audacity 4.0 beta 3' option to the bug report template and removed 'Audacity 4.0 beta 1'.