### PR TITLE
#11766 avoid duplicates in plugin paths

### DIFF
--- a/au3/libraries/au3-files/FileNames.cpp
+++ b/au3/libraries/au3-files/FileNames.cpp
@@ -677,6 +677,22 @@ void FileNames::AddMultiPathsToPathList(const wxString& multiPathStringArg,
     }
 }
 
+void FileNames::RemoveDuplicatesFromPathList(FilePaths& pathList)
+{
+    FilePaths uniquePaths;
+    FilePaths normalizedPaths;
+    for (const auto& path : pathList) {
+        wxFileName dir = wxFileName::DirName(path);
+        dir.MakeAbsolute();
+        const wxString normalized = dir.GetFullPath();
+        if (normalizedPaths.Index(normalized, wxFileName::IsCaseSensitive()) == wxNOT_FOUND) {
+            normalizedPaths.push_back(normalized);
+            uniquePaths.push_back(path);
+        }
+    }
+    pathList = std::move(uniquePaths);
+}
+
 #include <wx/log.h>
 
 // static

--- a/au3/libraries/au3-files/FileNames.cpp
+++ b/au3/libraries/au3-files/FileNames.cpp
@@ -23,7 +23,10 @@ used throughout Audacity into this one place.
 #include "FileNames.h"
 #include "PathList.h"
 
+#include <algorithm>
+#include <filesystem>
 #include <memory>
+#include <system_error>
 
 #include <wx/dir.h> // for wxDIR_FILES
 #include <wx/defs.h>
@@ -677,6 +680,31 @@ void FileNames::AddMultiPathsToPathList(const wxString& multiPathStringArg,
     }
 }
 
