### PR TITLE
Fix label creation position

### DIFF
--- a/src/trackedit/internal/au3/au3labelsinteraction.cpp
+++ b/src/trackedit/internal/au3/au3labelsinteraction.cpp
@@ -102,8 +102,14 @@ muse::RetVal<LabelKey> Au3LabelsInteraction::addLabelToSelection()
         muse::secs_t recordPos = playbackState->playbackPosition();
         selectedRegion.setTimes(recordPos, recordPos);
     } else {
-        selectedRegion.setTimes(selectionController()->dataSelectedStartTime(),
-                                selectionController()->dataSelectedEndTime());
+        const double selectionStart = selectionController()->dataSelectedStartTime();
+        const double selectionEnd = selectionController()->dataSelectedEndTime();
+        if (muse::RealIsEqualOrLess(selectionEnd, selectionStart)) {
+            muse::secs_t playbackPos = playbackState->playbackPosition();
+            selectedRegion.setTimes(playbackPos, playbackPos);
+        } else {
+            selectedRegion.setTimes(selectionStart, selectionEnd);
+        }
     }
 
     int64_t newLabelId = labelTrack->AddLabel(selectedRegion, title);

--- a/src/trackedit/tests/au3labelsinteractions_tests.cpp
+++ b/src/trackedit/tests/au3labelsinteractions_tests.cpp
@@ -211,6 +211,13 @@ TEST_F(Au3LabelsInteractionsTests, AddLabelToSelectionWithZeroLengthSelection)
     ON_CALL(*m_trackNavigationController, focusedTrack())
     .WillByDefault(Return(INVALID_TRACK));
 
+    //! [GIVEN] Playback is not active at position 3.5 seconds
+    const double playbackPosition = 3.5;
+    ON_CALL(*m_playbackState, isPlaying())
+    .WillByDefault(Return(false));
+    ON_CALL(*m_playbackState, playbackPosition())
+    .WillByDefault(Return(playbackPosition));
+
     //! [EXPECT] The project is notified about a new track and a new label being added
     EXPECT_CALL(*m_trackEditProject, notifyAboutTrackAdded(_)).Times(1);
     EXPECT_CALL(*m_trackEditProject, notifyAboutLabelAdded(_)).Times(1);
@@ -230,11 +237,11 @@ TEST_F(Au3LabelsInteractionsTests, AddLabelToSelectionWithZeroLengthSelection)
     ASSERT_NE(labelTrack, nullptr) << "Label track should exist";
     ASSERT_EQ(labelTrack->GetNumLabels(), 1) << "Label track should contain one label";
 
-    //! [THEN] The label is a point label (same start and end time)
+    //! [THEN] The label is a point label (same start and end time), at the playback position
     const Au3Label* label = labelTrack->GetLabel(0);
     ASSERT_NE(label, nullptr) << "Label should exist";
-    ASSERT_DOUBLE_EQ(label->getT0(), cursorPosition) << "Label start should be at cursor position";
-    ASSERT_DOUBLE_EQ(label->getT1(), cursorPosition) << "Label end should be at cursor position";
+    ASSERT_DOUBLE_EQ(label->getT0(), playbackPosition) << "Label start should be at playback position";
+    ASSERT_DOUBLE_EQ(label->getT1(), playbackPosition) << "Label end should be at playback position";
 }
 
 TEST_F(Au3LabelsInteractionsTests, AddMultipleLabelsToSameLabelTrack)


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/11682

When the track selection is a point, create a label at the playback position. Before this change, the label was created at the selection position, which may be ambiguous since you cannot see the point selection.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [ ] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
