### PR TITLE
Fix translations

### DIFF
--- a/buildscripts/packaging/MacOS/MacOSXBundleInfo.plist.in
+++ b/buildscripts/packaging/MacOS/MacOSXBundleInfo.plist.in
@@ -116,7 +116,6 @@
 	<false/>
 	<key>CFBundleLocalizations</key>
 	<array>
-		<string>en</string>
-	</array>
+${AU4_BUNDLE_LOCALIZATIONS}	</array>
 </dict>
 </plist>

--- a/buildscripts/packaging/MacOS/MacOSXBundleInfo.plist.in
+++ b/buildscripts/packaging/MacOS/MacOSXBundleInfo.plist.in
@@ -5,7 +5,7 @@
 	<key>NSPrincipalClass</key>
     <string>NSApplication</string>
 	<key>CFBundleDevelopmentRegion</key>
-	<string>English</string>
+	<string>en-US</string>
 	<!-- UTI declarations for OS X >= 10.4	-->
 	<key>UTExportedTypeDeclarations</key>
 	<array>

--- a/share/nyquist-plug-ins/rms.ny
+++ b/share/nyquist-plug-ins/rms.ny
@@ -1,10 +1,10 @@
-;nyquist plug-in
-;version 5
-;type analyze nogroup
-;name "Measure RMS"
-;debugbutton false
-;author "Steve Daulton"
-;release 4.0.0
+$nyquist plug-in
+$version 5
+$type analyze nogroup
+$name (_ "Measure RMS")
+$debugbutton false
+$author (_ "Steve Daulton")
+$release 4.0.0
 $copyright (_ "GNU General Public License v2.0 or later")
 
 ;; License: GPL v2+

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -242,6 +242,19 @@ if (MUSE_ENABLE_UNIT_TESTS_CODE_COVERAGE)
 endif()
 
 if (OS_IS_MAC)