+namespace {
+std::filesystem::path FilesystemPath(const wxString& path)
+{
+#if defined(__WXMSW__)
+    return std::filesystem::path { path.ToStdWstring() };
+#else
+    return std::filesystem::path { std::string { path.utf8_str() } };
+#endif
+}
+
+bool SameDirectory(const wxString& lhs, const wxString& rhs)
+{
+    // Case sensitivity is a property of the volume, not of the OS, so ask the
+    // file system itself whether the two spellings name the same directory
+    // (this also sees through symlinks). It can only answer for directories
+    // that exist; for the rest an exact comparison suffices, since a
+    // nonexistent directory contributes no files however often it is scanned.
+
+    // Use std::error_code to avoid throwing if the directories do not exist.
+    std::error_code ec;
+    return std::filesystem::equivalent(FilesystemPath(lhs), FilesystemPath(rhs), ec)
+           || lhs == rhs;
+}
+}
+
 void FileNames::RemoveDuplicatesFromPathList(FilePaths& pathList)
 {
     FilePaths uniquePaths;
@@ -685,7 +713,10 @@ void FileNames::RemoveDuplicatesFromPathList(FilePaths& pathList)
         wxFileName dir = wxFileName::DirName(path);
         dir.MakeAbsolute();
         const wxString normalized = dir.GetFullPath();
-        if (normalizedPaths.Index(normalized, wxFileName::IsCaseSensitive()) == wxNOT_FOUND) {
+        const bool isDuplicate = std::any_of(normalizedPaths.begin(), normalizedPaths.end(), [&](const wxString& kept) {
+            return SameDirectory(normalized, kept);
+        });
+        if (!isDuplicate) {
             normalizedPaths.push_back(normalized);
             uniquePaths.push_back(path);
         }

--- a/au3/libraries/au3-files/FileNames.h
+++ b/au3/libraries/au3-files/FileNames.h
@@ -202,6 +202,7 @@ FILES_API void AddUniquePathToPathList(const FilePath& path, FilePaths& pathList
 FILES_API void AddMultiPathsToPathList(const wxString& multiPathString, FilePaths& pathList);
 //! Squashes equivalent paths, yet keeping the original spelling of the first occurrence,
 //! e.g. {`~/.vst3/`, `/home/me/.vst3`} returns {`~/.vst3/`} and not e.g. {`/home/me/.vst3`})
+//! Directories that do not exist are deduplicated only on exact spelling.
 FILES_API void RemoveDuplicatesFromPathList(FilePaths& pathList);
 FILES_API void FindFilesInPathList(const wxString& pattern, const FilePaths& pathList, FilePaths& results);
 

--- a/au3/libraries/au3-files/FileNames.h
+++ b/au3/libraries/au3-files/FileNames.h
@@ -200,6 +200,9 @@ FilePath WithDefaultPath
 // Useful functions for working with search paths
 FILES_API void AddUniquePathToPathList(const FilePath& path, FilePaths& pathList);
 FILES_API void AddMultiPathsToPathList(const wxString& multiPathString, FilePaths& pathList);
+//! Squashes equivalent paths, yet keeping the original spelling of the first occurrence,
+//! e.g. {`~/.vst3/`, `/home/me/.vst3`} returns {`~/.vst3/`} and not e.g. {`/home/me/.vst3`})
+FILES_API void RemoveDuplicatesFromPathList(FilePaths& pathList);
 FILES_API void FindFilesInPathList(const wxString& pattern, const FilePaths& pathList, FilePaths& results);
 
 //! Check location on writable access and return true if checked successfully.

--- a/au3/libraries/au3-module-manager/PluginManager.cpp
+++ b/au3/libraries/au3-module-manager/PluginManager.cpp
@@ -241,22 +241,14 @@ void PluginManager::FindFilesInPathList(const wxString& pattern,
     ff.AppendDir(wxT("nyquist-plug-ins"));
     paths.push_back(ff.GetPath());
 
-    // Weed out duplicates
-    for (const auto& filePath : pathList) {
-        ff = filePath;
-        const wxString path{ ff.GetFullPath() };
-        if (paths.Index(path, wxFileName::IsCaseSensitive()) == wxNOT_FOUND) {
-            paths.push_back(path);
-        }
-    }
+    std::copy(pathList.begin(), pathList.end(), std::back_inserter(paths));
+    FileNames::RemoveDuplicatesFromPathList(paths);
 
     // Find all matching files in each path
     for (size_t i = 0, cnt = paths.size(); i < cnt; i++) {
         ff = paths[i] + wxFILE_SEP_PATH + pattern;
         wxDir::GetAllFiles(ff.GetPath(), &files, ff.GetFullName(), directories ? wxDIR_DEFAULT : wxDIR_FILES);
     }
-
-    return;
 }
 
 bool PluginManager::HasConfigGroup(ConfigurationType type, const PluginID& ID,

--- a/au3/libraries/au3-nyquist-effects/LoadNyquist.cpp
+++ b/au3/libraries/au3-nyquist-effects/LoadNyquist.cpp
@@ -10,6 +10,8 @@
 
 #include "LoadNyquist.h"
 
+#include <algorithm>
+
 #include <wx/log.h>
 
 #include "NyquistBase.h"
@@ -238,11 +240,9 @@ PluginPaths NyquistEffectsModule::FindModulePaths(PluginManagerInterface& pm, Ba
     // LLL:  Works for all platform with NEW plugin support (dups are removed)
     pm.FindFilesInPathList(wxT("*.NY"), pathList, files); // Ed's fix for bug 179
 
-    // Remove duplicates - case-insensitive comparison.
-    std::sort(files.begin(), files.end(),
-              [](const wxString& a, const wxString& b) { return a.CmpNoCase(b) < 0; });
-    files.erase(std::unique(files.begin(), files.end(),
-                            [](const wxString& a, const wxString& b) { return a.CmpNoCase(b) == 0; }), files.end());
+    // On Windows both globs above match the same files: remove exact duplicates.
+    std::sort(files.begin(), files.end());
+    files.erase(std::unique(files.begin(), files.end()), files.end());
 
     wxLogDebug("Found %zu total files", files.size());
     for (size_t i = 0; i < files.size(); ++i) {

--- a/au3/libraries/au3-vst3/VST3EffectsModule.cpp
+++ b/au3/libraries/au3-vst3/VST3EffectsModule.cpp
@@ -259,7 +259,6 @@ VST3EffectsModule::FindModulePaths(PluginManagerInterface& pluginManager,
     }
 
     // VST3 paths are filesystem paths: we can use this helper to remove duplicates.
-    // On Windows, the deduplication is case-insensitive.
     FileNames::RemoveDuplicatesFromPathList(pathList);
 
     PluginPaths result;

--- a/au3/libraries/au3-vst3/VST3EffectsModule.cpp
+++ b/au3/libraries/au3-vst3/VST3EffectsModule.cpp
@@ -26,6 +26,7 @@
 #include "au3-module-manager/ModuleManager.h"
 
 #include "au3-strings/wxArrayStringEx.h"
+#include "au3-files/FileNames.h"
 #include "au3-files/PlatformCompatibility.h"
 #include "au3-module-manager/PluginInterface.h"
 #include "au3-components/PluginProvider.h"
@@ -256,6 +257,10 @@ VST3EffectsModule::FindModulePaths(PluginManagerInterface& pluginManager,
         auto customPaths = pluginManager.ReadCustomPaths(*this);
         std::copy(customPaths.begin(), customPaths.end(), std::back_inserter(pathList));
     }
+
+    // VST3 paths are filesystem paths: we can use this helper to remove duplicates.
+    // On Windows, the deduplication is case-insensitive.
+    FileNames::RemoveDuplicatesFromPathList(pathList);
 
     PluginPaths result;
 

--- a/src/au3wrap/tests/CMakeLists.txt
+++ b/src/au3wrap/tests/CMakeLists.txt
@@ -9,6 +9,12 @@ set(MODULE_TEST_SRC
     ${CMAKE_CURRENT_LIST_DIR}/tracktemplatefactory.cpp
 
     ${CMAKE_CURRENT_LIST_DIR}/mocks/au3projectmock.h
+
+    ${CMAKE_CURRENT_LIST_DIR}/filenames_tests.cpp
+)
+
+set(MODULE_TEST_LINK
+    au3wrap
 )
 
 set(MODULE_TEST_LINK

--- a/src/au3wrap/tests/filenames_tests.cpp
+++ b/src/au3wrap/tests/filenames_tests.cpp
@@ -1,0 +1,91 @@
+/*
+* Audacity: A Digital Audio Editor
+*/
+#include <gtest/gtest.h>
+
+#include <filesystem>
+
+#include "au3-files/FileNames.h"
+
+namespace fs = std::filesystem;
+
+class FileNamesTests : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        m_base = fs::temp_directory_path() / "au3_filenames_tests";
+        fs::remove_all(m_base);
+        fs::create_directories(m_base / "real");
+        fs::create_directories(m_base / "other");
+    }
+
+    void TearDown() override
+    {
+        fs::remove_all(m_base);
+    }
+
+    wxString path(const char* name) const
+    {
+        return wxString::FromUTF8((m_base / name).string());
+    }
+
+    fs::path m_base;
+};
+
+TEST_F(FileNamesTests, ExactDuplicatesAreRemovedKeepingTheFirst)
+{
+    FilePaths paths { path("real"), path("other"), path("real") };
+    FileNames::RemoveDuplicatesFromPathList(paths);
+    ASSERT_EQ(paths.size(), 2);
+    EXPECT_EQ(paths[0], path("real"));
+    EXPECT_EQ(paths[1], path("other"));
+}
+
+TEST_F(FileNamesTests, DistinctDirectoriesAreKept)
+{
+    FilePaths paths { path("real"), path("other") };
+    FileNames::RemoveDuplicatesFromPathList(paths);
+    EXPECT_EQ(paths.size(), 2);
+}
+
+TEST_F(FileNamesTests, TrailingSlashSpellingOfSameDirectoryIsRemoved)
+{
+    FilePaths paths { path("real"), path("real") + "/" };
+    FileNames::RemoveDuplicatesFromPathList(paths);
+    ASSERT_EQ(paths.size(), 1);
+    EXPECT_EQ(paths[0], path("real"));
+}
+
+TEST_F(FileNamesTests, DotDotSpellingOfSameDirectoryIsRemoved)
+{
+    FilePaths paths { path("real"), path("other/../real") };
+    FileNames::RemoveDuplicatesFromPathList(paths);
+    ASSERT_EQ(paths.size(), 1);
+    EXPECT_EQ(paths[0], path("real"));
+}
+
+#ifndef _WIN32
+TEST_F(FileNamesTests, SymlinkToAlreadyListedDirectoryIsRemoved)
+{
+    fs::create_directory_symlink(m_base / "real", m_base / "link");
+    FilePaths paths { path("real"), path("link") };
+    FileNames::RemoveDuplicatesFromPathList(paths);
+    ASSERT_EQ(paths.size(), 1);
+    EXPECT_EQ(paths[0], path("real"));
+}
+#endif
+
+TEST_F(FileNamesTests, NonexistentDuplicateSpellingsAreRemoved)
+{
+    FilePaths paths { path("no-such-dir"), path("no-such-dir") };
+    FileNames::RemoveDuplicatesFromPathList(paths);
+    EXPECT_EQ(paths.size(), 1);
+}
+
+TEST_F(FileNamesTests, NonexistentDirectoryIsNotMergedWithExistingOne)
+{
+    FilePaths paths { path("no-such-dir"), path("real") };
+    FileNames::RemoveDuplicatesFromPathList(paths);
+    EXPECT_EQ(paths.size(), 2);
+}


### PR DESCRIPTION
Resolves: #11766

`RegisterAudioPluginsScenario::scanPlugins`'s implementation assumes that `IAudioPluginsScanner::scanPlugins` doesn't return path duplicates and the final `registered.erase(it);` on the first iteration of a path duplicate resulted in the second iteration adding it to `result.newPluginPaths` ...
Certainly there is no sense for a scanner to do that, too, so I modified the signature of `FindModulePaths` to return a set instead of a vector of paths.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
