### PR TITLE
11373 improve unsaved cloud project flow

### DIFF
--- a/src/project/internal/projectactionscontroller.cpp
+++ b/src/project/internal/projectactionscontroller.cpp
@@ -578,45 +578,47 @@ bool ProjectActionsController::closeOpenedProject(const bool quitApp)
         return true;
     }
 
-    bool result = true;
-
     if (project->hasUnsavedChanges()) {
-        IInteractive::Button btn = askAboutSavingProject(project);
+        const IInteractive::Button btn = askAboutSavingProject(project);
 
         if (btn == IInteractive::Button::Cancel) {
-            result = false;
-        } else if (btn == IInteractive::Button::Save) {
-            result = saveProject();
-        } else if (btn == IInteractive::Button::DontSave) {
-            result = true;
+            return false;
         }
-    }
 
-    if (result && project->isCloudProject()) {
-        result = askAboutStoppingCloudSync();
-    }
+        if (btn == IInteractive::Button::Save) {
+            if (!saveProject()) {
+                return false;
+            }
 
-    if (result) {
-        interactive()->closeAllDialogsSync();
-
-        project->close();
-
-        globalContext()->setCurrentProject(nullptr);
-
-        if (quitApp) {
-            //! NOTE: we need to call `quit` in the next event loop due to controlling the lifecycle of this method
-            muse::async::Async::call(this, [this](){
-                dispatcher()->dispatch("quit", actions::ActionData::make_arg1<bool>(false));
-            });
-        } else {
-            Ret ret = openPageIfNeed(HOME_PAGE_URI);
-            if (!ret) {
-                LOGE() << ret.toString();
+            if (audioComService()->syncingInProgressChanged().val) {
+                return false;
             }
         }
     }
 
-    return result;
+    if (project->isCloudProject() && !askAboutStoppingCloudSync()) {
+        return false;
+    }
+
+    interactive()->closeAllDialogsSync();
+
+    project->close();
+
+    globalContext()->setCurrentProject(nullptr);
+
+    if (quitApp) {
+        //! NOTE: we need to call `quit` in the next event loop due to controlling the lifecycle of this method
+        muse::async::Async::call(this, [this](){
+            dispatcher()->dispatch("quit", actions::ActionData::make_arg1<bool>(false));
+        });
+    } else {
+        Ret ret = openPageIfNeed(HOME_PAGE_URI);
+        if (!ret) {
+            LOGE() << ret.toString();
+        }
+    }
+
+    return true;
 }
 
 bool ProjectActionsController::askAboutStoppingCloudSync()


### PR DESCRIPTION
Resolves: #11373 

Improve unsaved cloud project on close

```mermaid
flowchart TD
	A[Unsaved]
	B{Is syncing?}
	C{Want to save?}
	D{Want to save?}
	E{Stop sync?}
	F[Close]
	G[Do not close]
	
	A --> B
	B -- No --> C
	C -- No --> F
	C -- Yes --> G
	B -- Yes --> D
	D -- Yes --> G
	D -- No --> E
	E -- Yes --> F
	E -- No --> G
```

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