+    # macOS localizes its own interface - the native file pickers, standard
+    # buttons and the application menu - according to the localizations the
+    # bundle declares, not according to the Qt catalogues we load. Build the
+    # list from the languages we ship so the two cannot drift apart.
+    file(READ ${PROJECT_SOURCE_DIR}/share/locale/languages.json AU4_LANGUAGES_JSON)
+    string(JSON AU4_LANGUAGES_COUNT LENGTH ${AU4_LANGUAGES_JSON})
+    math(EXPR AU4_LANGUAGES_LAST_INDEX "${AU4_LANGUAGES_COUNT} - 1")
+    set(AU4_BUNDLE_LOCALIZATIONS "")
+    foreach(index RANGE ${AU4_LANGUAGES_LAST_INDEX})
+        string(JSON AU4_LANGUAGE_CODE MEMBER ${AU4_LANGUAGES_JSON} ${index})
+        string(APPEND AU4_BUNDLE_LOCALIZATIONS "\t\t<string>${AU4_LANGUAGE_CODE}</string>\n")
+    endforeach()
+
     set_target_properties(audacity
         PROPERTIES MACOSX_BUNDLE_INFO_PLIST ${PROJECT_SOURCE_DIR}/buildscripts/packaging/MacOS/MacOSXBundleInfo.plist.in
         XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER ${MACOSX_BUNDLE_GUI_IDENTIFIER}

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -244,15 +244,18 @@ endif()
 if (OS_IS_MAC)
     # macOS localizes its own interface - the native file pickers, standard
     # buttons and the application menu - according to the localizations the
-    # bundle declares, not according to the Qt catalogues we load. Build the
-    # list from the languages we ship so the two cannot drift apart.
-    file(READ ${PROJECT_SOURCE_DIR}/share/locale/languages.json AU4_LANGUAGES_JSON)
-    string(JSON AU4_LANGUAGES_COUNT LENGTH ${AU4_LANGUAGES_JSON})
-    math(EXPR AU4_LANGUAGES_LAST_INDEX "${AU4_LANGUAGES_COUNT} - 1")
+    # bundle declares, not according to the Qt catalogues we load. Declare
+    # every localization macOS itself provides, so its native UI always
+    # follows the system language, independently of the app language.
+    file(GLOB AU4_APPKIT_LPROJ_DIRS
+         "/System/Library/Frameworks/AppKit.framework/Versions/C/Resources/*.lproj")
+    list(SORT AU4_APPKIT_LPROJ_DIRS)
     set(AU4_BUNDLE_LOCALIZATIONS "")
-    foreach(index RANGE ${AU4_LANGUAGES_LAST_INDEX})
-        string(JSON AU4_LANGUAGE_CODE MEMBER ${AU4_LANGUAGES_JSON} ${index})
-        string(APPEND AU4_BUNDLE_LOCALIZATIONS "\t\t<string>${AU4_LANGUAGE_CODE}</string>\n")
+    foreach(lproj_dir ${AU4_APPKIT_LPROJ_DIRS})
+        get_filename_component(AU4_LANGUAGE_CODE ${lproj_dir} NAME_WE)
+        if (NOT AU4_LANGUAGE_CODE STREQUAL "Base")
+            string(APPEND AU4_BUNDLE_LOCALIZATIONS "\t\t<string>${AU4_LANGUAGE_CODE}</string>\n")
+        endif()
     endforeach()
 
     set_target_properties(audacity

--- a/src/appshell/qml/Audacity/AppShell/aboutmodel.cpp
+++ b/src/appshell/qml/Audacity/AppShell/aboutmodel.cpp
@@ -326,10 +326,12 @@ QVariantList AboutModel::creditList() const
 {
     static const QVariantList cached = [] {
         QVariantList creditList = {
-            makeSection("Audacity Team Members", buildCredits(sTeamMembers)),
-            makeSection("Emeritus", "Distinguished Audacity Team members, not currently active", buildCredits(sEmeritusTeam)),
-            makeSection("Contributors", buildCredits(sContributors)),
-            makeSection("Website and Graphics", buildCredits(sGraphics)),
+            makeSection(QT_TRANSLATE_NOOP("appshell/about", "Audacity Team Members"), buildCredits(sTeamMembers)),
+            makeSection(QT_TRANSLATE_NOOP("appshell/about", "Emeritus"),
+                        QT_TRANSLATE_NOOP("appshell/about", "Distinguished Audacity Team members, not currently active"),
+                        buildCredits(sEmeritusTeam)),
+            makeSection(QT_TRANSLATE_NOOP("appshell/about", "Contributors"), buildCredits(sContributors)),
+            makeSection(QT_TRANSLATE_NOOP("appshell/about", "Website and Graphics"), buildCredits(sGraphics)),
         };
 
         /* i18n-hint: Replace this with the names of the translators for your language.
@@ -338,11 +340,13 @@ QVariantList AboutModel::creditList() const
             Leave untranslated to hide the Translators section. */
         QString translationCredits = muse::qtrc("appshell/about", "translator_credits");
         if (translationCredits != "translator_credits") {
-            creditList.append(makeSection("Translators", translationCredits));
+            creditList.append(makeSection(QT_TRANSLATE_NOOP("appshell/about", "Translators"), translationCredits));
         }
 
-        creditList.append(makeSection("Libraries", "Audacity includes code from the following projects:", buildCredits(sLibraries)));
-        creditList.append(makeSection("Special Thanks", buildCredits(sThanks)));
+        creditList.append(makeSection(QT_TRANSLATE_NOOP("appshell/about", "Libraries"),
+                                      QT_TRANSLATE_NOOP("appshell/about", "Audacity includes code from the following projects:"),
+                                      buildCredits(sLibraries)));
+        creditList.append(makeSection(QT_TRANSLATE_NOOP("appshell/about", "Special Thanks"), buildCredits(sThanks)));
         return creditList;
     }();
     return cached;

--- a/src/appshell/qml/Audacity/AppShell/appmenumodel.cpp
+++ b/src/appshell/qml/Audacity/AppShell/appmenumodel.cpp
@@ -21,6 +21,8 @@
  */
 #include "appmenumodel.h"
 
+#include "shared/types/workspacetitles.h"
+
 #include "global/containers.h"
 #include "types/translatablestring.h"
 
@@ -51,39 +53,6 @@ static QString makeId(const ActionCode& actionCode, int itemIndex)
 static const ActionCode RENAME_ITEM_CODE("rename-item");
 static const QString RENAME_CLIP_ITEM_ID("rename-clip-item");
 static const QString RENAME_LABEL_ITEM_ID("rename-label-item");
-
-namespace {
-//! NOTE Workspace names are file names, so they exist only as data and cannot
-//! be extracted for translation. Give the workspaces we ship a translated title;
-muse::TranslatableString workspaceTitle(const std::string& name)
-{
-    if (name == "Classic") {
-        return muse::TranslatableString("workspace", "Classic");
-    } else if (name == "Modern") {
-        return muse::TranslatableString("workspace", "Modern");
-    } else if (name == "Music") {
-        return muse::TranslatableString("workspace", "Music");
-    }
-
-    return muse::TranslatableString::untranslatable(muse::String::fromStdString(name));
-}
-
-const muse::uicomponents::MenuItemList& translateWorkspaceTitles(const muse::uicomponents::MenuItemList& items)
-{
-    for (muse::uicomponents::MenuItem* item : items) {
-        const muse::actions::ActionData args = item->args();
-        if (args.empty()) {
-            continue;
-        }
-
-        muse::ui::UiAction action = item->action();
-        action.title = workspaceTitle(args.arg<std::string>(0));
-        item->setAction(action);
-    }
-
-    return items;
-}
-}
 
 AppMenuModel::AppMenuModel(QObject* parent)
     : AbstractMenuModel(parent)
@@ -158,7 +127,7 @@ void AppMenuModel::setupConnections()
 #ifdef MUSE_MODULE_WORKSPACE
     connect(m_workspacesMenuModel.get(), &workspace::WorkspacesMenuModel::itemsChanged, this, [this](){
         MenuItem& workspacesItem = findMenu("menu-workspaces");
-        translateWorkspaceTitles(m_workspacesMenuModel->items());
+        au::shared::translateWorkspaceTitles(m_workspacesMenuModel->items());
         workspacesItem.setSubitems(m_workspacesMenuModel->items());
     });
 #endif
@@ -387,7 +356,7 @@ MenuItem* AppMenuModel::makeViewMenu()
               << makeSeparator()
 #ifdef MUSE_MODULE_WORKSPACE
         << makeMenu(TranslatableString("appshell-menu-view", "W&orkspaces"),
-                    translateWorkspaceTitles(m_workspacesMenuModel->items()), "menu-workspaces")
+                    au::shared::translateWorkspaceTitles(m_workspacesMenuModel->items()), "menu-workspaces")
         << makeSeparator()
 #endif
 #ifndef Q_OS_MAC

--- a/src/appshell/qml/Audacity/AppShell/appmenumodel.cpp
+++ b/src/appshell/qml/Audacity/AppShell/appmenumodel.cpp
@@ -52,6 +52,39 @@ static const ActionCode RENAME_ITEM_CODE("rename-item");
 static const QString RENAME_CLIP_ITEM_ID("rename-clip-item");
 static const QString RENAME_LABEL_ITEM_ID("rename-label-item");
 
+namespace {
+//! NOTE Workspace names are file names, so they exist only as data and cannot
+//! be extracted for translation. Give the workspaces we ship a translated title;
+muse::TranslatableString workspaceTitle(const std::string& name)
+{
+    if (name == "Classic") {
+        return muse::TranslatableString("workspace", "Classic");
+    } else if (name == "Modern") {
+        return muse::TranslatableString("workspace", "Modern");
+    } else if (name == "Music") {
+        return muse::TranslatableString("workspace", "Music");
+    }
+
+    return muse::TranslatableString::untranslatable(muse::String::fromStdString(name));
+}
+
+const muse::uicomponents::MenuItemList& translateWorkspaceTitles(const muse::uicomponents::MenuItemList& items)
+{
+    for (muse::uicomponents::MenuItem* item : items) {
+        const muse::actions::ActionData args = item->args();
+        if (args.empty()) {
+            continue;
+        }
+
+        muse::ui::UiAction action = item->action();
+        action.title = workspaceTitle(args.arg<std::string>(0));
+        item->setAction(action);
+    }
+
+    return items;
+}
+}
+
 AppMenuModel::AppMenuModel(QObject* parent)
     : AbstractMenuModel(parent)
 {
@@ -125,6 +158,7 @@ void AppMenuModel::setupConnections()
 #ifdef MUSE_MODULE_WORKSPACE
     connect(m_workspacesMenuModel.get(), &workspace::WorkspacesMenuModel::itemsChanged, this, [this](){
         MenuItem& workspacesItem = findMenu("menu-workspaces");
+        translateWorkspaceTitles(m_workspacesMenuModel->items());
         workspacesItem.setSubitems(m_workspacesMenuModel->items());
     });
 #endif
@@ -352,7 +386,8 @@ MenuItem* AppMenuModel::makeViewMenu()
               << makeMenuItem("toggle-history")
               << makeSeparator()
 #ifdef MUSE_MODULE_WORKSPACE
-        << makeMenu(TranslatableString("appshell-menu-view", "W&orkspaces"), m_workspacesMenuModel->items(), "menu-workspaces")
+        << makeMenu(TranslatableString("appshell-menu-view", "W&orkspaces"),
+                    translateWorkspaceTitles(m_workspacesMenuModel->items()), "menu-workspaces")
         << makeSeparator()
 #endif
 #ifndef Q_OS_MAC

--- a/src/effects/effects_base/internal/realtimeeffectservice.cpp
+++ b/src/effects/effects_base/internal/realtimeeffectservice.cpp
@@ -378,7 +378,7 @@ void RealtimeEffectService::moveRealtimeEffect(const RealtimeEffectStatePtr& sta
     const auto effectName = getEffectName(*state);
     const auto trackName = effectTrackName(*tId);
     muse::String description;
-    if (oldIndex < newIndex) {
+    if (newIndex < oldIndex) {
         //: History entry. %1 is an effect name, %2 is a track name,
         //: e.g. "Moved Compressor up in Track 1"
         description = muse::mtrc("effects", "Moved %1 up in %2");

--- a/src/effects/effects_base/internal/realtimeeffectservice.cpp
+++ b/src/effects/effects_base/internal/realtimeeffectservice.cpp
@@ -275,8 +275,11 @@ RealtimeEffectStatePtr RealtimeEffectService::addRealtimeEffect(TrackId trackId,
         const auto effectName = getEffectName(*state);
         const auto trackName = effectTrackName(trackId);
         projectHistory()->pushHistoryState(
+            //: History entry. %1 is an effect name, %2 is a track name,
+            //: e.g. "Added Compressor to Track 1"
             muse::mtrc("effects", "Added %1 to %2")
             .arg(muse::String::fromStdString(effectName)).arg(muse::String::fromStdString(trackName.value_or(""))).toStdString(),
+            //: Undo entry name. %1 is an effect name, e.g. "Add Compressor"
             muse::mtrc("effects", "Add %1").arg(muse::String::fromStdString(effectName)).toStdString());
         return state;
     }
@@ -313,8 +316,11 @@ void RealtimeEffectService::removeRealtimeEffect(TrackId trackId, const Realtime
     const auto effectName = getEffectName(*state);
     const auto trackName = effectTrackName(trackId);
     projectHistory()->pushHistoryState(
+        //: History entry. %1 is an effect name, %2 is a track name,
+        //: e.g. "Removed Compressor from Track 1"
         muse::mtrc("effects", "Removed %1 from %2")
         .arg(muse::String::fromStdString(effectName)).arg(muse::String::fromStdString(trackName.value_or(""))).toStdString(),
+        //: Undo entry name. %1 is an effect name, e.g. "Remove Compressor"
         muse::mtrc("effects", "Remove %1").arg(muse::String::fromStdString(effectName)).toStdString());
 }
 
@@ -334,8 +340,11 @@ RealtimeEffectStatePtr RealtimeEffectService::replaceRealtimeEffect(TrackId trac
         const auto oldEffectName = getEffectName(*oldState);
         const auto newEffectName = getEffectName(*newState);
         projectHistory()->pushHistoryState(
+            //: History entry. %1 and %2 are effect names,
+            //: e.g. "Replaced Compressor with Limiter"
             muse::mtrc("effects", "Replaced %1 with %2")
             .arg(muse::String::fromStdString(oldEffectName)).arg(muse::String::fromStdString(newEffectName)).toStdString(),
+            //: Undo entry name. %1 is an effect name, e.g. "Replace Compressor"
             muse::mtrc("effects", "Replace %1").arg(muse::String::fromStdString(oldEffectName)).toStdString());
         return newState;
     }
@@ -368,11 +377,18 @@ void RealtimeEffectService::moveRealtimeEffect(const RealtimeEffectStatePtr& sta
 
     const auto effectName = getEffectName(*state);
     const auto trackName = effectTrackName(*tId);
+    muse::String description;
+    if (oldIndex < newIndex) {
+        //: History entry. %1 is an effect name, %2 is a track name,
+        //: e.g. "Moved Compressor up in Track 1"
+        description = muse::mtrc("effects", "Moved %1 up in %2");
+    } else {
+        //: History entry. %1 is an effect name, %2 is a track name,
+        //: e.g. "Moved Compressor down in Track 1"
+        description = muse::mtrc("effects", "Moved %1 down in %2");
+    }
     projectHistory()->pushHistoryState(
-        (oldIndex < newIndex
-         ? muse::mtrc("effects", "Moved %1 up in %2")
-         : muse::mtrc("effects", "Moved %1 down in %2"))
-        .arg(muse::String::fromStdString(effectName)).arg(muse::String::fromStdString(trackName.value_or(""))).toStdString(),
+        description.arg(muse::String::fromStdString(effectName)).arg(muse::String::fromStdString(trackName.value_or(""))).toStdString(),
         muse::trc("effects", "Change effect order"));
 }
 

--- a/src/effects/effects_base/internal/realtimeeffectservice.cpp
+++ b/src/effects/effects_base/internal/realtimeeffectservice.cpp
@@ -1,5 +1,7 @@
 #include "realtimeeffectservice.h"
 
+#include "global/translation.h"
+
 #include "realtimeeffectrestorer.h"
 #include "realtimeeffectserviceutils.h"
 #include "effectsutils.h"
@@ -272,7 +274,10 @@ RealtimeEffectStatePtr RealtimeEffectService::addRealtimeEffect(TrackId trackId,
     if (const auto state = AudioIO::Get()->AddState(*data->au3Project, data->au3Track, effectId.toStdString())) {
         const auto effectName = getEffectName(*state);
         const auto trackName = effectTrackName(trackId);
-        projectHistory()->pushHistoryState("Added " + effectName + " to " + trackName.value_or(""), "Add " + effectName);
+        projectHistory()->pushHistoryState(
+            muse::mtrc("effects", "Added %1 to %2")
+            .arg(muse::String::fromStdString(effectName)).arg(muse::String::fromStdString(trackName.value_or(""))).toStdString(),
+            muse::mtrc("effects", "Add %1").arg(muse::String::fromStdString(effectName)).toStdString());
         return state;
     }
 
@@ -307,7 +312,10 @@ void RealtimeEffectService::removeRealtimeEffect(TrackId trackId, const Realtime
     AudioIO::Get()->RemoveState(*data->au3Project, data->au3Track, state);
     const auto effectName = getEffectName(*state);
     const auto trackName = effectTrackName(trackId);
-    projectHistory()->pushHistoryState("Removed " + effectName + " from " + trackName.value_or(""), "Remove " + effectName);
+    projectHistory()->pushHistoryState(
+        muse::mtrc("effects", "Removed %1 from %2")
+        .arg(muse::String::fromStdString(effectName)).arg(muse::String::fromStdString(trackName.value_or(""))).toStdString(),
+        muse::mtrc("effects", "Remove %1").arg(muse::String::fromStdString(effectName)).toStdString());
 }
 
 RealtimeEffectStatePtr RealtimeEffectService::replaceRealtimeEffect(TrackId trackId, int effectListIndex, const muse::String& newEffectId)
@@ -325,7 +333,10 @@ RealtimeEffectStatePtr RealtimeEffectService::replaceRealtimeEffect(TrackId trac
     if (const auto newState = AudioIO::Get()->ReplaceState(*data->au3Project, data->au3Track, effectListIndex, newEffectId.toStdString())) {
         const auto oldEffectName = getEffectName(*oldState);
         const auto newEffectName = getEffectName(*newState);
-        projectHistory()->pushHistoryState("Replaced " + oldEffectName + " with " + newEffectName, "Replace " + oldEffectName);
+        projectHistory()->pushHistoryState(
+            muse::mtrc("effects", "Replaced %1 with %2")
+            .arg(muse::String::fromStdString(oldEffectName)).arg(muse::String::fromStdString(newEffectName)).toStdString(),
+            muse::mtrc("effects", "Replace %1").arg(muse::String::fromStdString(oldEffectName)).toStdString());
         return newState;
     }
 
@@ -357,9 +368,12 @@ void RealtimeEffectService::moveRealtimeEffect(const RealtimeEffectStatePtr& sta
 
     const auto effectName = getEffectName(*state);
     const auto trackName = effectTrackName(*tId);
-    projectHistory()->pushHistoryState("Moved " + effectName
-                                       + (oldIndex < newIndex ? " up " : " down ") + " in " + trackName.value_or(""),
-                                       "Change effect order");
+    projectHistory()->pushHistoryState(
+        (oldIndex < newIndex
+         ? muse::mtrc("effects", "Moved %1 up in %2")
+         : muse::mtrc("effects", "Moved %1 down in %2"))
+        .arg(muse::String::fromStdString(effectName)).arg(muse::String::fromStdString(trackName.value_or(""))).toStdString(),
+        muse::trc("effects", "Change effect order"));
 }
 
 bool RealtimeEffectService::isActive(const RealtimeEffectStatePtr& state) const

--- a/src/importexport/labels/labelsmodule.cpp
+++ b/src/importexport/labels/labelsmodule.cpp
@@ -15,7 +15,6 @@
 #include "view/exportlabelsmodel.h"
 
 using namespace au::importexport;
-using namespace muse;
 
 static const std::string mname("iex_labels");
 
@@ -52,7 +51,7 @@ void LabelsModule::resolveImports()
 {
     auto ir = globalIoc()->resolve<muse::interactive::IInteractiveUriRegister>(mname);
     if (ir) {
-        ir->registerQmlUri(Uri("audacity://project/export/labels"), "Export/ExportLabelsDialog.qml");
+        ir->registerQmlUri(muse::Uri("audacity://project/export/labels"), "Export/ExportLabelsDialog.qml");
     }
 }
 

--- a/src/preferences/qml/Audacity/Preferences/internal/CrashReportsSection.qml
+++ b/src/preferences/qml/Audacity/Preferences/internal/CrashReportsSection.qml
@@ -36,7 +36,7 @@ BaseSection {
     StyledTextLabel {
         width: parent.width
 
-        text: qsTrc("appshell/preferences", "Crash reports require network access. When Audacity crashes, it sends a report that helps us find and fix the cause. These reports don't contain your audio or personal information. See our <a href=\"%1\">privacy policy</a> for more info.").arg(root.privacyPolicyUrl).replace("\n", "<br>")
+        text: qsTrc("appshell/preferences", "Crash reports require network access. When Audacity crashes, it sends a report that helps us find and fix the cause. These reports don’t contain your audio or personal information. See our <a href=\"%1\">privacy policy</a> for more info.").arg(root.privacyPolicyUrl).replace("\n", "<br>")
 
         horizontalAlignment: Qt.AlignLeft
         wrapMode: Text.WordWrap

--- a/src/project/tests/environment.cpp
+++ b/src/project/tests/environment.cpp
@@ -63,8 +63,8 @@ static muse::testing::SuiteEnvironment audacityproject_se
     });
 
     static std::vector<au::projectscene::ClipColorInfo> colorInfos = {
-        { "blue", 1 },
-        { "red", 2 },
+        { muse::TranslatableString::untranslatable("blue"), 1 },
+        { muse::TranslatableString::untranslatable("red"), 2 },
     };
 
     ON_CALL(*projectSceneConfigurator, clipColorInfos())

--- a/src/projectscene/internal/projectsceneconfiguration.cpp
+++ b/src/projectscene/internal/projectsceneconfiguration.cpp
@@ -194,15 +194,15 @@ muse::async::Notification ProjectSceneConfiguration::isEffectsPanelVisibleChange
 const std::vector<ClipColorInfo>& ProjectSceneConfiguration::clipColorInfos() const
 {
     static const std::vector<ClipColorInfo> infos = {
-        { "Blue", 1 },
-        { "Violet", 2 },
-        { "Magenta", 3 },
-        { "Red", 4 },
-        { "Orange", 5 },
-        { "Yellow", 6 },
-        { "Green", 7 },
-        { "Turquoise", 8 },
-        { "Cyan", 9 }
+        { muse::TranslatableString("projectscene", "Blue"), 1 },
+        { muse::TranslatableString("projectscene", "Violet"), 2 },
+        { muse::TranslatableString("projectscene", "Magenta"), 3 },
+        { muse::TranslatableString("projectscene", "Red"), 4 },
+        { muse::TranslatableString("projectscene", "Orange"), 5 },
+        { muse::TranslatableString("projectscene", "Yellow"), 6 },
+        { muse::TranslatableString("projectscene", "Green"), 7 },
+        { muse::TranslatableString("projectscene", "Turquoise"), 8 },
+        { muse::TranslatableString("projectscene", "Cyan"), 9 }
     };
 
     return infos;

--- a/src/projectscene/iprojectsceneconfiguration.h
+++ b/src/projectscene/iprojectsceneconfiguration.h
@@ -7,12 +7,13 @@
 #include "modularity/ioc.h"
 
 #include "global/types/color.h"
+#include "global/types/translatablestring.h"
 #include "trackedit/trackedittypes.h"
 #include "types/projectscenetypes.h"
 
 namespace au::projectscene {
 struct ClipColorInfo {
-    std::string name;
+    muse::TranslatableString title;
     trackedit::ClipColorIndex index = 0;
 };
 class IProjectSceneConfiguration : MODULE_GLOBAL_INTERFACE

--- a/src/projectscene/tests/environment.cpp
+++ b/src/projectscene/tests/environment.cpp
@@ -17,8 +17,8 @@ static muse::testing::SuiteEnvironment projectscene_se = muse::testing::SuiteEnv
     std::shared_ptr<NiceMock<ProjectSceneConfigurationMock> > projectSceneConfigurator(new NiceMock<ProjectSceneConfigurationMock>(),
                                                                                        [](ProjectSceneConfigurationMock*) {}); // no delete
     static std::vector<ClipColorInfo> colorInfos = {
-        { "blue", 1 },
-        { "red", 2 },
+        { muse::TranslatableString::untranslatable("blue"), 1 },
+        { muse::TranslatableString::untranslatable("red"), 2 },
     };
 
     ON_CALL(*projectSceneConfigurator, clipColorInfos())

--- a/src/projectscene/view/toolbars/workspacestoolbarmodel.cpp
+++ b/src/projectscene/view/toolbars/workspacestoolbarmodel.cpp
@@ -20,6 +20,37 @@ using namespace muse::uicomponents;
 using namespace muse::actions;
 using namespace muse::ui;
 
+namespace {
+//! NOTE Workspace names are file names, so they exist only as data and cannot
+//! be extracted for translation. Give the workspaces we ship a translated title;
+muse::TranslatableString workspaceTitle(const std::string& name)
+{
+    if (name == "Classic") {
+        return muse::TranslatableString("workspace", "Classic");
+    } else if (name == "Modern") {
+        return muse::TranslatableString("workspace", "Modern");
+    } else if (name == "Music") {
+        return muse::TranslatableString("workspace", "Music");
+    }
+
+    return muse::TranslatableString::untranslatable(muse::String::fromStdString(name));
+}
+
+void translateWorkspaceTitles(const muse::uicomponents::MenuItemList& items)
+{
+    for (muse::uicomponents::MenuItem* item : items) {
+        const muse::actions::ActionData args = item->args();
+        if (args.empty()) {
+            continue;
+        }
+
+        muse::ui::UiAction action = item->action();
+        action.title = workspaceTitle(args.arg<std::string>(0));
+        item->setAction(action);
+    }
+}
+}
+
 WorkspacesToolBarModel::WorkspacesToolBarModel(QObject* parent)
     : muse::uicomponents::AbstractToolBarModel(parent)
 {
@@ -75,6 +106,8 @@ void WorkspacesToolBarModel::updateState()
     }
 
     muse::TranslatableString currentWorkspaceName;
+
+    translateWorkspaceTitles(m_workspacesMenuModel->items());
 
     for (const MenuItem* menuItem : m_workspacesMenuModel->items()) {
         if (menuItem->selected()) {

--- a/src/projectscene/view/toolbars/workspacestoolbarmodel.cpp
+++ b/src/projectscene/view/toolbars/workspacestoolbarmodel.cpp
@@ -3,6 +3,8 @@
 */
 #include "workspacestoolbarmodel.h"
 
+#include "shared/types/workspacetitles.h"
+
 #include "muse_framework_config.h"
 
 #ifdef MUSE_MODULE_WORKSPACE
@@ -19,37 +21,6 @@ using namespace au::projectscene;
 using namespace muse::uicomponents;
 using namespace muse::actions;
 using namespace muse::ui;
-
-namespace {
-//! NOTE Workspace names are file names, so they exist only as data and cannot
-//! be extracted for translation. Give the workspaces we ship a translated title;
-muse::TranslatableString workspaceTitle(const std::string& name)
-{
-    if (name == "Classic") {
-        return muse::TranslatableString("workspace", "Classic");
-    } else if (name == "Modern") {
-        return muse::TranslatableString("workspace", "Modern");
-    } else if (name == "Music") {
-        return muse::TranslatableString("workspace", "Music");
-    }
-
-    return muse::TranslatableString::untranslatable(muse::String::fromStdString(name));
-}
-
-void translateWorkspaceTitles(const muse::uicomponents::MenuItemList& items)
-{
-    for (muse::uicomponents::MenuItem* item : items) {
-        const muse::actions::ActionData args = item->args();
-        if (args.empty()) {
-            continue;
-        }
-
-        muse::ui::UiAction action = item->action();
-        action.title = workspaceTitle(args.arg<std::string>(0));
-        item->setAction(action);
-    }
-}
-}
 
 WorkspacesToolBarModel::WorkspacesToolBarModel(QObject* parent)
     : muse::uicomponents::AbstractToolBarModel(parent)
@@ -107,7 +78,7 @@ void WorkspacesToolBarModel::updateState()
 
     muse::TranslatableString currentWorkspaceName;
 
-    translateWorkspaceTitles(m_workspacesMenuModel->items());
+    au::shared::translateWorkspaceTitles(m_workspacesMenuModel->items());
 
     for (const MenuItem* menuItem : m_workspacesMenuModel->items()) {
         if (menuItem->selected()) {

--- a/src/projectscene/view/tracksitemsview/clipcontextmenumodel.cpp
+++ b/src/projectscene/view/tracksitemsview/clipcontextmenumodel.cpp
@@ -265,14 +265,14 @@ MenuItemList ClipContextMenuModel::makeClipColourItems()
     MenuItemList items;
     items <<
         makeMenuItem("action://trackedit/clip/change-color-auto",
-                     muse::TranslatableString("clip", muse::String::fromStdString("Same as track color")));
+                     muse::TranslatableString("clip", "Same as track color"));
     items << makeSeparator();
     m_colorChangeActionCodeList.push_back("action://trackedit/clip/change-color-auto");
 
     const auto& colorInfos = projectSceneConfiguration()->clipColorInfos();
     for (const auto& info : colorInfos) {
         items << makeMenuItem(makeClipColorChangeAction(info.index).toString(),
-                              muse::TranslatableString("clip", muse::String::fromStdString(info.name)));
+                              info.title);
         m_colorChangeActionCodeList.push_back(makeClipColorChangeAction(info.index).toString());
     }
 

--- a/src/projectscene/view/tracksitemsview/waveview.cpp
+++ b/src/projectscene/view/tracksitemsview/waveview.cpp
@@ -3,6 +3,8 @@
 */
 #include "waveview.h"
 
+#include "global/translation.h"
+
 #include <QPainter>
 #include <QElapsedTimer>
 
@@ -651,7 +653,8 @@ void WaveView::onWaveZoomChanged()
 
 void WaveView::pushProjectHistorySampleEdit()
 {
-    projectHistory()->pushHistoryState("Moved Samples", "Sample Edit", trackedit::UndoPushType::CONSOLIDATE);
+    projectHistory()->pushHistoryState(muse::trc("projectscene", "Moved Samples"), muse::trc("projectscene", "Sample Edit"),
+                                       trackedit::UndoPushType::CONSOLIDATE);
 }
 
 au::context::IPlaybackStatePtr WaveView::playbackState() const

--- a/src/projectscene/view/trackspanel/trackcontextmenumodel.cpp
+++ b/src/projectscene/view/trackspanel/trackcontextmenumodel.cpp
@@ -381,6 +381,7 @@ void TrackContextMenuModel::updateTrackRateState()
     customRateItem.setChecked(!isOnAvailableRates);
 
     MenuItem& menu = findMenu(QString::fromUtf8(TRACK_RATE_MENU_ID));
+    //: %1 is a sample rate in hertz, e.g. "44100 Hz"
     menu.setTitle(muse::TranslatableString("trackcontextmenu", "Rate: %1 Hz")
                   .arg(muse::String::number(static_cast<int>(track.value().rate))));
 }
@@ -449,7 +450,7 @@ muse::uicomponents::MenuItemList TrackContextMenuModel::makeTrackColorItems()
     const auto& colorInfos = projectSceneConfiguration()->clipColorInfos();
     for (const auto& info : colorInfos) {
         items << makeMenuItem(makeTrackColorChangeAction(info.index).toString(),
-                              muse::TranslatableString("trackcontextmenu", muse::String::fromStdString(info.name)));
+                              info.title);
         m_colorChangeActionCodeList.push_back(makeTrackColorChangeAction(info.index).toString());
     }
 
@@ -471,7 +472,8 @@ muse::uicomponents::MenuItemList TrackContextMenuModel::makeTrackRateItems()
     muse::uicomponents::MenuItemList items;
     for (const auto& rate : audioDriverController()->sampleRates()) {
         items << makeMenuItem(makeTrackRateChangeAction(rate).toString(),
-                              muse::TranslatableString("trackcontextmenu", muse::String::number(static_cast<int>(rate)) + " Hz"));
+                              //: %1 is a sample rate in hertz, e.g. "44100 Hz"
+                              muse::TranslatableString("trackcontextmenu", "%1 Hz").arg(muse::String::number(static_cast<int>(rate))));
     }
     items << makeSeparator();
     items << makeItemWithArg("track-change-rate-custom");

--- a/src/projectscene/view/trackspanel/trackcontextmenumodel.cpp
+++ b/src/projectscene/view/trackspanel/trackcontextmenumodel.cpp
@@ -23,8 +23,6 @@ constexpr const char* TRACK_COLOR_MENU_ID = "trackColorMenu";
 constexpr const char* TRACK_FORMAT_MENU_ID = "trackFormatMenu";
 constexpr const char* TRACK_RATE_MENU_ID = "trackRateMenu";
 
-constexpr const char* TRANSLATABLE_STRING_CONTEXT = "trackcontextmenu";
-
 //! NOTE: can be moved to the framework
 bool containsAny(const ActionCodeList& list, const ActionCodeList& actionCodes)
 {
@@ -59,18 +57,18 @@ MenuItemList TrackContextMenuModel::makeStereoTrackItems()
         makeItemWithArg("track-duplicate"),
         makeItemWithArg("track-delete"),
         makeSeparator(),
-        makeMenu(muse::TranslatableString(TRANSLATABLE_STRING_CONTEXT, "Move track"), makeTrackMoveItems()),
-        makeMenu(muse::TranslatableString(TRANSLATABLE_STRING_CONTEXT, "Track visualization"), makeTrackVisualizationItems()),
-        makeMenu(muse::TranslatableString(TRANSLATABLE_STRING_CONTEXT, "Track color"), makeTrackColorItems(), TRACK_COLOR_MENU_ID),
+        makeMenu(muse::TranslatableString("trackcontextmenu", "Move track"), makeTrackMoveItems()),
+        makeMenu(muse::TranslatableString("trackcontextmenu", "Track visualization"), makeTrackVisualizationItems()),
+        makeMenu(muse::TranslatableString("trackcontextmenu", "Track color"), makeTrackColorItems(), TRACK_COLOR_MENU_ID),
         makeItemWithArg("toggle-vertical-rulers"),
-        makeMenu(muse::TranslatableString(TRANSLATABLE_STRING_CONTEXT, "Meters && monitoring"), makeMeterMonitoringItems()),
+        makeMenu(muse::TranslatableString("trackcontextmenu", "Meters && monitoring"), makeMeterMonitoringItems()),
         makeSeparator(),
         makeItemWithArg("track-swap-channels"),
         makeItemWithArg("track-split-stereo-to-lr"),
         makeItemWithArg("track-split-stereo-to-center"),
         makeSeparator(),
-        makeMenu(muse::TranslatableString(TRANSLATABLE_STRING_CONTEXT, "Format:"), makeTrackFormatItems(), TRACK_FORMAT_MENU_ID),
-        makeMenu(muse::TranslatableString(TRANSLATABLE_STRING_CONTEXT, "Rate:"), makeTrackRateItems(), TRACK_RATE_MENU_ID),
+        makeMenu(muse::TranslatableString("trackcontextmenu", "Format:"), makeTrackFormatItems(), TRACK_FORMAT_MENU_ID),
+        makeMenu(muse::TranslatableString("trackcontextmenu", "Rate:"), makeTrackRateItems(), TRACK_RATE_MENU_ID),
         makeItemWithArg("track-resample"),
     };
 
@@ -84,16 +82,16 @@ MenuItemList TrackContextMenuModel::makeMonoTrackItems()
         makeItemWithArg("track-duplicate"),
         makeItemWithArg("track-delete"),
         makeSeparator(),
-        makeMenu(muse::TranslatableString(TRANSLATABLE_STRING_CONTEXT, "Move track"), makeTrackMoveItems()),
-        makeMenu(muse::TranslatableString(TRANSLATABLE_STRING_CONTEXT, "Track visualization"), makeTrackVisualizationItems()),
-        makeMenu(muse::TranslatableString(TRANSLATABLE_STRING_CONTEXT, "Track color"), makeTrackColorItems(), TRACK_COLOR_MENU_ID),
+        makeMenu(muse::TranslatableString("trackcontextmenu", "Move track"), makeTrackMoveItems()),
+        makeMenu(muse::TranslatableString("trackcontextmenu", "Track visualization"), makeTrackVisualizationItems()),
+        makeMenu(muse::TranslatableString("trackcontextmenu", "Track color"), makeTrackColorItems(), TRACK_COLOR_MENU_ID),
         makeItemWithArg("toggle-vertical-rulers"),
-        makeMenu(muse::TranslatableString(TRANSLATABLE_STRING_CONTEXT, "Meters && monitoring"), makeMeterMonitoringItems()),
+        makeMenu(muse::TranslatableString("trackcontextmenu", "Meters && monitoring"), makeMeterMonitoringItems()),
         makeSeparator(),
         makeItemWithArg("track-make-stereo"),
         makeSeparator(),
-        makeMenu(muse::TranslatableString(TRANSLATABLE_STRING_CONTEXT, "Format:"), makeTrackFormatItems(), TRACK_FORMAT_MENU_ID),
-        makeMenu(muse::TranslatableString(TRANSLATABLE_STRING_CONTEXT, "Rate:"), makeTrackRateItems(), TRACK_RATE_MENU_ID),
+        makeMenu(muse::TranslatableString("trackcontextmenu", "Format:"), makeTrackFormatItems(), TRACK_FORMAT_MENU_ID),
+        makeMenu(muse::TranslatableString("trackcontextmenu", "Rate:"), makeTrackRateItems(), TRACK_RATE_MENU_ID),
         makeItemWithArg("track-resample"),
     };
 
@@ -107,8 +105,8 @@ MenuItemList TrackContextMenuModel::makeLabelTrackItems()
         makeItemWithArg("track-duplicate"),
         makeItemWithArg("track-delete"),
         makeSeparator(),
-        makeMenu(muse::TranslatableString(TRANSLATABLE_STRING_CONTEXT, "Move track"), makeTrackMoveItems()),
-        makeMenu(muse::TranslatableString(TRANSLATABLE_STRING_CONTEXT, "Track color"), makeTrackColorItems(), TRACK_COLOR_MENU_ID),
+        makeMenu(muse::TranslatableString("trackcontextmenu", "Move track"), makeTrackMoveItems()),
+        makeMenu(muse::TranslatableString("trackcontextmenu", "Track color"), makeTrackColorItems(), TRACK_COLOR_MENU_ID),
         makeSeparator(),
         makeItemWithArg("export-labels")
     };
@@ -350,7 +348,7 @@ void TrackContextMenuModel::updateTrackFormatState()
 
         item.setChecked(true);
         MenuItem& menu = findMenu(QString::fromUtf8(TRACK_FORMAT_MENU_ID));
-        menu.setTitle(muse::TranslatableString(TRANSLATABLE_STRING_CONTEXT, "Format: %1")
+        menu.setTitle(muse::TranslatableString("trackcontextmenu", "Format: %1")
                       .arg(muse::String(formatInfo.description)));
     }
 }
@@ -383,7 +381,7 @@ void TrackContextMenuModel::updateTrackRateState()
     customRateItem.setChecked(!isOnAvailableRates);
 
     MenuItem& menu = findMenu(QString::fromUtf8(TRACK_RATE_MENU_ID));
-    menu.setTitle(muse::TranslatableString(TRANSLATABLE_STRING_CONTEXT, "Rate: %1 Hz")
+    menu.setTitle(muse::TranslatableString("trackcontextmenu", "Rate: %1 Hz")
                   .arg(muse::String::number(static_cast<int>(track.value().rate))));
 }
 
@@ -451,7 +449,7 @@ muse::uicomponents::MenuItemList TrackContextMenuModel::makeTrackColorItems()
     const auto& colorInfos = projectSceneConfiguration()->clipColorInfos();
     for (const auto& info : colorInfos) {
         items << makeMenuItem(makeTrackColorChangeAction(info.index).toString(),
-                              muse::TranslatableString(TRANSLATABLE_STRING_CONTEXT, muse::String::fromStdString(info.name)));
+                              muse::TranslatableString("trackcontextmenu", muse::String::fromStdString(info.name)));
         m_colorChangeActionCodeList.push_back(makeTrackColorChangeAction(info.index).toString());
     }
 
@@ -463,7 +461,7 @@ muse::uicomponents::MenuItemList TrackContextMenuModel::makeTrackFormatItems()
     muse::uicomponents::MenuItemList items;
     for (const auto& formatInfo : trackedit::availableTrackFormats()) {
         items << makeMenuItem(makeTrackFormatChangeAction(formatInfo.format).toString(),
-                              muse::TranslatableString(TRANSLATABLE_STRING_CONTEXT, muse::String(formatInfo.description)));
+                              muse::TranslatableString("trackcontextmenu", muse::String(formatInfo.description)));
     }
     return items;
 }
@@ -473,7 +471,7 @@ muse::uicomponents::MenuItemList TrackContextMenuModel::makeTrackRateItems()
     muse::uicomponents::MenuItemList items;
     for (const auto& rate : audioDriverController()->sampleRates()) {
         items << makeMenuItem(makeTrackRateChangeAction(rate).toString(),
-                              muse::TranslatableString(TRANSLATABLE_STRING_CONTEXT, muse::String::number(static_cast<int>(rate)) + " Hz"));
+                              muse::TranslatableString("trackcontextmenu", muse::String::number(static_cast<int>(rate)) + " Hz"));
     }
     items << makeSeparator();
     items << makeItemWithArg("track-change-rate-custom");

--- a/src/projectscene/view/trackspanel/trackcontextmenumodel.cpp
+++ b/src/projectscene/view/trackspanel/trackcontextmenumodel.cpp
@@ -349,7 +349,7 @@ void TrackContextMenuModel::updateTrackFormatState()
         item.setChecked(true);
         MenuItem& menu = findMenu(QString::fromUtf8(TRACK_FORMAT_MENU_ID));
         menu.setTitle(muse::TranslatableString("trackcontextmenu", "Format: %1")
-                      .arg(muse::String(formatInfo.description)));
+                      .arg(formatInfo.description));
     }
 }
 
