### PR TITLE
App update new flow

### DIFF
--- a/buildscripts/packaging/MacOS/make_dmg.sh
+++ b/buildscripts/packaging/MacOS/make_dmg.sh
@@ -112,15 +112,13 @@ function change_rpath() {
 rm ${WORKING_DIRECTORY}/${COMPRESSEDDMGNAME}
 
 #tip: increase the size if error on copy or macdeployqt
-hdiutil create -size 750m -fs HFS+ -volname ${VOLNAME} ${WORKING_DIRECTORY}/${DMGNAME}
+hdiutil create -size 800m -fs APFS -volname ${VOLNAME} ${WORKING_DIRECTORY}/${DMGNAME}
 
 # Mount the disk image
-hdiutil attach ${WORKING_DIRECTORY}/${DMGNAME}
-
-# Obtain device information
-DEVS=$(hdiutil attach ${WORKING_DIRECTORY}/${DMGNAME} | cut -f 1)
-DEV=$(echo $DEVS | cut -f 1 -d ' ')
-VOLUME=$(mount |grep ${DEV} | cut -f 3 -d ' ')
+VOLUME="/Volumes/${VOLNAME}"
+ATTACH_OUTPUT=$(hdiutil attach "${WORKING_DIRECTORY}/${DMGNAME}" -mountpoint "${VOLUME}")
+echo "${ATTACH_OUTPUT}"
+DEV=$(echo "${ATTACH_OUTPUT}" | head -n1 | awk '{print $1}')
 
 # copy in the application bundle
 cp -Rp ${APP_PATH} ${VOLUME}/${APPNAME}.app
@@ -212,7 +210,7 @@ echo "Unmount"
 hdiutil detach $DEV -force || true
 
 # Convert the disk image to read-only
-hdiutil convert ${WORKING_DIRECTORY}/${DMGNAME} -format UDBZ -o ${WORKING_DIRECTORY}/${COMPRESSEDDMGNAME}
+hdiutil convert ${WORKING_DIRECTORY}/${DMGNAME} -format ULFO -o ${WORKING_DIRECTORY}/${COMPRESSEDDMGNAME}
 
 shasum -a 256 ${WORKING_DIRECTORY}/${COMPRESSEDDMGNAME}
 

--- a/buildscripts/packaging/Windows/Installer/WIX.template.in
+++ b/buildscripts/packaging/Windows/Installer/WIX.template.in
@@ -33,7 +33,10 @@
         Manufacturer="$(var.CPACK_PACKAGE_VENDOR)"
         UpgradeCode="$(var.CPACK_WIX_UPGRADE_GUID)">
 
-        <Package InstallerVersion="301" Compressed="yes" />
+        <!-- perMachine (ALLUSERS=1): otherwise the install context follows whoever ran
+             msiexec, and an update installed by the SYSTEM task would register under
+             SYSTEM and vanish from the user's "Installed apps". -->
+        <Package InstallerVersion="301" Compressed="yes" InstallScope="perMachine" />
 
         <Media Id="1" Cabinet="media1.cab" EmbedCab="yes" CompressionLevel="high" />
 
@@ -77,6 +80,36 @@
         <Property Id="WIXUI_EXITDIALOGOPTIONALCHECKBOX" Value="1" />
         <Property Id="WixShellExecTarget" Value="[#CM_FP_bin.$(var.ExeName)]" />
         <CustomAction Id="LaunchApplication" BinaryKey="WixCA" DllEntry="WixShellExec" Impersonate="yes" />
+
+        <!-- Background updates: a scheduled task running as SYSTEM installs the package
+             the application downloads, since an ordinary user cannot write to Program
+             Files. cert-from is this package, so the task accepts only updates signed
+             with the same key, chaining to the same root; upgrade-code and
+             product-version are what it is, so the task accepts only later versions of
+             this same product and nothing else that key ever signed. Failures are
+             ignored - without the task the application falls back to asking the user to
+             run the installer.
+             The trailing "\" doubles the one INSTALL_ROOT ends with, so that
+             CommandLineToArgvW does not read it as an escaped quote. -->
+        <CustomAction Id="SetRegisterUpdateTask" Property="RegisterUpdateTask"
+            Value="&quot;[INSTALL_ROOT]bin\museupdater.exe&quot; --register-task --app-id &quot;$(var.MUSE_EXECUTABLE_NAME)&quot; --app-exe &quot;bin\$(var.ExeName)&quot; --install-dir &quot;[INSTALL_ROOT]\&quot; --package-type msi --install-args &quot;INSTALL_ROOT={install-dir}&quot; --upgrade-code &quot;[UpgradeCode]&quot; --product-version &quot;[ProductVersion]&quot; --cert-from &quot;[OriginalDatabase]&quot;" />
+        <CustomAction Id="RegisterUpdateTask" BinaryKey="WixCA" DllEntry="WixQuietExec"
+            Execute="deferred" Impersonate="no" Return="ignore" />
+
+        <CustomAction Id="SetUnregisterUpdateTask" Property="UnregisterUpdateTask"
+            Value="&quot;[INSTALL_ROOT]bin\museupdater.exe&quot; --unregister-task --app-id &quot;$(var.MUSE_EXECUTABLE_NAME)&quot;" />
+        <CustomAction Id="UnregisterUpdateTask" BinaryKey="WixCA" DllEntry="WixQuietExec"
+            Execute="deferred" Impersonate="no" Return="ignore" />
+
+        <InstallExecuteSequence>
+            <Custom Action="SetRegisterUpdateTask" Before="RegisterUpdateTask">NOT REMOVE</Custom>
+            <Custom Action="RegisterUpdateTask" After="InstallFiles">NOT REMOVE</Custom>
+            <!-- NOT UPGRADINGPRODUCTCODE: on a major upgrade the removal of the previous
+                 version would delete the staged package msiexec is reading from
+                 (1316 -> 1603 -> rollback), and the new version re-registers anyway. -->
+            <Custom Action="SetUnregisterUpdateTask" Before="UnregisterUpdateTask">REMOVE="ALL" AND NOT UPGRADINGPRODUCTCODE</Custom>
+            <Custom Action="UnregisterUpdateTask" Before="RemoveFiles">REMOVE="ALL" AND NOT UPGRADINGPRODUCTCODE</Custom>
+        </InstallExecuteSequence>
 
         <Component Id="RegisterTypes" Directory="TARGETDIR" Guid="*">
             <!-- In order to work with Default Programs -->

--- a/src/appshell/internal/applicationactioncontroller.cpp
+++ b/src/appshell/internal/applicationactioncontroller.cpp
@@ -334,11 +334,23 @@ bool ApplicationActionController::quit(const muse::io::path_t& installerPath)
     }
 
     if (!installerPath.empty()) {
+        //! NOTE: All windows are quitting to complete the update, apply it
+        //! in-place, falling back to handing the package to the user.
+        bool applied = false;
+        if (appUpdateService()->canAutoInstall()) {
+            const muse::RetVal<muse::io::path_t> prepared = appUpdateService()->prepareUpdate(installerPath);
+            if (prepared.ret) {
+                applied = bool(appUpdateService()->finalizeUpdate(prepared.val));
+            }
+        }
+
+        if (!applied) {
 #if defined(Q_OS_LINUX)
-        platformInteractive()->revealInFileBrowser(installerPath);
+            platformInteractive()->revealInFileBrowser(installerPath);
 #else
-        platformInteractive()->openUrl(QUrl::fromLocalFile(installerPath.toQString()));
+            platformInteractive()->openUrl(QUrl::fromLocalFile(installerPath.toQString()));
 #endif
+        }
     }
 
     QCoreApplication::exit();

