### PR TITLE
Join a selected clip with touching neighbors

### DIFF
--- a/src/trackedit/internal/trackeditactionscontroller.cpp
+++ b/src/trackedit/internal/trackeditactionscontroller.cpp
@@ -968,7 +968,7 @@ void TrackeditActionsController::doGlobalJoin()
 std::optional<TrackeditActionsController::ContiguousClipsSpan> TrackeditActionsController::contiguousSelectedClipsSpan() const
 {
     const ClipKeyList clipKeys = selectionController()->selectedClips();
-    if (clipKeys.size() < 2) {
+    if (clipKeys.empty()) {
         return std::nullopt;
     }
 
@@ -986,6 +986,7 @@ std::optional<TrackeditActionsController::ContiguousClipsSpan> TrackeditActionsC
 
     const muse::async::NotifyList<Clip> trackClips = prj->clipList(trackId);
 
+    ClipKeyList clipsToJoin = clipKeys;
     size_t selectedCount = 0;
     double begin = std::numeric_limits<double>::max();
     double end = std::numeric_limits<double>::lowest();
@@ -1001,8 +1002,31 @@ std::optional<TrackeditActionsController::ContiguousClipsSpan> TrackeditActionsC
         return std::nullopt;
     }
 
+    if (clipKeys.size() == 1) {
+        const double selectedBegin = begin;
+        const double selectedEnd = end;
+
+        for (const Clip& clip : trackClips) {
+            if (muse::contains(clipKeys, clip.key)) {
+                continue;
+            }
+
+            if (muse::RealIsEqual(clip.endTime, selectedBegin)) {
+                clipsToJoin.push_back(clip.key);
+                begin = std::min(begin, clip.startTime);
+            } else if (muse::RealIsEqual(clip.startTime, selectedEnd)) {
+                clipsToJoin.push_back(clip.key);
+                end = std::max(end, clip.endTime);
+            }
+        }
+    }
+
+    if (clipsToJoin.size() < 2) {
+        return std::nullopt;
+    }
+
     for (const Clip& clip : trackClips) {
-        if (!muse::contains(clipKeys, clip.key) && clip.startTime < end && clip.endTime > begin) {
+        if (!muse::contains(clipsToJoin, clip.key) && clip.startTime < end && clip.endTime > begin) {
             return std::nullopt;
         }
     }

--- a/src/trackedit/internal/trackeditactionscontroller.cpp
+++ b/src/trackedit/internal/trackeditactionscontroller.cpp
@@ -5,6 +5,7 @@
 
 #include <algorithm>
 #include <limits>
+#include <vector>
 
 #include "global/translation.h"
 #include "global/defer.h"
@@ -1023,6 +1024,21 @@ std::optional<TrackeditActionsController::ContiguousClipsSpan> TrackeditActionsC
 
     if (clipsToJoin.size() < 2) {
         return std::nullopt;
+    }
+
+    std::vector<Clip> orderedClipsToJoin;
+    for (const Clip& clip : trackClips) {
+        if (muse::contains(clipsToJoin, clip.key)) {
+            orderedClipsToJoin.push_back(clip);
+        }
+    }
+    std::sort(orderedClipsToJoin.begin(), orderedClipsToJoin.end(), [](const Clip& left, const Clip& right) {
+        return left.startTime < right.startTime;
+    });
+    for (size_t i = 1; i < orderedClipsToJoin.size(); ++i) {
+        if (!muse::RealIsEqual(orderedClipsToJoin[i - 1].endTime, orderedClipsToJoin[i].startTime)) {
+            return std::nullopt;
+        }
     }
 
     for (const Clip& clip : trackClips) {

--- a/src/trackedit/tests/trackeditactionscontroller_tests.cpp
+++ b/src/trackedit/tests/trackeditactionscontroller_tests.cpp
@@ -5,9 +5,12 @@
 
 #include "trackedit/internal/trackeditactionscontroller.h"
 
+#include "context/tests/mocks/globalcontextmock.h"
+
 #include "mocks/selectioncontrollermock.h"
 #include "mocks/tracknavigationcontrollermock.h"
 #include "mocks/trackeditinteractionmock.h"
+#include "mocks/trackeditprojectmock.h"
 
 using ::testing::NiceMock;
 using ::testing::Return;
@@ -21,6 +24,8 @@ public:
         m_selectionController = std::make_shared<NiceMock<SelectionControllerMock> >();
         m_trackNavigationController = std::make_shared<NiceMock<TrackNavigationControllerMock> >();
         m_trackeditInteraction = std::make_shared<NiceMock<TrackeditInteractionMock> >();
+        m_globalContext = std::make_shared<NiceMock<context::GlobalContextMock> >();
+        m_trackeditProject = std::make_shared<NiceMock<TrackeditProjectMock> >();
 
         m_testCtx = std::make_shared<muse::modularity::Context>(999);
         m_controller = std::make_shared<TrackeditActionsController>(m_testCtx);
@@ -28,6 +33,10 @@ public:
         m_controller->selectionController.set(m_selectionController);
         m_controller->trackNavigationController.set(m_trackNavigationController);
         m_controller->trackeditInteraction.set(m_trackeditInteraction);
+        m_controller->globalContext.set(m_globalContext);
+
+        ON_CALL(*m_globalContext, currentTrackeditProject())
+        .WillByDefault(Return(m_trackeditProject));
 
         ON_CALL(*m_trackNavigationController, focusedItem())
         .WillByDefault(Return(TrackItemKey { INVALID_TRACK, INVALID_TRACK_ITEM }));
@@ -57,13 +66,94 @@ public:
         m_controller->doGlobalCancel();
     }
 
+    static Clip makeClip(const TrackId trackId, const TrackItemId itemId, const double startTime, const double endTime)
+    {
+        Clip clip;
+        clip.key = { trackId, itemId };
+        clip.startTime = startTime;
+        clip.endTime = endTime;
+        return clip;
+    }
+
+    void setupTrackClips(const TrackId trackId, const std::vector<Clip>& clips)
+    {
+        ON_CALL(*m_trackeditProject, clipList(trackId))
+        .WillByDefault([clips](const TrackId&) {
+            muse::async::NotifyList<Clip> list;
+            for (const Clip& clip : clips) {
+                list.push_back(clip);
+            }
+            return list;
+        });
+    }
+
+    struct ClipsSpan {
+        TrackId trackId = INVALID_TRACK;
+        secs_t begin = 0.0;
+        secs_t end = 0.0;
+    };
+
+    std::optional<ClipsSpan> selectedClipsSpan() const
+    {
+        const auto span = m_controller->contiguousSelectedClipsSpan();
+        if (!span) {
+            return std::nullopt;
+        }
+        return ClipsSpan { span->trackId, span->begin, span->end };
+    }
+
     std::shared_ptr<muse::modularity::Context> m_testCtx;
     std::shared_ptr<TrackeditActionsController> m_controller;
 
     std::shared_ptr<SelectionControllerMock> m_selectionController;
     std::shared_ptr<TrackNavigationControllerMock> m_trackNavigationController;
     std::shared_ptr<TrackeditInteractionMock> m_trackeditInteraction;
+    std::shared_ptr<context::GlobalContextMock> m_globalContext;
+    std::shared_ptr<TrackeditProjectMock> m_trackeditProject;
 };
+
+TEST_F(TrackeditActionsControllerTests, SingleSelectedClipJoinsTouchingNeighbors)
+{
+    const Clip left = makeClip(1, 101, 0.0, 1.0);
+    const Clip selected = makeClip(1, 102, 1.0, 2.0);
+    const Clip right = makeClip(1, 103, 2.0, 3.0);
+    setupTrackClips(1, { left, selected, right });
+    ON_CALL(*m_selectionController, selectedClips())
+    .WillByDefault(Return(ClipKeyList { selected.key }));
+
+    const auto span = selectedClipsSpan();
+
+    ASSERT_TRUE(span.has_value());
+    EXPECT_EQ(1, span->trackId);
+    EXPECT_DOUBLE_EQ(0.0, span->begin);
+    EXPECT_DOUBLE_EQ(3.0, span->end);
+}
+
+TEST_F(TrackeditActionsControllerTests, SingleSelectedClipJoinsOneTouchingNeighbor)
+{
+    const Clip selected = makeClip(1, 101, 0.0, 1.0);
+    const Clip right = makeClip(1, 102, 1.0, 2.0);
+    setupTrackClips(1, { selected, right });
+    ON_CALL(*m_selectionController, selectedClips())
+    .WillByDefault(Return(ClipKeyList { selected.key }));
+
+    const auto span = selectedClipsSpan();
+
+    ASSERT_TRUE(span.has_value());
+    EXPECT_DOUBLE_EQ(0.0, span->begin);
+    EXPECT_DOUBLE_EQ(2.0, span->end);
+}
+
+TEST_F(TrackeditActionsControllerTests, SingleSelectedClipDoesNotJoinAcrossGap)
+{
+    const Clip selected = makeClip(1, 101, 0.0, 1.0);
+    const Clip right = makeClip(1, 102, 1.1, 2.0);
+    setupTrackClips(1, { selected, right });
+    ON_CALL(*m_selectionController, selectedClips())
+    .WillByDefault(Return(ClipKeyList { selected.key }));
+
+    EXPECT_FALSE(selectedClipsSpan().has_value());
+}
 
 /**
  * Cancel always notifies about the in-progress drag edit being cancelled.

--- a/src/trackedit/tests/trackeditactionscontroller_tests.cpp
+++ b/src/trackedit/tests/trackeditactionscontroller_tests.cpp
@@ -155,6 +155,29 @@ TEST_F(TrackeditActionsControllerTests, SingleSelectedClipDoesNotJoinAcrossGap)
     EXPECT_FALSE(selectedClipsSpan().has_value());
 }
 
+TEST_F(TrackeditActionsControllerTests, MultipleSelectedClipsDoNotJoinAcrossGap)
+{
+    const Clip left = makeClip(1, 101, 0.0, 1.0);
+    const Clip right = makeClip(1, 102, 1.1, 2.0);
+    setupTrackClips(1, { left, right });
+    ON_CALL(*m_selectionController, selectedClips())
+    .WillByDefault(Return(ClipKeyList { left.key, right.key }));
+
+    EXPECT_FALSE(selectedClipsSpan().has_value());
+}
+
+TEST_F(TrackeditActionsControllerTests, SingleSelectedClipDoesNotJoinOverlappingTouchingNeighbors)
+{
+    const Clip left = makeClip(1, 101, 0.0, 1.0);
+    const Clip overlappingLeft = makeClip(1, 102, 0.5, 1.0);
+    const Clip selected = makeClip(1, 103, 1.0, 2.0);
+    setupTrackClips(1, { left, overlappingLeft, selected });
+    ON_CALL(*m_selectionController, selectedClips())
+    .WillByDefault(Return(ClipKeyList { selected.key }));
+
+    EXPECT_FALSE(selectedClipsSpan().has_value());
+}
+
 /**
  * Cancel always notifies about the in-progress drag edit being cancelled.
  */


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/5509

When exactly one clip is selected, the Join Clips action now includes clips whose boundaries touch the selected clip on either side. It still refuses to create a join across a gap or across an unrelated overlapping clip.

Previously, the contiguous-span calculation rejected selections containing fewer than two clips, so the command could not implement the single-selected-clip behavior described in the issue.

This also adds focused coverage for a selected clip with two touching neighbors, one touching neighbor, and a gap.

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [ ] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run

Automated validation:

- `cmake --build build-utest --config Debug --target trackedit_tests`
- `trackedit_tests.exe --gtest_filter=TrackeditActionsControllerTests.SingleSelectedClip*` (3 tests passed)