@@ -462,7 +462,7 @@ muse::uicomponents::MenuItemList TrackContextMenuModel::makeTrackFormatItems()
     muse::uicomponents::MenuItemList items;
     for (const auto& formatInfo : trackedit::availableTrackFormats()) {
         items << makeMenuItem(makeTrackFormatChangeAction(formatInfo.format).toString(),
-                              muse::TranslatableString("trackcontextmenu", muse::String(formatInfo.description)));
+                              formatInfo.description);
     }
     return items;
 }

--- a/src/record/tests/environment.cpp
+++ b/src/record/tests/environment.cpp
@@ -21,8 +21,8 @@ static muse::testing::SuiteEnvironment record_se
                                                                                        [](ProjectSceneConfigurationMock*) {}); // no delete
 
     static std::vector<ClipColorInfo> colorInfos = {
-        { "blue", 1 },
-        { "red", 2 },
+        { muse::TranslatableString::untranslatable("blue"), 1 },
+        { muse::TranslatableString::untranslatable("red"), 2 },
     };
 
     ON_CALL(*projectSceneConfigurator, clipColorInfos())

--- a/src/shared/CMakeLists.txt
+++ b/src/shared/CMakeLists.txt
@@ -17,6 +17,7 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/axis/axislabel.cpp
 
     ${CMAKE_CURRENT_LIST_DIR}/types/decibel.h
