### PR TITLE
11801 open in file manager on cloud context menu

### DIFF
--- a/src/project/view/cloudprojectcontextmenumodel.cpp
+++ b/src/project/view/cloudprojectcontextmenumodel.cpp
@@ -4,6 +4,7 @@
 #include "cloudprojectcontextmenumodel.h"
 
 #include "framework/actions/actiontypes.h"
+#include "framework/global/log.h"
 
 using namespace au::project;
 
@@ -11,10 +12,11 @@ namespace {
 constexpr const char* OPEN_PROJECT_ACTION = "cloud-file-open";
 constexpr const char* OPEN_PROJECT_PAGE_ACTION = "audacity://cloud/open-project-page";
 constexpr const char* UPDATE_AUDIO_PREVIEW_ACTION = "audacity://cloud/update-audio-preview-for-project";
+constexpr const char* SHOW_IN_FOLDER_ACTION = "project-show-in-folder";
 }
 
-CloudProjectContextMenuModel::CloudProjectContextMenuModel(QString projectId, QObject* parent)
-    : AbstractMenuModel(parent), m_projectId(std::move(projectId))
+CloudProjectContextMenuModel::CloudProjectContextMenuModel(QString projectId, muse::io::path_t localPath, QObject* parent)
+    : AbstractMenuModel(parent), m_projectId(std::move(projectId)), m_localPath(std::move(localPath))
 {
 }
 
@@ -22,11 +24,17 @@ void CloudProjectContextMenuModel::load()
 {
     muse::uicomponents::AbstractMenuModel::load();
 
-    muse::uicomponents::MenuItem* openItem = makeMenuItem(OPEN_PROJECT_ACTION);
-    muse::uicomponents::MenuItem* viewProjectPage = makeMenuItem(OPEN_PROJECT_PAGE_ACTION);
-    muse::uicomponents::MenuItem* updateAudioPreview = makeMenuItem(UPDATE_AUDIO_PREVIEW_ACTION);
+    muse::uicomponents::MenuItemList items = {
+        makeMenuItem(OPEN_PROJECT_ACTION),
+        makeMenuItem(OPEN_PROJECT_PAGE_ACTION),
+        makeMenuItem(UPDATE_AUDIO_PREVIEW_ACTION)
+    };
 
-    setItems({ openItem, viewProjectPage, updateAudioPreview });
+    if (!m_localPath.empty()) {
+        items.append(makeMenuItem(SHOW_IN_FOLDER_ACTION));
+    }
+
+    setItems(items);
 }
 
 void CloudProjectContextMenuModel::handleMenuItem(const QString& itemId)
@@ -48,6 +56,15 @@ void CloudProjectContextMenuModel::handleMenuItem(const QString& itemId)
         muse::actions::ActionQuery query(OPEN_PROJECT_PAGE_ACTION);
         query.addParam("id", muse::Val(m_projectId));
         dispatch(query);
+        return;
+    }
+
+    if (itemId == SHOW_IN_FOLDER_ACTION) {
+        IF_ASSERT_FAILED(!m_localPath.empty()) {
+            return;
+        }
+
+        platformInteractive()->revealInFileBrowser(m_localPath);
         return;
     }
 

--- a/src/project/view/cloudprojectcontextmenumodel.h
+++ b/src/project/view/cloudprojectcontextmenumodel.h
@@ -4,19 +4,26 @@
 #pragma once
 
 #include "framework/uicomponents/qml/Muse/UiComponents/abstractmenumodel.h"
+#include "framework/global/io/path.h"
+
+#include "framework/global/modularity/ioc.h"
+#include "framework/interactive/iplatforminteractive.h"
 
 namespace au::project {
 class CloudProjectContextMenuModel : public muse::uicomponents::AbstractMenuModel
 {
     Q_OBJECT
 
+    muse::GlobalInject<muse::IPlatformInteractive> platformInteractive;
+
 public:
-    CloudProjectContextMenuModel(QString projectId, QObject* parent = nullptr);
+    CloudProjectContextMenuModel(QString projectId, muse::io::path_t localPath, QObject* parent = nullptr);
 
     Q_INVOKABLE void load() override;
     void handleMenuItem(const QString& itemId) override;
 
 private:
     QString m_projectId;
+    muse::io::path_t m_localPath;
 };
 }

--- a/src/project/view/cloudprojectsmodel.cpp
+++ b/src/project/view/cloudprojectsmodel.cpp
@@ -143,8 +143,9 @@ void CloudProjectsModel::loadItemsIfNecessary()
                     obj[SHOW_INDICATOR_KEY] = true;
 
                     const auto id = obj[CLOUD_ITEM_ID_KEY].toString();
+                    const auto record = cloudProjectsProvider()->projectRecordForId(item.id);
                     obj[CONTEXT_MENU_MODEL_KEY] = QVariant::fromValue(
-                        new CloudProjectContextMenuModel(id, this));
+                        new CloudProjectContextMenuModel(id, record ? record->localPath : muse::io::path_t(), this));
 
                     m_items.push_back(obj);
                 }

--- a/src/project/view/cloudprojectsmodel.h
+++ b/src/project/view/cloudprojectsmodel.h
@@ -10,8 +10,8 @@
 #include "modularity/ioc.h"
 #include "iprojectconfiguration.h"
 #include "au3cloud/iau3audiocomservice.h"
+#include "au3cloud/icloudprojectsprovider.h"
 #include "framework/interactive/iinteractive.h"
-#include <qtmetamacros.h>
 
 namespace au::project {
 class CloudProjectsModel : public AbstractItemModel, public muse::async::Asyncable, public muse::Contextable
@@ -19,6 +19,7 @@ class CloudProjectsModel : public AbstractItemModel, public muse::async::Asyncab
     Q_OBJECT
 
     muse::GlobalInject<au::project::IProjectConfiguration> configuration;
+    muse::GlobalInject<au::au3cloud::ICloudProjectsProvider> cloudProjectsProvider;
     muse::ContextInject<au::au3cloud::IAu3AudioComService> audioComService { this };
     muse::ContextInject<muse::IInteractive> interactive { this };
 


### PR DESCRIPTION
Resolves: #11801 

Add "open in finder" option to cloud context menu.
The option is only present if the project was already downloaded.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
