### PR TITLE
11738 fix registration flow on welcome screen

### DIFF
--- a/au3/au3defs.cmake
+++ b/au3/au3defs.cmake
@@ -63,6 +63,9 @@ set( AUDACITY_VERSION_DEFS
     -DAUDACITY_REVISION=${MUSE_APP_VERSION_PATCH}
     -DAUDACITY_MODLEVEL=0
 
+    # Pre-release label from version.cmake; empty for dev and final releases
+    -DAUDACITY_VERSION_LABEL="${MUSE_APP_VERSION_LABEL}"
+
     # Version string for visual display
     -DAUDACITY_VERSION_STRING=L"${MUSE_APP_VERSION_MAJOR}.${MUSE_APP_VERSION_MINOR}.${MUSE_APP_VERSION_PATCH}${AUDACITY_SUFFIX}"
 

--- a/au3/libraries/au3-cloud-audiocom/OAuthService.cpp
+++ b/au3/libraries/au3-cloud-audiocom/OAuthService.cpp
@@ -389,7 +389,7 @@ std::string OAuthService::MakeAudioComAuthorizeURL(std::string_view userId, std:
         GetServiceConfig().GetAuthWithRedirectURL(), "?",
         tokenPrefix, token, "&",
         userPrefix, userId, "&",
-        urlPrefix, redirectUrl
+        urlPrefix, UrlEncode(std::string(redirectUrl))
         );
 
     if (SendAnonymousUsageInfo->Read()) {

--- a/au3/libraries/au3-cloud-audiocom/ServiceConfig.cpp
+++ b/au3/libraries/au3-cloud-audiocom/ServiceConfig.cpp
@@ -55,7 +55,7 @@ StringSetting audioComFinishUploadPage {
 
 StringSetting audioComTourPage {
     L"/CloudServices/AudioCom/TourPage",
-    L"https://audio.com/tour?mtm_campaign=audacitydesktop&mtm_content=app_launch_reg"
+    L"https://audio.com/tour?mtm_campaign=audacitydesktop&mtm_content=app_launch_reg&mtm_source={version_number}"
 };
 
 StringSetting audioComAuthWithRedirectURL {
@@ -174,7 +174,13 @@ std::string ServiceConfig::GetOAuthRedirectURL() const
 
 std::string ServiceConfig::GetTourPage() const
 {
-    return mTourPage;
+    const std::string versionLabel = AUDACITY_VERSION_LABEL;
+    std::string version = audacity::ToUTF8(AUDACITY_VERSION_STRING);
+    if (!versionLabel.empty()) {
+        version += "-" + versionLabel;
+    }
+
+    return Substitute(mTourPage, { { "version_number", version } });
 }
 
 std::string ServiceConfig::GetAuthWithRedirectURL() const

--- a/src/au3cloud/iau3audiocomservice.h
+++ b/src/au3cloud/iau3audiocomservice.h
@@ -72,6 +72,7 @@ public:
     virtual std::string getCloudProjectPage(const muse::io::path_t& projectPath) const = 0;
     virtual std::string getCloudAudioPage(const std::string& slug) const = 0;
     virtual std::string getCloudProfilePage() const = 0;
+    virtual std::string getTourPage() const = 0;
 
     virtual muse::Ret deleteCloudProject(const muse::io::path_t& localPath) = 0;
 

--- a/src/au3cloud/internal/au3audiocomservice.cpp
+++ b/src/au3cloud/internal/au3audiocomservice.cpp
@@ -840,6 +840,15 @@ std::string Au3AudioComService::getCloudProfilePage() const
     return oauthService.MakeAudioComAuthorizeURL(userId, profilePage);
 }
 
+std::string Au3AudioComService::getTourPage() const
+{
+    auto& oauthService = GetOAuthService();
+    const auto& serviceConfig = GetServiceConfig();
+
+    const auto userId = GetUserService().GetUserId().ToStdString();
+    return oauthService.MakeAudioComAuthorizeURL(userId, serviceConfig.GetTourPage());
+}
+
 muse::RetVal<muse::ProgressPtr> Au3AudioComService::downloadAudioFile(const std::string& audioId)
 {
     if (audioId.empty()) {

--- a/src/au3cloud/internal/au3audiocomservice.h
+++ b/src/au3cloud/internal/au3audiocomservice.h
@@ -77,6 +77,7 @@ public:
     std::string getCloudProjectPage(const muse::io::path_t& projectPath) const override;
     std::string getCloudAudioPage(const std::string& slug) const override;
     std::string getCloudProfilePage() const override;
+    std::string getTourPage() const override;
 
     muse::Ret deleteCloudProject(const muse::io::path_t& localPath) override;
 

--- a/src/au3cloud/internal/au3cloudactionscontroller.cpp
+++ b/src/au3cloud/internal/au3cloudactionscontroller.cpp
@@ -14,7 +14,6 @@ using namespace au::au3cloud;
 
 namespace {
 const muse::Uri SIGNIN_URI("audacity://signin/audiocom");
-const char* TOUR_PAGE_URL { "https://audio.com/tour?mtm_campaign=audacitydesktop&mtm_content=app_launch_reg" };
 
 const muse::actions::ActionQuery SHOW_TOUR_PAGE_ACTION("audacity://cloud/show-tour-page");
 const muse::actions::ActionQuery OPEN_SIGNIN_DIALOG_ACTION("audacity://cloud/open-signin-dialog");
@@ -90,11 +89,12 @@ void Au3CloudActionsController::showTourPage()
         const muse::UriQuery uri(SIGNIN_URI);
         const muse::RetVal<muse::Val> rv = interactive()->openSync(uri);
         if (!rv.ret) {
+            LOGW() << "Sign in cancelled: " << rv.ret.toString();
             return;
         }
     }
 
-    platformInteractive()->openUrl(TOUR_PAGE_URL);
+    platformInteractive()->openUrl(audioComService()->getTourPage());
 }
 
 void Au3CloudActionsController::openSignInDialog(const muse::actions::ActionQuery& query)

--- a/src/au3cloud/internal/au3cloudactionscontroller.cpp
+++ b/src/au3cloud/internal/au3cloudactionscontroller.cpp
@@ -86,7 +86,9 @@ void Au3CloudActionsController::openCreateAccountDialog(const muse::actions::Act
 void Au3CloudActionsController::showTourPage()
 {
     if (!authorization()->isAuthorized()) {
-        const muse::UriQuery uri(SIGNIN_URI);
+        muse::UriQuery uri(SIGNIN_URI);
+        uri.addParam(createAccountModeParam, muse::Val(true));
+
         const muse::RetVal<muse::Val> rv = interactive()->openSync(uri);
         if (!rv.ret) {
             LOGW() << "Sign in cancelled: " << rv.ret.toString();
@@ -104,10 +106,11 @@ void Au3CloudActionsController::openSignInDialog(const muse::actions::ActionQuer
     }
 
     const bool sync = query.param("sync").toBool();
-    const bool isCreateAccountMode = query.param(createAccountModeParam, muse::Val(false)).toBool();
 
     muse::UriQuery uri(SIGNIN_URI);
-    uri.addParam(createAccountModeParam, muse::Val(isCreateAccountMode));
+    if (query.contains(createAccountModeParam)) {
+        uri.addParam(createAccountModeParam, query.param(createAccountModeParam));
+    }
 
     if (sync) {
         const muse::RetVal<muse::Val> rv = interactive()->openSync(uri);

--- a/src/au3cloud/internal/au3cloudservice.cpp
+++ b/src/au3cloud/internal/au3cloudservice.cpp
@@ -26,9 +26,7 @@ void Au3CloudService::init()
         syncUsageInfoPrefs();
     });
 
-    auto& serviceConfig = audacity::cloud::audiocom::GetServiceConfig();
     m_replyHandler = new OAuthHttpServerReplyHandler(this);
-    m_replyHandler->setRedirectUrl(QUrl(serviceConfig.GetTourPage().c_str()));
     connect(m_replyHandler, &OAuthHttpServerReplyHandler::callbackReceived,
             this, [this](const QVariantMap& data) {
         // Extract authorization code from callback
@@ -205,17 +203,14 @@ void Au3CloudService::openBrowserSession()
 {
     auto& serviceConfig = audacity::cloud::audiocom::GetServiceConfig();
     auto& authService = audacity::cloud::audiocom::GetOAuthService();
-
-    const auto landingPage = m_accountInfo.userSlug.empty()
-                             ? serviceConfig.GetTourPage()
-                             : serviceConfig.GetProfilePagePath(m_accountInfo.userSlug, AudiocomTrace::ignore);
-    const auto url = authService.MakeAudioComAuthorizeURL(m_accountInfo.id, landingPage);
+    const auto url = authService.MakeAudioComAuthorizeURL(m_accountInfo.id, serviceConfig.GetTourPage());
 
     if (m_replyHandler->hasPendingSocket()) {
-        m_replyHandler->sendRedirect(QUrl(QString::fromStdString(url)));
-    } else {
-        platformInteractive()->openUrl(url);
+        m_replyHandler->sendRedirect(QString::fromStdString(url));
+        return;
     }
+
+    platformInteractive()->openUrl(url);
 }
 
 std::string Au3CloudService::buildOAuthRequestURL(const std::string& provider)

--- a/src/project/qml/Audacity/Project/SaveToCloudDialog.qml
+++ b/src/project/qml/Audacity/Project/SaveToCloudDialog.qml
@@ -51,7 +51,7 @@ StyledDialogView {
                 }
                 root.hide()
             } else {
-                model.openSignInDialog()
+                model.openCreateAccountDialog()
             }
         }
     }

--- a/src/stubs/au3cloud/au3audiocomservicestub.h
+++ b/src/stubs/au3cloud/au3audiocomservicestub.h
@@ -40,6 +40,7 @@ public:
     std::string getCloudProjectPage(const muse::io::path_t& projectPath) const override;
     std::string getCloudAudioPage(const std::string& audioId) const override;
     std::string getCloudProfilePage() const override;
+    std::string getTourPage() const override;
 
     void deinit() override;
 };


### PR DESCRIPTION
Resolves: #11738 

Redirect to audio.com tour page after sign in and registration.
Also signup should be the default view on audio.com dialog.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
