### PR TITLE
Fix project corruption (backport of #11378)

### DIFF
--- a/libraries/lib-project-file-io/DBConnection.cpp
+++ b/libraries/lib-project-file-io/DBConnection.cpp
@@ -588,10 +588,13 @@ void DBConnection::CheckpointThread(sqlite3 *db, const FilePath &fileName)
             throw SimpleMessageBoxException{ rc != SQLITE_FULL ? ExceptionType::Internal : ExceptionType::BadEnvironment,
                message, XO("Warning"), "Error:_Disk_full_or_not_writable" }; },
             SimpleGuard<void>{},
-            [this](AudacityException * e) {
-               // This executes in the main thread.
-               if (mCallback)
-                  mCallback();
+            [wProject = mpProject, callback = mCallback]
+            (AudacityException * e) {
+               // This executes in the main thread, by which time this
+               // connection may have been closed and destroyed
+               auto pProject = wProject.lock();
+               if (pProject && callback)
+                  callback();
                if (e)
                   e->DelayedHandlerAction();
             }

--- a/libraries/lib-project-file-io/DBConnection.cpp
+++ b/libraries/lib-project-file-io/DBConnection.cpp
@@ -285,6 +285,17 @@ bool DBConnection::Close()
       mCheckpointThread.join();
    }
 
+   // Force checkpointing on close (moves data from wal to main project file)
+   rc = sqlite3_wal_checkpoint_v2(
+      mDB, nullptr, SQLITE_CHECKPOINT_TRUNCATE, nullptr, nullptr);
+   if (rc != SQLITE_OK)
+   {
+      wxLogMessage("Failed final checkpoint on %s\n"
+                   "\tErrMsg: %s",
+                   sqlite3_db_filename(mDB, nullptr),
+                   sqlite3_errmsg(mDB));
+   }
+
    // We're done with the prepared statements
    {
       std::lock_guard<std::mutex> guard(mStatementMutex);
@@ -493,7 +504,8 @@ sqlite3_stmt *DBConnection::Prepare(enum StatementID id, const char *sql)
 void DBConnection::CheckpointThread(sqlite3 *db, const FilePath &fileName)
 {
    int rc = SQLITE_OK;
-   bool giveUp = false;
+   // do not giveUp on checkpointing
+   bool warned = false;
 
    while (true)
    {
@@ -521,9 +533,8 @@ void DBConnection::CheckpointThread(sqlite3 *db, const FilePath &fileName)
       // in the WAL.  They'll be gotten the next time around.
       using namespace std::chrono;
       do {
-         rc = giveUp ? SQLITE_OK :
-            sqlite3_wal_checkpoint_v2(
-               db, nullptr, SQLITE_CHECKPOINT_PASSIVE, nullptr, nullptr);
+         rc = sqlite3_wal_checkpoint_v2(
+            db, nullptr, SQLITE_CHECKPOINT_PASSIVE, nullptr, nullptr);
       }
       // Contentions for an exclusive lock on the database are possible,
       // even while the main thread is merely drawing the tracks, which
@@ -532,6 +543,11 @@ void DBConnection::CheckpointThread(sqlite3 *db, const FilePath &fileName)
 
       // Reset
       mCheckpointActive = false;
+
+      if (rc == SQLITE_OK)
+      {
+         warned = false;
+      }
 
       if (rc != SQLITE_OK)
       {
@@ -561,8 +577,10 @@ void DBConnection::CheckpointThread(sqlite3 *db, const FilePath &fileName)
             "%s"
          ).Format(message1);
 
-         // Stop trying to checkpoint
-         giveUp = true;
+         // Display error once
+         if (warned)
+            continue;
+         warned = true;
 
          // Stop the audio.
          GuardedCall(

--- a/libraries/lib-project-file-io/DBConnection.h
+++ b/libraries/lib-project-file-io/DBConnection.h
@@ -85,6 +85,8 @@ public:
    };
    sqlite3_stmt *Prepare(enum StatementID id, const char *sql);
 
+   std::mutex &TransactionMutex() { return mTransactionMutex; }
+
    void SetBypass( bool bypass );
    bool ShouldBypass();
 
@@ -122,6 +124,8 @@ private:
    std::mutex mStatementMutex;
    using StatementIndex = std::pair<enum StatementID, std::thread::id>;
    std::map<StatementIndex, sqlite3_stmt *> mStatements;
+
+   std::mutex mTransactionMutex;
 
    std::shared_ptr<DBConnectionErrors> mpErrors;
    CheckpointFailureCallback mCallback;

--- a/libraries/lib-project-file-io/ProjectFileIO.cpp
+++ b/libraries/lib-project-file-io/ProjectFileIO.cpp
@@ -2046,6 +2046,13 @@ auto ProjectFileIO::LoadProject(const FilePath &fileName, bool ignoreAutosave)
    if (!OpenConnection(fileName))
       return {};
 
+   // Prevent opening file read only
+   if (sqlite3_db_readonly(DB(), "main") == 1)
+   {
+      SetError(XO("The project file is read-only"), {}, SQLITE_READONLY);
+      return {};
+   }
+
    int64_t rowId = -1;
 
    bool useAutosave =
@@ -2083,18 +2090,6 @@ auto ProjectFileIO::LoadProject(const FilePath &fileName, bool ignoreAutosave)
             XO("Unable to parse project information.")
          );
          return {};
-      }
-
-      // Check for orphans blocks...sets mRecovered if any were deleted
-
-      auto blockids = WaveTrackFactory::Get( mProject )
-         .GetSampleBlockFactory()
-            ->GetActiveBlockIDs();
-      if (blockids.size() > 0)
-      {
-         success = DeleteBlocks(blockids, true);
-         if (!success)
-            return {};
       }
 
       // Remember if we used autosave or not

--- a/libraries/lib-project-file-io/ProjectFileIO.cpp
+++ b/libraries/lib-project-file-io/ProjectFileIO.cpp
@@ -16,7 +16,16 @@ Paul Licameli split from AudacityProject.cpp
 #include <optional>
 #include <cstring>
 
+#if defined(__WXMSW__)
+#include <wx/msw/wrapwin.h>
+#include <io.h>
+#else
+#include <fcntl.h>
+#include <unistd.h>
+#endif
+
 #include <wx/crt.h>
+#include <wx/file.h>
 #include <wx/log.h>
 #include <wx/sstream.h>
 #include <wx/utils.h>
@@ -1415,6 +1424,27 @@ ProjectFileIO::BackupProject::~BackupProject()
    }
 }
 
