### PR TITLE
11571 decouple audioio monitoring and buffer exchange

### DIFF
--- a/.github/workflows/au4_check_unit_tests.yml
+++ b/.github/workflows/au4_check_unit_tests.yml
@@ -93,6 +93,9 @@ jobs:
 
     - name: Run tests
       run: |
+        # A capture device for the audio tests: PortAudio ignores ALSA's
+        # predefined "null" device, but not an alias of it.
+        echo 'pcm.test_null { type null }' >> ~/.asoundrc
         cmake -P ${CI_DIR}/linux/ci_run_utests.cmake
       env:
         ASAN_OPTIONS: "detect_leaks=0"

--- a/au3/libraries/au3-audio-devices/AudioIOBase.h
+++ b/au3/libraries/au3-audio-devices/AudioIOBase.h
@@ -275,8 +275,6 @@ public:
     /** \brief Find out if playback / recording is currently paused */
     bool IsPaused() const;
 
-    virtual void StopStream() = 0;
-
     /** \brief  Returns true if audio i/o is busy starting, stopping, playing,
      * or recording.
      *

--- a/au3/libraries/au3-audio-io/AudioIO.cpp
+++ b/au3/libraries/au3-audio-io/AudioIO.cpp
@@ -249,7 +249,7 @@ AudioIO::AudioIO()
     mAudioThreadSequenceBufferExchangeLoopActive
     .store(false, std::memory_order_relaxed);
 
-    mAudioThreadAcknowledge.store(Acknowledge::eNone, std::memory_order_relaxed);
+    mBufferExchangeAcknowledge.store(Acknowledge::eNone, std::memory_order_relaxed);
 
     mPortStreamV19 = NULL;
 
@@ -916,7 +916,7 @@ void AudioIO::StartMonitoring(const AudioIOStartStreamOptions& options)
 void AudioIO::StopMonitoring()
 {
     if (IsMonitoring()) {
-        StopStream();
+        StopBufferExchange();
         WaitWhileBusy();
     }
 }
@@ -929,9 +929,9 @@ void AudioIO::WaitWhileBusy() const
     }
 }
 
-int AudioIO::StartStream(const TransportSequences& sequences,
-                         double t0, double t1, double mixerLimit,
-                         const AudioIOStartStreamOptions& options)
+int AudioIO::StartBufferExchange(const TransportSequences& sequences,
+                                 double t0, double t1, double mixerLimit,
+                                 const AudioIOStartStreamOptions& options)
 {
     // precondition
     assert(std::all_of(
@@ -1205,7 +1205,7 @@ int AudioIO::StartStream(const TransportSequences& sequences,
         // Probably not needed so urgently before portaudio thread start for usual
         // playback, since our ring buffers have been primed already with 4 sec
         // of audio, but then we might be scrubbing, so do it.
-        StartAudioThread();
+        StartBufferExchangeOnAudioThread();
 
         mForceFadeOut.store(false, std::memory_order_relaxed);
 
@@ -1216,7 +1216,7 @@ int AudioIO::StartStream(const TransportSequences& sequences,
         if (err != paNoError) {
             mStreamToken = 0;
 
-            StopAudioThread();
+            StopBufferExchangeOnAudioThread();
 
             if (pListener && mNumCaptureChannels > 0) {
                 pListener->OnAudioIOStopRecording();
@@ -1245,7 +1245,7 @@ int AudioIO::StartStream(const TransportSequences& sequences,
 
     commit = true;
 
-    WaitForAudioThreadStarted();
+    WaitForBufferExchangeStartedOnAudioThread();
 
     return mStreamToken;
 }
@@ -1556,7 +1556,7 @@ bool AudioIO::IsAvailable(AudacityProject& project) const
     return !pOwningProject || pOwningProject.get() == &project;
 }
 
-void AudioIO::StopStream()
+void AudioIO::StopBufferExchange()
 {
     StopMeters();
     ResetMeters();
@@ -1633,7 +1633,7 @@ void AudioIO::StopStream()
     // DV: Seems that Pa_CloseStream calls Pa_AbortStream internally,
     // at least for PortAudio 19.7.0+
 
-    StopAudioThread();
+    StopBufferExchangeOnAudioThread();
 
     // Turn off HW playthrough if PortMixer is being used
 
@@ -1663,7 +1663,7 @@ void AudioIO::StopStream()
 
     // We previously told AudioThread to stop processing, now let's
     // be sure it has really stopped before resetting mpTransportState
-    WaitForAudioThreadStopped();
+    WaitForBufferExchangeStoppedOnAudioThread();
 
     for ( auto& ext : Extensions()) {
         ext.StopOtherStream();
@@ -1927,8 +1927,8 @@ void AudioIO::AudioThread(std::atomic<bool>& finish)
                    .load(std::memory_order_relaxed)) {
             if (lastState != ProcessingState::eCallbackProcessing) {
                 // Main thread has told us to start - acknowledge that we do
-                gAudioIO->mAudioThreadAcknowledge.store(Acknowledge::eStart,
-                                                        std::memory_order_release);
+                gAudioIO->mBufferExchangeAcknowledge.store(Acknowledge::eStart,
+                                                           std::memory_order_release);
             }
             lastState = ProcessingState::eCallbackProcessing;
 
@@ -1945,8 +1945,8 @@ void AudioIO::AudioThread(std::atomic<bool>& finish)
                 || (lastState == ProcessingState::ePrimeProcessing)) {
                 // Main thread has told us to stop; (actually: to neither process "once" nor "loop running")
                 // acknowledge that we received the order and that no more processing will be done.
-                gAudioIO->mAudioThreadAcknowledge.store(Acknowledge::eStop,
-                                                        std::memory_order_release);
+                gAudioIO->mBufferExchangeAcknowledge.store(Acknowledge::eStop,
+                                                           std::memory_order_release);
             }
             lastState = ProcessingState::eSkipProcessing;
 
@@ -2414,7 +2414,7 @@ void AudioIO::DrainRecordBuffers()
         // but StopStream() contains that exception, and the logic in
         // AudacityException::DelayedHandlerAction prevents redundant message
         // boxes.
-        StopStream();
+        StopBufferExchange();
         WaitWhileBusy();
 
         DefaultDelayedHandlerAction(pException);
@@ -3497,7 +3497,7 @@ int AudioIoCallback::CallbackDoSeek()
     // a single call to StopAudioThreadAndWait()
     //
     // CAUTION: when trying the above, you must also replace the setting of the
-    // atomic before the return, with a call to StartAudioThread()
+    // atomic before the return, with a call to StartBufferExchangeOnAudioThread()
     //
     // If that works, then we can remove mAudioThreadSequenceBufferExchangeLoopActive,
     // as it will become unused; consequently, the AudioThread loop would get simpler too.
@@ -3576,34 +3576,34 @@ auto AudioIoCallback::AudioIOExtIterator::operator *() const -> AudioIOExt
     return *static_cast<AudioIOExt*>(mIterator->get());
 }
 
-void AudioIoCallback::StartAudioThread()
+void AudioIoCallback::StartBufferExchangeOnAudioThread()
 {
     mAudioThreadSequenceBufferExchangeLoopRunning.store(true, std::memory_order_release);
 }
 
-void AudioIoCallback::WaitForAudioThreadStarted()
+void AudioIoCallback::WaitForBufferExchangeStartedOnAudioThread()
 {
-    while (mAudioThreadAcknowledge.load(std::memory_order_acquire) != Acknowledge::eStart)
+    while (mBufferExchangeAcknowledge.load(std::memory_order_acquire) != Acknowledge::eStart)
     {
         using namespace std::chrono;
         std::this_thread::sleep_for(50ms);
     }
-    mAudioThreadAcknowledge.store(Acknowledge::eNone, std::memory_order_release);
+    mBufferExchangeAcknowledge.store(Acknowledge::eNone, std::memory_order_release);
 }
 
-void AudioIoCallback::StopAudioThread()
+void AudioIoCallback::StopBufferExchangeOnAudioThread()
 {
     mAudioThreadSequenceBufferExchangeLoopRunning.store(false, std::memory_order_release);
 }
 
-void AudioIoCallback::WaitForAudioThreadStopped()
+void AudioIoCallback::WaitForBufferExchangeStoppedOnAudioThread()
 {
-    while (mAudioThreadAcknowledge.load(std::memory_order_acquire) != Acknowledge::eStop)
+    while (mBufferExchangeAcknowledge.load(std::memory_order_acquire) != Acknowledge::eStop)
     {
         using namespace std::chrono;
         std::this_thread::sleep_for(50ms);
     }
-    mAudioThreadAcknowledge.store(Acknowledge::eNone, std::memory_order_release);
+    mBufferExchangeAcknowledge.store(Acknowledge::eNone, std::memory_order_release);
 }
 
 void AudioIoCallback::ProcessOnceAndWait(std::chrono::milliseconds sleepTime)

--- a/au3/libraries/au3-audio-io/AudioIO.cpp
+++ b/au3/libraries/au3-audio-io/AudioIO.cpp
@@ -303,7 +303,7 @@ AudioIO::AudioIO()
 
 void AudioIO::StartThread()
 {
-    mAudioThread = std::thread(AudioThread, ref(mFinishAudioThread));
+    mAudioThread = std::thread([this] { AudioThread(*this, ref(mFinishAudioThread)); });
 }
 
 AudioIO::~AudioIO()
@@ -1923,35 +1923,34 @@ void AudioIoCallback::SetAudioThreadPacerForTests(std::shared_ptr<AudioThreadPac
 }
 
 //! Sits in a thread loop reading and writing audio.
-void AudioIO::AudioThread(std::atomic<bool>& finish)
+void AudioIO::AudioThread(AudioIO& audioIO, std::atomic<bool>& finish)
 {
     const auto pacer = AudioThreadPacerStorage();
     enum class ProcessingState {
         eSkipProcessing, ePrimeProcessing, eCallbackProcessing
     } lastState = ProcessingState::eSkipProcessing;
-    AudioIO* const gAudioIO = AudioIO::Get();
     while (!finish.load(std::memory_order_acquire)) {
         using Clock = std::chrono::steady_clock;
         auto loopPassStart = Clock::now();
-        auto& schedule = gAudioIO->mPlaybackSchedule;
+        auto& schedule = audioIO.mPlaybackSchedule;
         const auto interval = schedule.GetPolicy().SleepInterval(schedule);
 
         // Set LoopActive outside the tests to avoid race condition
-        gAudioIO->mAudioThreadSequenceBufferExchangeLoopActive
+        audioIO.mAudioThreadSequenceBufferExchangeLoopActive
         .store(true, std::memory_order_relaxed);
-        if (gAudioIO->mAudioThreadShouldCallSequenceBufferExchangeOnce
+        if (audioIO.mAudioThreadShouldCallSequenceBufferExchangeOnce
             .load(std::memory_order_acquire)) {
-            gAudioIO->SequenceBufferExchange();
-            gAudioIO->mAudioThreadShouldCallSequenceBufferExchangeOnce
+            audioIO.SequenceBufferExchange();
+            audioIO.mAudioThreadShouldCallSequenceBufferExchangeOnce
             .store(false, std::memory_order_release);
 
             lastState = ProcessingState::ePrimeProcessing;
-        } else if (gAudioIO->mAudioThreadSequenceBufferExchangeLoopRunning
+        } else if (audioIO.mAudioThreadSequenceBufferExchangeLoopRunning
                    .load(std::memory_order_relaxed)) {
             if (lastState != ProcessingState::eCallbackProcessing) {
                 // Main thread has told us to start - acknowledge that we do
-                gAudioIO->mBufferExchangeAcknowledge.store(Acknowledge::eStart,
-                                                           std::memory_order_release);
+                audioIO.mBufferExchangeAcknowledge.store(Acknowledge::eStart,
+                                                         std::memory_order_release);
             }
             lastState = ProcessingState::eCallbackProcessing;
 
@@ -1961,19 +1960,19 @@ void AudioIO::AudioThread(std::atomic<bool>& finish)
             // This is unlike the case with mAudioThreadShouldCallSequenceBufferExchangeOnce where the
             // store really means that the one-time exchange was done.
 
-            gAudioIO->SequenceBufferExchange();
+            audioIO.SequenceBufferExchange();
         } else {
             if ((lastState == ProcessingState::eCallbackProcessing)
                 || (lastState == ProcessingState::ePrimeProcessing)) {
                 // Main thread has told us to stop; (actually: to neither process "once" nor "loop running")
                 // acknowledge that we received the order and that no more processing will be done.
-                gAudioIO->mBufferExchangeAcknowledge.store(Acknowledge::eStop,
-                                                           std::memory_order_release);
+                audioIO.mBufferExchangeAcknowledge.store(Acknowledge::eStop,
+                                                         std::memory_order_release);
             }
             lastState = ProcessingState::eSkipProcessing;
         }
 
-        gAudioIO->mAudioThreadSequenceBufferExchangeLoopActive
+        audioIO.mAudioThreadSequenceBufferExchangeLoopActive
         .store(false, std::memory_order_relaxed);
 
         pacer->SleepUntil(loopPassStart + interval);

--- a/au3/libraries/au3-audio-io/AudioIO.cpp
+++ b/au3/libraries/au3-audio-io/AudioIO.cpp
@@ -798,9 +798,6 @@ void AudioIO::StopPortAudioStream()
     // Re-enable system sleep
     wxPowerResource::Release(wxPOWER_RESOURCE_SCREEN);
 #endif
-
-    mNumCaptureChannels = 0;
-    mNumPlaybackChannels = 0;
 }
 
 wxString AudioIO::LastPaErrorString()
@@ -950,6 +947,7 @@ void AudioIO::StopMonitoring()
     ResetMeters();
 
     StopPortAudioStream();
+    mNumCaptureChannels = mNumPlaybackChannels = 0;
 
     ResetOwningProject();
 
@@ -1263,6 +1261,8 @@ int AudioIO::StartBufferExchange(const TransportSequences& sequences,
                 pListener->OnAudioIOStopRecording();
             }
             StopPortAudioStream();
+            mNumCaptureChannels = mNumPlaybackChannels = 0;
+
             StartStreamCleanup();
             ResetOwningProject();
             // PRL: PortAudio error messages are sadly not internationalized
@@ -1676,8 +1676,6 @@ void AudioIO::StopBufferExchange()
 
     StopBufferExchangeOnAudioThread();
 
-    const auto wasPlaying = mNumPlaybackChannels > 0;
-    const auto wasRecording = mNumCaptureChannels > 0;
     StopPortAudioStream();
 
     // We previously told AudioThread to stop processing, now let's
@@ -1696,6 +1694,11 @@ void AudioIO::StopBufferExchange()
     // to call SequenceBufferExchange one last time (it normally would not do
     // so since Pa_GetStreamActive() would now return false
     ProcessOnceAndWait();
+
+    // Now there won't be activity on the audio thread until we restart the stream and we can reset those two member variables.
+    const auto wasPlaying = mNumPlaybackChannels > 0;
+    const auto wasRecording = mNumCaptureChannels > 0;
+    mNumCaptureChannels = mNumPlaybackChannels = 0;
 
     // No longer need effects processing. This must be done after the stream is stopped
     // to prevent the callback from being invoked after the effects are finalized.

--- a/au3/libraries/au3-audio-io/AudioIO.cpp
+++ b/au3/libraries/au3-audio-io/AudioIO.cpp
@@ -1900,9 +1900,21 @@ double AudioIO::GetStreamTime()
 //
 //////////////////////////////////////////////////////////////////////
 
+static std::shared_ptr<AudioIoCallback::AudioThreadPacer>& AudioThreadPacerStorage()
+{
+    static std::shared_ptr<AudioIoCallback::AudioThreadPacer> pacer = std::make_shared<AudioIoCallback::AudioThreadPacer>();
+    return pacer;
+}
+
+void AudioIoCallback::SetAudioThreadPacerForTests(std::shared_ptr<AudioThreadPacer> pacer)
+{
+    AudioThreadPacerStorage() = pacer ? std::move(pacer) : std::make_shared<AudioThreadPacer>();
+}
+
 //! Sits in a thread loop reading and writing audio.
 void AudioIO::AudioThread(std::atomic<bool>& finish)
 {
+    const auto pacer = AudioThreadPacerStorage();
     enum class ProcessingState {
         eSkipProcessing, ePrimeProcessing, eMonitoringProcessing, eCallbackProcessing
     } lastState = ProcessingState::eSkipProcessing;
@@ -1958,7 +1970,7 @@ void AudioIO::AudioThread(std::atomic<bool>& finish)
         gAudioIO->mAudioThreadSequenceBufferExchangeLoopActive
         .store(false, std::memory_order_relaxed);
 
-        std::this_thread::sleep_until(loopPassStart + interval);
+        pacer->SleepUntil(loopPassStart + interval);
     }
 }
 
@@ -3583,10 +3595,12 @@ void AudioIoCallback::StartBufferExchangeOnAudioThread()
 
 void AudioIoCallback::WaitForBufferExchangeStartedOnAudioThread()
 {
-    while (mBufferExchangeAcknowledge.load(std::memory_order_acquire) != Acknowledge::eStart)
+    const auto pacer = AudioThreadPacerStorage();
+    while (mBufferExchangeAcknowledge.load(std::memory_order_acquire) != Acknowledge::eStart
+           && pacer->KeepWaiting())
     {
         using namespace std::chrono;
-        std::this_thread::sleep_for(50ms);
+        pacer->SleepFor(50ms);
     }
     mBufferExchangeAcknowledge.store(Acknowledge::eNone, std::memory_order_release);
 }
@@ -3598,10 +3612,12 @@ void AudioIoCallback::StopBufferExchangeOnAudioThread()
 
 void AudioIoCallback::WaitForBufferExchangeStoppedOnAudioThread()
 {
-    while (mBufferExchangeAcknowledge.load(std::memory_order_acquire) != Acknowledge::eStop)
+    const auto pacer = AudioThreadPacerStorage();
+    while (mBufferExchangeAcknowledge.load(std::memory_order_acquire) != Acknowledge::eStop
+           && pacer->KeepWaiting())
     {
         using namespace std::chrono;
-        std::this_thread::sleep_for(50ms);
+        pacer->SleepFor(50ms);
     }
     mBufferExchangeAcknowledge.store(Acknowledge::eNone, std::memory_order_release);
 }

--- a/au3/libraries/au3-audio-io/AudioIO.cpp
+++ b/au3/libraries/au3-audio-io/AudioIO.cpp
@@ -479,19 +479,6 @@ bool AudioIO::StartPortAudioStream(const AudioIOStartStreamOptions& options,
 {
     auto sampleRate = options.rate;
     mNumPauseFrames = 0;
-    SetOwningProject(options.pProject);
-    bool success = false;
-    auto cleanup = finally([&]{
-        if (!success) {
-            ResetOwningProject();
-        }
-    });
-
-    // PRL:  Protection from crash reported by David Bailes, involving starting
-    // and stopping with frequent changes of active window, hard to reproduce
-    if (mOwningProject.expired()) {
-        return false;
-    }
 
     ResetMeters();
 
@@ -776,7 +763,44 @@ bool AudioIO::StartPortAudioStream(const AudioIOStartStreamOptions& options,
     }
 #endif
 
-    return success = (mLastPaError == paNoError);
+    return mLastPaError == paNoError;
+}
+
+void AudioIO::StopPortAudioStream()
+{
+    // Turn off HW playthrough if PortMixer is being used
+
+  #if defined(USE_PORTMIXER)
+    if (mPortMixer) {
+      #if __WXMAC__
+        if (Px_SupportsPlaythrough(mPortMixer) && mPreviousHWPlaythrough >= 0.0) {
+            Px_SetPlaythrough(mPortMixer, mPreviousHWPlaythrough);
+        }
+        mPreviousHWPlaythrough = -1.0;
+      #endif
+    }
+  #endif
+
+    if (mPortStreamV19) {
+        // DV: Pa_CloseStream will close Pa_AbortStream internally,
+        // but it doesn't hurt to do it ourselves.
+        // PA_AbortStream will silently fail if stream is stopped.
+        if (!Pa_IsStreamStopped(mPortStreamV19)) {
+            Pa_AbortStream(mPortStreamV19);
+        }
+
+        Pa_CloseStream(mPortStreamV19);
+
+        mPortStreamV19 = NULL;
+    }
+
+#if (defined(__WXMAC__) || defined(__WXMSW__)) && wxCHECK_VERSION(3, 1, 0)
+    // Re-enable system sleep
+    wxPowerResource::Release(wxPOWER_RESOURCE_SCREEN);
+#endif
+
+    mNumCaptureChannels = 0;
+    mNumPlaybackChannels = 0;
 }
 
 wxString AudioIO::LastPaErrorString()
@@ -886,18 +910,17 @@ void AudioIO::StartMonitoring(const AudioIOStartStreamOptions& options)
                                               static_cast<unsigned int>(playbackChannels),
                                               static_cast<unsigned int>(captureChannels));
 
-    const auto pOwningProject = mOwningProject.lock();
     if (!success) {
         using namespace BasicUI;
         const auto msg = TranslatableString("audio-io", "Error opening recording device.\nError code: %1")
                          .Format(Get()->LastPaErrorString());
-        ShowErrorDialog(*ProjectFramePlacement(pOwningProject.get()),
+        ShowErrorDialog(*ProjectFramePlacement(options.pProject.get()),
                         TranslatableString("audio-io", "Error"), msg, wxT("Error_opening_sound_device"),
                         ErrorDialogOptions { ErrorDialogType::ModalErrorReport });
         return;
     }
 
-    Publish({ pOwningProject.get(), AudioIOEvent::MONITOR, true });
+    SetOwningProject(options.pProject);
 
     // FIXME: TRAP_ERR PaErrorCode 'noted' but not reported in StartMonitoring.
     // Now start the PortAudio stream!
@@ -915,9 +938,24 @@ void AudioIO::StartMonitoring(const AudioIOStartStreamOptions& options)
 
 void AudioIO::StopMonitoring()
 {
-    if (IsMonitoring()) {
-        StopBufferExchange();
-        WaitWhileBusy();
+    if (!IsMonitoring()) {
+        return;
+    }
+
+    // Monitoring never started the buffer exchange on the audio thread, nor
+    // any transport state: all there is to undo is what StartMonitoring
+    // (via StartPortAudioStream) set up.
+
+    StopMeters();
+    ResetMeters();
+
+    StopPortAudioStream();
+
+    ResetOwningProject();
+
+    if (auto pListener = GetListener()) {
+        // Tell UI to hide sample rate
+        pListener->OnAudioIORate(0);
     }
 }
 
@@ -1135,6 +1173,7 @@ int AudioIO::StartBufferExchange(const TransportSequences& sequences,
         }
     }
 
+    SetOwningProject(options.pProject);
     mpTransportState = std::make_unique<TransportState>(mOwningProject, mPlaybackSequences, mNumPlaybackChannels, mRate,
                                                         mPlaybackSamplesToCopy);
 
@@ -1216,12 +1255,16 @@ int AudioIO::StartBufferExchange(const TransportSequences& sequences,
         if (err != paNoError) {
             mStreamToken = 0;
 
+            WaitForBufferExchangeStartedOnAudioThread();
             StopBufferExchangeOnAudioThread();
+            WaitForBufferExchangeStoppedOnAudioThread();
 
             if (pListener && mNumCaptureChannels > 0) {
                 pListener->OnAudioIOStopRecording();
             }
+            StopPortAudioStream();
             StartStreamCleanup();
+            ResetOwningProject();
             // PRL: PortAudio error messages are sadly not internationalized
             BasicUI::ShowMessageBox(
                 TranslatableString::untranslatable(LAT1CTOWX(Pa_GetErrorText(err))));
@@ -1235,12 +1278,11 @@ int AudioIO::StartBufferExchange(const TransportSequences& sequences,
         pListener->OnAudioIORate((int)mRate);
     }
 
-    auto pOwningProject = mOwningProject.lock();
     if (mNumPlaybackChannels > 0) {
-        Publish({ pOwningProject.get(), AudioIOEvent::PLAYBACK, true });
+        Publish({ options.pProject.get(), AudioIOEvent::PLAYBACK, true });
     }
     if (mNumCaptureChannels > 0) {
-        Publish({ pOwningProject.get(), AudioIOEvent::CAPTURE, true });
+        Publish({ options.pProject.get(), AudioIOEvent::CAPTURE, true });
     }
 
     commit = true;
@@ -1558,6 +1600,10 @@ bool AudioIO::IsAvailable(AudacityProject& project) const
 
 void AudioIO::StopBufferExchange()
 {
+    if (mStreamToken == 0) {
+        return;
+    }
+
     StopMeters();
     ResetMeters();
 
@@ -1583,11 +1629,6 @@ void AudioIO::StopBufferExchange()
     if ( Pa_IsStreamStopped(mPortStreamV19) )
        return;
     */