+    ${CMAKE_CURRENT_LIST_DIR}/types/workspacetitles.h
     ${CMAKE_CURRENT_LIST_DIR}/types/decibel.cpp
 )
 

--- a/src/shared/types/workspacetitles.h
+++ b/src/shared/types/workspacetitles.h
@@ -16,10 +16,16 @@ namespace au::shared {
 inline muse::TranslatableString workspaceTitle(const std::string& name)
 {
     if (name == "Classic") {
+        //: The name of a built-in workspace (an interface layout);
+        //: an adjective in languages where that applies
         return muse::TranslatableString("workspace", "Classic");
     } else if (name == "Modern") {
+        //: The name of a built-in workspace (an interface layout);
+        //: an adjective in languages where that applies
         return muse::TranslatableString("workspace", "Modern");
     } else if (name == "Music") {
+        //: The name of a built-in workspace (an interface layout);
+        //: an adjective in languages where that applies
         return muse::TranslatableString("workspace", "Music");
     }
 

--- a/src/shared/types/workspacetitles.h
+++ b/src/shared/types/workspacetitles.h
@@ -1,0 +1,44 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+#pragma once
+
+#include <string>
+
+#include "framework/actions/actiontypes.h"
+#include "framework/global/types/translatablestring.h"
+#include "framework/ui/uiaction.h"
+#include "framework/uicomponents/qml/Muse/UiComponents/menuitem.h"
+
+namespace au::shared {
+//! NOTE Give the workspaces we ship a translated title;
+//! workspaces created by the user keep their own name.
+inline muse::TranslatableString workspaceTitle(const std::string& name)
+{
+    if (name == "Classic") {
+        return muse::TranslatableString("workspace", "Classic");
+    } else if (name == "Modern") {
+        return muse::TranslatableString("workspace", "Modern");
+    } else if (name == "Music") {
+        return muse::TranslatableString("workspace", "Music");
+    }
+
+    return muse::TranslatableString::untranslatable(muse::String::fromStdString(name));
+}
+
+inline const muse::uicomponents::MenuItemList& translateWorkspaceTitles(const muse::uicomponents::MenuItemList& items)
+{
+    for (muse::uicomponents::MenuItem* item : items) {
+        const muse::actions::ActionData args = item->args();
+        if (args.empty()) {
+            continue;
+        }
+
+        muse::ui::UiAction action = item->action();
+        action.title = workspaceTitle(args.arg<std::string>(0));
+        item->setAction(action);
+    }
+
+    return items;
+}
+}

--- a/src/shared/types/workspacetitles.h
+++ b/src/shared/types/workspacetitles.h
@@ -5,9 +5,8 @@
 
 #include <string>
 
-#include "framework/actions/actiontypes.h"
 #include "framework/global/types/translatablestring.h"
-#include "framework/ui/uiaction.h"
+#include "framework/rcommand/commandtypes.h"
 #include "framework/uicomponents/qml/Muse/UiComponents/menuitem.h"
 
 namespace au::shared {
@@ -35,14 +34,12 @@ inline muse::TranslatableString workspaceTitle(const std::string& name)
 inline const muse::uicomponents::MenuItemList& translateWorkspaceTitles(const muse::uicomponents::MenuItemList& items)
 {
     for (muse::uicomponents::MenuItem* item : items) {
-        const muse::actions::ActionData args = item->args();
-        if (args.empty()) {
+        const muse::rcommand::CommandQuery query = item->commandQuery();
+        if (!query.contains("name")) {
             continue;
         }
 
-        muse::ui::UiAction action = item->action();
-        action.title = workspaceTitle(args.arg<std::string>(0));
-        item->setAction(action);
+        item->setTitle(workspaceTitle(query.param("name").toString()));
     }
 
     return items;

--- a/src/trackedit/dom/track.h
+++ b/src/trackedit/dom/track.h
@@ -7,6 +7,7 @@
 
 #include "../trackedittypes.h"
 #include "global/types/string.h"
+#include "global/types/translatablestring.h"
 
 #include "clip.h" // IWYU pragma: export
 #include "label.h" // IWYU pragma: export
@@ -41,15 +42,18 @@ enum class TrackViewType : int {
 
 struct TrackFormatInfo {
     TrackFormat format;
-    const char* description;
+    muse::TranslatableString description;
 };
 
 inline const std::array<TrackFormatInfo, 3>& availableTrackFormats()
 {
-    static constexpr std::array<TrackFormatInfo, 3> AVAILABLE_TRACK_FORMATS = { {
-        { au::trackedit::TrackFormat::Int16, "16-bit PCM" },
-        { au::trackedit::TrackFormat::Int24, "24-bit PCM" },
-        { au::trackedit::TrackFormat::Float32, "32-bit Float" }
+    static const std::array<TrackFormatInfo, 3> AVAILABLE_TRACK_FORMATS = { {
+        //: The format of the audio samples on a track
+        { au::trackedit::TrackFormat::Int16, muse::TranslatableString("trackcontextmenu", "16-bit PCM") },
+        //: The format of the audio samples on a track
+        { au::trackedit::TrackFormat::Int24, muse::TranslatableString("trackcontextmenu", "24-bit PCM") },
+        //: The format of the audio samples on a track
+        { au::trackedit::TrackFormat::Float32, muse::TranslatableString("trackcontextmenu", "32-bit Float") }
     } };
     return AVAILABLE_TRACK_FORMATS;
 }

--- a/src/trackedit/internal/au3/au3trackeditproject.cpp
+++ b/src/trackedit/internal/au3/au3trackeditproject.cpp
@@ -406,17 +406,17 @@ void Au3TrackeditProject::setTimeSignature(const trackedit::TimeSignature& timeS
 
     std::string historyStateMessage;
     if (!muse::is_equal(timeSig.GetTempo(), timeSignature.tempo)) {
-        historyStateMessage = "Tempo changed";
+        historyStateMessage = muse::trc("trackedit", "Tempo changed");
     }
     timeSig.SetTempo(timeSignature.tempo);
 
     if (!muse::is_equal(timeSig.GetUpperTimeSignature(), timeSignature.upper)) {
-        historyStateMessage = "Upper time signature changed";
+        historyStateMessage = muse::trc("trackedit", "Upper time signature changed");
     }
     timeSig.SetUpperTimeSignature(timeSignature.upper);
 
     if (!muse::is_equal(timeSig.GetLowerTimeSignature(), timeSignature.lower)) {
-        historyStateMessage = "Lower time signature changed";
+        historyStateMessage = muse::trc("trackedit", "Lower time signature changed");
     }
     timeSig.SetLowerTimeSignature(timeSignature.lower);
 

--- a/src/trackedit/internal/trackeditoperationcontroller.cpp
+++ b/src/trackedit/internal/trackeditoperationcontroller.cpp
@@ -35,6 +35,7 @@ bool TrackeditOperationController::trimTracksData(const std::vector<trackedit::T
 {
     if (tracksInteraction()->trimTracksData(tracksIds, begin, end)) {
         projectHistory()->pushHistoryState(
+            //: History entry. %1 and %2 are positions in seconds
             muse::qtrc("trackedit", "Trim selected audio tracks from %1 seconds to %2 seconds")
             .arg(begin.to_double()).arg(end.to_double()).toStdString(),
             muse::trc("trackedit", "Trim Audio"));
@@ -47,6 +48,7 @@ bool TrackeditOperationController::silenceTracksData(const std::vector<trackedit
 {
     if (tracksInteraction()->silenceTracksData(tracksIds, begin, end)) {
         projectHistory()->pushHistoryState(
+            //: History entry. %1 and %2 are positions in seconds
             muse::qtrc("trackedit", "Silenced selected tracks from %1 seconds to %2 seconds")
             .arg(begin.to_double()).arg(end.to_double()).toStdString(),
             muse::trc("trackedit", "Silence"));
@@ -1121,6 +1123,8 @@ muse::Progress TrackeditOperationController::progress() const
 void TrackeditOperationController::pushProjectHistoryJoinState(secs_t start, secs_t duration)
 {
     projectHistory()->pushHistoryState(
+        //: History entry. %1 is a duration in seconds,
+        //: %2 is the position in seconds it starts at
         muse::qtrc("trackedit", "Joined %1 seconds at %2")
         .arg(duration.to_double()).arg(start.to_double()).toStdString(),
         muse::trc("trackedit", "Join"));
@@ -1139,6 +1143,8 @@ void TrackeditOperationController::pushProjectHistorySplitDeleteState()
 void TrackeditOperationController::pushProjectHistoryDeleteState(secs_t start, secs_t duration)
 {
     projectHistory()->pushHistoryState(
+        //: History entry. %1 is a duration in seconds,
+        //: %2 is the position in seconds it starts at
         muse::qtrc("trackedit", "Delete %1 seconds at %2")
         .arg(duration.to_double()).arg(start.to_double()).toStdString(),
         muse::trc("trackedit", "Delete"));

--- a/src/trackedit/internal/trackeditoperationcontroller.cpp
+++ b/src/trackedit/internal/trackeditoperationcontroller.cpp
@@ -34,9 +34,10 @@ muse::async::Channel<ClipKey, secs_t /*newStartTime*/, bool /*completed*/> Track
 bool TrackeditOperationController::trimTracksData(const std::vector<trackedit::TrackId>& tracksIds, secs_t begin, secs_t end)
 {
     if (tracksInteraction()->trimTracksData(tracksIds, begin, end)) {
-        std::stringstream ss;
-        ss << "Trim selected audio tracks from " << begin << " seconds to " << end << " seconds";
-        projectHistory()->pushHistoryState(ss.str(), "Trim Audio");
+        projectHistory()->pushHistoryState(
+            muse::qtrc("trackedit", "Trim selected audio tracks from %1 seconds to %2 seconds")
+            .arg(begin.to_double()).arg(end.to_double()).toStdString(),
+            muse::trc("trackedit", "Trim Audio"));
         return true;
     }
     return false;
@@ -45,9 +46,10 @@ bool TrackeditOperationController::trimTracksData(const std::vector<trackedit::T
 bool TrackeditOperationController::silenceTracksData(const std::vector<trackedit::TrackId>& tracksIds, secs_t begin, secs_t end)
 {
     if (tracksInteraction()->silenceTracksData(tracksIds, begin, end)) {
-        std::stringstream ss;
-        ss << "Silenced selected tracks for " << begin << " seconds at " << end << "seconts";
-        projectHistory()->pushHistoryState(ss.str(), "Silence");
+        projectHistory()->pushHistoryState(
+            muse::qtrc("trackedit", "Silenced selected tracks from %1 seconds to %2 seconds")
+            .arg(begin.to_double()).arg(end.to_double()).toStdString(),
+            muse::trc("trackedit", "Silence"));
         return true;
     }
     return false;
@@ -65,7 +67,7 @@ bool TrackeditOperationController::silenceClips(const ClipKeyList& clipKeyList)
     }
 
     if (anySilenced) {
-        projectHistory()->pushHistoryState("Silenced selected clips", "Silence");
+        projectHistory()->pushHistoryState(muse::trc("trackedit", "Silenced selected clips"), muse::trc("trackedit", "Silence"));
     }
     return anySilenced;
 }
@@ -78,7 +80,7 @@ bool TrackeditOperationController::tracksDataIsSilent(const std::vector<trackedi
 bool TrackeditOperationController::changeTrackTitle(const trackedit::TrackId trackId, const muse::String& title)
 {
     if (tracksInteraction()->changeTrackTitle(trackId, title)) {
-        projectHistory()->pushHistoryState("Track Title", "Changed Track Title");
+        projectHistory()->pushHistoryState(muse::trc("trackedit", "Track Title"), muse::trc("trackedit", "Changed Track Title"));
         return true;
     }
     return false;
@@ -87,7 +89,7 @@ bool TrackeditOperationController::changeTrackTitle(const trackedit::TrackId tra
 bool TrackeditOperationController::changeClipTitle(const ClipKey& clipKey, const muse::String& newTitle)
 {
     if (clipsInteraction()->changeClipTitle(clipKey, newTitle)) {
-        projectHistory()->pushHistoryState("Clip Title", "Changed clip title");
+        projectHistory()->pushHistoryState(muse::trc("trackedit", "Clip Title"), muse::trc("trackedit", "Changed clip title"));
         return true;
     }
     return false;
@@ -96,7 +98,7 @@ bool TrackeditOperationController::changeClipTitle(const ClipKey& clipKey, const
 bool TrackeditOperationController::changeClipPitch(const ClipKey& clipKey, int pitch)
 {
     if (clipsInteraction()->changeClipPitch(clipKey, pitch)) {
-        projectHistory()->pushHistoryState("Pitch Shift", "Changed Pitch Shift");
+        projectHistory()->pushHistoryState(muse::trc("trackedit", "Pitch Shift"), muse::trc("trackedit", "Changed Pitch Shift"));
         return true;
     }
     return false;
@@ -105,7 +107,7 @@ bool TrackeditOperationController::changeClipPitch(const ClipKey& clipKey, int p
 bool TrackeditOperationController::resetClipPitch(const ClipKey& clipKey)
 {
     if (clipsInteraction()->resetClipPitch(clipKey)) {
-        projectHistory()->pushHistoryState("Reset Clip Pitch", "Reset Clip Pitch");
+        projectHistory()->pushHistoryState(muse::trc("trackedit", "Reset Clip Pitch"), muse::trc("trackedit", "Reset Clip Pitch"));
         return true;
     }
     return false;
@@ -114,7 +116,7 @@ bool TrackeditOperationController::resetClipPitch(const ClipKey& clipKey)
 bool TrackeditOperationController::changeClipSpeed(const ClipKey& clipKey, double speed)
 {
     if (clipsInteraction()->changeClipSpeed(clipKey, speed)) {
-        projectHistory()->pushHistoryState("Changed Speed", "Changed Speed");
+        projectHistory()->pushHistoryState(muse::trc("trackedit", "Changed Speed"), muse::trc("trackedit", "Changed Speed"));
         return true;
     }
     return false;
@@ -123,7 +125,7 @@ bool TrackeditOperationController::changeClipSpeed(const ClipKey& clipKey, doubl
 bool TrackeditOperationController::resetClipSpeed(const ClipKey& clipKey)
 {
     if (clipsInteraction()->resetClipSpeed(clipKey)) {
-        projectHistory()->pushHistoryState("Reset Clip Speed", "Reset Clip Speed");
+        projectHistory()->pushHistoryState(muse::trc("trackedit", "Reset Clip Speed"), muse::trc("trackedit", "Reset Clip Speed"));
         return true;
     }
     return false;
@@ -137,7 +139,7 @@ bool TrackeditOperationController::changeClipColor(const ClipKey& clipKey, ClipC
 bool TrackeditOperationController::changeTracksColor(const TrackIdList& tracksIds, ClipColorIndex colorIndex)
 {
     if (tracksInteraction()->changeTracksColor(tracksIds, colorIndex)) {
-        projectHistory()->pushHistoryState("Changed track color", "Changed track color");
+        projectHistory()->pushHistoryState(muse::trc("trackedit", "Changed track color"), muse::trc("trackedit", "Changed track color"));
         return true;
     }
     return false;
@@ -153,7 +155,8 @@ bool TrackeditOperationController::resetClipPitchAndSpeed(const ClipKey& clipKey
     const bool pitchOk = clipsInteraction()->resetClipPitch(clipKey);
     const bool speedOk = clipsInteraction()->resetClipSpeed(clipKey);
     if (pitchOk || speedOk) {
-        projectHistory()->pushHistoryState("Reset Clip Pitch and Speed", "Reset Clip Pitch and Speed");
+        projectHistory()->pushHistoryState(muse::trc("trackedit", "Reset Clip Pitch and Speed"),
+                                           muse::trc("trackedit", "Reset Clip Pitch and Speed"));
         return true;
     }
     return false;
@@ -162,7 +165,7 @@ bool TrackeditOperationController::resetClipPitchAndSpeed(const ClipKey& clipKey
 bool TrackeditOperationController::renderClipPitchAndSpeed(const ClipKey& clipKey)
 {
     if (clipsInteraction()->renderClipPitchAndSpeed(clipKey)) {
-        projectHistory()->pushHistoryState("Rendered time-stretched audio", "Render");
+        projectHistory()->pushHistoryState(muse::trc("trackedit", "Rendered time-stretched audio"), muse::trc("trackedit", "Render"));
         return true;
     }
     return false;
@@ -201,7 +204,7 @@ muse::Ret TrackeditOperationController::pasteFromClipboard(secs_t begin, bool mo
     if (ret) {
         //! NOTE Importing files pushes its own "Import" history state
         if (!pastingFromSystemClipboard) {
-            projectHistory()->pushHistoryState("Pasted from the clipboard", "Paste");
+            projectHistory()->pushHistoryState(muse::trc("trackedit", "Pasted from the clipboard"), muse::trc("trackedit", "Paste"));
         }
 
         if (recreateRangeSelection) {
@@ -223,7 +226,7 @@ bool TrackeditOperationController::cutClipIntoClipboard(const ClipKey& clipKey)
         return false;
     }
     clipboard()->addTrackData(std::move(data));
-    projectHistory()->pushHistoryState("Cut to the clipboard", "Cut");
+    projectHistory()->pushHistoryState(muse::trc("trackedit", "Cut to the clipboard"), muse::trc("trackedit", "Cut"));
     return true;
 }
 
@@ -243,7 +246,7 @@ bool TrackeditOperationController::cutItemDataIntoClipboard(const TrackIdList& t
         clipboard()->addTrackData(std::move(trackData));
     }
     clipboard()->setRangeSelectionCopy(isRangeSelection);
-    projectHistory()->pushHistoryState("Cut to the clipboard", "Cut");
+    projectHistory()->pushHistoryState(muse::trc("trackedit", "Cut to the clipboard"), muse::trc("trackedit", "Cut"));
     return true;
 }
 
@@ -302,8 +305,9 @@ bool TrackeditOperationController::removeClips(const ClipKeyList& clipKeyList, b
             labelsInteraction()->removeLabels(selectedLabels(), moveClips);
         }
 
-        const std::string msg = hasLabels ? "Remove multiple items" : "Remove multiple clips";
-        projectHistory()->pushHistoryState("Remove", msg);
+        const std::string msg
+            = hasLabels ? muse::trc("trackedit", "Remove multiple items") : muse::trc("trackedit", "Remove multiple clips");
+        projectHistory()->pushHistoryState(muse::trc("trackedit", "Remove"), msg);
         return true;
     }
     return false;
@@ -312,7 +316,7 @@ bool TrackeditOperationController::removeClips(const ClipKeyList& clipKeyList, b
 bool TrackeditOperationController::removeTracksData(const TrackIdList& tracksIds, secs_t begin, secs_t end, bool moveClips)
 {
     if (tracksInteraction()->removeTracksData(tracksIds, begin, end, moveClips)) {
-        projectHistory()->pushHistoryState("Delete", "Delete and close gap");
+        projectHistory()->pushHistoryState(muse::trc("trackedit", "Delete"), muse::trc("trackedit", "Delete and close gap"));
         return true;
     }
     return false;
@@ -357,8 +361,8 @@ muse::RetVal<ClipKeyList> TrackeditOperationController::moveClips(const ClipKeyL
             globalContext()->currentTrackeditProject()->reload();
         }
     } else if (completed) {
-        const std::string msg = !selectedLabels.empty() ? "Items moved" : "Clip moved";
-        projectHistory()->pushHistoryState(msg, "Move clip");
+        const std::string msg = !selectedLabels.empty() ? muse::trc("trackedit", "Items moved") : muse::trc("trackedit", "Clip moved");
+        projectHistory()->pushHistoryState(msg, muse::trc("trackedit", "Move clip"));
     }
     return result;
 }
@@ -406,7 +410,7 @@ bool TrackeditOperationController::moveRangeSelection(secs_t timePositionOffset,
         selectionController()->dataSelectedEndTime() + clampedOffset, false);
 
     if (completed) {
-        projectHistory()->pushHistoryState("Items moved", "Move items");
+        projectHistory()->pushHistoryState(muse::trc("trackedit", "Items moved"), muse::trc("trackedit", "Move items"));
     }
 
     return true;
@@ -426,7 +430,7 @@ void TrackeditOperationController::cancelItemDragEdit()
 bool TrackeditOperationController::splitTracksAt(const TrackIdList& tracksIds, std::vector<secs_t> pivots)
 {
     if (tracksInteraction()->splitTracksAt(tracksIds, pivots)) {
-        projectHistory()->pushHistoryState("Split", "Split");
+        projectHistory()->pushHistoryState(muse::trc("trackedit", "Split"), muse::trc("trackedit", "Split"));
         return true;
     }
     return false;
@@ -435,7 +439,7 @@ bool TrackeditOperationController::splitTracksAt(const TrackIdList& tracksIds, s
 bool TrackeditOperationController::splitClipsAtSilences(const ClipKeyList& clipKeyList)
 {
     if (clipsInteraction()->splitClipsAtSilences(clipKeyList)) {
-        projectHistory()->pushHistoryState("Split clips at silence", "Split at silence");
+        projectHistory()->pushHistoryState(muse::trc("trackedit", "Split clips at silence"), muse::trc("trackedit", "Split at silence"));
         return true;
     }
     return false;
@@ -444,7 +448,7 @@ bool TrackeditOperationController::splitClipsAtSilences(const ClipKeyList& clipK
 bool TrackeditOperationController::splitRangeSelectionAtSilences(const TrackIdList& tracksIds, secs_t begin, secs_t end)
 {
     if (tracksInteraction()->splitRangeSelectionAtSilences(tracksIds, begin, end)) {
-        projectHistory()->pushHistoryState("Split clips at silence", "Split at silence");
+        projectHistory()->pushHistoryState(muse::trc("trackedit", "Split clips at silence"), muse::trc("trackedit", "Split at silence"));
         return true;
     }
     return false;
@@ -453,7 +457,7 @@ bool TrackeditOperationController::splitRangeSelectionAtSilences(const TrackIdLi
 bool TrackeditOperationController::splitRangeSelectionIntoNewTracks(const TrackIdList& tracksIds, secs_t begin, secs_t end)
 {
     if (tracksInteraction()->splitRangeSelectionIntoNewTracks(tracksIds, begin, end)) {
-        projectHistory()->pushHistoryState("Split into new track", "Split into new track");
+        projectHistory()->pushHistoryState(muse::trc("trackedit", "Split into new track"), muse::trc("trackedit", "Split into new track"));
         return true;
     }
     return false;
@@ -462,7 +466,7 @@ bool TrackeditOperationController::splitRangeSelectionIntoNewTracks(const TrackI
 bool TrackeditOperationController::splitClipsIntoNewTracks(const ClipKeyList& clipKeyList)
 {
     if (clipsInteraction()->splitClipsIntoNewTracks(clipKeyList)) {
-        projectHistory()->pushHistoryState("Split into new track", "Split into new track");
+        projectHistory()->pushHistoryState(muse::trc("trackedit", "Split into new track"), muse::trc("trackedit", "Split into new track"));
         return true;
     }
     return false;
@@ -508,7 +512,7 @@ bool TrackeditOperationController::clipSplitCut(const ClipKey& clipKey)
         return false;
     }
     clipboard()->addTrackData(std::move(data));
-    projectHistory()->pushHistoryState("Split-cut to the clipboard", "Split cut");
+    projectHistory()->pushHistoryState(muse::trc("trackedit", "Split-cut to the clipboard"), muse::trc("trackedit", "Split cut"));
     return true;
 }
 
@@ -531,7 +535,7 @@ bool TrackeditOperationController::splitCutSelectedOnTracks(const TrackIdList tr
         clipboard()->addTrackData(std::move(trackData));
     }
     clipboard()->setRangeSelectionCopy(true);
-    projectHistory()->pushHistoryState("Split-cut to the clipboard", "Split cut");
+    projectHistory()->pushHistoryState(muse::trc("trackedit", "Split-cut to the clipboard"), muse::trc("trackedit", "Split cut"));
     return true;
 }
 
@@ -561,8 +565,8 @@ bool TrackeditOperationController::trimClipsLeft(const ClipKeyList& clipKeyList,
     }
 
     if (completed) {
-        std::string msg = hasLabels ? "Trim items left" : "Trim clip left";
-        projectHistory()->pushHistoryState("Trim", msg, type);
+        std::string msg = hasLabels ? muse::trc("trackedit", "Trim items left") : muse::trc("trackedit", "Trim clip left");
+        projectHistory()->pushHistoryState(muse::trc("trackedit", "Trim"), msg, type);
     }
     return success;
 }
@@ -583,8 +587,8 @@ bool TrackeditOperationController::trimClipsRight(const ClipKeyList& clipKeyList
         labelsInteraction()->stretchLabelsRight(labelKeys, -deltaSec, completed);
     }
     if (completed) {
-        std::string msg = hasLabels ? "Trim items right" : "Trim clip right";
-        projectHistory()->pushHistoryState("Trim", msg, type);
+        std::string msg = hasLabels ? muse::trc("trackedit", "Trim items right") : muse::trc("trackedit", "Trim clip right");
+        projectHistory()->pushHistoryState(muse::trc("trackedit", "Trim"), msg, type);
     }
     return success;
 }
@@ -673,7 +677,7 @@ muse::Ret TrackeditOperationController::makeRoomForClip(const ClipKey& clipKey)
 bool TrackeditOperationController::newMonoTrack()
 {
     if (tracksInteraction()->newMonoTrack()) {
-        projectHistory()->pushHistoryState("Created new mono track", "New mono track");
+        projectHistory()->pushHistoryState(muse::trc("trackedit", "Created new mono track"), muse::trc("trackedit", "New mono track"));
         return true;
     }
     return false;
@@ -682,7 +686,7 @@ bool TrackeditOperationController::newMonoTrack()
 bool TrackeditOperationController::newStereoTrack()
 {
     if (tracksInteraction()->newStereoTrack()) {
-        projectHistory()->pushHistoryState("Created new stereo track", "New stereo track");
+        projectHistory()->pushHistoryState(muse::trc("trackedit", "Created new stereo track"), muse::trc("trackedit", "New stereo track"));
         return true;
     }
     return false;
@@ -692,7 +696,7 @@ muse::RetVal<TrackId> TrackeditOperationController::newLabelTrack(const muse::St
 {
     auto track = tracksInteraction()->newLabelTrack(title);
     if (track.ret.success()) {
-        projectHistory()->pushHistoryState("Created label track", "New label track");
+        projectHistory()->pushHistoryState(muse::trc("trackedit", "Created label track"), muse::trc("trackedit", "New label track"));
     }
     return track;
 }
@@ -700,7 +704,7 @@ muse::RetVal<TrackId> TrackeditOperationController::newLabelTrack(const muse::St
 bool TrackeditOperationController::deleteTracks(const TrackIdList& trackIds)
 {
     if (tracksInteraction()->deleteTracks(trackIds)) {
-        projectHistory()->pushHistoryState("Delete track", "Delete track");
+        projectHistory()->pushHistoryState(muse::trc("trackedit", "Delete track"), muse::trc("trackedit", "Delete track"));
         return true;
     }
     return false;
@@ -709,7 +713,7 @@ bool TrackeditOperationController::deleteTracks(const TrackIdList& trackIds)
 bool TrackeditOperationController::duplicateTracks(const TrackIdList& trackIds)
 {
     if (tracksInteraction()->duplicateTracks(trackIds)) {
-        projectHistory()->pushHistoryState("Duplicate track", "Duplicate track");
+        projectHistory()->pushHistoryState(muse::trc("trackedit", "Duplicate track"), muse::trc("trackedit", "Duplicate track"));
         return true;
     }
     return false;
@@ -718,14 +722,14 @@ bool TrackeditOperationController::duplicateTracks(const TrackIdList& trackIds)
 void TrackeditOperationController::moveTracks(const TrackIdList& trackIds, TrackMoveDirection direction)
 {
     if (tracksInteraction()->moveTracks(trackIds, direction)) {
-        projectHistory()->pushHistoryState("Move track", "Move track");
+        projectHistory()->pushHistoryState(muse::trc("trackedit", "Move track"), muse::trc("trackedit", "Move track"));
     }
 }
 
 void TrackeditOperationController::moveTracksTo(const TrackIdList& trackIds, int pos)
 {
     if (tracksInteraction()->moveTracksTo(trackIds, pos)) {
-        projectHistory()->pushHistoryState("Move track", "Move track");
+        projectHistory()->pushHistoryState(muse::trc("trackedit", "Move track"), muse::trc("trackedit", "Move track"));
     }
 }
 
@@ -796,13 +800,13 @@ void TrackeditOperationController::setClipGroupId(const trackedit::ClipKey& clip
 void TrackeditOperationController::groupClips(const trackedit::ClipKeyList& clipKeyList)
 {
     clipsInteraction()->groupClips(clipKeyList);
-    projectHistory()->pushHistoryState("Clips grouped", "Clips grouped");
+    projectHistory()->pushHistoryState(muse::trc("trackedit", "Clips grouped"), muse::trc("trackedit", "Clips grouped"));
 }
 
 void TrackeditOperationController::ungroupClips(const trackedit::ClipKeyList& clipKeyList)
 {
     clipsInteraction()->ungroupClips(clipKeyList);
-    projectHistory()->pushHistoryState("Clips ungrouped", "Clips ungrouped");
+    projectHistory()->pushHistoryState(muse::trc("trackedit", "Clips ungrouped"), muse::trc("trackedit", "Clips ungrouped"));
 }
 
 ClipKeyList TrackeditOperationController::clipsInGroup(int64_t id) const
@@ -813,7 +817,7 @@ ClipKeyList TrackeditOperationController::clipsInGroup(int64_t id) const
 bool TrackeditOperationController::changeTracksFormat(const TrackIdList& tracksIds, trackedit::TrackFormat format)
 {
     if (tracksInteraction()->changeTracksFormat(tracksIds, format)) {
-        projectHistory()->pushHistoryState("Changed track format", "Changed track format");
+        projectHistory()->pushHistoryState(muse::trc("trackedit", "Changed track format"), muse::trc("trackedit", "Changed track format"));
         return true;
     }
     return false;
@@ -822,7 +826,7 @@ bool TrackeditOperationController::changeTracksFormat(const TrackIdList& tracksI
 bool TrackeditOperationController::changeTracksRate(const TrackIdList& tracksIds, int rate)
 {
     if (tracksInteraction()->changeTracksRate(tracksIds, rate)) {
-        projectHistory()->pushHistoryState("Changed track rate", "Changed track rate");
+        projectHistory()->pushHistoryState(muse::trc("trackedit", "Changed track rate"), muse::trc("trackedit", "Changed track rate"));
         return true;
     }
     return false;
@@ -831,7 +835,8 @@ bool TrackeditOperationController::changeTracksRate(const TrackIdList& tracksIds
 bool TrackeditOperationController::swapStereoChannels(const TrackIdList& tracksIds)
 {
     if (tracksInteraction()->swapStereoChannels(tracksIds)) {
-        projectHistory()->pushHistoryState("Swapped stereo channels", "Swapped stereo channels");
+        projectHistory()->pushHistoryState(muse::trc("trackedit", "Swapped stereo channels"),
+                                           muse::trc("trackedit", "Swapped stereo channels"));
         return true;
     }
     return false;
@@ -840,7 +845,8 @@ bool TrackeditOperationController::swapStereoChannels(const TrackIdList& tracksI
 bool TrackeditOperationController::splitStereoTracksToLRMono(const TrackIdList& tracksIds)
 {
     if (tracksInteraction()->splitStereoTracksToLRMono(tracksIds)) {
-        projectHistory()->pushHistoryState("Split stereo tracks to L/R mono", "Split stereo tracks to L/R mono");
+        projectHistory()->pushHistoryState(muse::trc("trackedit", "Split stereo tracks to L/R mono"),
+                                           muse::trc("trackedit", "Split stereo tracks to L/R mono"));
         return true;
     }
     return false;
@@ -849,7 +855,8 @@ bool TrackeditOperationController::splitStereoTracksToLRMono(const TrackIdList& 
 bool TrackeditOperationController::splitStereoTracksToCenterMono(const TrackIdList& tracksIds)
 {
     if (tracksInteraction()->splitStereoTracksToCenterMono(tracksIds)) {
-        projectHistory()->pushHistoryState("Split stereo tracks to center mono", "Split stereo tracks to center mono");
+        projectHistory()->pushHistoryState(muse::trc("trackedit", "Split stereo tracks to center mono"),
+                                           muse::trc("trackedit", "Split stereo tracks to center mono"));
         return true;
     }
     return false;
@@ -858,7 +865,7 @@ bool TrackeditOperationController::splitStereoTracksToCenterMono(const TrackIdLi
 bool TrackeditOperationController::makeStereoTrack(const TrackId left, const TrackId right)
 {
     if (tracksInteraction()->makeStereoTrack(left, right)) {
-        projectHistory()->pushHistoryState("Make stereo track", "Make stereo track");
+        projectHistory()->pushHistoryState(muse::trc("trackedit", "Make stereo track"), muse::trc("trackedit", "Make stereo track"));
         return true;
     }
     return false;
@@ -867,7 +874,7 @@ bool TrackeditOperationController::makeStereoTrack(const TrackId left, const Tra
 bool TrackeditOperationController::resampleTracks(const TrackIdList& tracksIds, int rate)
 {
     if (tracksInteraction()->resampleTracks(tracksIds, rate)) {
-        projectHistory()->pushHistoryState("Resampled audio track(s)", "Resample track");
+        projectHistory()->pushHistoryState(muse::trc("trackedit", "Resampled audio track(s)"), muse::trc("trackedit", "Resample track"));
         return true;
     }
     return false;
@@ -877,7 +884,7 @@ muse::RetVal<LabelKey> TrackeditOperationController::addLabel(const TrackId& toT
 {
     muse::RetVal<LabelKey> retVal = labelsInteraction()->addLabel(toTrackId);
     if (retVal.ret) {
-        projectHistory()->pushHistoryState("Label added", "Add label");
+        projectHistory()->pushHistoryState(muse::trc("trackedit", "Label added"), muse::trc("trackedit", "Add label"));
     }
 
     return retVal;
@@ -886,7 +893,7 @@ muse::RetVal<LabelKey> TrackeditOperationController::addLabel(const TrackId& toT
 bool TrackeditOperationController::addLabelToSelection()
 {
     if (labelsInteraction()->addLabelToSelection()) {
-        projectHistory()->pushHistoryState("Label added", "Add label");
+        projectHistory()->pushHistoryState(muse::trc("trackedit", "Label added"), muse::trc("trackedit", "Add label"));
         return true;
     }
     return false;
@@ -895,7 +902,7 @@ bool TrackeditOperationController::addLabelToSelection()
 bool TrackeditOperationController::changeLabelTitle(const LabelKey& labelKey, const muse::String& title)
 {
     if (labelsInteraction()->changeLabelTitle(labelKey, title)) {
-        projectHistory()->pushHistoryState("Label title changed", "Changed label title");
+        projectHistory()->pushHistoryState(muse::trc("trackedit", "Label title changed"), muse::trc("trackedit", "Changed label title"));
         return true;
     }
     return false;
@@ -904,7 +911,8 @@ bool TrackeditOperationController::changeLabelTitle(const LabelKey& labelKey, co
 bool TrackeditOperationController::changeLabelLowFrequency(const LabelKey& labelKey, double frequency)
 {
     if (labelsInteraction()->changeLabelLowFrequency(labelKey, frequency)) {
-        projectHistory()->pushHistoryState("Label low frequency changed", "Change label low frequency");
+        projectHistory()->pushHistoryState(muse::trc("trackedit", "Label low frequency changed"),
+                                           muse::trc("trackedit", "Change label low frequency"));
         return true;
     }
     return false;
@@ -913,7 +921,8 @@ bool TrackeditOperationController::changeLabelLowFrequency(const LabelKey& label
 bool TrackeditOperationController::changeLabelHighFrequency(const LabelKey& labelKey, double frequency)
 {
     if (labelsInteraction()->changeLabelHighFrequency(labelKey, frequency)) {
-        projectHistory()->pushHistoryState("Label high frequency changed", "Change label high frequency");
+        projectHistory()->pushHistoryState(muse::trc("trackedit", "Label high frequency changed"),
+                                           muse::trc("trackedit", "Change label high frequency"));
         return true;
     }
     return false;
@@ -927,7 +936,7 @@ bool TrackeditOperationController::cutLabel(const LabelKey& labelKey)
     }
 
     clipboard()->addTrackData(std::move(data));
-    projectHistory()->pushHistoryState("Cut", "Cut label");
+    projectHistory()->pushHistoryState(muse::trc("trackedit", "Cut"), muse::trc("trackedit", "Cut label"));
     return true;
 }
 
@@ -944,7 +953,7 @@ bool TrackeditOperationController::copyLabel(const LabelKey& labelKey)
 bool TrackeditOperationController::removeLabel(const LabelKey& labelKey)
 {
     if (labelsInteraction()->removeLabel(labelKey)) {
-        projectHistory()->pushHistoryState("Remove", "Remove label");
+        projectHistory()->pushHistoryState(muse::trc("trackedit", "Remove"), muse::trc("trackedit", "Remove label"));
         return true;
     }
     return false;
@@ -959,9 +968,9 @@ bool TrackeditOperationController::removeLabels(const LabelKeyList& labelKeys, b
         }
 
         if (hasClips) {
-            projectHistory()->pushHistoryState("Remove", "Remove multiple items");
+            projectHistory()->pushHistoryState(muse::trc("trackedit", "Remove"), muse::trc("trackedit", "Remove multiple items"));
         } else {
-            projectHistory()->pushHistoryState("Remove", "Remove multiple labels");
+            projectHistory()->pushHistoryState(muse::trc("trackedit", "Remove"), muse::trc("trackedit", "Remove multiple labels"));
         }
 
         return true;
@@ -997,8 +1006,8 @@ bool TrackeditOperationController::moveLabels(const LabelKeyList& labelKeys, sec
 
     muse::RetVal<LabelKeyList> retVal = labelsInteraction()->moveLabels(labelKeys, timePositionOffset, 0);
     if (retVal.ret && completed) {
-        const std::string msg = !selectedClips.empty() ? "Move items" : "Move labels";
-        projectHistory()->pushHistoryState("Move", msg);
+        const std::string msg = !selectedClips.empty() ? muse::trc("trackedit", "Move items") : muse::trc("trackedit", "Move labels");
+        projectHistory()->pushHistoryState(muse::trc("trackedit", "Move"), msg);
     }
     return retVal.ret;
 }
@@ -1019,8 +1028,8 @@ muse::RetVal<LabelKeyList> TrackeditOperationController::moveLabels(const LabelK
     }
 
     if (completed) {
-        const std::string msg = clipsSelected ? "Move items" : "Movel labels";
-        projectHistory()->pushHistoryState("Move", msg);
+        const std::string msg = clipsSelected ? muse::trc("trackedit", "Move items") : muse::trc("trackedit", "Move labels");
+        projectHistory()->pushHistoryState(muse::trc("trackedit", "Move"), msg);
     }
 
     return retVal;
@@ -1031,7 +1040,7 @@ muse::RetVal<LabelKeyList> TrackeditOperationController::moveLabelsToTrack(const
 {
     muse::RetVal<LabelKeyList> retVal = labelsInteraction()->moveLabelsToTrack(labelKeys, toTrackId);
     if (retVal.ret && completed) {
-        projectHistory()->pushHistoryState("Labels moved", "Move labels");
+        projectHistory()->pushHistoryState(muse::trc("trackedit", "Labels moved"), muse::trc("trackedit", "Move labels"));
     }
     return retVal;
 }
@@ -1040,7 +1049,7 @@ bool TrackeditOperationController::stretchLabelLeft(const LabelKey& labelKey, se
 {
     bool success = labelsInteraction()->stretchLabelLeft(labelKey, newStartTime, completed);
     if (success && completed) {
-        projectHistory()->pushHistoryState("Label stretched", "Stretch label left");
+        projectHistory()->pushHistoryState(muse::trc("trackedit", "Label stretched"), muse::trc("trackedit", "Stretch label left"));
     }
     return success;
 }
@@ -1060,8 +1069,9 @@ bool TrackeditOperationController::stretchLabelsLeft(const LabelKeyList& labelKe
     }
 
     if (completed) {
-        const std::string msg = clipsSelected ? "Stretch items left" : "Stretch labels left";
-        projectHistory()->pushHistoryState("Stretch", msg);
+        const std::string msg
+            = clipsSelected ? muse::trc("trackedit", "Stretch items left") : muse::trc("trackedit", "Stretch labels left");
+        projectHistory()->pushHistoryState(muse::trc("trackedit", "Stretch"), msg);
     }
 
     return success;
@@ -1071,7 +1081,7 @@ bool TrackeditOperationController::stretchLabelRight(const LabelKey& labelKey, s
 {
     bool success = labelsInteraction()->stretchLabelRight(labelKey, newEndTime, completed);
     if (success && completed) {
-        projectHistory()->pushHistoryState("Label stretched", "Stretch label right");
+        projectHistory()->pushHistoryState(muse::trc("trackedit", "Label stretched"), muse::trc("trackedit", "Stretch label right"));
     }
     return success;
 }
@@ -1091,8 +1101,9 @@ bool TrackeditOperationController::stretchLabelsRight(const LabelKeyList& labelK
     }
 
     if (completed) {
-        const std::string msg = clipsSelected ? "Stretch items right" : "Stretch labels right";
-        projectHistory()->pushHistoryState("Stretch", msg);
+        const std::string msg = clipsSelected ? muse::trc("trackedit", "Stretch items right") : muse::trc("trackedit",
+                                                                                                          "Stretch labels right");
+        projectHistory()->pushHistoryState(muse::trc("trackedit", "Stretch"), msg);
     }
     return success;
 }
@@ -1109,26 +1120,28 @@ muse::Progress TrackeditOperationController::progress() const
 
 void TrackeditOperationController::pushProjectHistoryJoinState(secs_t start, secs_t duration)
 {
-    std::stringstream ss;
-    ss << "Joined " << duration << " seconds at " << start;
-    projectHistory()->pushHistoryState(ss.str(), "Join");
+    projectHistory()->pushHistoryState(
+        muse::qtrc("trackedit", "Joined %1 seconds at %2")
+        .arg(duration.to_double()).arg(start.to_double()).toStdString(),
+        muse::trc("trackedit", "Join"));
 }
 
 void TrackeditOperationController::pushProjectHistoryDuplicateState()
 {
-    projectHistory()->pushHistoryState("Duplicated", "Duplicate");
+    projectHistory()->pushHistoryState(muse::trc("trackedit", "Duplicated"), muse::trc("trackedit", "Duplicate"));
 }
 
 void TrackeditOperationController::pushProjectHistorySplitDeleteState()
 {
-    projectHistory()->pushHistoryState("Split-deleted clips", "Split delete");
+    projectHistory()->pushHistoryState(muse::trc("trackedit", "Split-deleted clips"), muse::trc("trackedit", "Split delete"));
 }
 
 void TrackeditOperationController::pushProjectHistoryDeleteState(secs_t start, secs_t duration)
 {
-    std::stringstream ss;
-    ss << "Delete " << duration << " seconds at " << start;
-    projectHistory()->pushHistoryState(ss.str(), "Delete");
+    projectHistory()->pushHistoryState(
+        muse::qtrc("trackedit", "Delete %1 seconds at %2")
+        .arg(duration.to_double()).arg(start.to_double()).toStdString(),
+        muse::trc("trackedit", "Delete"));
 }
 
 std::optional<secs_t> TrackeditOperationController::shortestLabelDuration(const LabelKeyList& labelKeys) const

--- a/src/trackedit/tests/environment.cpp
+++ b/src/trackedit/tests/environment.cpp
@@ -21,8 +21,8 @@ static muse::testing::SuiteEnvironment trackedit_se
                                                                                        [](ProjectSceneConfigurationMock*) {}); // no delete
 
     static std::vector<ClipColorInfo> colorInfos = {
-        { "blue", 1 },
-        { "red", 2 },
+        { muse::TranslatableString::untranslatable("blue"), 1 },
+        { muse::TranslatableString::untranslatable("red"), 2 },
     };
 
     ON_CALL(*projectSceneConfigurator, clipColorInfos())


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/11721

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA, verify if there are no untranslated strings in:

- [x] Track context menu (audio/label)
- [x] Plugin manager filters and table
- [x] Undo & redo entry names
- [x] About dialog creding headers (Audacity Team Members, Contributors, etc)
- [x] Workspace names (in the Workspace dropdown and View->Workspaces->..., the workspaces are not translated only in workspaces editor because it belongs to muse framework)
- [x] Native file dialogs (file, import, export: open/save/cancel buttons should be translated)

Check for regressions:
- [x] saved projects still load with their realtime effects attached
- [x] plugin manager filters still filter
- [x] workspace switching works
- [x] undo&redo still works correctly
