### PR TITLE
Au3Record: read record channels and track-name preferences via IRecordConfiguration  #11732

### DIFF
--- a/src/record/internal/au3/au3record.cpp
+++ b/src/record/internal/au3/au3record.cpp
@@ -3,13 +3,15 @@
 */
 
 #include "au3record.h"
+
+#include <cfloat>
+
 #include "au3-strings/TranslatableString.h"
 
 #include "framework/global/translation.h"
 #include "framework/global/log.h"
 
 #include "au3-audio-io/ProjectAudioIO.h"
-#include "au3-audio-devices/AudioIOBase.h"
 #include "au3-time-frequency-selection/ViewInfo.h"
 #include "au3-track/Track.h"
 #include "au3-track/PendingTracks.h"
@@ -824,22 +826,16 @@ Ret Au3Record::doRecord(Au3Project& project,
 
     if (transportSequences.captureSequences.empty()) {
         // recording to NEW track(s).
-        bool recordingNameCustom, useTrackNumber, useDateStamp, useTimeStamp;
-        wxString defaultTrackName, defaultRecordingTrackName;
-
         // Count the tracks.
         auto numTracks = trackList.Any<const Au3WaveTrack>().size();
 
         const auto recordingChannels = std::max(1, audioDriverController()->configuration().inputChannels);
 
-        gPrefs->Read(wxT("/GUI/TrackNames/RecordingNameCustom"), &recordingNameCustom, false);
-        gPrefs->Read(wxT("/GUI/TrackNames/TrackNumber"), &useTrackNumber, false);
-        gPrefs->Read(wxT("/GUI/TrackNames/DateStamp"), &useDateStamp, false);
-        gPrefs->Read(wxT("/GUI/TrackNames/TimeStamp"), &useTimeStamp, false);
-        defaultTrackName = trackList.MakeUniqueTrackName(Au3WaveTrack::GetDefaultAudioTrackNamePreference());
-        gPrefs->Read(wxT("/GUI/TrackNames/RecodingTrackName"), &defaultRecordingTrackName, defaultTrackName);
-
-        wxString baseTrackName = recordingNameCustom ? defaultRecordingTrackName : defaultTrackName;
+        const RecordingTrackNameOptions nameOptions = recordConfiguration()->recordingTrackNameOptions();
+        const wxString defaultTrackName = trackList.MakeUniqueTrackName(Au3WaveTrack::GetDefaultAudioTrackNamePreference());
+        const wxString baseTrackName = nameOptions.useCustomName && !nameOptions.customName.empty()
+                                       ? wxFromStdString(nameOptions.customName)
+                                       : defaultTrackName;
 
         std::vector<WaveTrack::Holder> newTracks;
         if (recordingChannels == 2u) {
@@ -865,18 +861,18 @@ Ret Au3Record::doRecord(Au3Project& project,
             newTrack->MoveTo(t0);
             wxString nameSuffix = wxString(wxT(""));
 
-            if (useTrackNumber) {
+            if (nameOptions.addTrackNumber) {
                 nameSuffix += wxString::Format(wxT("%d"), 1 + (int)numTracks + trackCounter++);
             }
 
-            if (useDateStamp) {
+            if (nameOptions.addDateStamp) {
                 if (!nameSuffix.empty()) {
                     nameSuffix += wxT("_");
                 }
                 nameSuffix += wxDateTime::Now().FormatISODate();
             }
 
-            if (useTimeStamp) {
+            if (nameOptions.addTimeStamp) {
                 if (!nameSuffix.empty()) {
                     nameSuffix += wxT("_");
                 }

--- a/src/record/internal/au3/au3record.cpp
+++ b/src/record/internal/au3/au3record.cpp
@@ -70,10 +70,10 @@ PropertiesOfSelected GetPropertiesOfSelected(const Au3Project& proj)
     return result;
 }
 
-WritableSampleTrackArray ChooseExistingRecordingTracks(Au3Project& proj, const bool selectedOnly, const double targetRate)
+WritableSampleTrackArray ChooseExistingRecordingTracks(Au3Project& proj, const bool selectedOnly, const double targetRate,
+                                                       const size_t recordingChannels)
 {
     auto p = &proj;
-    size_t recordingChannels = std::max(0, AudioIORecordChannels.Read());
     bool strictRules = (recordingChannels <= 2);
 
     // Iterate over all wave tracks, or over selected wave tracks only.
@@ -383,9 +383,11 @@ muse::Ret Au3Record::start()
     }
 
     if (appendRecord) {
+        const size_t recordingChannels = std::max(0, audioDriverController()->configuration().inputChannels);
+
         // Try to find wave tracks to record into.  (If any are selected,
         // try to choose only from them; else if wave tracks exist, may record into any.)
-        existingTracks = ChooseExistingRecordingTracks(project, true, rateOfSelected);
+        existingTracks = ChooseExistingRecordingTracks(project, true, rateOfSelected, recordingChannels);
         if (!existingTracks.empty()) {
             projectRate = rateOfSelected;
         } else {
@@ -393,7 +395,7 @@ muse::Ret Au3Record::start()
                 return make_ret(Err::TooFewCompatibleTracksSelected);
             }
 
-            existingTracks = ChooseExistingRecordingTracks(project, false, projectRate);
+            existingTracks = ChooseExistingRecordingTracks(project, false, projectRate, recordingChannels);
         }
     }
 
@@ -508,7 +510,8 @@ muse::Ret Au3Record::leadInRecording()
     }
 
     // Find tracks to record into (must be selected)
-    auto tracks = ChooseExistingRecordingTracks(project, true, rateOfSelected);
+    const size_t recordingChannels = std::max(0, audioDriverController()->configuration().inputChannels);
+    auto tracks = ChooseExistingRecordingTracks(project, true, rateOfSelected, recordingChannels);
     if (tracks.empty()) {
         return make_ret(Err::LeadInRecordingNoTracksSelected);
     }
@@ -827,7 +830,7 @@ Ret Au3Record::doRecord(Au3Project& project,
         // Count the tracks.
         auto numTracks = trackList.Any<const Au3WaveTrack>().size();
 
-        auto recordingChannels = std::max(1, AudioIORecordChannels.Read());
+        const auto recordingChannels = std::max(1, audioDriverController()->configuration().inputChannels);
 
         gPrefs->Read(wxT("/GUI/TrackNames/RecordingNameCustom"), &recordingNameCustom, false);
         gPrefs->Read(wxT("/GUI/TrackNames/TrackNumber"), &useTrackNumber, false);

--- a/src/record/internal/au3/au3record.cpp
+++ b/src/record/internal/au3/au3record.cpp
@@ -73,7 +73,7 @@ PropertiesOfSelected GetPropertiesOfSelected(const Au3Project& proj)
 }
 
 WritableSampleTrackArray ChooseExistingRecordingTracks(Au3Project& proj, const bool selectedOnly, const double targetRate,
-                                                       const size_t recordingChannels)
+                                                       const int recordingChannels)
 {
     auto p = &proj;
     bool strictRules = (recordingChannels <= 2);
@@ -101,8 +101,8 @@ WritableSampleTrackArray ChooseExistingRecordingTracks(Au3Project& proj, const b
 
     auto& trackList = Au3TrackList::Get(*p);
     WritableSampleTrackArray candidates;
-    std::vector<unsigned> channelCounts;
-    size_t totalChannels = 0;
+    std::vector<int> channelCounts;
+    int totalChannels = 0;
     const auto range = trackList.Any<Au3WaveTrack>();
     for (auto candidate : selectedOnly ? range + &Au3Track::IsSelected : range) {
         if (targetRate != RATE_NOT_SELECTED && candidate->GetRate() != targetRate) {
@@ -110,7 +110,7 @@ WritableSampleTrackArray ChooseExistingRecordingTracks(Au3Project& proj, const b
         }
 
         // count channels in this track
-        const auto nChannels = candidate->NChannels();
+        const int nChannels = static_cast<int>(candidate->NChannels());
         if (strictRules && nChannels > recordingChannels) {
             const bool stereoTrackMonoInput
                 =(recordingChannels == 1 && nChannels == 2 && candidates.empty());
@@ -385,7 +385,7 @@ muse::Ret Au3Record::start()
     }
 
     if (appendRecord) {
-        const size_t recordingChannels = std::max(0, audioDriverController()->configuration().inputChannels);
+        const int recordingChannels = std::max(0, audioDriverController()->configuration().inputChannels);
 
         // Try to find wave tracks to record into.  (If any are selected,
         // try to choose only from them; else if wave tracks exist, may record into any.)
@@ -512,7 +512,7 @@ muse::Ret Au3Record::leadInRecording()
     }
 
     // Find tracks to record into (must be selected)
-    const size_t recordingChannels = std::max(0, audioDriverController()->configuration().inputChannels);
+    const int recordingChannels = std::max(0, audioDriverController()->configuration().inputChannels);
     auto tracks = ChooseExistingRecordingTracks(project, true, rateOfSelected, recordingChannels);
     if (tracks.empty()) {
         return make_ret(Err::LeadInRecordingNoTracksSelected);
@@ -838,7 +838,7 @@ Ret Au3Record::doRecord(Au3Project& project,
                                        : defaultTrackName;
 
         std::vector<WaveTrack::Holder> newTracks;
-        if (recordingChannels == 2u) {
+        if (recordingChannels == 2) {
             newTracks.push_back(WaveTrackFactory::Get(*p).Create(2));
         } else {
             for (int i = 0; i < recordingChannels; ++i) {

--- a/src/record/internal/recordconfiguration.cpp
+++ b/src/record/internal/recordconfiguration.cpp
@@ -13,6 +13,15 @@ const muse::Settings::Key MIC_METERING_KEY("record", "record/micMetering");
 const muse::Settings::Key INPUT_MONITORING_KEY("record", "record/inputMonitoring");
 const muse::Settings::Key LEAD_IN_TIME_DURATION_KEY("record", "record/leadInTimeDuration");
 const muse::Settings::Key CROSSFADE_DURATION_KEY("record", "record/crossfadeDuration");
+
+//! NOTE: these keys deliberately match the au3 preference paths (bridged to the
+//! same settings storage), so values recorded by au3 code stay readable;
+//! "RecodingTrackName" reproduces the au3 key's typo
+const muse::Settings::Key RECORDING_NAME_CUSTOM_KEY("record", "GUI/TrackNames/RecordingNameCustom");
+const muse::Settings::Key CUSTOM_TRACK_NAME_KEY("record", "GUI/TrackNames/RecodingTrackName");
+const muse::Settings::Key TRACK_NUMBER_KEY("record", "GUI/TrackNames/TrackNumber");
+const muse::Settings::Key DATE_STAMP_KEY("record", "GUI/TrackNames/DateStamp");
+const muse::Settings::Key TIME_STAMP_KEY("record", "GUI/TrackNames/TimeStamp");
 }
 
 void RecordConfiguration::init()
@@ -96,4 +105,15 @@ void RecordConfiguration::setCrossfadeDuration(double milliseconds)
 muse::async::Notification RecordConfiguration::crossfadeDurationChanged() const
 {
     return m_crossfadeDurationChanged;
+}
+
+RecordingTrackNameOptions RecordConfiguration::recordingTrackNameOptions() const
+{
+    RecordingTrackNameOptions options;
+    options.useCustomName = muse::settings()->value(RECORDING_NAME_CUSTOM_KEY).toBool();
+    options.customName = muse::settings()->value(CUSTOM_TRACK_NAME_KEY).toString();
+    options.addTrackNumber = muse::settings()->value(TRACK_NUMBER_KEY).toBool();
+    options.addDateStamp = muse::settings()->value(DATE_STAMP_KEY).toBool();
+    options.addTimeStamp = muse::settings()->value(TIME_STAMP_KEY).toBool();
+    return options;
 }

--- a/src/record/internal/recordconfiguration.h
+++ b/src/record/internal/recordconfiguration.h
@@ -32,6 +32,8 @@ public:
     void setCrossfadeDuration(double milliseconds) override;
     muse::async::Notification crossfadeDurationChanged() const override;
 
+    RecordingTrackNameOptions recordingTrackNameOptions() const override;
+
 private:
     muse::async::Notification m_isMicMeteringOnChanged;
     muse::async::Notification m_isInputMonitoringOnChanged;

--- a/src/record/irecordconfiguration.h
+++ b/src/record/irecordconfiguration.h
@@ -3,11 +3,22 @@
 */
 #pragma once
 
+#include <string>
+
 #include "global/modularity/imoduleinterface.h"
 #include "global/async/notification.h"
 #include "draw/types/color.h"
 
 namespace au::record {
+//! Naming scheme for newly recorded tracks
+struct RecordingTrackNameOptions {
+    bool useCustomName = false;
+    std::string customName;
+    bool addTrackNumber = false;
+    bool addDateStamp = false;
+    bool addTimeStamp = false;
+};
+
 class IRecordConfiguration : MODULE_GLOBAL_INTERFACE
 {
     INTERFACE_ID(IRecordConfiguration)
@@ -30,5 +41,7 @@ public:
     virtual double crossfadeDuration() const = 0;
     virtual void setCrossfadeDuration(double milliseconds) = 0;
     virtual muse::async::Notification crossfadeDurationChanged() const = 0;
+
+    virtual RecordingTrackNameOptions recordingTrackNameOptions() const = 0;
 };
 }

--- a/src/record/tests/au3record_tests.cpp
+++ b/src/record/tests/au3record_tests.cpp
@@ -236,7 +236,8 @@ TEST_F(Au3RecordTests, RecordingToNewTrackUsesConfiguredTrackName)
 
     //! [THEN] Recording goes to a new track named after the configured scheme
     const auto tracks = Au3TrackList::Get(projectRef()).Any<Au3WaveTrack>();
-    ASSERT_FALSE(tracks.empty());
+    ASSERT_EQ(tracks.size(), 1u);
+    EXPECT_EQ((*tracks.begin())->NChannels(), 2u);
     EXPECT_EQ((*tracks.begin())->GetName(), wxString("MyTake_1"));
 }
 

--- a/src/record/tests/au3record_tests.cpp
+++ b/src/record/tests/au3record_tests.cpp
@@ -87,6 +87,11 @@ public:
         ON_CALL(*m_audioDriverController, inputChannelsAvailable())
         .WillByDefault(Return(2));
 
+        audio::AudioConfiguration audioConfiguration;
+        audioConfiguration.inputChannels = 2;
+        ON_CALL(*m_audioDriverController, configuration())
+        .WillByDefault(Return(audioConfiguration));
+
         ON_CALL(*m_recordConfiguration, leadInTimeDuration())
         .WillByDefault(Return(2.0));
         ON_CALL(*m_recordConfiguration, crossfadeDuration())

--- a/src/record/tests/au3record_tests.cpp
+++ b/src/record/tests/au3record_tests.cpp
@@ -216,6 +216,30 @@ TEST_F(Au3RecordTests, LeadInRecordingAtZeroPlayheadFails)
     EXPECT_FALSE(ret);
 }
 
+TEST_F(Au3RecordTests, RecordingToNewTrackUsesConfiguredTrackName)
+{
+    //! [GIVEN] No recordable track exists and a custom recording track name
+    //! with the track number suffix is configured
+    RecordingTrackNameOptions nameOptions;
+    nameOptions.useCustomName = true;
+    nameOptions.customName = "MyTake";
+    nameOptions.addTrackNumber = true;
+    ON_CALL(*m_recordConfiguration, recordingTrackNameOptions())
+    .WillByDefault(Return(nameOptions));
+
+    EXPECT_CALL(*m_audioEngine, startStream(_, _, _, _, _, _))
+    .WillOnce(Return(1));
+
+    //! [WHEN] Recording is initiated
+    muse::Ret ret = m_record->start();
+    EXPECT_TRUE(ret);
+
+    //! [THEN] Recording goes to a new track named after the configured scheme
+    const auto tracks = Au3TrackList::Get(projectRef()).Any<Au3WaveTrack>();
+    ASSERT_FALSE(tracks.empty());
+    EXPECT_EQ((*tracks.begin())->GetName(), wxString("MyTake_1"));
+}
+
 TEST_F(Au3RecordTests, RecordingWithBusyEngineStartsUnpausedAtPlayhead)
 {
     //! [GIVEN] A selected track, the playhead at 8s and the engine still holding

--- a/src/record/tests/mocks/recordconfigurationmock.h
+++ b/src/record/tests/mocks/recordconfigurationmock.h
@@ -26,5 +26,7 @@ public:
     MOCK_METHOD(double, crossfadeDuration, (), (const, override));
     MOCK_METHOD(void, setCrossfadeDuration, (double), (override));
     MOCK_METHOD(muse::async::Notification, crossfadeDurationChanged, (), (const, override));
+
+    MOCK_METHOD(RecordingTrackNameOptions, recordingTrackNameOptions, (), (const, override));
 };
 }


### PR DESCRIPTION
Resolves: Au3Record: read record channels and track-name preferences via IRecordConfiguration #11732
Part of https://github.com/audacity/audacity/issues/11551

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
