### PR TITLE
Use framework's way to open URLs in StyledTextLabels

### DIFF
--- a/src/appshell/qml/Audacity/AppShell/AboutDialogAudacityTab.qml
+++ b/src/appshell/qml/Audacity/AppShell/AboutDialogAudacityTab.qml
@@ -187,10 +187,6 @@ ColumnLayout {
 
                                 return c.role ? c.name + ", " + c.role : c.name
                             }).join("<br>")
-
-                            onLinkActivated: function (link) {
-                                Qt.openUrlExternally(link)
-                            }
                         }
                     }
                 }
@@ -201,10 +197,6 @@ ColumnLayout {
                         return qsTrc("appshell/about", "Audacity website: %1").arg('<a href="' + websiteUrl.url + '">' + websiteUrl.displayName + '</a>')
                     }
                     font: ui.theme.bodyFont
-
-                    onLinkActivated: function (link) {
-                        Qt.openUrlExternally(link)
-                    }
                 }
 
                 Column {

--- a/src/appshell/qml/Audacity/AppShell/AboutDialogPrivacyTab.qml
+++ b/src/appshell/qml/Audacity/AppShell/AboutDialogPrivacyTab.qml
@@ -54,10 +54,6 @@ ColumnLayout {
                 return prv.privacySubtitle.arg("<a href=\"%1\">%2</a>".arg(privacyUrl.url).arg(qsTrc("appshell/about", "privacy policy")))
             }
             font: ui.theme.bodyFont
-
-            onLinkActivated: function (link) {
-                Qt.openUrlExternally(link)
-            }
         }
     }
 
@@ -100,10 +96,6 @@ ColumnLayout {
                     text: root.model.gplText()
 
                     font: ui.theme.bodyFont
-
-                    onLinkActivated: function (link) {
-                        Qt.openUrlExternally(link)
-                    }
                 }
             }
         }

--- a/src/preferences/qml/Audacity/Preferences/internal/AutomaticUpdateSection.qml
+++ b/src/preferences/qml/Audacity/Preferences/internal/AutomaticUpdateSection.qml
@@ -62,9 +62,5 @@ BaseSection {
         horizontalAlignment: Qt.AlignLeft
         wrapMode: Text.WordWrap
         maximumLineCount: 3
-
-        onLinkActivated: function (link) {
-            Qt.openUrlExternally(link)
-        }
     }
 }

--- a/src/preferences/qml/Audacity/Preferences/internal/CrashReportsSection.qml
+++ b/src/preferences/qml/Audacity/Preferences/internal/CrashReportsSection.qml
@@ -41,9 +41,5 @@ BaseSection {
         horizontalAlignment: Qt.AlignLeft
         wrapMode: Text.WordWrap
         maximumLineCount: 3
-
-        onLinkActivated: function (link) {
-            Qt.openUrlExternally(link)
-        }
     }
 }

--- a/src/preferences/qml/Audacity/Preferences/internal/UsageInfoSection.qml
+++ b/src/preferences/qml/Audacity/Preferences/internal/UsageInfoSection.qml
@@ -41,9 +41,5 @@ BaseSection {
         horizontalAlignment: Qt.AlignLeft
         wrapMode: Text.WordWrap
         maximumLineCount: 3
-
-        onLinkActivated: function (link) {
-            Qt.openUrlExternally(link)
-        }
     }
 }

--- a/src/projectscene/qml/Audacity/ProjectScene/trackspanel/TrackEffectsSection.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/trackspanel/TrackEffectsSection.qml
@@ -171,10 +171,6 @@ Rectangle {
             elide: Text.ElideNone
             verticalAlignment: Text.AlignTop
             horizontalAlignment: Text.AlignLeft
-
-            onLinkActivated: function (link) {
-                Qt.openUrlExternally(link)
-            }
         }
     }
 }


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/11725

Merge only with bumped framework containing https://github.com/musescore/muse_framework/pull/233 change

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
- [ ] Test if all the URLs in the AU4 open a browser correctly
