### PR TITLE
Avoid busy idle loop for hidden track panels

### DIFF
--- a/src/TrackPanel.cpp
+++ b/src/TrackPanel.cpp
@@ -405,12 +405,8 @@ void TrackPanel::OnIdle(wxIdleEvent& event)
       GetProjectFrame( *GetProject() ).Unbind(wxEVT_IDLE,
          &TrackPanel::OnIdle, this);
    }
-   else
-   {
-      // Get another idle event, wx only guarantees we get one
-      // event after "some other normal events occur"
-      event.RequestMore();
-   }
+   // When hidden, wait for the next regular idle event. RequestMore() creates
+   // a tight loop until the window is shown.
 }
 
 /// AS: This gets called on our wx timer events.


### PR DESCRIPTION
Related: https://github.com/audacity/audacity/issues/6839

`TrackPanel::OnIdle` currently calls `wxIdleEvent::RequestMore()` whenever the panel is not shown. On wxWidgets/macOS, that prevents the event loop from blocking: each requested idle pass recursively sends idle events through the top-level window tree and updates the UI, then this handler immediately requests another pass.

I observed Audacity 3.7.8 using a sustained 60–68% CPU after a long-running session. In a 10-second macOS sample, the main thread spent 4,032 of 7,099 samples under:

```
wxApp::ProcessIdle
  wxAppBase::ProcessIdle
    wxWindowBase::SendIdleEvents
      wxWindowBase::SendIdleEvents
        wxWindowBase::UpdateWindowUI
```

The audio worker was sleeping for 7,090 of 7,099 samples, which rules out active audio processing as the source of the load.

This change stops explicitly requesting more idle events while the panel is hidden. The handler remains bound, so a normal event that makes the window visible is followed by an idle event; the timer then starts and the handler unbinds as before.

The same mechanism may explain #6839, but I have not confirmed that its cloud-upload completion dialog leaves a `TrackPanel` hidden. This is a draft so the existing reproduction can be tested against the change before treating it as a resolution.

Validation:

- Applied the same source change to the `Audacity-3.7.8` tag.
- Configured and compiled an ARM64 `RelWithDebInfo` build on macOS.
- The patched `TrackPanel.cpp` compiled and the Audacity executable linked.
- The copied app bundle passed `codesign --verify --deep --strict` and the executable ran successfully with `--version`.
- `git diff --check` passes on this branch.

- [ ] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
