### PR TITLE
Fix crashes when rt effect view is open

### DIFF
--- a/libraries/lib-effects/EffectOutputTracks.cpp
+++ b/libraries/lib-effects/EffectOutputTracks.cpp
@@ -42,9 +42,9 @@ EffectOutputTracks::EffectOutputTracks(
 
    for (auto aTrack : trackRange) {
       auto pTrack = aTrack->Duplicate();
-      // Explicitly copy effect list and their states
+      // Explicitly share the effect states, the duplicate replaces the original in Commit()
       if (const auto pWaveTrack = dynamic_cast<WaveTrack*>(aTrack))
-         RealtimeEffectList::Set(*pTrack, RealtimeEffectList::Get(*pWaveTrack).Duplicate());
+         RealtimeEffectList::ShareStates(*pTrack, *pWaveTrack);
       mIMap.push_back(aTrack);
       mOMap.push_back(pTrack.get());
       mOutputTracks->Add(pTrack);

--- a/libraries/lib-effects/EffectOutputTracks.cpp
+++ b/libraries/lib-effects/EffectOutputTracks.cpp
@@ -9,6 +9,7 @@
 **********************************************************************/
 #include "EffectOutputTracks.h"
 #include "BasicUI.h"
+#include "RealtimeEffectList.h"
 #include "SyncLock.h"
 #include "UserException.h"
 #include "WaveTrack.h"
@@ -41,6 +42,9 @@ EffectOutputTracks::EffectOutputTracks(
 
    for (auto aTrack : trackRange) {
       auto pTrack = aTrack->Duplicate();
+      // Explicitly copy effect list and their states
+      if (const auto pWaveTrack = dynamic_cast<WaveTrack*>(aTrack))
+         RealtimeEffectList::Set(*pTrack, RealtimeEffectList::Get(*pWaveTrack).Duplicate());
       mIMap.push_back(aTrack);
       mOMap.push_back(pTrack.get());
       mOutputTracks->Add(pTrack);

--- a/libraries/lib-realtime-effects/RealtimeEffectList.cpp
+++ b/libraries/lib-realtime-effects/RealtimeEffectList.cpp
@@ -307,6 +307,12 @@ struct MasterEffectListRestorer final : UndoStateExtension
    MasterEffectListRestorer(AudacityProject &project)
       : list{ RealtimeEffectList::Get(project).Duplicate(RealtimeEffectList::CopyDepth::Shallow) }
    {
+      // One instance of each effect state is shared with every undo state,
+      // so only their values can be restored
+      for (size_t i = 0, count = list->GetStatesCount(); i < count; ++i) {
+         const auto pState = list->GetStateAt(i);
+         stateSettings.push_back({ pState, pState->GetSettings() });
+      }
    }
 
    void RestoreUndoRedoState(AudacityProject& project) override
@@ -318,9 +324,22 @@ struct MasterEffectListRestorer final : UndoStateExtension
       for (auto i = 0; i < list->GetStatesCount(); ++i)
          projectList.AddState(list->GetStateAt(i));
       projectList.SetActive(list->IsActive());
+
+      for (const auto &item : stateSettings) {
+         item.pState->SetActive(item.settings.extra.GetActive());
+         const auto access = item.pState->GetAccess();
+         access->Set(EffectSettings { item.settings });
+         access->Flush();
+      }
    }
 
+   struct StateAndSettings {
+      std::shared_ptr<RealtimeEffectState> pState;
+      EffectSettings settings;
+   };
+
    const std::unique_ptr<RealtimeEffectList> list;
+   std::vector<StateAndSettings> stateSettings;
 };
 
 static UndoRedoExtensionRegistry::Entry sEntry {

--- a/libraries/lib-realtime-effects/RealtimeEffectList.cpp
+++ b/libraries/lib-realtime-effects/RealtimeEffectList.cpp
@@ -21,6 +21,7 @@ RealtimeEffectList::~RealtimeEffectList()
 {
 }
 
+// Deep copy of states
 std::unique_ptr<ClientData::Cloneable<>> RealtimeEffectList::Clone() const
 {
    auto result = std::make_unique<RealtimeEffectList>();
@@ -30,7 +31,7 @@ std::unique_ptr<ClientData::Cloneable<>> RealtimeEffectList::Clone() const
    return result;
 }
 
-// Deep copy of states
+// Shallow copy of states
 std::unique_ptr<RealtimeEffectList> RealtimeEffectList::Duplicate() const
 {
    auto result = std::make_unique<RealtimeEffectList>();
@@ -87,6 +88,13 @@ const RealtimeEffectList &RealtimeEffectList::Get(
    const ChannelGroup &group)
 {
    return Get(const_cast<ChannelGroup &>(group));
+}
+
+RealtimeEffectList &RealtimeEffectList::Set(ChannelGroup &group, std::unique_ptr<RealtimeEffectList> list)
+{
+   auto &result = *list;
+   group.Attachments::Assign(channelGroupEffects, std::move(list));
+   return result;
 }
 
 bool

--- a/libraries/lib-realtime-effects/RealtimeEffectList.cpp
+++ b/libraries/lib-realtime-effects/RealtimeEffectList.cpp
@@ -21,22 +21,16 @@ RealtimeEffectList::~RealtimeEffectList()
 {
 }
 
-// Deep copy of states
 std::unique_ptr<ClientData::Cloneable<>> RealtimeEffectList::Clone() const
 {
-   auto result = std::make_unique<RealtimeEffectList>();
-   for (auto &pState : mStates)
-      result->mStates.push_back(pState->Clone());
-   result->SetActive(this->IsActive());
-   return result;
+   return Duplicate(CopyDepth::Deep);
 }
 
-// Shallow copy of states
-std::unique_ptr<RealtimeEffectList> RealtimeEffectList::Duplicate() const
+std::unique_ptr<RealtimeEffectList> RealtimeEffectList::Duplicate(CopyDepth depth) const
 {
    auto result = std::make_unique<RealtimeEffectList>();
    for (auto &pState : mStates)
-      result->mStates.push_back(pState);
+      result->mStates.push_back(depth == CopyDepth::Deep ? pState->Clone() : pState);
    result->SetActive(this->IsActive());
    return result;
 }
@@ -95,6 +89,11 @@ RealtimeEffectList &RealtimeEffectList::Set(ChannelGroup &group, std::unique_ptr
    auto &result = *list;
    group.Attachments::Assign(channelGroupEffects, std::move(list));
    return result;
+}
+
+void RealtimeEffectList::ShareStates(ChannelGroup &group, const ChannelGroup &other)
+{
+   Set(group, Get(other).Duplicate(CopyDepth::Shallow));
 }
 
 bool
@@ -306,7 +305,7 @@ void RealtimeEffectList::SetActive(bool value)
 struct MasterEffectListRestorer final : UndoStateExtension
 {
    MasterEffectListRestorer(AudacityProject &project)
-      : list{ RealtimeEffectList::Get(project).Duplicate() }
+      : list{ RealtimeEffectList::Get(project).Duplicate(RealtimeEffectList::CopyDepth::Shallow) }
    {
    }
 

--- a/libraries/lib-realtime-effects/RealtimeEffectList.h
+++ b/libraries/lib-realtime-effects/RealtimeEffectList.h
@@ -60,9 +60,9 @@ public:
 
    Lock &GetLock() const { return mLock; }
 
-   //! Should be called (for pushing undo states) only from main thread, to
-   //! avoid races
+   //! Should be called (for pushing undo states) only from main thread, to avoid races
    std::unique_ptr<ClientData::Cloneable<>> Clone() const override;
+   //! Shallow copy, shares the states with this
    std::unique_ptr<RealtimeEffectList> Duplicate() const;
 
    static RealtimeEffectList &Get(AudacityProject &project);
@@ -73,6 +73,7 @@ public:
 
    static RealtimeEffectList &Get(ChannelGroup &group);
    static const RealtimeEffectList &Get(const ChannelGroup &group);
+   static RealtimeEffectList &Set(ChannelGroup &group, std::unique_ptr<RealtimeEffectList> list);
 
    // Type that state visitor functions would have for out-of-line definition
    // of Visit

--- a/libraries/lib-realtime-effects/RealtimeEffectList.h
+++ b/libraries/lib-realtime-effects/RealtimeEffectList.h
@@ -60,10 +60,11 @@ public:
 
    Lock &GetLock() const { return mLock; }
 
+   enum class CopyDepth { Shallow, Deep };
+
    //! Should be called (for pushing undo states) only from main thread, to avoid races
    std::unique_ptr<ClientData::Cloneable<>> Clone() const override;
-   //! Shallow copy, shares the states with this
-   std::unique_ptr<RealtimeEffectList> Duplicate() const;
+   std::unique_ptr<RealtimeEffectList> Duplicate(CopyDepth depth) const;
 
    static RealtimeEffectList &Get(AudacityProject &project);
    static const RealtimeEffectList &Get(const AudacityProject &project);
@@ -74,6 +75,10 @@ public:
    static RealtimeEffectList &Get(ChannelGroup &group);
    static const RealtimeEffectList &Get(const ChannelGroup &group);
    static RealtimeEffectList &Set(ChannelGroup &group, std::unique_ptr<RealtimeEffectList> list);
+
+   //! Give group the same effect state instances as other, not copies of them,
+   //! so they stay alive after other is destroyed
+   static void ShareStates(ChannelGroup &group, const ChannelGroup &other);
 
    // Type that state visitor functions would have for out-of-line definition
    // of Visit

--- a/src/ProjectAudioManager.cpp
+++ b/src/ProjectAudioManager.cpp
@@ -32,6 +32,7 @@ Paul Licameli split from ProjectManager.cpp
 #include "ProjectRate.h"
 #include "ProjectStatus.h"
 #include "ProjectWindows.h"
+#include "RealtimeEffectList.h"
 #include "ScrubState.h"
 #include "TrackFocus.h"
 #include "prefs/TracksPrefs.h"
@@ -845,6 +846,8 @@ bool ProjectAudioManager::DoRecord(AudacityProject &project,
                auto &dst = static_cast<WaveTrack&>(d);
                auto &src = static_cast<const WaveTrack&>(s);
                dst.Init(src);
+               // Explicitly copy effect list
+               RealtimeEffectList::Set(dst, RealtimeEffectList::Get(src).Duplicate());
             };
 
             // End of current track is before or at recording start time.

--- a/src/ProjectAudioManager.cpp
+++ b/src/ProjectAudioManager.cpp
@@ -846,8 +846,8 @@ bool ProjectAudioManager::DoRecord(AudacityProject &project,
                auto &dst = static_cast<WaveTrack&>(d);
                auto &src = static_cast<const WaveTrack&>(s);
                dst.Init(src);
-               // Explicitly copy effect list
-               RealtimeEffectList::Set(dst, RealtimeEffectList::Get(src).Duplicate());
+               // Explicitly share the effect states, the pending track replaces the source on stop
+               RealtimeEffectList::ShareStates(dst, src);
             };
 
             // End of current track is before or at recording start time.

--- a/src/effects/VST/VSTEditor.cpp
+++ b/src/effects/VST/VSTEditor.cpp
@@ -576,6 +576,8 @@ bool VSTEditor::StoreSettingsToInstance(const EffectSettings& settings)
 
 bool VSTEditor::ValidateUI()
 {
+   if (!mAccess.Get().has_value())
+      return true;
    mAccess.ModifySettings([this](EffectSettings& settings)
    {
       if (mType == EffectTypeGenerate)

--- a/src/effects/VST3/VST3Editor.cpp
+++ b/src/effects/VST3/VST3Editor.cpp
@@ -167,14 +167,17 @@ void VST3Editor::OnClose()
 
    mWrapper.EndParameterEdit();
 
-   mAccess.ModifySettings([&](EffectSettings &settings){
-      if (mDuration != nullptr)
-         settings.extra.SetDuration(mDuration->GetValue());
-      //Flush changes if there is no processing performed at the moment
-      mWrapper.FlushParameters(settings);
-      mWrapper.StoreSettings(settings);
-      return nullptr;
-   });
+   if (mAccess.Get().has_value())
+   {
+      mAccess.ModifySettings([&](EffectSettings &settings){
+         if (mDuration != nullptr)
+            settings.extra.SetDuration(mDuration->GetValue());
+         //Flush changes if there is no processing performed at the moment
+         mWrapper.FlushParameters(settings);
+         mWrapper.StoreSettings(settings);
+         return nullptr;
+      });
+   }
    //Make sure that new state has been written to the caches...
    mAccess.Flush();
 

--- a/src/effects/audiounits/AudioUnitEditor.cpp
+++ b/src/effects/audiounits/AudioUnitEditor.cpp
@@ -38,12 +38,6 @@ AudioUnitEditor::AudioUnitEditor(CreateToken,
    wxTheApp->Bind(wxEVT_IDLE, &AudioUnitEditor::OnIdle, this);
 }
 
-AudioUnitEditor::~AudioUnitEditor()
-{
-   if (mpControl)
-      mpControl->Close();
-}
-
 auto AudioUnitEditor::MakeListener()
    -> EventListenerPtr
 {

--- a/src/effects/audiounits/AudioUnitEditor.h
+++ b/src/effects/audiounits/AudioUnitEditor.h
@@ -38,8 +38,6 @@ public:
       const EffectUIServices &effect, EffectSettingsAccess &access,
       AudioUnitInstance &instance, AUControl *pControl, bool isGraphical);
 
-   ~AudioUnitEditor() override;
-
    bool UpdateUI() override;
    bool ValidateUI() override;
    bool IsGraphicalUI() override;


### PR DESCRIPTION
Resolves: #10141
Resolves: #8686
Resolves: #11708
Resolves: #11712

Fixes:

- Crash when a realtime effect dialog saves settings on close. In some situations (applying destructive effect, undo/redo, etc) the dialog closes when the effect state is destroyed. Regression from #7873.
- Master effect settings were not restored with undo/redo, because master effect state is a project-wide singleton, and the state saved in the undo system is the same state being edited by the dialog.
- Memory corruption on closing AudioUnit dialog
 

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [ ] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
