### PR TITLE
Cancel in-flight cloud work when a window's context is torn down

### DIFF
--- a/src/au3cloud/internal/au3audiocomservice.cpp
+++ b/src/au3cloud/internal/au3audiocomservice.cpp
@@ -598,6 +598,7 @@ muse::RetVal<muse::ProgressPtr> Au3AudioComService::updateAudioPreview(au::proje
     }
 
     muse::ProgressPtr progress = std::make_shared<muse::Progress>();
+    trackProgress(progress);
 
     if (auto oldProgress = std::exchange(m_audioPreviewProgress, progress)) {
         oldProgress->cancel();
@@ -847,6 +848,7 @@ muse::RetVal<muse::ProgressPtr> Au3AudioComService::downloadAudioFile(const std:
     }
 
     muse::ProgressPtr progress = std::make_shared<muse::Progress>();
+    trackProgress(progress);
 
     auto progressCallback = [progress](double p) -> bool {
         if (progress->isCanceled()) {
@@ -858,6 +860,10 @@ muse::RetVal<muse::ProgressPtr> Au3AudioComService::downloadAudioFile(const std:
     };
 
     auto cancellationContext = audacity::concurrency::CancellationContext::Create();
+    progress->canceled().onNotify(this, [cancellationContext]() {
+        cancellationContext->Cancel();
+    });
+
     auto future = CloudSyncService::Get().DownloadCloudAudio(audioId, std::move(progressCallback), cancellationContext);
 
     // Blocked is resolved synchronously (another download is already in progress)
@@ -921,6 +927,7 @@ muse::RetVal<muse::ProgressPtr> Au3AudioComService::openCloudProject(const muse:
     }
 
     muse::ProgressPtr progress = std::make_shared<muse::Progress>();
+    trackProgress(progress);
 
     auto progressCallback = [progress](double p) -> bool {
         if (progress->isCanceled()) {
@@ -932,6 +939,9 @@ muse::RetVal<muse::ProgressPtr> Au3AudioComService::openCloudProject(const muse:
     };
 
     auto cancellationContext = audacity::concurrency::CancellationContext::Create();
+    progress->canceled().onNotify(this, [cancellationContext]() {
+        cancellationContext->Cancel();
+    });
 
     std::thread([weak = weak_from_this(), progress, dbProjectData, cloudProjectId, snapshotId, forceOverwrite,
                  cancellationContext, progressCallback = std::move(progressCallback)]() mutable {
@@ -977,6 +987,7 @@ muse::RetVal<muse::ProgressPtr> Au3AudioComService::openCloudProject(const muse:
 muse::RetVal<muse::ProgressPtr> Au3AudioComService::shareAudio(const std::string& title)
 {
     muse::ProgressPtr progress = std::make_shared<muse::Progress>();
+    trackProgress(progress);
 
     std::thread([weak = weak_from_this(), title, progress]() {
         auto self = weak.lock();
@@ -1116,9 +1127,19 @@ muse::Ret Au3AudioComService::checkUnsyncedProject(const std::string& cloudProje
     return make_ret(hasValidSnapshot ? Err::CloudProjectNotFullySynced : Err::CloudProjectNeverSynced);
 }
 
+void Au3AudioComService::trackProgress(const muse::ProgressPtr& progress)
+{
+    m_activeProgresses.erase(std::remove_if(m_activeProgresses.begin(), m_activeProgresses.end(),
+                                            [](const std::weak_ptr<muse::Progress>& p) { return p.expired(); }),
+                             m_activeProgresses.end());
+
+    m_activeProgresses.push_back(progress);
+}
+
 muse::ProgressPtr Au3AudioComService::createSyncProgress()
 {
     auto oldProgress = std::exchange(m_syncInProgress, std::make_shared<muse::Progress>());
+    trackProgress(m_syncInProgress);
 
     std::weak_ptr<muse::Progress> weakProgress = m_syncInProgress;
 
@@ -1148,5 +1169,17 @@ muse::ProgressPtr Au3AudioComService::createSyncProgress()
 
 void Au3AudioComService::deinit()
 {
+    stopProjectSync();
+
+    for (const std::weak_ptr<muse::Progress>& weakProgress : m_activeProgresses) {
+        muse::ProgressPtr progress = weakProgress.lock();
+        if (progress && !progress->isCanceled()) {
+            progress->cancel();
+        }
+    }
+    m_activeProgresses.clear();
+
+    m_downloadManager->cancelAll();
+
     audacity::cloud::audiocom::sync::CloudProjectsDatabase::Get().CloseConnection();
 }

--- a/src/au3cloud/internal/au3audiocomservice.h
+++ b/src/au3cloud/internal/au3audiocomservice.h
@@ -9,6 +9,7 @@
 #include <mutex>
 #include <optional>
 #include <string>
+#include <vector>
 
 #include "au3cloud/internal/downloadmanager.h"
 #include "framework/global/async/asyncable.h"
@@ -84,6 +85,7 @@ public:
 
 private:
     muse::ProgressPtr createSyncProgress();
+    void trackProgress(const muse::ProgressPtr& progress);
     void startNewSnapshotUpload(au::project::IAudacityProjectPtr project, muse::ProgressPtr progress, const std::string& name,
                                 UploadMode uploadMode, std::function<bool()> projectSaveCallback);
     void resumePendingSnapshotOrStartNew(au::project::IAudacityProjectPtr project, muse::ProgressPtr progress,
@@ -120,5 +122,6 @@ private:
     muse::ValCh<bool> m_syncingInProgressChangedChannel;
     muse::ProgressPtr m_syncInProgress;
     muse::ProgressPtr m_audioPreviewProgress;
+    std::vector<std::weak_ptr<muse::Progress> > m_activeProgresses;
 };
 }

--- a/src/au3cloud/internal/downloadmanager.cpp
+++ b/src/au3cloud/internal/downloadmanager.cpp
@@ -41,6 +41,19 @@ void DownloadManager::scheduleDownloads(const std::vector<DownloadRequest>& requ
     }
 }
 
+void DownloadManager::cancelAll()
+{
+    std::map<std::string, muse::Progress> activeProgresses;
+    {
+        std::lock_guard lock(m_mutex);
+        activeProgresses = m_activeProgresses;
+    }
+
+    for (auto& [id, progress] : activeProgresses) {
+        progress.cancel();
+    }
+}
+
 muse::async::Channel<std::string, muse::io::path_t> DownloadManager::downloadCompleted() const
 {
     return m_downloadCompleted;
@@ -67,6 +80,7 @@ void DownloadManager::startDownload(const std::string& id, const std::string& ur
         }
 
         m_activeManagers[id] = std::move(manager);
+        m_activeProgresses[id] = retVal.val;
     }
 
     retVal.val.finished().onReceive(this,
@@ -74,6 +88,7 @@ void DownloadManager::startDownload(const std::string& id, const std::string& ur
         {
             std::lock_guard lock(m_mutex);
             m_activeManagers.erase(id);
+            m_activeProgresses.erase(id);
             m_inProgressIds.erase(id);
         }
 

--- a/src/au3cloud/internal/downloadmanager.h
+++ b/src/au3cloud/internal/downloadmanager.h
@@ -26,6 +26,7 @@ class DownloadManager : public muse::async::Asyncable
 
 public:
     void scheduleDownloads(const std::vector<DownloadRequest>& requests);
+    void cancelAll();
 
     muse::async::Channel<std::string, muse::io::path_t> downloadCompleted() const;
 
@@ -35,6 +36,7 @@ private:
     muse::async::Channel<std::string, muse::io::path_t> m_downloadCompleted;
 
     std::map<std::string, muse::network::INetworkManagerPtr> m_activeManagers;
+    std::map<std::string, muse::Progress> m_activeProgresses;
 
     std::set<std::string> m_inProgressIds;
     std::mutex m_mutex;


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/11619

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
