### PR TITLE
11851 Fix registration flow during onboarding

### DIFF
--- a/src/appshell/qml/Audacity/AppShell/FirstLaunchSetup/FirstLaunchSetupDialog.qml
+++ b/src/appshell/qml/Audacity/AppShell/FirstLaunchSetup/FirstLaunchSetupDialog.qml
@@ -100,7 +100,14 @@ StyledDialogView {
 
             Layout.fillWidth: true
             Layout.preferredHeight: 366
-            source: model.currentPage.url
+
+            Connections {
+                target: model
+
+                function onCurrentPageChanged() {
+                    pageLoader.setSource(model.currentPage.url, model.currentPage.properties)
+                }
+            }
 
             onLoaded: {
                 item.navigationSection = root.navigationSection

--- a/src/appshell/qml/Audacity/AppShell/FirstLaunchSetup/firstlaunchsetupmodel.cpp
+++ b/src/appshell/qml/Audacity/AppShell/FirstLaunchSetup/firstlaunchsetupmodel.cpp
@@ -52,7 +52,7 @@ void FirstLaunchSetupModel::load()
     }
 
     if (au3CloudService()->enabled()) {
-        m_pages.append(Page { SIGNIN_AUDIO_COM_PAGE, "audacity://project" });
+        m_pages.append(Page { SIGNIN_AUDIO_COM_PAGE, "audacity://project", { { "isCreateAccountMode", true } } });
         m_pages.append(Page { APP_UPDATES_AND_USAGE_INFO_PAGE, "audacity://project" });
     }
 
@@ -74,6 +74,7 @@ QVariantMap FirstLaunchSetupModel::Page::toMap() const
 {
     return {
         { "url", m_url },
+        { "properties", m_properties },
     };
 }
 

--- a/src/appshell/qml/Audacity/AppShell/FirstLaunchSetup/firstlaunchsetupmodel.h
+++ b/src/appshell/qml/Audacity/AppShell/FirstLaunchSetup/firstlaunchsetupmodel.h
@@ -23,6 +23,7 @@
 #define AU_APPSHELL_FIRSTLAUNCHSETUPMODEL_H
 
 #include <QObject>
+#include <QVariant>
 #include <QtQml/qqmlregistration.h>
 
 #include "framework/global/async/asyncable.h"
@@ -85,6 +86,7 @@ private:
     struct Page {
         QString m_url;
         std::string m_backgroundUri;
+        QVariantMap m_properties;
 
         [[nodiscard]] QVariantMap toMap() const;
     };


### PR DESCRIPTION
Resolves: #11851 

During onboarding the audio com page should defaults to create account instead of sign in.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
