### PR TITLE
11568 prefer lossy format on cloud upload audio preview

### DIFF
--- a/src/au3cloud/iau3cloudconfiguration.h
+++ b/src/au3cloud/iau3cloudconfiguration.h
@@ -20,7 +20,7 @@ public:
     virtual muse::io::path_t cloudProjectsPath() const = 0;
     virtual void setCloudProjectsPath(const muse::io::path_t& path) = 0;
 
-    virtual std::vector<std::string> preferredAudioFormats() const = 0;
+    virtual std::vector<std::string> preferredAudioFormats(bool preferLossless = true) const = 0;
     virtual std::string exportConfig(const std::string& mimeType) const = 0;
 
     virtual bool shouldWarnOnSyncError() const = 0;

--- a/src/au3cloud/internal/au3audiocomservice.cpp
+++ b/src/au3cloud/internal/au3audiocomservice.cpp
@@ -630,7 +630,7 @@ muse::RetVal<muse::ProgressPtr> Au3AudioComService::updateAudioPreview(au::proje
             return;
         }
 
-        const auto preferredFormats = self->exporter()->cloudPreferredAudioFormats();
+        const auto preferredFormats = self->exporter()->cloudPreferredAudioFormats(false);
         if (preferredFormats.empty()) {
             progress->finish(make_ret(Err::NoExportPlugin));
             return;

--- a/src/au3cloud/internal/au3audiocomservice.cpp
+++ b/src/au3cloud/internal/au3audiocomservice.cpp
@@ -597,6 +597,7 @@ muse::RetVal<muse::ProgressPtr> Au3AudioComService::updateAudioPreview(au::proje
                                                          muse::trc("cloud", "Project is not synced with the cloud"));
     }
 
+    const std::string projectPage = ::getCloudProjectPage(project);
     muse::ProgressPtr progress = std::make_shared<muse::Progress>();
 
     if (auto oldProgress = std::exchange(m_audioPreviewProgress, progress)) {
@@ -617,7 +618,7 @@ muse::RetVal<muse::ProgressPtr> Au3AudioComService::updateAudioPreview(au::proje
         cancellationContext->Cancel();
     });
 
