### PR TITLE
Fix label stretch: invert label ears when stretched backwards

### DIFF
--- a/src/trackedit/internal/au3/au3labelsinteraction.cpp
+++ b/src/trackedit/internal/au3/au3labelsinteraction.cpp
@@ -511,7 +511,10 @@ bool Au3LabelsInteraction::stretchLabelLeft(const LabelKey& labelKey, secs_t new
 
     newStartTime = std::max(0.0, newStartTime.to_double());
 
-    au3Label.selectedRegion.setTimes(newStartTime, anchorT1);
+    // If the left anchor is dragged after the right one, set them to a point, the final stretch performed by the autoscroll completion will invert the anchors.
+    if (au3Label.selectedRegion.setTimes(newStartTime, anchorT1) && completed) {
+        au3Label.selectedRegion.setTimes(anchorT1, anchorT1);
+    }
     labelTrack->SetLabel(labelIndex, au3Label);
 
     const auto prj = globalContext()->currentTrackeditProject();
@@ -581,7 +584,10 @@ bool Au3LabelsInteraction::stretchLabelRight(const LabelKey& labelKey, secs_t ne
 
     newEndTime = std::max(0.0, newEndTime.to_double());
 
-    au3Label.selectedRegion.setTimes(anchorT0, newEndTime);
+    // If the right anchor is dragged before the left one, set them to a point, the final stretch performed by the autoscroll completion will invert the anchors.
+    if (au3Label.selectedRegion.setTimes(anchorT0, newEndTime) && completed) {
+        au3Label.selectedRegion.setTimes(anchorT0, anchorT0);
+    }
     labelTrack->SetLabel(labelIndex, au3Label);
 
     const auto prj = globalContext()->currentTrackeditProject();

--- a/src/trackedit/tests/au3labelsinteractions_tests.cpp
+++ b/src/trackedit/tests/au3labelsinteractions_tests.cpp
@@ -1391,12 +1391,12 @@ TEST_F(Au3LabelsInteractionsTests, StretchLabelLeftBeyondEndTime)
     //! [THEN] The operation succeeds
     ASSERT_TRUE(result) << "Stretching label left beyond end time should succeed";
 
-    //! [THEN] The label has inverted times (start > end)
+    //! [THEN] The label is shrunk to a point (start == end)
     const Au3Label* stretchedLabel = labelTrack->GetLabel(0);
     ASSERT_NE(stretchedLabel, nullptr) << "Label should exist";
     ASSERT_EQ(stretchedLabel->GetId(), labelId) << "Label should have correct ID";
     ASSERT_DOUBLE_EQ(stretchedLabel->getT0(), 5.0) << "Label start time should be 5.0";
-    ASSERT_DOUBLE_EQ(stretchedLabel->getT1(), 6.0) << "Label end time should be 6.0";
+    ASSERT_DOUBLE_EQ(stretchedLabel->getT1(), 5.0) << "Label end time should be 5.0";
 }
 
 TEST_F(Au3LabelsInteractionsTests, StretchLabelRightBeforeStartTime)
@@ -1425,11 +1425,11 @@ TEST_F(Au3LabelsInteractionsTests, StretchLabelRightBeforeStartTime)
     //! [THEN] The operation succeeds
     ASSERT_TRUE(result) << "Stretching label right before start time should succeed";
 
-    //! [THEN] The label has inverted times (end < start)
+    //! [THEN] The label is shrunk to a point (start == end)
     const Au3Label* stretchedLabel = labelTrack->GetLabel(0);
     ASSERT_NE(stretchedLabel, nullptr) << "Label should exist";
     ASSERT_EQ(stretchedLabel->GetId(), labelId) << "Label should have correct ID";
-    ASSERT_DOUBLE_EQ(stretchedLabel->getT0(), 2.0) << "Label start time should be 2.0";
+    ASSERT_DOUBLE_EQ(stretchedLabel->getT0(), 3.0) << "Label start time should be 3.0";
     ASSERT_DOUBLE_EQ(stretchedLabel->getT1(), 3.0) << "Label end time should be 3.0";
 }
 
@@ -1474,9 +1474,9 @@ TEST_F(Au3LabelsInteractionsTests, StretchLabelRightInverse)
     bool result3 = m_labelsInteraction->stretchLabelRight(labelKey, 1.5, true);
     ASSERT_TRUE(result3) << "Third stretch should succeed";
 
-    //! [THEN] Anchor should still be at original left edge 3.0
+    //! [THEN] Anchor should still be at original left edge 3.0, the label becomes a point.
     const Au3Label* label3 = labelTrack->GetLabel(0);
-    ASSERT_DOUBLE_EQ(label3->getT0(), 1.5) << "After swap, T0 should be 1.5";
+    ASSERT_DOUBLE_EQ(label3->getT0(), 3.0) << "After swap, T0 should be 3.0";
     ASSERT_DOUBLE_EQ(label3->getT1(), 3.0) << "After swap, T1 should still be original left edge 3.0";
 }
 
@@ -1521,10 +1521,10 @@ TEST_F(Au3LabelsInteractionsTests, StretchLabelLeftInverse)
     bool result3 = m_labelsInteraction->stretchLabelLeft(labelKey, 7.5, true);
     ASSERT_TRUE(result3) << "Third stretch should succeed";
 
-    //! [THEN] Anchor should still be at original right edge 6.0
+    //! [THEN] Anchor should still be at original right edge 6.0, the label becomes a point.
     const Au3Label* label3 = labelTrack->GetLabel(0);
     ASSERT_DOUBLE_EQ(label3->getT0(), 6.0) << "After swap, T0 should still be original right edge 6.0";
-    ASSERT_DOUBLE_EQ(label3->getT1(), 7.5) << "After swap, T1 should be 7.5";
+    ASSERT_DOUBLE_EQ(label3->getT1(), 6.0) << "After swap, T1 should be 6.0";
 }
 
 TEST_F(Au3LabelsInteractionsTests, StretchOppositeEdgeAfterInterruptedStretch)


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/11681

Before this change, stretching the right ear of a label beyond the left one results in the label being shrunk to a point (similar behavior for the left stretch). This is particularly unintuitive if the starting label is already a point, as it is not easy to select the right ear and it might seems like the label is not stretching (see attached issue).

Now the label will be inverted, resulting in the label stretching even if one ear is pulled beyond the other.


<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [ ] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [x] Testflow test cases have been run
