### PR TITLE
11416 effect panel default focus control

### DIFF
--- a/src/appshell/qml/Audacity/AppShell/ProjectPage/ProjectPage.qml
+++ b/src/appshell/qml/Audacity/AppShell/ProjectPage/ProjectPage.qml
@@ -60,22 +60,26 @@ DockPage {
         order: 2
     }
 
-    property NavigationSection trackEffectsKeyNavSec: NavigationSection {
-        name: "TrackEffectsSection"
+    property NavigationSection effectsKeyNavSec: NavigationSection {
+        name: "EffectsSection"
         enabled: root.visible && tracksPanel.showEffectsSection
         order: playbackToolBarKeyNavSec.order + 1
     }
 
-    property NavigationSection masterEffectsKeyNavSec: NavigationSection {
-        name: "MasterEffectsSection"
+    property NavigationPanel effectsKeyNavPanel: NavigationPanel {
+        name: "EffectsPanel"
+        section: root.effectsKeyNavSec
         enabled: root.visible && tracksPanel.showEffectsSection
-        order: trackEffectsKeyNavSec.order + 1
+        direction: NavigationPanel.Vertical
+        order: 0
+
+        accessible.name: qsTrc("appshell", "Real-time effects panel")
     }
 
     property NavigationSection addNewTrackKeyNavSec: NavigationSection {
         name: "AddNewTrackSection"
         enabled: root.visible
-        order: masterEffectsKeyNavSec.order + 1
+        order: effectsKeyNavSec.order + 1
     }
 
     property NavigationSection keynavTopPanelSec: NavigationSection {
@@ -318,6 +322,7 @@ DockPage {
                     id: trackstitleBarItem
 
                     navigation.section: root.addNewTrackKeyNavSec
+                    effectsNavigationPanel: root.effectsKeyNavPanel
 
                     effectsSectionWidth: tracksPanel.effectsSectionWidth
                     showEffectsSection: tracksPanel.showEffectsSection
@@ -342,11 +347,8 @@ DockPage {
 
                     navigationPanels: tracksNavModel.trackItemPanels
                     headerNavigationPanels: tracksNavModel.trackHeaderPanels
-                    effectColumnNavigationPanel: trackstitleBarItem.closeEffectsNavigation
+                    effectsNavigationPanel: root.effectsKeyNavPanel
                     effectsSectionWidth: tracksPanel.effectsSectionWidth
-
-                    trackEffectsNavigationSection: root.trackEffectsKeyNavSec
-                    masterEffectsNavigationSection: root.masterEffectsKeyNavSec
 
                     onOpenEffectsRequested: {
                         tracksPanel.showEffectsSection = true

--- a/src/project/internal/projectuiactions.cpp
+++ b/src/project/internal/projectuiactions.cpp
@@ -325,7 +325,7 @@ const UiActionList ProjectUiActions::m_actions = {
              ),
     UiAction("toggle-effects",
              au::context::UiCtxAny,
-             au::context::CTX_ANY,
+             au::context::CTX_PROJECT_OPENED,
              //: Action title: shown as a menu item or a button label; keep it short
              TranslatableString("action", "Show effects panel"),
              //: Action description: shown as a tooltip; can be a full sentence
@@ -494,7 +494,7 @@ const UiActionList ProjectUiActions::m_actions = {
     // effects menu
     UiAction("add-realtime-effects",
              au::context::UiCtxAny,
-             au::context::CTX_ANY,
+             au::context::CTX_PROJECT_OPENED,
              //: Action title: shown as a menu item or a button label; keep it short
              TranslatableString("action", "Add track effects"),
              //: Action description: shown as a tooltip; can be a full sentence

--- a/src/projectscene/qml/Audacity/ProjectScene/trackspanel/TrackEffectList.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/trackspanel/TrackEffectList.qml
@@ -25,6 +25,7 @@ Rectangle {
     property int pendingGripFocusIndex: -1
     property bool pendingGripFocusHandle: false
     property int pendingDialogRestoreIndex: -1
+    readonly property bool hasPendingDialogRestore: root.pendingDialogRestoreIndex >= 0
 
     Component.onCompleted: {
         trackEffectListModel.load()

--- a/src/projectscene/qml/Audacity/ProjectScene/trackspanel/TrackEffectsSection.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/trackspanel/TrackEffectsSection.qml
@@ -28,6 +28,10 @@ Rectangle {
         menuModel.init()
     }
 
+    function requestActive() {
+        addEffectButton.navigation.requestActive()
+    }
+
     QtObject {
         id: prv
         property bool enabled: effectList.trackName !== ""

--- a/src/projectscene/qml/Audacity/ProjectScene/trackspanel/TrackEffectsSection.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/trackspanel/TrackEffectsSection.qml
@@ -20,6 +20,7 @@ Rectangle {
     property NavigationPanel navigationPanel: null
     property int navigationOrderStart: 0
     readonly property int navigationOrderEnd: navigationOrderStart + effectList.count + 1
+    property alias hasPendingDialogRestore: effectList.hasPendingDialogRestore
 
     color: ui.theme.backgroundPrimaryColor
 

--- a/src/projectscene/qml/Audacity/ProjectScene/trackspanel/TrackEffectsSection.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/trackspanel/TrackEffectsSection.qml
@@ -17,7 +17,6 @@ Rectangle {
     property alias isMasterTrack: effectList.isMasterTrack
     property alias minimumHeight: prv.addEffectButtonHeight
 
-    property NavigationSection navigationSection: null
     property NavigationPanel navigationPanel: null
     property int navigationOrderStart: 0
     readonly property int navigationOrderEnd: navigationOrderStart + effectList.count + 1

--- a/src/projectscene/qml/Audacity/ProjectScene/trackspanel/TracksPanel.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/trackspanel/TracksPanel.qml
@@ -82,7 +82,7 @@ Item {
                 onFocusEffectsPanelRequested: {
                     Qt.callLater(function () {
                         if (root.effectColumnNavigationPanel && effectColumn.visible) {
-                            root.effectColumnNavigationPanel.requestActive()
+                            trackEffectsSection.requestActive()
                         }
                     })
                 }
@@ -266,6 +266,8 @@ Item {
                                 tracksModel.focusTrack(index)
                                 effectSectionModel.showEffectsSection = true
                                 root.openEffectsRequested()
+
+                                trackEffectsSection.requestActive()
                             }
 
                             onRemoveSelectionRequested: {

--- a/src/projectscene/qml/Audacity/ProjectScene/trackspanel/TracksPanel.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/trackspanel/TracksPanel.qml
@@ -22,10 +22,7 @@ Item {
 
     property var navigationPanels: null
     property var headerNavigationPanels: null
-    property NavigationPanel effectColumnNavigationPanel: null
-
-    property NavigationSection trackEffectsNavigationSection: null
-    property NavigationSection masterEffectsNavigationSection: null
+    property NavigationPanel effectsNavigationPanel: null
 
     signal openEffectsRequested
     signal panelActive(var trackId)
@@ -81,7 +78,7 @@ Item {
 
                 onFocusEffectsPanelRequested: {
                     Qt.callLater(function () {
-                        if (root.effectColumnNavigationPanel && effectColumn.visible) {
+                        if (root.effectsNavigationPanel && effectColumn.visible) {
                             trackEffectsSection.requestActive()
                         }
                     })
@@ -93,8 +90,7 @@ Item {
             TrackEffectsSection {
                 id: trackEffectsSection
 
-                navigationSection: trackEffectsNavigationSection
-                navigationPanel: root.effectColumnNavigationPanel
+                navigationPanel: root.effectsNavigationPanel
                 navigationOrderStart: 1
 
                 Layout.fillWidth: true
@@ -136,8 +132,7 @@ Item {
             TrackEffectsSection {
                 id: masterEffectsSection
 
-                navigationSection: masterEffectsNavigationSection
-                navigationPanel: root.effectColumnNavigationPanel
+                navigationPanel: root.effectsNavigationPanel
                 navigationOrderStart: trackEffectsSection.navigationOrderEnd + 1
 
                 Layout.fillWidth: true

--- a/src/projectscene/qml/Audacity/ProjectScene/trackspanel/TracksPanel.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/trackspanel/TracksPanel.qml
@@ -76,6 +76,8 @@ Item {
             RealtimeEffectSectionModel {
                 id: effectSectionModel
 
+                navigationFocusInsideEffectsPanel: root.effectsNavigationPanel.section.active || trackEffectsSection.hasPendingDialogRestore || masterEffectsSection.hasPendingDialogRestore
+
                 onFocusEffectsPanelRequested: {
                     Qt.callLater(function () {
                         if (root.effectsNavigationPanel && effectColumn.visible) {

--- a/src/projectscene/qml/Audacity/ProjectScene/trackspanel/TracksTitleBar.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/trackspanel/TracksTitleBar.qml
@@ -9,9 +9,8 @@ Item {
     id: root
 
     property alias navigation: buttonContainer.navigation
-    property alias realtimeEffectsNavigation: effectsTitleBar.navigation
-    property alias closeEffectsNavigation: effectsTitleBar.navigation
     property alias addTrackNavigation: addNewTrackBtn.navigation
+    property NavigationPanel effectsNavigationPanel: null
 
     property int effectsSectionWidth: 0
     property bool showEffectsSection: false
@@ -48,15 +47,6 @@ Item {
             id: effectsTitleBar
 
             property int padding: parent.height / 4
-            property NavigationPanel navigation: NavigationPanel {
-                name: "RealtimeEffectsSectionPanel"
-                enabled: root.enabled && root.visible && root.showEffectsSection
-                section: buttonContainer.navigation.section
-                direction: NavigationPanel.Vertical
-                order: 0
-
-                accessible.name: qsTrc("projectscene", "Real-time effects panel")
-            }
 
             Layout.preferredWidth: root.effectsSectionWidth
             Layout.preferredHeight: root.height
@@ -94,7 +84,7 @@ Item {
                     height: parent.height - 2 * effectsTitleBar.padding
 
                     navigation.name: "CloseEffectsSection"
-                    navigation.panel: effectsTitleBar.navigation
+                    navigation.panel: root.effectsNavigationPanel
                     navigation.order: 0
 
                     //: Tooltip of the button that closes the panel

--- a/src/projectscene/view/trackspanel/realtimeeffectsectionmodel.cpp
+++ b/src/projectscene/view/trackspanel/realtimeeffectsectionmodel.cpp
@@ -3,6 +3,9 @@
  */
 #include "realtimeeffectsectionmodel.h"
 
+#include <algorithm>
+#include <utility>
+
 using namespace muse;
 using namespace au::projectscene;
 
@@ -14,6 +17,12 @@ RealtimeEffectSectionModel::RealtimeEffectSectionModel(QObject* parent)
 void RealtimeEffectSectionModel::load()
 {
     configuration()->isEffectsPanelVisibleChanged().onNotify(this, [this]() {
+        if (configuration()->isEffectsPanelVisible()) {
+            savePreviouslyFocusedControl();
+        } else {
+            restorePreviouslyFocusedControl();
+        }
+
         emit showEffectsSectionChanged();
     });
 
@@ -44,4 +53,47 @@ bool RealtimeEffectSectionModel::prop_showEffectsSection() const
 void RealtimeEffectSectionModel::prop_setShowEffectsSection(bool show)
 {
     configuration()->setIsEffectsPanelVisible(show);
+}
+
+bool RealtimeEffectSectionModel::prop_navigationFocusInsideEffectsPanel() const
+{
+    return m_navigationFocusInsideEffectsPanel;
+}
+
+void RealtimeEffectSectionModel::prop_setNavigationFocusInsideEffectsPanel(bool inside)
+{
+    if (m_navigationFocusInsideEffectsPanel == inside) {
+        return;
+    }
+
+    m_navigationFocusInsideEffectsPanel = inside;
+    emit navigationFocusInsideEffectsPanelChanged();
+}
+
+void RealtimeEffectSectionModel::savePreviouslyFocusedControl()
+{
+    m_previouslyFocusedControl = navigationController()->activeControl();
+}
+
+void RealtimeEffectSectionModel::restorePreviouslyFocusedControl()
+{
+    muse::ui::INavigationControl* const control = std::exchange(m_previouslyFocusedControl, nullptr);
+    if (!control || !m_navigationFocusInsideEffectsPanel) {
+        return;
+    }
+
+    const std::set<muse::ui::INavigationSection*>& sections = navigationController()->sections();
+    const bool isRegistered = std::any_of(sections.cbegin(), sections.cend(), [control](const muse::ui::INavigationSection* section) {
+        const std::set<muse::ui::INavigationPanel*>& panels = section->panels();
+
+        return std::any_of(panels.cbegin(), panels.cend(), [control](const muse::ui::INavigationPanel* panel) {
+            return panel->controls().count(control) > 0;
+        });
+    });
+
+    if (!isRegistered) {
+        return;
+    }
+
+    control->requestActive();
 }

--- a/src/projectscene/view/trackspanel/realtimeeffectsectionmodel.cpp
+++ b/src/projectscene/view/trackspanel/realtimeeffectsectionmodel.cpp
@@ -27,19 +27,11 @@ void RealtimeEffectSectionModel::load()
     });
 
     dispatcher()->reg(this, "toggle-effects", [this] {
-        const bool shouldShow = !configuration()->isEffectsPanelVisible();
-        configuration()->setIsEffectsPanelVisible(shouldShow);
-        if (shouldShow) {
-            emit focusEffectsPanelRequested();
-        }
+        toggleEffectsPanel();
     });
 
     dispatcher()->reg(this, "add-realtime-effects", [this] {
-        const bool shouldShow = !configuration()->isEffectsPanelVisible();
-        configuration()->setIsEffectsPanelVisible(shouldShow);
-        if (shouldShow) {
-            emit focusEffectsPanelRequested();
-        }
+        toggleEffectsPanel();
     });
 
     emit showEffectsSectionChanged();
@@ -68,6 +60,20 @@ void RealtimeEffectSectionModel::prop_setNavigationFocusInsideEffectsPanel(bool 
 
     m_navigationFocusInsideEffectsPanel = inside;
     emit navigationFocusInsideEffectsPanelChanged();
+}
+
+void RealtimeEffectSectionModel::toggleEffectsPanel()
+{
+    const muse::ui::INavigationSection* section = navigationController()->activeSection();
+    if (section && section->type() == muse::ui::INavigationSection::Type::Exclusive) {
+        return;
+    }
+
+    const bool shouldShow = !configuration()->isEffectsPanelVisible();
+    configuration()->setIsEffectsPanelVisible(shouldShow);
+    if (shouldShow) {
+        emit focusEffectsPanelRequested();
+    }
 }
 
 void RealtimeEffectSectionModel::savePreviouslyFocusedControl()

--- a/src/projectscene/view/trackspanel/realtimeeffectsectionmodel.h
+++ b/src/projectscene/view/trackspanel/realtimeeffectsectionmodel.h
@@ -8,6 +8,7 @@
 #include "actions/actionable.h"
 #include "async/asyncable.h"
 #include "modularity/ioc.h"
+#include "ui/inavigationcontroller.h"
 #include <QObject>
 #include <map>
 
@@ -17,10 +18,13 @@ class RealtimeEffectSectionModel : public QObject, public muse::actions::Actiona
     Q_OBJECT
 
     Q_PROPERTY(bool showEffectsSection READ prop_showEffectsSection WRITE prop_setShowEffectsSection NOTIFY showEffectsSectionChanged)
+    Q_PROPERTY(
+        bool navigationFocusInsideEffectsPanel READ prop_navigationFocusInsideEffectsPanel WRITE prop_setNavigationFocusInsideEffectsPanel NOTIFY navigationFocusInsideEffectsPanelChanged)
 
     muse::GlobalInject<IProjectSceneConfiguration> configuration;
 
     muse::ContextInject<muse::actions::IActionsDispatcher> dispatcher{ this };
+    muse::ContextInject<muse::ui::INavigationController> navigationController{ this };
 
 public:
     explicit RealtimeEffectSectionModel(QObject* parent = nullptr);
@@ -30,8 +34,19 @@ public:
     bool prop_showEffectsSection() const;
     void prop_setShowEffectsSection(bool show);
 
+    bool prop_navigationFocusInsideEffectsPanel() const;
+    void prop_setNavigationFocusInsideEffectsPanel(bool inside);
+
 signals:
     void showEffectsSectionChanged();
     void focusEffectsPanelRequested();
+    void navigationFocusInsideEffectsPanelChanged();
+
+private:
+    void savePreviouslyFocusedControl();
+    void restorePreviouslyFocusedControl();
+
+    muse::ui::INavigationControl* m_previouslyFocusedControl = nullptr;
+    bool m_navigationFocusInsideEffectsPanel = false;
 };
 }

--- a/src/projectscene/view/trackspanel/realtimeeffectsectionmodel.h
+++ b/src/projectscene/view/trackspanel/realtimeeffectsectionmodel.h
@@ -43,6 +43,8 @@ signals:
     void navigationFocusInsideEffectsPanelChanged();
 
 private:
+    void toggleEffectsPanel();
+
     void savePreviouslyFocusedControl();
     void restorePreviouslyFocusedControl();
 


### PR DESCRIPTION
Resolves: #11416 

Shift focus to add effects btn when entering the effect panel by shortcut 'e' or by pressing the effect button on track panel.
When entering the panel the previous control is persisted so we can go back to it when closing the effect panel.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Check for regressions on effect panel navigation, including tabing in an out the panel and navigating the elements inside the panel.
- [ ] Press 'e' to enter and close the panel while different elements in focus.
- [ ] Close effect panel while some effect dialog is opened.

- [ ] Testflow test cases have been run
