### PR TITLE
Fix crash on record cancellation

### DIFF
--- a/libraries/lib-track/PendingTracks.cpp
+++ b/libraries/lib-track/PendingTracks.cpp
@@ -208,8 +208,9 @@ void PendingTracks::ClearPendingTracks(
       const auto pTrack = *it;
       ++it;
       if (pTrack->GetId() == TrackId{}) {
+         auto removed = mTracks.Remove(*pTrack);
          if (pAdded)
-            pAdded->emplace_back(mTracks.Remove(*pTrack));
+            pAdded->emplace_back(move(removed));
       }
       else {
          if (pAdded)


### PR DESCRIPTION
Resolves: #9145 

ClearPendingTracks was only clearing tracks if they were read out.
CancelRecording calls it without an out arg, so pending tracks accumulated.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
