### PR TITLE
Keep VSCode file watchers from monitoring ./build dir

### DIFF
--- a/.vscode/audacity.code-workspace
+++ b/.vscode/audacity.code-workspace
@@ -20,5 +20,22 @@
         "cmake.copyCompileCommands": "${workspaceFolder}/compile_commands.json",
         "cmake.buildBeforeRun": false, // Useful if you are running the "audacity (install)" target :
         "uncrustify.executablePath.linux": "/usr/local/bin/uncrustify_074",
+
+        // build/ is gitignored but VSCode doesn't consult .gitignore for its
+        // file watcher or search by default. Left unexcluded, it accounts for
+        // ~60-70% of this workspace's directories (all build output), which
+        // means an inotify watch per subdirectory set up on every window open,
+        // plus every build artifact showing up in search results. Excluding
+        // it noticeably speeds up opening this workspace.
+        "files.watcherExclude": {
+            "**/build/**": true,
+            "**/.cache/**": true,
+            "**/.tools/**": true,
+        },
+        "search.exclude": {
+            "**/build": true,
+            "**/.cache": true,
+            "**/.tools": true,
+        }
     }
 }


### PR DESCRIPTION
Opening the repo in VSCode can be very slow. Even if .gitignored, the ./build directory still gets watched. Disabling this speeds things up quite a bit.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