+// According to docs, wxFile::Flush is noop on Windows
+// and weak on macos, hence this function
+static bool FlushToDisk(const wxString &path)
+{
+   wxFile file(path, wxFile::read_write);
+   if (!file.IsOpened())
+      return false;
+
+#if defined(__WXMSW__)
+   return FlushFileBuffers(
+      reinterpret_cast<HANDLE>(_get_osfhandle(file.fd()))) != 0;
+#elif defined(__APPLE__)
+   // on macos fsync is not enough
+   if (fcntl(file.fd(), F_FULLFSYNC) == 0)
+      return true;
+   return fsync(file.fd()) == 0;
+#else
+   return fsync(file.fd()) == 0;
+#endif
+}
+
 void ProjectFileIO::Compact(
    const std::vector<const TrackList *> &tracks, bool force)
 {
@@ -1475,8 +1505,12 @@ void ProjectFileIO::Compact(
          // gets cleaned up.
          if (wxFileName::GetSize(tempName) < wxFileName::GetSize(origName))
          {
+            if (!FlushToDisk(tempName))
+            {
+               wxLogWarning(wxT("Compaction failed to flush %s"), tempName);
+            }
             // Rename the original to backup
-            if (wxRenameFile(origName, backName))
+            else if (wxRenameFile(origName, backName))
             {
                // Rename the temporary to original
                if (wxRenameFile(tempName, origName))

--- a/libraries/lib-project-file-io/ProjectFileIO.cpp
+++ b/libraries/lib-project-file-io/ProjectFileIO.cpp
@@ -11,6 +11,7 @@ Paul Licameli split from AudacityProject.cpp
 #include "ProjectFileIO.h"
 
 #include <atomic>
+#include <mutex>
 #include <sqlite3.h>
 #include <optional>
 #include <cstring>
@@ -1840,6 +1841,7 @@ bool ProjectFileIO::WriteDoc(const char *table,
                              const char *schema /* = "main" */)
 {
    auto db = DB();
+   std::lock_guard<std::mutex> lock(CurrConn()->TransactionMutex());
 
    TransactionScope transaction(mProject, "UpdateProject");
 

--- a/libraries/lib-project-file-io/ProjectFileIO.cpp
+++ b/libraries/lib-project-file-io/ProjectFileIO.cpp
@@ -338,11 +338,15 @@ private:
 
    std::optional<SQLiteBlobStream> mBlobStream;
    size_t mNextBlobIndex { 0 };
+   bool mReadError { false };
 
    sqlite3* mDB;
    const char* mSchema;
    const char* mTable;
    const int64_t mRowID;
+
+public:
+   bool HadReadError() const { return mReadError; }
 
 protected:
    bool HasMoreData() const override
@@ -368,6 +372,7 @@ protected:
          // the next one
          mBlobStream = {};
          mNextBlobIndex = Columns.size();
+         mReadError = true;
 
          return 0;
       }
@@ -2120,7 +2125,7 @@ auto ProjectFileIO::LoadProject(const FilePath &fileName, bool ignoreAutosave)
 
       success = ProjectSerializer::Decode(stream, this);
 
-      if (!success)
+      if (!success || stream.HadReadError())
       {
          SetError(
             XO("Unable to parse project information.")

--- a/libraries/lib-project-file-io/SqliteSampleBlock.cpp
+++ b/libraries/lib-project-file-io/SqliteSampleBlock.cpp
@@ -775,6 +775,8 @@ void SqliteSampleBlock::Commit(Sizes sizes)
    auto db = DB();
    int rc;
 
+   std::lock_guard<std::mutex> lock(Conn()->TransactionMutex());
+
    // Prepare and cache statement...automatically finalized at DB close
    sqlite3_stmt *stmt = Conn()->Prepare(DBConnection::InsertSampleBlock,
       "INSERT INTO sampleblocks (sampleformat, summin, summax, sumrms,"
@@ -844,6 +846,8 @@ void SqliteSampleBlock::Delete()
    int rc;
 
    wxASSERT(!IsSilent());
+
+   std::lock_guard<std::mutex> lock(Conn()->TransactionMutex());
 
    // Prepare and cache statement...automatically finalized at DB close
    sqlite3_stmt *stmt = Conn()->Prepare(DBConnection::DeleteSampleBlock,

--- a/libraries/lib-wave-track/Sequence.cpp
+++ b/libraries/lib-wave-track/Sequence.cpp
@@ -804,6 +804,7 @@ size_t Sequence::GetBestBlockSize(sampleCount start) const
 }
 
 static constexpr auto Start_attr = "start";
+static constexpr auto Length_attr = "length";
 static constexpr auto MaxSamples_attr = "maxsamples";
 static constexpr auto SampleFormat_attr = "sampleformat";
 static constexpr auto EffectiveSampleFormat_attr = "effectivesampleformat";
@@ -1038,6 +1039,7 @@ void Sequence::WriteXML(XMLWriter &xmlFile) const
 
       xmlFile.StartTag(WaveBlock_tag);
       xmlFile.WriteAttr(Start_attr, bb.start.as_long_long());
+      xmlFile.WriteAttr(Length_attr, static_cast<long long>(bb.sb->GetSampleCount()));
 
       bb.sb->SaveXML(xmlFile);
 


### PR DESCRIPTION
This may resolve these issues, but we can't reproduce them. We will keep the issues open for now to improve discoverability if more reports come in:
- #1754
- #11359
- #11419

Might fix:  #8319, #11244

This pr is a backport of #11378

Changes: 

* when closing a recovered unsaved project we should drop autosave
* there was a tiny but possible corruption when the disk is full
* there was a possible data loss on close if, for example, an external drive was unplugged immediately after closing the project
* when disk went full, the checkpointing was stopped, so on close wal file was left unmerged
* For better recoverability, a length field for each waveblock was added

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [ ] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