--- a/src/appshell/internal/applicationactioncontroller.h
+++ b/src/appshell/internal/applicationactioncontroller.h
@@ -36,6 +36,7 @@
 #include "framework/ui/iuiactionsregister.h"
 #include "framework/ui/imainwindow.h"
 #include "framework/ui/inavigationcontroller.h"
+#include "framework/update/iappupdateservice.h"
 
 #include "iappshellconfiguration.h"
 #include "iapplication.h"
@@ -69,6 +70,7 @@ class ApplicationActionController : public QObject, public IApplicationActionCon
     muse::ContextInject<muse::ui::IMainWindow> mainWindow { this };
     muse::ContextInject<muse::ui::INavigationController> navigationController { this };
     muse::ContextInject<muse::IInteractive> interactive { this };
+    muse::ContextInject<muse::update::IAppUpdateService> appUpdateService { this };
     muse::ContextInject<appshell::IStartupScenario> startupScenario { this };
     muse::ContextInject<project::IProjectFilesController> projectFilesController { this };
     muse::ContextInject<record::IRecordController> recordController { this };

--- a/src/appshell/internal/startupscenario.cpp
+++ b/src/appshell/internal/startupscenario.cpp
@@ -193,13 +193,6 @@ void StartupScenario::onStartupPageOpened(StartupModeType modeType)
 {
     TRACEFUNC;
 
-    if (appUpdateScenario() && appUpdateScenario()->checkInProgress()) {
-        appUpdateScenario()->checkInProgressChanged().onNotify(this, [this, modeType]() {
-            appUpdateScenario()->checkInProgressChanged().disconnect(this);
-            showStartupDialogsIfNeed(modeType);
-        }, muse::async::Asyncable::Mode::SetReplace);
-    }
-
     showStartupDialogsIfNeed(modeType);
 
     if (!m_startupMediaFiles.empty()) {
@@ -248,11 +241,6 @@ void StartupScenario::showStartupDialogsIfNeed(StartupModeType)
         return;
     }
 
-    // Delay popups until update check finished
-    if (appUpdateScenario() && appUpdateScenario()->checkInProgress()) {
-        return;
-    }
-
     const auto showWelcomeDialogIfNeed = [this]() {
         const auto showWelcomePage = [this]() {
             const std::string welcomeDialogLastShownVersion(configuration()->welcomeDialogLastShownVersion());
@@ -276,7 +264,7 @@ void StartupScenario::showStartupDialogsIfNeed(StartupModeType)
         };
 
         if (!configuration()->hasCompletedFirstLaunchSetup()) {
-            interactive()->open(FIRST_LAUNCH_SETUP_URI).then(this, [showWelcomePage](const muse::Val&, auto resolve) {
+            interactive()->open(FIRST_LAUNCH_SETUP_URI).then(this, [](const muse::Val&, auto resolve) {
                 return resolve();
             });
         } else {
@@ -284,19 +272,7 @@ void StartupScenario::showStartupDialogsIfNeed(StartupModeType)
         }
     };
 
-    if (!appUpdateScenario() || !appUpdateScenario()->hasUpdate()) {
-        showWelcomeDialogIfNeed();
-        return;
-    }
-
-    auto promise = appUpdateScenario()->showUpdate();
-    promise.onResolve(this, [showWelcomeDialogIfNeed](const muse::Ret& ret) {
-        // Ok means close the app and install the update
-        if (ret.code() == static_cast<int>(muse::Ret::Code::Ok)) {
-            return;
-        }
-        showWelcomeDialogIfNeed();
-    });
+    showWelcomeDialogIfNeed();
 }
 
 muse::Uri StartupScenario::startupPageUri(StartupModeType modeType) const

--- a/src/appshell/qml/Audacity/AppShell/CMakeLists.txt
+++ b/src/appshell/qml/Audacity/AppShell/CMakeLists.txt
@@ -104,6 +104,7 @@ qt_add_qml_module(appshell_qml
         TARGET muse_shortcuts_qml
         TARGET muse_toast_qml
         TARGET muse_tours_qml
+        TARGET muse_update_qml
 )
 
 if (AU_BUILD_CLOUD_AUDIOCOM)

--- a/src/appshell/qml/Audacity/AppShell/HomePage/HomeMenu.qml
+++ b/src/appshell/qml/Audacity/AppShell/HomePage/HomeMenu.qml
@@ -26,6 +26,7 @@ import QtQuick.Layouts 1.3
 import Muse.Ui 1.0
 import Muse.UiComponents
 import Muse.Cloud 1.0
+import Muse.Update 1.0
 
 Item {
     id: root
@@ -129,6 +130,13 @@ Item {
                     root.selected(modelData["name"])
                 }
             }
+        }
+
+        UpdateBanner {
+            Layout.fillWidth: true
+            Layout.margins: 8
+
+            visible: hasReadyUpdate && !root.iconsOnly
         }
     }
 }


### PR DESCRIPTION
Copy-paste of https://github.com/musescore/MuseScore/pull/34682

This PR fixes the master build with the latest framework. The new update flow should already work if we make a new release. However, the new flow is not yet complete, and there will be changes that I will also update for Audacity.

Green stable builds:
[[AU4] Build: Windows](https://github.com/audacity/audacity/actions/runs/33517229713)
[[AU4] Build: Linux](https://github.com/audacity/audacity/actions/runs/33517179274)
[[AU4] Build: macOS](https://github.com/audacity/audacity/actions/runs/33618619453)