### PR TITLE
Build an AppImage only when "app-portable" is set

### DIFF
--- a/SetupConfigure.cmake
+++ b/SetupConfigure.cmake
@@ -107,7 +107,9 @@ endif()
 
 if(BUILD_CONFIGURE MATCHES "APP-PORTABLE")
     set(AU4_GENERAL_APP ON)
-    set(WIN_PORTABLE ON)
+    if (OS_IS_WIN)
+        set(WIN_PORTABLE ON)
+    endif()
 endif()
 
 if (AU4_GENERAL_APP)

--- a/buildscripts/packaging/Linux+BSD/SetupAppImagePackaging.cmake
+++ b/buildscripts/packaging/Linux+BSD/SetupAppImagePackaging.cmake
@@ -6,28 +6,29 @@ endif()
 
 set(DESKTOP_LAUNCHER_NAME "${MUSE_APP_NAME_VERSION} Portable")
 
-# Build portable AppImage as per https://github.com/probonopd/AppImageKit
-add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/portable)
-
-execute_process(COMMAND echo ${CMAKE_INSTALL_PREFIX} OUTPUT_FILE PREFIX.txt)
-
-# Prepare portable scripts:
-configure_file(${CMAKE_CURRENT_LIST_DIR}/portable/AppRun.in AppRun @ONLY)
-configure_file(${CMAKE_CURRENT_LIST_DIR}/portable/portable-utils.in portable-utils @ONLY)
-install(PROGRAMS ${PROJECT_BINARY_DIR}/AppRun DESTINATION . COMPONENT portable)
-install(PROGRAMS ${PROJECT_BINARY_DIR}/portable-utils
-    ${CMAKE_CURRENT_LIST_DIR}/portable/ldd-recursive
-    ${CMAKE_CURRENT_LIST_DIR}/portable/rm-empty-dirs DESTINATION bin COMPONENT portable)
-
-install(FILES ${CMAKE_CURRENT_LIST_DIR}/portable/qt.conf DESTINATION bin COMPONENT portable)
-
-install(PROGRAMS ${CMAKE_CURRENT_LIST_DIR}/portable/wrappers/xdg-open DESTINATION wrappers COMPONENT portable)
-
-
 # Identify App's main window so that it receives the correct name
 # and icon in the OS dock / taskbar. Run `xprop WM_CLASS` and click on
 # App's main window to find out what string to use here.
 set(WINDOW_MANAGER_CLASS ${MUSE_APP_NAME_VERSION})
+
+if (AU4_BUILD_CONFIGURATION STREQUAL "app-portable")
+    # Build portable AppImage as per https://github.com/probonopd/AppImageKit
+    add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/portable)
+
+    execute_process(COMMAND echo ${CMAKE_INSTALL_PREFIX} OUTPUT_FILE PREFIX.txt)
+
+    # Prepare portable scripts:
+    configure_file(${CMAKE_CURRENT_LIST_DIR}/portable/AppRun.in AppRun @ONLY)
+    configure_file(${CMAKE_CURRENT_LIST_DIR}/portable/portable-utils.in portable-utils @ONLY)
+    install(PROGRAMS ${PROJECT_BINARY_DIR}/AppRun DESTINATION . COMPONENT portable)
+    install(PROGRAMS ${PROJECT_BINARY_DIR}/portable-utils
+        ${CMAKE_CURRENT_LIST_DIR}/portable/ldd-recursive
+        ${CMAKE_CURRENT_LIST_DIR}/portable/rm-empty-dirs DESTINATION bin COMPONENT portable)
+
+    install(FILES ${CMAKE_CURRENT_LIST_DIR}/portable/qt.conf DESTINATION bin COMPONENT portable)
+
+    install(PROGRAMS ${CMAKE_CURRENT_LIST_DIR}/portable/wrappers/xdg-open DESTINATION wrappers COMPONENT portable)
+endif()
 
 # Install desktop file (perform variable substitution first)
 configure_file(${CMAKE_CURRENT_LIST_DIR}/org.audacityteam.Audacity.desktop.in org.audacityteam.Audacity${MUSE_APP_INSTALL_SUFFIX}.desktop)

--- a/ci_build.cmake
+++ b/ci_build.cmake
@@ -156,6 +156,7 @@ elseif(BUILD_TYPE STREQUAL "RELEASE_INSTALL")
 
 elseif(BUILD_TYPE STREQUAL "APPIMAGE")
 
+    set(BUILD_CONFIGURATION "app-portable")
     set(INSTALL_SUFFIX "4portable${INSTALL_SUFFIX}") # e.g. "4portable" or "4portablenightly"
     set(SKIP_RPATH ON)
     set(BUILD_DIR build.release)


### PR DESCRIPTION
Resolves: skip creating appimage-only files when no appimage is needed

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
