### PR TITLE
11604 mark plugins that crash audacity as broken

### DIFF
--- a/src/effects/effects_base/internal/au3effectloader.cpp
+++ b/src/effects/effects_base/internal/au3effectloader.cpp
@@ -68,6 +68,11 @@ bool Au3EffectLoader::ensurePluginIsLoaded(const EffectId& effectId)
     ::PluginDescriptor desc;
     ::PluginPath au3path;
 
+    // Loading a third-party binary may crash the whole application; leave a
+    // sentinel on disk so the plugin gets marked as broken at the next launch
+    // if we don't survive this (see IAudioPluginsLoadGuard).
+    loadGuard()->beginLoad(effectId.toStdString());
+
     // We need the complete effect's path, e.g. in VST a .vst3 bundle (one path) may contain several effects.
     // Hence an effect's UUID is appended to the .vst3 path for disambiguation.
     m_pluginProvider.DiscoverPluginsAtPath(
@@ -84,12 +89,10 @@ bool Au3EffectLoader::ensurePluginIsLoaded(const EffectId& effectId)
         return desc.GetID();
     });
 
-    if (au3path.empty()) {
-        LOGE() << "Failed to find plugin path for effect: " << effectId;
-        return false;
-    }
-
     m_loadedInterfaces.emplace(effectId, m_pluginProvider.LoadPlugin(au3path));
+
+    loadGuard()->endLoad(effectId.toStdString());
+
     if (!m_loadedInterfaces.at(effectId)) {
         LOGE() << "Failed to load plugin: " << effectId;
         m_loadedInterfaces.erase(effectId);

--- a/src/effects/effects_base/internal/au3effectloader.h
+++ b/src/effects/effects_base/internal/au3effectloader.h
@@ -8,6 +8,7 @@
 #include "au3-components/ComponentInterface.h"
 
 #include "framework/audioplugins/iknownaudiopluginsregister.h"
+#include "framework/audioplugins/iaudiopluginsloadguard.h"
 #include "framework/global/modularity/ioc.h"
 
 class PluginProvider;
@@ -17,6 +18,7 @@ class Au3EffectLoader : public IEffectLoader
 {
 public:
     muse::GlobalInject<muse::audioplugins::IKnownAudioPluginsRegister> knownPlugins;
+    muse::GlobalInject<muse::audioplugins::IAudioPluginsLoadGuard> loadGuard;
 
 public:
     Au3EffectLoader(PluginProvider& provider, EffectFamily family);


### PR DESCRIPTION
Resolves: #11604

Integration of framework PR https://github.com/audacity/audacity/issues/11604, plus a few lines of integration.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

Try this (on MacOS):
* get an old BOREALIS MuseHub-distributed plugin from @saintmatthieu and paste it in `/Library/Audio/Plug-ins/VST3/`,
* in your known_audio_plugins.json, add the entry
```json
{
      "meta": {
        "attributes": {
          "activated": "true",
          "category": "None",
          "description": "n/a",
          "isRealtimeCapable": "true",
          "module": "Module__The Audacity Team_VST3 Effects_",
          "paramsAreInputAgnostic": "true",
          "title": "BOREALIS",
          "type": "Effect",
          "version": "1.6"
        },
        "id": "Effect_VST3_BOREALIS_/Library/Audio/Plug-ins/VST3/BOREALIS.vst3",
        "type": "VstPlugin",
        "vendor": "BABY Audio"
      },
      "path": "/Library/Audio/Plug-ins/VST3/BOREALIS.vst3",
      "state": "Validated"
    },
```
* run Audacity. Open a project, find that effect and open it. You should get a "Missing authorization" dialog, and then the app should crash.
* Start Audacity again. Reopen that project.
  * Look for the plugin: you shouldn't find it anymore.
  * In the Plugin manager, it should be listed as Broken.
- [ ] Testflow test cases have been run
