### PR TITLE
11460 remove cloud project from db when overwritten as local

### DIFF
--- a/src/project/internal/projectactionscontroller.cpp
+++ b/src/project/internal/projectactionscontroller.cpp
@@ -673,7 +673,7 @@ muse::Ret ProjectActionsController::saveProjectToCloud(const CloudProjectInfo& c
     }
 
     auto [uploadRet, progress] = audioComService()->uploadProject(project, cloudInfo.name.toStdString(), [this, projectFilePath]() {
-        return saveProjectLocally(projectFilePath, SaveMode::Save);
+        return doSaveProjectLocally(projectFilePath, SaveMode::Save);
     }, toUploadMode(cloudSaveMode));
 
     if (!uploadRet) {
@@ -740,6 +740,25 @@ muse::Ret ProjectActionsController::saveProjectToCloud(const CloudProjectInfo& c
 }
 
 bool ProjectActionsController::saveProjectLocally(const muse::io::path_t& filePath, SaveMode saveMode)
+{
+    IAudacityProjectPtr project = currentProject();
+    if (!project) {
+        return false;
+    }
+
+    if (cloudProjectsProvider()->projectRecordForPath(filePath).has_value()) {
+        LOGI() << "unregistering the cloud project at the local save destination: " << filePath;
+
+        const Ret deleteRet = audioComService()->deleteCloudProject(filePath);
+        if (!deleteRet) {
+            LOGW() << deleteRet.toString();
+        }
+    }
+
+    return doSaveProjectLocally(filePath, saveMode);
+}
+
+bool ProjectActionsController::doSaveProjectLocally(const muse::io::path_t& filePath, SaveMode saveMode)
 {
     IAudacityProjectPtr project = currentProject();
     if (!project) {

--- a/src/project/internal/projectactionscontroller.h
+++ b/src/project/internal/projectactionscontroller.h
@@ -112,6 +112,7 @@ private:
     muse::Ret canSaveProject() const;
     bool saveProject(SaveMode saveMode, SaveLocationType saveLocationType = SaveLocationType::Undefined, bool force = false);
     bool saveProjectAt(const SaveLocation& saveLocation, SaveMode saveMode = SaveMode::Save, bool force = false);
+    bool doSaveProjectLocally(const muse::io::path_t& filePath, SaveMode saveMode);
 
     RecentFile makeRecentFile(IAudacityProjectPtr project);
     void clearRecentProjects();


### PR DESCRIPTION
Resolves: #11460 

If we try to overwrite a cloud project using save as local now we remove the project from the cloud database and save it as a local project instead.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
