### PR TITLE
bundled (and old) libsystemd prevents system ffmpeg from loading

### DIFF
--- a/buildscripts/ci/linux/make_appimage.sh
+++ b/buildscripts/ci/linux/make_appimage.sh
@@ -134,6 +134,7 @@ system_libs=(
   libmount.so.1
   libblkid.so.1
   libuuid.so.1
+  libsystemd.so.0
 )
 for lib in "${system_libs[@]}"; do
   rm -f "${appdir}/lib/${lib}"


### PR DESCRIPTION
Resolves: #11794
Resolves: https://github.com/audacity/audacity/issues/11168

bundled (and old) libsystemd prevents system ffmpeg from loading

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
