### PR TITLE
TrackLabel: Fixed letter descendant's cropping on the label header

### DIFF
--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/LabelHeader.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/LabelHeader.qml
@@ -33,7 +33,7 @@ Rectangle {
     signal headerHoveredChanged(bool value)
 
     property int contentWidth: Math.max(50, Math.min(400, titleLoader.contentWidth + 8))
-    property int contentHeight: titleLoader.isEditState && titleLoader.item ? titleLoader.item.contentHeight : 14
+    property int contentHeight: titleLoader.isEditState && titleLoader.item ? titleLoader.item.contentHeight : 20
 
     x: root.isPoint ? root.earWidth + 3 : 0
     y: 0


### PR DESCRIPTION

Previously, the header used to be cropped due to insufficient label header height. Now this has been fixed by increasing the height from 14 to 20 (px).

<img width="1214" height="204" alt="Screenshot 2026-08-29 at 14 44 26" src="https://github.com/user-attachments/assets/54120d8b-2a54-4451-8095-62a0ddcfb943" />
Resolves: #11631 

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run

Seems like an easy fix. I am not sure if there are any other side effects after increasing the label header height, however, for now, after re-scalling the project window and adding more labels, I didn't see anything breaking.