### PR TITLE
11675 Avoid crash on undo of realtime effect change

### DIFF
--- a/src/projectscene/view/trackspanel/realtimeeffectlistitemmodel.cpp
+++ b/src/projectscene/view/trackspanel/realtimeeffectlistitemmodel.cpp
@@ -27,12 +27,11 @@ RealtimeEffectListItemModel::RealtimeEffectListItemModel(QObject* parent, effect
 
 RealtimeEffectListItemModel::~RealtimeEffectListItemModel()
 {
-    const auto state = m_effectState.lock();
-    IF_ASSERT_FAILED(state) {
-        // Effect state lifetime is expected to span more than this.
-        return;
+    // After undo/redo the state may already be destroyed. Then no dialog can
+    // be open for it (open dialogs share ownership), so there's nothing to hide.
+    if (const auto state = m_effectState.lock()) {
+        effectViewController()->hideEffect(state);
     }
-    effectViewController()->hideEffect(state);
 }
 
 bool RealtimeEffectListItemModel::prop_isMasterEffect() const


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/11675


<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
