### PR TITLE
#11812: expand ~ in vst3 default path for macos

### DIFF
--- a/au3/libraries/au3-vst3/VST3EffectsModule.cpp
+++ b/au3/libraries/au3-vst3/VST3EffectsModule.cpp
@@ -233,7 +233,7 @@ VST3EffectsModule::FindModulePaths(PluginManagerInterface& pluginManager,
         }
     }
 #elif __WXMAC__
-    pathList.push_back("~/Library/Audio/Plug-ins/VST3/");
+    pathList.push_back(wxGetHomeDir() + "/Library/Audio/Plug-ins/VST3/");
     pathList.push_back("/Library/Audio/Plug-ins/VST3/");
     pathList.push_back("/Network/Library/Audio/Plug-ins/VST3/");
 #elif __WXGTK__


### PR DESCRIPTION
Resolves:  #11812 

The `~` character never expanded on mac.

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
