### PR TITLE
Fix copy-paste commands when the first track is created

### DIFF
--- a/src/trackedit/tests/tracknavigationmodel_tests.cpp
+++ b/src/trackedit/tests/tracknavigationmodel_tests.cpp
@@ -303,6 +303,68 @@ TEST_F(TrackNavigationModelTests, TrackAddedAppendsPanels)
 }
 
 /**
+ * Adding the first track to an empty project keeps navigation state in sync
+ */
+TEST_F(TrackNavigationModelTests, FirstAddedTrackFocusWaitsForNavigationControl)
+{
+    //! [GIVEN] An empty project with the fallback control
+    makeFallbackControl();
+    loadWithTracks({});
+
+    //! [WHEN] The first track is added before its control
+    m_trackAdded.send(makeTrack(20));
+
+    //! [AND] The tracks controller focuses it
+    m_focusedTrackChanged.send(20, false);
+
+    //! [THEN] Creating the control synchronizes navigation with the focused track
+    EXPECT_CALL(*m_navigationController,
+                requestActivateByName(std::string(SECTION_NAME), trackPanelName(20).toStdString(), std::string("track-20"))).Times(1);
+
+    addItemControl(m_model->trackItemPanels().at(0), "track-20", 0);
+}
+
+/**
+ * Inserting the first track to an empty project keeps navigation state in sync
+ */
+TEST_F(TrackNavigationModelTests, FirstInsertedTrackFocusWaitsForNavigationControl)
+{
+    //! [GIVEN] An empty project with the fallback control
+    makeFallbackControl();
+    loadWithTracks({});
+
+    //! [WHEN] The first track is inserted
+    m_trackInserted.send(makeTrack(20), 0);
+
+    //! [AND] The tracks controller focuses it before its control exists
+    m_focusedTrackChanged.send(20, false);
+
+    //! [THEN] Creating the control synchronizes navigation with the focused track
+    EXPECT_CALL(*m_navigationController, requestActivateByName(
+                    std::string(SECTION_NAME), trackPanelName(20).toStdString(), std::string("track-20"))).Times(1);
+
+    addItemControl(m_model->trackItemPanels().at(0), "track-20", 0);
+}
+
+/**
+ * Item focus is retained until QML creates the matching item control.
+ */
+TEST_F(TrackNavigationModelTests, FocusedItemWaitsForNavigationControl)
+{
+    //! [GIVEN] Without a navigation control
+    loadWithTracks({ makeTrack(20) });
+
+    //! [WHEN] An item is focused
+    m_focusedItemChanged.send({ 20, 200 }, false);
+
+    //! [THEN] Creating the navigation control executes pending navigation request
+    EXPECT_CALL(*m_navigationController, requestActivateByName(
+                    std::string(SECTION_NAME), itemsPanelName(20).toStdString(), std::string("200"))).Times(1);
+
+    addItemControl(m_model->viewItemPanels().at(0), "200", 0);
+}
+
+/**
  * Inserting a track places its panels at the position, the orders follow the
  * (new) track order rather than the insertion history.
  */

--- a/src/trackedit/view/tracknavigationmodel.cpp
+++ b/src/trackedit/view/tracknavigationmodel.cpp
@@ -116,6 +116,16 @@ void TrackNavigationModel::init(muse::ui::NavigationSection* section)
 
         syncFocusedItem(activePanel, activeControl);
     });
+
+    if (interactive()) {
+        interactive()->currentUri().ch.onReceive(this, [this](const muse::Uri&) {
+            //! WindowView restores the dialog's saved parent control after emitting
+            //! closed(), so retry the pending track activation on the next event-loop turn.
+            QMetaObject::invokeMethod(this, [this]() {
+                updatePendingNavigation();
+            }, Qt::QueuedConnection);
+        });
+    }
 }
 
 void TrackNavigationModel::load()