-
-#if (defined(__WXMAC__) || defined(__WXMSW__)) && wxCHECK_VERSION(3, 1, 0)
-    // Re-enable system sleep
-    wxPowerResource::Release(wxPOWER_RESOURCE_SCREEN);
-#endif
 
     if (mAudioThreadSequenceBufferExchangeLoopRunning
         .load(std::memory_order_relaxed)) {
@@ -1635,31 +1676,9 @@ void AudioIO::StopBufferExchange()
 
     StopBufferExchangeOnAudioThread();
 
-    // Turn off HW playthrough if PortMixer is being used
-
-  #if defined(USE_PORTMIXER)
-    if (mPortMixer) {
-      #if __WXMAC__
-        if (Px_SupportsPlaythrough(mPortMixer) && mPreviousHWPlaythrough >= 0.0) {
-            Px_SetPlaythrough(mPortMixer, mPreviousHWPlaythrough);
-        }
-        mPreviousHWPlaythrough = -1.0;
-      #endif
-    }
-  #endif
-
-    if (mPortStreamV19) {
-        // DV: Pa_CloseStream will close Pa_AbortStream internally,
-        // but it doesn't hurt to do it ourselves.
-        // PA_AbortStream will silently fail if stream is stopped.
-        if (!Pa_IsStreamStopped(mPortStreamV19)) {
-            Pa_AbortStream(mPortStreamV19);
-        }
-
-        Pa_CloseStream(mPortStreamV19);
-
-        mPortStreamV19 = NULL;
-    }
+    const auto wasPlaying = mNumPlaybackChannels > 0;
+    const auto wasRecording = mNumCaptureChannels > 0;
+    StopPortAudioStream();
 
     // We previously told AudioThread to stop processing, now let's
     // be sure it has really stopped before resetting mpTransportState
@@ -1671,16 +1690,12 @@ void AudioIO::StopBufferExchange()
 
     auto pListener = GetListener();
 
-    // If there's no token, we were just monitoring, so we can
-    // skip this next part...
-    if (mStreamToken > 0) {
-        // In either of the above cases, we want to make sure that any
-        // capture data that made it into the PortAudio callback makes it
-        // to the target RecordableSequence.  To do this, we ask the audio thread
-        // to call SequenceBufferExchange one last time (it normally would not do
-        // so since Pa_GetStreamActive() would now return false
-        ProcessOnceAndWait();
-    }
+    // We want to make sure that any
+    // capture data that made it into the PortAudio callback makes it
+    // to the target RecordableSequence.  To do this, we ask the audio thread
+    // to call SequenceBufferExchange one last time (it normally would not do
+    // so since Pa_GetStreamActive() would now return false
+    ProcessOnceAndWait();
 
     // No longer need effects processing. This must be done after the stream is stopped
     // to prevent the callback from being invoked after the effects are finalized.
@@ -1697,75 +1712,73 @@ void AudioIO::StopBufferExchange()
     mPlaybackSchedule.mTimeQueue.Clear();
     mPlaybackTracks.clear();
 
-    if (mStreamToken > 0) {
+    //
+    // Offset all recorded sequences to account for latency
+    //
+    if (mCaptureSequences.size() > 0) {
+        mCaptureBuffers.clear();
+        mResample.clear();
+
         //
-        // Offset all recorded sequences to account for latency
+        // We only apply latency correction when we actually played back
+        // sequences during the recording. If we did not play back sequences,
+        // there's nothing we could be out of sync with. This also covers the
+        // case that we do not apply latency correction when recording the
+        // first sequence in a project.
         //
-        if (mCaptureSequences.size() > 0) {
-            mCaptureBuffers.clear();
-            mResample.clear();
 
-            //
-            // We only apply latency correction when we actually played back
-            // sequences during the recording. If we did not play back sequences,
-            // there's nothing we could be out of sync with. This also covers the
-            // case that we do not apply latency correction when recording the
-            // first sequence in a project.
-            //
+        for (auto& sequence : mCaptureSequences) {
+            // The calls to Flush
+            // may cause exceptions because of exhaustion of disk space.
+            // Stop those exceptions here, or else they propagate through too
+            // many parts of Audacity that are not effects or editing
+            // operations.  GuardedCall ensures that the user sees a warning.
 
-            for (auto& sequence : mCaptureSequences) {
-                // The calls to Flush
-                // may cause exceptions because of exhaustion of disk space.
-                // Stop those exceptions here, or else they propagate through too
-                // many parts of Audacity that are not effects or editing
-                // operations.  GuardedCall ensures that the user sees a warning.
+            // Also be sure to Flush each sequence, at the top of the
+            // guarded call, relying on the guarantee that the sequence will be
+            // left in a flushed state, though the append buffer may be lost.
 
-                // Also be sure to Flush each sequence, at the top of the
-                // guarded call, relying on the guarantee that the sequence will be
-                // left in a flushed state, though the append buffer may be lost.
+            GuardedCall([&] {
+                // use No-fail-guarantee that sequence is flushed,
+                // Partial-guarantee that some initial length of the recording
+                // is saved.
+                // See comments in SequenceBufferExchange().
+                sequence->Flush();
+            });
+        }
 
-                GuardedCall([&] {
-                    // use No-fail-guarantee that sequence is flushed,
-                    // Partial-guarantee that some initial length of the recording
-                    // is saved.
-                    // See comments in SequenceBufferExchange().
-                    sequence->Flush();
-                });
+        if (!mLostCaptureIntervals.empty()) {
+            // This scope may combine many insertions of silence
+            // into one transaction, lessening the number of checkpoints
+            std::optional<TransactionScope> pScope;
+            if (auto pOwningProject = mOwningProject.lock()) {
+                pScope.emplace(*pOwningProject, "Dropouts");
             }
-
-            if (!mLostCaptureIntervals.empty()) {
-                // This scope may combine many insertions of silence
-                // into one transaction, lessening the number of checkpoints
-                std::optional<TransactionScope> pScope;
-                if (auto pOwningProject = mOwningProject.lock()) {
-                    pScope.emplace(*pOwningProject, "Dropouts");
-                }
-                for (auto& interval : mLostCaptureIntervals) {
-                    auto& start = interval.first;
-                    auto duration = interval.second;
-                    for (auto& sequence : mCaptureSequences) {
-                        GuardedCall([&] {
-                            sequence->InsertSilence(start, duration);
-                        });
-                    }
-                }
-                if (pScope) {
-                    pScope->Commit();
+            for (auto& interval : mLostCaptureIntervals) {
+                auto& start = interval.first;
+                auto duration = interval.second;
+                for (auto& sequence : mCaptureSequences) {
+                    GuardedCall([&] {
+                        sequence->InsertSilence(start, duration);
+                    });
                 }
             }
-
-            if (pListener) {
-                pListener->OnCommitRecording();
+            if (pScope) {
+                pScope->Commit();
             }
+        }
+
+        if (pListener) {
+            pListener->OnCommitRecording();
         }
     }
 
-    if (pListener && mNumCaptureChannels > 0) {
+    if (pListener && wasRecording) {
         pListener->OnAudioIOStopRecording();
     }
 
-    BasicUI::CallAfter([this]{
-        if (mPortStreamV19 && mNumCaptureChannels > 0) {
+    BasicUI::CallAfter([this, wasRecording]{
+        if (mPortStreamV19 && wasRecording) {
             // Recording was restarted between StopStream and idle time
             // So the actions can keep waiting
             return;
@@ -1780,30 +1793,19 @@ void AudioIO::StopBufferExchange()
         DelayActions(false);
     });
 
-    //
-    // Only set token to 0 after we're totally finished with everything
-    //
-    bool wasMonitoring = mStreamToken == 0;
     mStreamToken = 0;
 
     {
         auto pOwningProject = mOwningProject.lock();
-        if (mNumPlaybackChannels > 0) {
+        if (wasPlaying) {
             Publish({ pOwningProject.get(), AudioIOEvent::PLAYBACK, false });
         }
-        if (mNumCaptureChannels > 0) {
-            Publish({ pOwningProject.get(),
-                      wasMonitoring
-                      ? AudioIOEvent::MONITOR
-                      : AudioIOEvent::CAPTURE,
-                      false });
+        if (wasRecording) {
+            Publish({ pOwningProject.get(), AudioIOEvent::CAPTURE, false });
         }
     }
 
     ResetOwningProject();
-
-    mNumCaptureChannels = 0;
-    mNumPlaybackChannels = 0;
 
     mPlaybackSequences.clear();
     mCaptureSequences.clear();
@@ -1818,6 +1820,12 @@ void AudioIO::StopBufferExchange()
 
     // Don't cause a busy wait in the audio thread after stopping scrubbing
     mPlaybackSchedule.ResetMode();
+}
+
+void AudioIO::StopStream()
+{
+    StopBufferExchange();
+    StopMonitoring();
 }
 
 void AudioIO::SeekStream(double seconds)
@@ -1916,7 +1924,7 @@ void AudioIO::AudioThread(std::atomic<bool>& finish)
 {
     const auto pacer = AudioThreadPacerStorage();
     enum class ProcessingState {
-        eSkipProcessing, ePrimeProcessing, eMonitoringProcessing, eCallbackProcessing
+        eSkipProcessing, ePrimeProcessing, eCallbackProcessing
     } lastState = ProcessingState::eSkipProcessing;
     AudioIO* const gAudioIO = AudioIO::Get();
     while (!finish.load(std::memory_order_acquire)) {
@@ -1953,7 +1961,6 @@ void AudioIO::AudioThread(std::atomic<bool>& finish)
             gAudioIO->SequenceBufferExchange();
         } else {
             if ((lastState == ProcessingState::eCallbackProcessing)
-                || (lastState == ProcessingState::eMonitoringProcessing)
                 || (lastState == ProcessingState::ePrimeProcessing)) {
                 // Main thread has told us to stop; (actually: to neither process "once" nor "loop running")
                 // acknowledge that we received the order and that no more processing will be done.
@@ -1961,10 +1968,6 @@ void AudioIO::AudioThread(std::atomic<bool>& finish)
                                                            std::memory_order_release);
             }
             lastState = ProcessingState::eSkipProcessing;
-
-            if (gAudioIO->IsMonitoring()) {
-                lastState = ProcessingState::eMonitoringProcessing;
-            }
         }
 
         gAudioIO->mAudioThreadSequenceBufferExchangeLoopActive

--- a/au3/libraries/au3-audio-io/AudioIO.h
+++ b/au3/libraries/au3-audio-io/AudioIO.h
@@ -313,6 +313,26 @@ public:
     void StopBufferExchangeOnAudioThread();
     void WaitForBufferExchangeStoppedOnAudioThread();
 
+    struct AudioThreadPacer {
+        virtual ~AudioThreadPacer() = default;
+        virtual void SleepUntil(const std::chrono::steady_clock::time_point& deadline)
+        {
+            std::this_thread::sleep_until(deadline);
+        }
+
+        virtual void SleepFor(const std::chrono::milliseconds& ms)
+        {
+            std::this_thread::sleep_for(ms);
+        }
+
+        virtual bool KeepWaiting() const
+        {
+            return true;
+        }
+    };
+    //! Default, production pacer will be used if this function is not called.
+    static void SetAudioThreadPacerForTests(std::shared_ptr<AudioThreadPacer> pacer);
+
     void ProcessOnceAndWait(std::chrono::milliseconds sleepTime = std::chrono::milliseconds(50));
 
     std::atomic<bool> mForceFadeOut{ false };

--- a/au3/libraries/au3-audio-io/AudioIO.h
+++ b/au3/libraries/au3-audio-io/AudioIO.h
@@ -598,7 +598,7 @@ public:
      */
     double GetStreamTime();
 
-    static void AudioThread(std::atomic<bool>& finish);
+    static void AudioThread(AudioIO& audioIO, std::atomic<bool>& finish);
 
     static void Init();
     static void Deinit();

--- a/au3/libraries/au3-audio-io/AudioIO.h
+++ b/au3/libraries/au3-audio-io/AudioIO.h
@@ -57,9 +57,10 @@ enum class Acknowledge {
 };
 
 /*!
- Emitted by the global AudioIO object when play, recording, or monitoring
- starts or stops
-*/
+ * Emitted by the global AudioIO object when play, recording, or monitoring
+ * starts or stops. Think twice before using these callbacks to start/stop
+ * playback, recording or monitoring ;)
+ */
 struct AudioIOEvent {
     AudacityProject* pProject;
     enum Type {

--- a/au3/libraries/au3-audio-io/AudioIO.h
+++ b/au3/libraries/au3-audio-io/AudioIO.h
@@ -65,7 +65,6 @@ struct AudioIOEvent {
     enum Type {
         PLAYBACK,
         CAPTURE,
-        MONITOR,
         PAUSE,
     } type;
     bool on;
@@ -509,15 +508,20 @@ public:
     int StartBufferExchange(const TransportSequences& sequences, double t0, double t1, double mixerLimit, //!< Time at which mixer stops producing, maybe > t1
                             const AudioIOStartStreamOptions& options);
 
-    /** \brief Stop recording, playback or input monitoring.
+    /** \brief Stop recording or playback.
      *
-     * Does quite a bit of housekeeping, including switching off monitoring,
+     * Does quite a bit of housekeeping, including
      * flushing recording buffers out to RecordableSequences, and applies latency
      * correction to recorded sequences if necessary */
     void StopBufferExchange();
     /** \brief Move the playback / recording position of the current stream
      * by the specified amount from where it is now */
     void SeekStream(double seconds);
+
+    /**
+     * @brief Closes the stream, which might have been opened for input monitoring, playback or recording.
+     */
+    void StopStream();
 
     using PostRecordingAction = std::function<void ()>;
 
@@ -616,6 +620,11 @@ private:
      * being floating point always. Returns true if the stream opened successfully
      * and false if it did not. */
     bool StartPortAudioStream(const AudioIOStartStreamOptions& options, unsigned int numPlaybackChannels, unsigned int numCaptureChannels);
+
+    /**
+     * \brief Undoes the hardware setup of StartPortAudioStream
+     */
+    void StopPortAudioStream();
 
     void SetOwningProject(const std::shared_ptr<AudacityProject>& pProject);
     void ResetOwningProject();

--- a/au3/libraries/au3-audio-io/AudioIO.h
+++ b/au3/libraries/au3-audio-io/AudioIO.h
@@ -303,15 +303,15 @@ public:
     std::atomic<bool> mAudioThreadSequenceBufferExchangeLoopRunning;
     std::atomic<bool> mAudioThreadSequenceBufferExchangeLoopActive;
 
-    std::atomic<Acknowledge> mAudioThreadAcknowledge;
+    std::atomic<Acknowledge> mBufferExchangeAcknowledge;
 
     // Async start/stop + wait of AudioThread processing.
     // Provided to allow more flexibility, however use with caution:
     // never call Stop between Start and the wait for Started (and the converse)
-    void StartAudioThread();
-    void WaitForAudioThreadStarted();
-    void StopAudioThread();
-    void WaitForAudioThreadStopped();
+    void StartBufferExchangeOnAudioThread();
+    void WaitForBufferExchangeStartedOnAudioThread();
+    void StopBufferExchangeOnAudioThread();
+    void WaitForBufferExchangeStoppedOnAudioThread();
 
     void ProcessOnceAndWait(std::chrono::milliseconds sleepTime = std::chrono::milliseconds(50));
 
@@ -473,7 +473,7 @@ public:
     /** \brief Wait for busy state to end */
     void WaitWhileBusy() const;
 
-    /** \brief Start recording or playing back audio
+    /** \brief Start recording or playing back audio (exchanging buffers between driver and audio threads)
      *
      * Allocates buffers for recording and playback, gets the Audio thread to
      * fill them, and sets the stream rolling.
@@ -486,15 +486,15 @@ public:
      *    `sequences.captureSequences`
      */
 
-    int StartStream(const TransportSequences& sequences, double t0, double t1, double mixerLimit, //!< Time at which mixer stops producing, maybe > t1
-                    const AudioIOStartStreamOptions& options);
+    int StartBufferExchange(const TransportSequences& sequences, double t0, double t1, double mixerLimit, //!< Time at which mixer stops producing, maybe > t1
+                            const AudioIOStartStreamOptions& options);
 
     /** \brief Stop recording, playback or input monitoring.
      *
      * Does quite a bit of housekeeping, including switching off monitoring,
      * flushing recording buffers out to RecordableSequences, and applies latency
      * correction to recorded sequences if necessary */
-    void StopStream() override;
+    void StopBufferExchange();
     /** \brief Move the playback / recording position of the current stream
      * by the specified amount from where it is now */
     void SeekStream(double seconds);

--- a/docs/11571-driver-audio-thread-handshake-mechanism.md
+++ b/docs/11571-driver-audio-thread-handshake-mechanism.md
@@ -1,0 +1,94 @@
+# [11571](https://github.com/audacity/audacity/issues/11571)
+
+## Intro
+
+Issue [Audacity freezes when adding a track](https://github.com/audacity/audacity/issues/11571) exposed a deadlock, that was never uncovered before (although foreseen by Paul Licameli), but due to programmatic-fast start/stop monitoring event sequence finally was reproduced.
+
+We draw here an explanation to strengthen the intuitive understanding of an otherwise rather complex construct. This is a simplification.
+
+## Happy path
+
+```mermaid
+sequenceDiagram
+participant MainThread@{"type":"control"}
+participant AudioIO
+participant AudioThread@{"type":"control"}
+
+note over MainThread, AudioThread:Startup
+MainThread ->> AudioIO: mACK = none
+
+note over MainThread, AudioThread:Running ...
+AudioThread ->> AudioIO: IsMonitoring()
+AudioIO -->> AudioThread: false
+note over AudioThread:do nothing
+
+MainThread ->> AudioIO: StartMonitoring()
+AudioIO -->> MainThread:
+
+AudioThread ->> AudioIO: IsMonitoring()
+AudioIO -->> AudioThread: true
+note over AudioThread:Ok, then ...
+AudioThread ->> AudioIO: mACK = stop
+AudioIO -->> AudioThread:
+
+MainThread ->> AudioIO: StopMonitoring
+loop while mACK != stop
+note over MainThread:already satisfied
+end
+MainThread ->> AudioIO:mACK = none
+AudioIO -->> MainThread:
+```
+
+## Deadlock
+
+`StopMonitoring()` comes after `StartMonitoring()`, _before_ AudioThread can set `mACK = stop`
+
+```mermaid
+sequenceDiagram
+participant MainThread@{"type":"control"}
+participant AudioIO
+participant AudioThread@{"type":"control"}
+
+MainThread ->> AudioIO: StartMonitoring()
+AudioIO -->> MainThread:
+MainThread ->> AudioIO: StopMonitoring()
+loop while mACK != stop
+MainThread ->> MainThread:spins forever
+end
+AudioThread ->> AudioIO: IsMonitoring()
+AudioIO -->> AudioThread: false
+note over AudioThread:do nothing
+```
+
+## StartMonitoring handshake
+
+```mermaid
+sequenceDiagram
+participant MainThread@{"type":"control"}
+participant AudioIO
+participant AudioThread@{"type":"control"}
+
+note over AudioIO:mACK = none
+MainThread ->> AudioIO: StartMonitoring()
+note over AudioIO:this time we shake hands
+AudioIO ->> AudioIO: mStart = true
+loop while mACK != start
+MainThread ->> MainThread:spin
+alt if mStart == true
+AudioThread ->> AudioIO: mACK = start
+AudioIO -->> AudioThread:
+end
+end
+AudioIO ->> AudioIO: mACK = none
+AudioIO -->> MainThread:
+MainThread ->> AudioIO: StopMonitoring()
+```
+
+## Notes
+
+Those diagrams are a simplification. The handshake mechanism in fact primarily applies to start/stop of playback or recording, ie., of buffer exchange between the audio thread (where audio is processed) and the driver thread (soundcard IO).
+
+In fact, for audio monitoring, one needs an _open stream_ but not the audio thread at all, and even less buffer exchange. There are hence two ways the deadlock can be resolved:
+
+- extending the handshake mechanism to monitoring - small diff but adds complexity
+- decoupling monitoring from the audio thread completely - bigger diff, but final state should be simpler.

--- a/share/testflowscripts/Test-Recording.js
+++ b/share/testflowscripts/Test-Recording.js
@@ -1,0 +1,117 @@
+var Home = require("steps/Home.js");
+var Project = require("Audacity.Project");
+var u = require("steps/TestUtils.js");
+
+const RECORDING_DURATION_MS = 150;
+const MINIMUM_EXPECTED_DURATION_SECONDS = 0.05;
+const TRIAL_COUNT = 3;
+
+var results = [];
+var failures = 0;
+
+function performShortRecording(trial) {
+    var firstNewTrackIndex = Project.trackCount();
+
+    api.log.info(
+        "Trial " +
+            trial +
+            ": starting " +
+            RECORDING_DURATION_MS +
+            " ms recording",
+    );
+
+    // This creates and selects a new track before starting recording.
+    u.run("record-on-new-track");
+
+    // Keep this below mMinCaptureSecsToCopy, which is 200 ms.
+    u.sleep(RECORDING_DURATION_MS);
+
+    u.run("action://record/stop");
+
+    // Allow recording finalization and project notifications to complete.
+    u.sleep(750);
+
+    const clip = Project.clipsOnTrack(Project.trackCount() - 1)[0];
+    const duration = clip.end - clip.start;
+    results.push(duration);
+
+    api.log.info(
+        "Trial " +
+            trial +
+            ": clip duration = " +
+            duration.toFixed(6) +
+            " seconds",
+    );
+
+    if (duration < MINIMUM_EXPECTED_DURATION_SECONDS) {
+        ++failures;
+        api.log.error(
+            "Trial " +
+                trial +
+                ": recording is empty or too short; final capture buffer " +
+                "was probably not drained",
+        );
+    }
+}
+
+var testCase = {
+    name: "TC3.1: Recording final capture-buffer drain",
+    description:
+        "Checks that a sub-200 ms recording is committed when recording stops",
+
+    steps: [
+        {
+            name: "Create a clean project",
+            func: function () {
+                u.run("file-close");
+                u.sleep(300);
+
+                Home.goToHome();
+                u.sleep(300);
+
+                Home.createNewProject();
+                u.sleep(1000);
+            },
+        },
+
+        {
+            name: "Make short recordings",
+            func: function () {
+                for (var trial = 1; trial <= TRIAL_COUNT; ++trial) {
+                    performShortRecording(trial);
+                }
+            },
+        },
+
+        {
+            name: "Verify recorded durations",
+            func: function () {
+                var summary = [];
+
+                for (var i = 0; i < results.length; ++i) {
+                    summary.push(results[i].toFixed(6));
+                }
+
+                api.log.info(
+                    "Recorded durations: [" + summary.join(", ") + "]",
+                );
+
+                if (failures > 0) {
+                    u.fail(
+                        failures +
+                            " of " +
+                            TRIAL_COUNT +
+                            " short recordings contained less than " +
+                            MINIMUM_EXPECTED_DURATION_SECONDS.toFixed(3) +
+                            " seconds of audio",
+                    );
+                }
+            },
+        },
+    ],
+};
+
+function main() {
+    api.testflow.setInterval(250);
+    api.testflow.runTestCase(testCase);
+}

--- a/src/au3audio/internal/au3audioengine.cpp
+++ b/src/au3audio/internal/au3audioengine.cpp
@@ -117,7 +117,7 @@ int Au3AudioEngine::startStream(const TransportSequences& sequences, const doubl
         au3Options.pStartTime = *options.streamStartTime;
     }
     auto& audioIO = *AudioIO::Get();
-    const int token = audioIO.StartStream(sequences, startTime, endTime, mixerEndTime, au3Options);
+    const int token = audioIO.StartBufferExchange(sequences, startTime, endTime, mixerEndTime, au3Options);
     if (token > 0) {
         LOGI() << "PortAudio latency report (ms): outputLatency=" << audioIO.GetHardwarePlaybackLatencyMs() <<
             ", inputLatency=" << audioIO.GetHardwareCaptureLatencyMs();
@@ -127,7 +127,7 @@ int Au3AudioEngine::startStream(const TransportSequences& sequences, const doubl
 
 void Au3AudioEngine::stopStream()
 {
-    AudioIO::Get()->StopStream();
+    AudioIO::Get()->StopBufferExchange();
     AudioIO::Get()->WaitWhileBusy();
 }
 

--- a/src/au3audio/internal/au3audioengine.cpp
+++ b/src/au3audio/internal/au3audioengine.cpp
@@ -127,7 +127,7 @@ int Au3AudioEngine::startStream(const TransportSequences& sequences, const doubl
 
 void Au3AudioEngine::stopStream()
 {
-    AudioIO::Get()->StopBufferExchange();
+    AudioIO::Get()->StopStream();
     AudioIO::Get()->WaitWhileBusy();
 }
 

--- a/src/au3audio/tests/CMakeLists.txt
+++ b/src/au3audio/tests/CMakeLists.txt
@@ -5,13 +5,19 @@
 set(MODULE_TEST au3audio_tests)
 
 set(MODULE_TEST_SRC
+    ${CMAKE_CURRENT_LIST_DIR}/environment.cpp
+
     ${CMAKE_CURRENT_LIST_DIR}/au3audiodrivercontroller_tests.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/au3audioio_tests.cpp
     ${CMAKE_CURRENT_LIST_DIR}/mocks/audioenginemock.h
+    ${CMAKE_CURRENT_LIST_DIR}/mocks/audiothreadloopcontroller.h
     )
 
 set(MODULE_TEST_LINK
     au3audio
     au3wrap
+    au3-audio-io
+    portaudio::portaudio
     )
 
 set(MODULE_TEST_DATA_ROOT ${CMAKE_CURRENT_LIST_DIR})

--- a/src/au3audio/tests/au3audioio_tests.cpp
+++ b/src/au3audio/tests/au3audioio_tests.cpp
@@ -1,0 +1,137 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+#include <algorithm>
+#include <string>
+
+#include <gtest/gtest.h>
+
+#include <portaudio.h>
+
+#include "au3-audio-devices/AudioIOBase.h"
+#include "au3-audio-io/AudioIO.h"
+#include "au3-project/Project.h"
+
+#include "au3wrap/internal/au3project.h"
+#include "au3wrap/au3types.h"
+#include "project/tests/testtools.h"
+#include "mocks/audiothreadloopcontroller.h"
+
+using namespace std::chrono_literals;
+
+namespace au::au3audio {
+/**
+ * @brief Fixture allowing to test concurrency between the main thread and the audio thread.
+ *
+ * @details Uses a pacer for the loop in `::AudioThread`.
+ * Runs on any platform with a capture device; on headless Linux CI, a `test_null` ALSA device
+ * (an alias of `null`, which PortAudio ignores) is defined in the workflow to fill that role.
+ * No audio needs to flow, the only hardware dependency is that Pa_OpenStream must succeed.
+ */
+class MainAndAudioThreadConcurrencyTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        // StartPortAudioStream refuses to run without an owning project
+        // (AudioIO.cpp: `if (mOwningProject.expired()) return false;`),
+        // so load a real (empty) one, like au3record_tests does.
+        m_au3ProjectAccessor = std::make_shared<au::au3::Au3ProjectAccessor>(muse::modularity::globalCtx());
+        const std::string source = std::string(au3audio_tests_DATA_ROOT) + "/../../trackedit/tests/data/empty.aup4";
+        m_workingProjectPath = std::string(au3audio_tests_DATA_ROOT) + "/monitoring_working.aup4";
+        testtools::removeProjectIfExists(m_workingProjectPath);
+        ASSERT_TRUE(testtools::copyFile(source, m_workingProjectPath));
+        constexpr auto discardAutosave = false;
+        ASSERT_TRUE(m_au3ProjectAccessor->load(muse::io::path_t(m_workingProjectPath), discardAutosave));
+    }
+
+    void TearDown() override
+    {
+        m_pacer->release(); // Deinit joins the audio thread
+        AudioIO::Deinit();
+        AudioIoCallback::SetAudioThreadPacerForTests(nullptr);
+
+        if (m_au3ProjectAccessor && m_au3ProjectAccessor->au3ProjectPtr()) {
+            m_au3ProjectAccessor->clearSavedState();
+            m_au3ProjectAccessor->close();
+        }
+        testtools::removeProjectIfExists(m_workingProjectPath);
+    }
+
+    au::au3::Au3Project& projectRef() const
+    {
+        return *reinterpret_cast<au::au3::Au3Project*>(m_au3ProjectAccessor->au3ProjectPtr());
+    }
+
+    //! Points the recording-device prefs at a usable capture device.
+    //! Selects "test_null" if available (headless CI), else tries default input device first, because likely less flaky than other random devices.
+    //! Returns false if none exists.
+    bool selectCaptureDevice()
+    {
+        const PaDeviceIndex deviceCount = Pa_GetDeviceCount();
+        const PaDeviceInfo* chosen = nullptr;
+        for (PaDeviceIndex i = 0; i < deviceCount; ++i) {
+            const PaDeviceInfo* info = Pa_GetDeviceInfo(i);
+            if (info && info->maxInputChannels > 0 && std::string(info->name) == "test_null") {
+                chosen = info;
+                break;
+            }
+        }
+        if (!chosen) {
+            const PaDeviceIndex defaultInput = Pa_GetDefaultInputDevice();
+            if (defaultInput != paNoDevice) {
+                chosen = Pa_GetDeviceInfo(defaultInput);
+            }
+        }
+        for (PaDeviceIndex i = 0; !chosen && i < deviceCount; ++i) {
+            const PaDeviceInfo* info = Pa_GetDeviceInfo(i);
+            if (info && info->maxInputChannels > 0) {
+                chosen = info;
+            }
+        }
+        if (!chosen) {
+            return false;
+        }
+        const PaHostApiInfo* host = Pa_GetHostApiInfo(chosen->hostApi);
+        AudioIOHost.Write(host->name);
+        AudioIORecordingDevice.Write(chosen->name);
+        AudioIORecordChannels.Write(std::min(2, chosen->maxInputChannels));
+        return true;
+    }
+
+    std::shared_ptr<test::AudioThreadLoopController> m_pacer;
+    std::shared_ptr<au::au3::Au3ProjectAccessor> m_au3ProjectAccessor;
+    std::string m_workingProjectPath;
+};
+
+//! https://github.com/audacity/audacity/issues/11571 and https://github.com/audacity/audacity/issues/11825
+//! are caused by `StartMonitoring` - `StopMonitoring` calls sufficiently fast one after the other so that
+//! the `AudioThread` doesn't have time to complete the otherwise expected iterations.
+//!
+//! (In #11825 the calls are fast because due to repeated track-focus toggling (and hence monitoring) upon track creation.
+//! In #11571 it was for something similar.)
+//!
+//! We simulate this situation by not letting the `AudioThreadLoopController` any iteration of the `AudioThread` loop complete.
+TEST_F(MainAndAudioThreadConcurrencyTest, ImmediateStopAfterStartDoesNotDeadlock)
+{
+    // Three iterations are normally sufficient for the handshake to complete.
+    constexpr auto maxLoopIterations = 3;
+    m_pacer = std::make_shared<test::AudioThreadLoopController>(maxLoopIterations);
+
+    AudioIoCallback::SetAudioThreadPacerForTests(m_pacer);
+    AudioIO::Init();
+
+    if (!selectCaptureDevice()) {
+        GTEST_SKIP() << "no capture device available";
+    }
+
+    AudioIO* gAudioIO = AudioIO::Get();
+    const AudioIOStartStreamOptions options(projectRef().shared_from_this(), 44100.0);
+
+    gAudioIO->StartMonitoring(options);
+    ASSERT_TRUE(gAudioIO->IsMonitoring());
+    gAudioIO->StopMonitoring();
+
+    EXPECT_FALSE(m_pacer->waitGaveUp()) << "acknowledge handshake never completed";
+}
+} // namespace au::au3audio

--- a/src/au3audio/tests/environment.cpp
+++ b/src/au3audio/tests/environment.cpp
@@ -1,0 +1,13 @@
+/*
+* Audacity: A Digital Audio Editor
+*/
+
+#include "testing/environment.h"
+
+#include "au3wrap/au3wrapmodule.h"
+
+//! Au3WrapModule provides the au3 settings bridge (gPrefs) and the project
+//! implementation needed by Au3ProjectAccessor.
+static muse::testing::SuiteEnvironment au3audio_se
+    = muse::testing::SuiteEnvironment()
+      .setDependencyModules({ new au::au3::Au3WrapModule(), });

--- a/src/au3audio/tests/mocks/audiothreadloopcontroller.h
+++ b/src/au3audio/tests/mocks/audiothreadloopcontroller.h
@@ -1,0 +1,71 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+#include <chrono>
+#include <condition_variable>
+#include <mutex>
+#include <string>
+
+#include "au3-audio-io/AudioIO.h"
+
+namespace au::au3audio::test {
+/**
+ * @brief Allows control of the AudioThread loop iterations.
+ */
+class AudioThreadLoopController final : public AudioIoCallback::AudioThreadPacer
+{
+public:
+    AudioThreadLoopController(int maxLoopIterations, int audioThreadIterationsPerMainThreadWait = 1)
+        : m_maxLoopIterations{maxLoopIterations}, m_audioThreadIterationsPerMainThreadWait{audioThreadIterationsPerMainThreadWait} {}
+
+    //! NOTE: Must be called before AudioIO::Deinit, which joins the (otherwise blocked) thread.
+    void release()
+    {
+        std::unique_lock<std::mutex> lock(m_mutex);
+        m_released = true;
+        m_cv.notify_all();
+    }
+
+    bool waitGaveUp() const { return m_completed >= m_maxLoopIterations; }
+
+    // Called by production code.
+private:
+    // ... from AudioThread
+    void SleepUntil(const std::chrono::steady_clock::time_point&) override
+    {
+        std::unique_lock<std::mutex> lock(m_mutex);
+        m_cv.wait(lock, [this] {
+            return m_released || m_allowed > m_completed;
+        });
+        ++m_completed;
+        m_cv.notify_all();
+    }
+
+    // ... from Main thread
+    void SleepFor(const std::chrono::milliseconds&) override
+    {
+        std::unique_lock<std::mutex> lock(m_mutex);
+        m_allowed += m_audioThreadIterationsPerMainThreadWait;
+        m_cv.notify_all();
+        m_cv.wait(lock, [this] {
+            return m_completed >= m_allowed;
+        });
+    }
+
+    // ... from Main thread
+    bool KeepWaiting() const override
+    {
+        return m_completed < m_maxLoopIterations;
+    }
+
+private:
+    std::mutex m_mutex;
+    std::condition_variable m_cv;
+
+    const int m_maxLoopIterations;
+    const int m_audioThreadIterationsPerMainThreadWait;
+    int m_allowed = 0;
+    int m_completed = 0;
+    bool m_released = false;
+};
+}


### PR DESCRIPTION
Resolves: #11571
Resolves: #11825

This PR intends to decouple input monitoring start and stop mechanism from the audio thread (where the audio is processed), as in principle it only needs an audio stream (in both capture and render directions). The difficulty is to disentangle the two without causing a regression.

The diff is larger than in the [original PR](https://github.com/audacity/audacity/pull/11572), but hopefully the code in its final state will make more sense.

A markdown file was added with sequence diagrams of the said mechanism and why it deadlocked.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Play/pause/seek work without freezing
- [ ] No regression with the monitoring toggles
- [ ] Testflow test cases have been run
