### PR TITLE
Hide preferences panels for disabled features

### DIFF
--- a/src/preferences/qml/Audacity/Preferences/GeneralPreferencesPage.qml
+++ b/src/preferences/qml/Audacity/Preferences/GeneralPreferencesPage.qml
@@ -98,9 +98,15 @@ PreferencesPage {
             }
         }
 
-        SeparatorLine {}
+        SeparatorLine {
+            visible: automaticUpdateSection.visible
+        }
 
         AutomaticUpdateSection {
+            id: automaticUpdateSection
+
+            visible: updateModel.isAppUpdatable()
+
             isAppUpdatable: updateModel.isAppUpdatable()
             needCheckForNewAppVersion: updateModel.needCheckForNewAppVersion
             privacyPolicyUrl: updateModel.privacyPolicyUrl()
@@ -119,9 +125,15 @@ PreferencesPage {
             }
         }
 
-        SeparatorLine {}
+        SeparatorLine {
+            visible: crashReportsSection.visible
+        }
 
         CrashReportsSection {
+            id: crashReportsSection
+
+            visible: usageInfoModel.isCrashReportingAvailable()
+
             sendCrashReports: usageInfoModel.sendCrashReports
             privacyPolicyUrl: updateModel.privacyPolicyUrl()
 
@@ -139,9 +151,15 @@ PreferencesPage {
             }
         }
 
-        SeparatorLine {}
+        SeparatorLine {
+            visible: usageInfoSection.visible
+        }
 
         UsageInfoSection {
+            id: usageInfoSection
+
+            visible: usageInfoModel.isUsageInfoAvailable()
+
             sendAnonymousUsageInfo: usageInfoModel.sendAnonymousUsageInfo
             privacyPolicyUrl: updateModel.privacyPolicyUrl()
 

--- a/src/preferences/qml/Audacity/Preferences/usageinfopreferencesmodel.cpp
+++ b/src/preferences/qml/Audacity/Preferences/usageinfopreferencesmodel.cpp
@@ -3,11 +3,27 @@
  */
 #include "usageinfopreferencesmodel.h"
 
+#include "muse_framework_config.h"
+
 using namespace au::appshell;
 
 UsageInfoPreferencesModel::UsageInfoPreferencesModel(QObject* parent)
     : QObject(parent)
 {
+}
+
+bool UsageInfoPreferencesModel::isCrashReportingAvailable() const
+{
+#ifdef MUSE_MODULE_DIAGNOSTICS_CRASHPAD_CLIENT
+    return true;
+#else
+    return false;
+#endif
+}
+
+bool UsageInfoPreferencesModel::isUsageInfoAvailable() const
+{
+    return usageInfo()->isUsageInfoAvailable();
 }
 
 bool UsageInfoPreferencesModel::sendAnonymousUsageInfo() const

--- a/src/preferences/qml/Audacity/Preferences/usageinfopreferencesmodel.h
+++ b/src/preferences/qml/Audacity/Preferences/usageinfopreferencesmodel.h
@@ -25,6 +25,9 @@ class UsageInfoPreferencesModel : public QObject
 public:
     explicit UsageInfoPreferencesModel(QObject* parent = nullptr);
 
+    Q_INVOKABLE bool isCrashReportingAvailable() const;
+    Q_INVOKABLE bool isUsageInfoAvailable() const;
+
     bool sendAnonymousUsageInfo() const;
     bool sendCrashReports() const;
 

--- a/src/stubs/au3cloud/au3audiocomservicestub.cpp
+++ b/src/stubs/au3cloud/au3audiocomservicestub.cpp
@@ -93,6 +93,11 @@ std::string Au3AudioComServiceStub::getCloudProfilePage() const
     return {};
 }
 
+std::string Au3AudioComServiceStub::getTourPage() const
+{
+    return {};
+}
+
 std::string Au3AudioComServiceStub::getCloudProjectPage(const std::string& /*unused*/) const
 {
     return {};

--- a/src/stubs/usageinfo/usageinfostub.cpp
+++ b/src/stubs/usageinfo/usageinfostub.cpp
@@ -5,6 +5,11 @@
 
 using namespace au::usageinfo;
 
+bool UsageInfoStub::isUsageInfoAvailable() const
+{
+    return false;
+}
+
 void UsageInfoStub::setSendAnonymousUsageInfo(bool)
 {
 }

--- a/src/stubs/usageinfo/usageinfostub.h
+++ b/src/stubs/usageinfo/usageinfostub.h
@@ -9,6 +9,8 @@ namespace au::usageinfo {
 class UsageInfoStub : public IUsageInfo
 {
 public:
+    bool isUsageInfoAvailable() const override;
+
     void setSendAnonymousUsageInfo(bool allow) override;
     bool getSendAnonymousUsageInfo() const override;
 

--- a/src/usageinfo/internal/usageinfoservice.cpp
+++ b/src/usageinfo/internal/usageinfoservice.cpp
@@ -27,6 +27,11 @@ void UsageInfoService::init()
     }
 }
 
+bool UsageInfoService::isUsageInfoAvailable() const
+{
+    return true;
+}
+
 void UsageInfoService::setSendAnonymousUsageInfo(bool allow)
 {
     if (allow == getSendAnonymousUsageInfo()) {

--- a/src/usageinfo/internal/usageinfoservice.h
+++ b/src/usageinfo/internal/usageinfoservice.h
@@ -18,6 +18,8 @@ class UsageInfoService : public IUsageInfo, public muse::update::IUpdateRequestP
 public:
     void init();
 
+    bool isUsageInfoAvailable() const override;
+
     void setSendAnonymousUsageInfo(bool allow) override;
     bool getSendAnonymousUsageInfo() const override;
 

--- a/src/usageinfo/iusageinfo.h
+++ b/src/usageinfo/iusageinfo.h
@@ -15,6 +15,8 @@ class IUsageInfo : MODULE_GLOBAL_INTERFACE
 public:
     virtual ~IUsageInfo() = default;
 
+    virtual bool isUsageInfoAvailable() const = 0;
+
     virtual void setSendAnonymousUsageInfo(bool allow) = 0;
     virtual bool getSendAnonymousUsageInfo() const = 0;
 


### PR DESCRIPTION
Resolves: hides updates, crash reporting and usage info panels when they are disabled

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