@@ -539,6 +549,10 @@ void TrackNavigationModel::requestNavigation(const TrackItemKey& itemKey, bool h
 void TrackNavigationModel::updatePendingNavigation()
 {
     if (!m_pendingNavigation) {
+        return;
+    }
+
+    if (interactive() && interactive()->isCurrentUriDialog().val) {
         return;
     }
 

--- a/src/trackedit/view/tracknavigationmodel.cpp
+++ b/src/trackedit/view/tracknavigationmodel.cpp
@@ -125,8 +125,6 @@ void TrackNavigationModel::load()
         return;
     }
 
-    m_activateDefaultNavigationRequested = true;
-
     prj->tracksChanged().onReceive(this, [this](const std::vector<au::trackedit::Track> tracks) {
         clearPanels();
 
@@ -136,15 +134,10 @@ void TrackNavigationModel::load()
 
         if (tracks.empty()) {
             addDefaultNavigation();
-        } else {
-            disableDefaultNavigation();
         }
     });
 
     prj->trackAdded().onReceive(this, [this](const Track& track) {
-        if (m_panels.isEmpty()) {
-            disableDefaultNavigation();
-        }
         addPanels(track.id, m_panels.size());
         resetPanelOrder();
     });
@@ -160,9 +153,6 @@ void TrackNavigationModel::load()
     });
 
     prj->trackInserted().onReceive(this, [this](const Track& track, int pos) {
-        if (m_panels.isEmpty()) {
-            disableDefaultNavigation();
-        }
         addPanels(track.id, pos);
         resetPanelOrder();
     });
@@ -190,7 +180,7 @@ void TrackNavigationModel::load()
         addDefaultNavigation();
     }
 
-    updateDefaultNavigationControl();
+    activateDefaultNavigation();
 
     tracksNavigationController()->focusedTrackChanged().onReceive(this, [this](const TrackId& trackId, bool highlight) {
         MYLOG() << "focused track changed: " << trackId << ", highlight: " << highlight;
@@ -205,14 +195,7 @@ void TrackNavigationModel::load()
             return;
         }
 
-        QTimer::singleShot(10, [this, trackId, highlight](){
-            if (isNavigationOnTrack(trackId)) {
-                MYLOG() << "skipped, the navigation is already on the track " << trackId;
-                return;
-            }
-
-            activateNavigation(trackId, highlight);
-        });
+        requestNavigation({ trackId, INVALID_TRACK_ITEM }, highlight);
     }, muse::async::Asyncable::Mode::SetReplace);
 
     tracksNavigationController()->focusedItemChanged().onReceive(this, [this](const TrackItemKey& itemKey, bool highlight) {
@@ -224,9 +207,7 @@ void TrackNavigationModel::load()
             return;
         }
 
-        QTimer::singleShot(10, [this, itemKey, highlight](){
-            activateNavigation(itemKey, highlight);
-        });
+        requestNavigation(itemKey, highlight);
     }, muse::async::Asyncable::Mode::SetReplace);
 }
 
@@ -250,6 +231,7 @@ void TrackNavigationModel::addPanels(const TrackId& trackId, int pos)
 
     trackPanel->controlsListChanged().onNotify(this, [this]() {
         updateDefaultNavigationControl();
+        updatePendingNavigation();
     });
 
     muse::ui::NavigationPanel* headerPanel = makePanel(makeTrackHeaderPanelName(trackId), orderBase + 1);
@@ -264,6 +246,10 @@ void TrackNavigationModel::addPanels(const TrackId& trackId, int pos)
     });
 
     muse::ui::NavigationPanel* itemsPanel = makePanel(makeTrackItemsPanelName(trackId), orderBase + 2);