-    std::thread([weak = weak_from_this(), project, progress, cancellationContext, projectId, snapshotId]() {
+    std::thread([weak = weak_from_this(), project, progress, cancellationContext, projectId, snapshotId, projectPage]() {
         auto self = weak.lock();
         if (!self) {
             progress->finish(muse::make_ret(muse::Ret::Code::InternalError, muse::trc("cloud", "Service destroyed")));
@@ -687,7 +688,7 @@ muse::RetVal<muse::ProgressPtr> Au3AudioComService::updateAudioPreview(au::proje
         cancellationContext->OnCancelled(response);
 
         response->setRequestFinishedCallback(
-            [self, response, progress, cancellationContext, tempPath](auto) {
+            [self, response, progress, cancellationContext, tempPath, projectPage](auto) {
             if (response->getError() != audacity::network_manager::NetworkError::NoError) {
                 self->filesystem()->remove(tempPath);
                 if (!progress->isCanceled()) {
@@ -718,7 +719,7 @@ muse::RetVal<muse::ProgressPtr> Au3AudioComService::updateAudioPreview(au::proje
                 audacity::cloud::audiocom::GetServiceConfig(),
                 syncState->MixdownUrls,
                 tempPath.toStdString(),
-                [progress, tempPath, filesystem = self->filesystem()](audacity::cloud::audiocom::ResponseResult result) {
+                [progress, tempPath, projectPage, filesystem = self->filesystem()](audacity::cloud::audiocom::ResponseResult result) {
                 filesystem->remove(tempPath);
 
                 if (progress->isCanceled()) {
@@ -726,7 +727,7 @@ muse::RetVal<muse::ProgressPtr> Au3AudioComService::updateAudioPreview(au::proje
                 }
 
                 if (result.Code == audacity::cloud::audiocom::SyncResultCode::Success) {
-                    progress->finish(muse::make_ok());
+                    progress->finish(muse::RetVal<muse::Val>::make_ok(muse::Val(projectPage)));
                 } else if (result.Code == audacity::cloud::audiocom::SyncResultCode::Cancelled) {
                     progress->finish(make_ret(Err::Cancelled));
                 } else {

--- a/src/au3cloud/internal/au3cloudconfiguration.cpp
+++ b/src/au3cloud/internal/au3cloudconfiguration.cpp
@@ -30,9 +30,9 @@ void Au3CloudConfiguration::setCloudProjectsPath(const muse::io::path_t& path)
     audacity::cloud::audiocom::CloudProjectsSavePath.Write(path.toStdString());
 }
 
-std::vector<std::string> Au3CloudConfiguration::preferredAudioFormats() const
+std::vector<std::string> Au3CloudConfiguration::preferredAudioFormats(bool preferLossless) const
 {
-    return audacity::cloud::audiocom::GetServiceConfig().GetPreferredAudioFormats(true);
+    return audacity::cloud::audiocom::GetServiceConfig().GetPreferredAudioFormats(preferLossless);
 }
 
 std::string Au3CloudConfiguration::exportConfig(const std::string& mimeType) const

--- a/src/au3cloud/internal/au3cloudconfiguration.h
+++ b/src/au3cloud/internal/au3cloudconfiguration.h
@@ -14,7 +14,7 @@ public:
     muse::io::path_t cloudProjectsPath() const override;
     void setCloudProjectsPath(const muse::io::path_t& path) override;
 
-    std::vector<std::string> preferredAudioFormats() const override;
+    std::vector<std::string> preferredAudioFormats(bool preferLossless) const override;
     std::string exportConfig(const std::string& mimeType) const override;
 
     bool shouldWarnOnSyncError() const override;

--- a/src/importexport/export/iexporter.h
+++ b/src/importexport/export/iexporter.h
@@ -46,7 +46,7 @@ public:
     virtual std::vector<std::string> formatsList() const = 0;
     virtual int formatIndex(const std::string& format) const = 0;
     virtual std::vector<std::string> formatExtensions(const std::string& format) const = 0;
-    virtual std::vector<std::string> cloudPreferredAudioFormats() const = 0;
+    virtual std::vector<std::string> cloudPreferredAudioFormats(bool preferLossless = true) const = 0;
     virtual ExportParameters cloudExportParameters(const std::string& format) const = 0;
     virtual bool isCustomFFmpegExportFormat() const = 0;
     virtual bool isOggExportFormat() const = 0;

--- a/src/importexport/export/internal/au3/au3exporter.cpp
+++ b/src/importexport/export/internal/au3/au3exporter.cpp
@@ -416,12 +416,12 @@ std::vector<std::string> Au3Exporter::formatExtensions(const std::string& format
     return {};
 }
 
-std::vector<std::string> Au3Exporter::cloudPreferredAudioFormats() const
+std::vector<std::string> Au3Exporter::cloudPreferredAudioFormats(bool preferLossless) const
 {
     const auto& registry = ExportPluginRegistry::Get();
 
     std::vector<std::string> result;
-    for (const auto& mimeType : cloudConfiguration()->preferredAudioFormats()) {
+    for (const auto& mimeType : cloudConfiguration()->preferredAudioFormats(preferLossless)) {
         for (auto [plugin, formatIndex] : registry) {
             for (const auto& mime : plugin->GetMimeTypes(formatIndex)) {
                 if (mime == mimeType) {

--- a/src/importexport/export/internal/au3/au3exporter.h
+++ b/src/importexport/export/internal/au3/au3exporter.h
@@ -37,7 +37,7 @@ public:
     std::vector<std::string> formatsList() const override;
     int formatIndex(const std::string& format) const override;
     std::vector<std::string> formatExtensions(const std::string& format) const override;
-    std::vector<std::string> cloudPreferredAudioFormats() const override;
+    std::vector<std::string> cloudPreferredAudioFormats(bool preferLossless) const override;
     ExportParameters cloudExportParameters(const std::string& format) const override;
     bool isCustomFFmpegExportFormat() const override;
     bool isOggExportFormat() const override;

--- a/src/project/internal/projectactionscontroller.cpp
+++ b/src/project/internal/projectactionscontroller.cpp
@@ -1487,8 +1487,13 @@ void ProjectActionsController::doUpdateCloudAudioPreview(const IAudacityProjectP
             }
 
             if (result.ret.success()) {
-                interactive()->info(trc("cloud", "Cloud audio preview updated"),
-                                    trc("cloud", "The audio preview has been uploaded to audio.com"));
+                const std::string url = result.val.toString();
+                if (url.empty()) {
+                    LOGE() << "Cannot open cloud project page: empty URL";
+                    return;
+                }
+
+                platformInteractive()->openUrl(url);
                 return;
             }
 

--- a/src/stubs/au3cloud/au3cloudconfigurationstub.cpp
+++ b/src/stubs/au3cloud/au3cloudconfigurationstub.cpp
@@ -14,7 +14,7 @@ void Au3CloudConfigurationStub::setCloudProjectsPath(const muse::io::path_t&)
 {
 }
 
-std::vector<std::string> Au3CloudConfigurationStub::preferredAudioFormats() const
+std::vector<std::string> Au3CloudConfigurationStub::preferredAudioFormats(bool) const
 {
     return {};
 }

--- a/src/stubs/au3cloud/au3cloudconfigurationstub.h
+++ b/src/stubs/au3cloud/au3cloudconfigurationstub.h
@@ -12,7 +12,7 @@ public:
     muse::io::path_t cloudProjectsPath() const override;
     void setCloudProjectsPath(const muse::io::path_t& path) override;
 
-    std::vector<std::string> preferredAudioFormats() const override;
+    std::vector<std::string> preferredAudioFormats(bool preferLossless) const override;
     std::string exportConfig(const std::string& mimeType) const override;
 
     bool shouldWarnOnSyncError() const override;


### PR DESCRIPTION
Resolves: #11568 

Upload audio preview in using a loss format just as au3.
This makes the preview to be available faster.
I still see "Couldn't load preview" while the preview is loading once in a while but it is the same on au3 here.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
