### PR TITLE
11374 Improve cloud project open flow on error

### DIFF
--- a/src/project/internal/projectactionscontroller.cpp
+++ b/src/project/internal/projectactionscontroller.cpp
@@ -1690,6 +1690,8 @@ void ProjectActionsController::handleCloudOpenError(const muse::Ret& error, cons
 {
     const auto ret = openSaveProjectScenario()->showCloudOpenError(error, localPath);
 
+    std::optional<muse::Ret> retryRet;
+
     switch (ret.code()) {
     case IOpenSaveProjectScenario::RET_CODE_OPEN_LOCAL:
         doOpenProject(localPath);
@@ -1752,10 +1754,10 @@ void ProjectActionsController::handleCloudOpenError(const muse::Ret& error, cons
         break;
     }
     case IOpenSaveProjectScenario::RET_CODE_OPEN_CLOUD_FORCE:
-        openCloudProject(localPath, {}, {}, true);
+        retryRet = openCloudProject(localPath, {}, {}, true);
         break;
     case IOpenSaveProjectScenario::RET_CODE_LOAD_LATEST_SYNCED:
-        openCloudProject(localPath, muse::String::fromStdString(cloudProjectId), {}, true);
+        retryRet = openCloudProject(localPath, muse::String::fromStdString(cloudProjectId), {}, true);
         break;
     case IOpenSaveProjectScenario::RET_CODE_OPEN_ON_AUDIOCOM:
         if (!cloudProjectId.empty()) {
@@ -1765,6 +1767,23 @@ void ProjectActionsController::handleCloudOpenError(const muse::Ret& error, cons
     default:
         break;
     }
+
+    if (retryRet.has_value() && retryRet.value().success()) {
+        return;
+    }
+
+    if (globalContext()->currentProject()) {
+        return;
+    }
+
+    //! NOTE No project ended up open.
+    //! Close the window if multiple opened or go to home page
+    if (multiwindowsProvider()->windowCount() > 1) {
+        mainWindow()->qWindow()->close();
+        return;
+    }
+
+    openPageIfNeed(HOME_PAGE_URI);
 }
 
 void ProjectActionsController::handleCloudSaveError(const muse::Ret& error)


### PR DESCRIPTION
Resolves: #11374 

If we fail to open a cloud project in a new window we could have a dangling project pointer.
After this change, if no project is available we close the window if there is more than one project or we navigate to the home page for single window case.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