+
+    itemsPanel->controlsListChanged().onNotify(this, [this]() {
+        updatePendingNavigation();
+    });
 
     connect(itemsPanel, &muse::ui::NavigationPanel::navigationEvent, this,
             [this, itemsPanel](muse::ui::NavigationEvent* event) {
@@ -450,6 +436,10 @@ void TrackNavigationModel::activateDefaultNavigation()
 
 void TrackNavigationModel::updateDefaultNavigationControl()
 {
+    if (!m_panels.isEmpty()) {
+        disableDefaultNavigation();
+    }
+
     //! NOTE: the default navigation control is the control the navigation returns to
     //! (Escape, reset of the navigation): the first track if there are tracks,
     //! the fallback control otherwise
@@ -535,6 +525,60 @@ void TrackNavigationModel::syncFocusedItem(const muse::ui::INavigationPanel* act
     }
 }
 
+void TrackNavigationModel::requestNavigation(const TrackItemKey& itemKey, bool highlight)
+{
+    if (itemKey.trackId == INVALID_TRACK) {
+        m_pendingNavigation.reset();
+        return;
+    }
+
+    m_pendingNavigation = NavigationRequest { itemKey, highlight };
+    updatePendingNavigation();
+}
+
+void TrackNavigationModel::updatePendingNavigation()
+{
+    if (!m_pendingNavigation) {
+        return;
+    }
+
+    const NavigationRequest request = *m_pendingNavigation;
+
+    const int pos = indexOfTrack(request.itemKey.trackId);
+    if (pos < 0) {
+        return;
+    }
+
+    const TrackPanels& panels = m_panels.at(pos);
+    const muse::ui::INavigationControl* control = nullptr;
+
+    if (request.itemKey.itemId == INVALID_TRACK_ITEM) {
+        if (isNavigationOnTrack(request.itemKey.trackId)) {
+            MYLOG() << "skipped, the navigation is already on the track " << request.itemKey.trackId;
+            m_pendingNavigation.reset();
+            return;
+        }
+
+        control = findFirstEnabledControl(panels.track);
+    } else {
+        const QString controlName = QString::number(request.itemKey.itemId);
+        for (const muse::ui::INavigationControl* candidate : panels.items->controls()) {
+            if (candidate && candidate->enabled() && candidate->name() == controlName) {
+                control = candidate;
+                break;
+            }
+        }
+    }
+
+    if (!control) {
+        return;
+    }
+
+    m_pendingNavigation.reset();
+
+    activateNavigation(control, request.highlight);
+}
+
 void TrackNavigationModel::moveFocusTo(const QVariant& trackId)
 {
     tracksNavigationController()->setFocusedTrack(trackId.toInt(), false /*highlight*/);
@@ -543,6 +587,8 @@ void TrackNavigationModel::moveFocusTo(const QVariant& trackId)
 void TrackNavigationModel::cleanup()
 {
     MYLOG() << "====";
+
+    m_pendingNavigation.reset();
 
     disableDefaultNavigation();
 

--- a/src/trackedit/view/tracknavigationmodel.h
+++ b/src/trackedit/view/tracknavigationmodel.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <optional>
+
 #include <QPointer>
 #include <QQuickItem>
 
@@ -78,6 +80,12 @@ private:
         muse::ui::NavigationPanel* items = nullptr;
     };
 
+    struct NavigationRequest
+    {
+        TrackItemKey itemKey;
+        bool highlight = false;
+    };
+
     void load();
     void cleanup();
     void clearPanels();
@@ -92,6 +100,8 @@ private:
     QList<muse::ui::NavigationPanel*> panelsList(muse::ui::NavigationPanel* TrackPanels::* panel) const;
     void updateNavigationActive(const muse::ui::INavigationPanel* activePanel);
     void syncFocusedItem(const muse::ui::INavigationPanel* activePanel, const muse::ui::INavigationControl* activeControl);
+    void requestNavigation(const TrackItemKey& itemKey, bool highlight);
+    void updatePendingNavigation();
 
     void addDefaultNavigation();
     void disableDefaultNavigation();
@@ -113,6 +123,7 @@ private:
     QPointer<QQuickItem> m_trackViewItem;
 
     bool m_activateDefaultNavigationRequested = false;
+    std::optional<NavigationRequest> m_pendingNavigation;
     bool m_isFocusSyncing = false;
 
     int m_lastActivePanelOrder = -1;

--- a/src/trackedit/view/tracknavigationmodel.h
+++ b/src/trackedit/view/tracknavigationmodel.h
@@ -13,6 +13,7 @@
 #include "global/modularity/ioc.h"
 #include "context/iglobalcontext.h"
 #include "actions/iactionsdispatcher.h"
+#include "interactive/iinteractive.h"
 #include "ui/inavigationcontroller.h"
 #include "trackedit/internal/itracknavigationcontroller.h"
 
@@ -23,6 +24,7 @@ class TrackNavigationModel : public QObject, public muse::async::Asyncable, publ
 
     muse::ContextInject<au::context::IGlobalContext> globalContext{ this };
     muse::ContextInject<muse::actions::IActionsDispatcher> dispatcher{ this };
+    muse::ContextInject<muse::IInteractive> interactive{ this };
     muse::ContextInject<muse::ui::INavigationController> navigationController{ this };
     muse::ContextInject<ITrackNavigationController> tracksNavigationController{ this };
 


### PR DESCRIPTION
Resolves: #11659

Replaces QTimer 10ms delay with connection to `itemsPanel->controlsListChanged()`

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
