### PR TITLE
Fix freeze when double-clicking timeline with a midi track present

### DIFF
--- a/libraries/lib-audio-io/AudioIO.cpp
+++ b/libraries/lib-audio-io/AudioIO.cpp
@@ -983,13 +983,14 @@ int AudioIO::StartStream(const TransportSequences &sequences,
    mPlaybackSchedule.GetPolicy().Initialize( mPlaybackSchedule, mRate );
 
    auto range = Extensions();
+   const double playStartTime = pStartTime ? *pStartTime : t0;
    successAudio = successAudio &&
       std::all_of(range.begin(), range.end(),
-         [this, &sequences, t0](auto &ext){
+         [this, &sequences, playStartTime](auto &ext){
             return ext.StartOtherStream(sequences,
               (mPortStreamV19 != NULL && mLastPaError == paNoError)
                  ? Pa_GetStreamInfo(mPortStreamV19) : nullptr,
-              t0, mRate ); });
+              playStartTime, mRate ); });
 
    if (!successAudio) {
       if (pListener && numCaptureChannels > 0)

--- a/libraries/lib-note-track/MIDIPlay.cpp
+++ b/libraries/lib-note-track/MIDIPlay.cpp
@@ -746,20 +746,24 @@ void MIDIPlay::StopOtherStream()
 
       mMidiOutputComplete = true;
 
-      // now we can assume "ownership" of the mMidiStream
-      // if output in progress, send all off, etc.
-      AllNotesOff();
-      // AllNotesOff() should be sufficient to stop everything, but
-      // in Linux, if you Pm_Close() immediately, it looks like
-      // messages are dropped. ALSA then seems to send All Sound Off
-      // and Reset All Controllers messages, but not all synthesizers
-      // respond to these messages. This is probably a bug in PortMidi
-      // if the All Off messages do not get out, but for security,
-      // delay a bit so that messages can be delivered before closing
-      // the stream. Add 2ms of "padding" to avoid any rounding errors.
-      while (mMaxMidiTimestamp + 2 > MidiTime()) {
-         using namespace std::chrono;
-         std::this_thread::sleep_for(1ms); // deliver the all-off messages
+      // If mCallbackCount == 0 nothing was written to the device, there are
+      // no notes to turn off, and nothing to drain
+      if (mCallbackCount > 0) {
+         // now we can assume "ownership" of the mMidiStream
+         // if output in progress, send all off, etc.
+         AllNotesOff();
+         // AllNotesOff() should be sufficient to stop everything, but
+         // in Linux, if you Pm_Close() immediately, it looks like
+         // messages are dropped. ALSA then seems to send All Sound Off
+         // and Reset All Controllers messages, but not all synthesizers
+         // respond to these messages. This is probably a bug in PortMidi
+         // if the All Off messages do not get out, but for security,
+         // delay a bit so that messages can be delivered before closing
+         // the stream. Add 2ms of "padding" to avoid any rounding errors.
+         while (mMaxMidiTimestamp + 2 > MidiTime()) {
+            using namespace std::chrono;
+            std::this_thread::sleep_for(1ms); // deliver the all-off messages
+         }
       }
       Pm_Close(mMidiStream);
       mMidiStream = NULL;
@@ -835,7 +839,7 @@ bool Iterator::OutputEvent(double pauseTime, bool midiStateOnly, bool hasSolo)
    // (RBD)
    // if mNextEvent's channel is visible, play it, visibility can
    // be updated while playing.
-   
+
    // Be careful: if we have a note-off,
    // then we must not pay attention to the channel selection
    // or mute/solo buttons because we must turn the note off

--- a/libraries/lib-note-track/MIDIPlay.cpp
+++ b/libraries/lib-note-track/MIDIPlay.cpp
@@ -551,8 +551,12 @@ MIDIPlay::~MIDIPlay()
 }
 
 bool MIDIPlay::StartOtherStream(const TransportSequences &tracks,
-   const PaStreamInfo* info, double, double rate)
+   const PaStreamInfo* info, double startTime, double rate)
 {
+   // MIDI events are timed in warped seconds from mT0, so AudioTime() must match.
+   // Without a time track this is just startTime.
+   mWarpedStartTime = mPlaybackSchedule.mT0 + mPlaybackSchedule.RealDurationSigned(startTime);
+
    mMidiPlaybackTracks.clear();
    for (const auto &pSequence : tracks.otherPlayableSequences)
       if (const auto pNoteTrack =
@@ -592,7 +596,7 @@ bool MIDIPlay::StartOtherStream(const TransportSequences &tracks,
    bool successMidi = true;
 
    if(!mMidiPlaybackTracks.empty()){
-      successMidi = StartPortMidiStream(rate);
+      successMidi = StartPortMidiStream(startTime, rate);
    }
 
    // On the other hand, if MIDI cannot be opened, we will not complain
@@ -675,7 +679,7 @@ double Iterator::GetNextEventTime() const
    return mNextEventTime;
 }
 
-bool MIDIPlay::StartPortMidiStream(double rate)
+bool MIDIPlay::StartPortMidiStream(double startTime, double rate)
 {
 #ifdef __WXGTK__
    // Duplicating a bit of AudioIO::StartStream
@@ -728,7 +732,7 @@ bool MIDIPlay::StartPortMidiStream(double rate)
       mMidiLoopPasses = 0;
       mMidiOutputComplete = false;
       mMaxMidiTimestamp = 0;
-      PrepareMidiIterator(true, mPlaybackSchedule.mT0, 0);
+      PrepareMidiIterator(true, startTime, 0);
 
       // It is ok to call this now, but do not send timestamped midi
       // until after the first audio callback, which provides necessary
@@ -1124,7 +1128,7 @@ void MIDIPlay::ComputeOtherTimings(double rate, bool paused,
 {
    if (mCallbackCount++ == 0) {
        // This is effectively mSystemMinusAudioTime when the buffer is empty:
-       mStartTime = SystemTime(mUsingAlsa) - mPlaybackSchedule.mT0;
+       mStartTime = SystemTime(mUsingAlsa) - mWarpedStartTime;
        // later, mStartTime - mSystemMinusAudioTime will tell us latency
    }
 

--- a/libraries/lib-note-track/MIDIPlay.h
+++ b/libraries/lib-note-track/MIDIPlay.h
@@ -86,10 +86,13 @@ struct MIDIPlay : AudioIOExt
    ~MIDIPlay() override;
 
    double AudioTime(double rate) const
-   { return mPlaybackSchedule.mT0 + mNumFrames / rate; }
+   { return mWarpedStartTime + mNumFrames / rate; }
 
    const PlaybackSchedule &mPlaybackSchedule;
    NoteTrackConstArray mMidiPlaybackTracks;
+
+   //! Where AudioTime() starts, warped to match MIDI event times
+   double mWarpedStartTime = 0.0;
 
    /// True when output reaches mT1
    static bool      mMidiOutputComplete;
@@ -148,7 +151,7 @@ struct MIDIPlay : AudioIOExt
 #endif
 
    void PrepareMidiIterator(bool send, double startTime, double offset);
-   bool StartPortMidiStream(double rate);
+   bool StartPortMidiStream(double startTime, double rate);
    double PauseTime(double rate, unsigned long pauseFrames);
    void AllNotesOff(bool looping = false);
 


### PR DESCRIPTION
Resolves: #11664
Resolves: #2359

When the playback is restarted with a click on a timeline, it stops all streams first. During stop we wait for all midi events to be drained.

But if the playback is restarted twice in quick succession, the first midi playback doesnt have time to fully initialize which results in a 1000s wait. Introduced in #1637

Call stack:
```
(anonymous namespace)::MIDIPlay::MidiTime() (libraries/lib-note-track/MIDIPlay.cpp:1059)
(anonymous namespace)::MIDIPlay::StopOtherStream() (libraries/lib-note-track/MIDIPlay.cpp:760)
AudioIO::StopStream() (libraries/lib-audio-io/AudioIO.cpp:1535)
ProjectAudioManager::Stop(bool) (src/ProjectAudioManager.cpp:531)
AdornedRulerPanel::StartQPPlay(bool, bool, double const*) (src/AdornedRulerPanel.cpp:2111)
AdornedRulerPanel::CommonRulerHandle::StartPlay(AudacityProject&, wxMouseEvent const&) (src/AdornedRulerPanel.cpp:192)
AdornedRulerPanel::PlayRegionAdjustingHandle::Release(TrackPanelMouseEvent const&, AudacityProject*, wxWindow*) (src/AdornedRulerPanel.cpp:296)
CellularPanel::OnMouseEvent(wxMouseEvent&) (src/CellularPanel.cpp:814)
wxAppConsoleBase::HandleEvent(wxEvtHandler*, void (wxEvtHandler::*)(wxEvent&), wxEvent&) const (.conan2/p/b/wxwid222b45a67b428/b/src/src/common/appbase.cpp:657)
wxAppConsoleBase::CallEventHandler(wxEvtHandler*, wxEventFunctor&, wxEvent&) const 
```

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
