### PR TITLE
Fix signing process

### DIFF
--- a/buildscripts/ci/windows/sign_service_aws.sh
+++ b/buildscripts/ci/windows/sign_service_aws.sh
@@ -29,9 +29,17 @@ if [ -z "$S3_SECRET" ]; then echo "error: not set S3_SECRET"; exit 1; fi
 if [ -z "$FILE_PATH" ]; then echo "error: not set FILE_PATH"; exit 1; fi
 
 FILE_NAME="$(basename "${FILE_PATH}")"
-S3_UNSIGNED_URL="s3://$S3_BUCKET/$S3_UNSIGNED_DIR/$FILE_NAME"
-S3_SIGNED_URL="s3://$S3_BUCKET/$S3_SIGNED_DIR/$FILE_NAME"
+
+# Upload under a unique name so concurrent runs can't pick up each other's files
+GUID="$(uuidgen 2>/dev/null || powershell.exe -NoProfile -Command '[guid]::NewGuid().ToString()' | tr -d '\r')"
+if [ -z "$GUID" ]; then echo "error: failed to generate GUID"; exit 1; fi
+
+S3_FILE_NAME="${FILE_NAME%.*}_${GUID}.${FILE_NAME##*.}"
+S3_UNSIGNED_URL="s3://$S3_BUCKET/$S3_UNSIGNED_DIR/$S3_FILE_NAME"
+S3_SIGNED_URL="s3://$S3_BUCKET/$S3_SIGNED_DIR/$S3_FILE_NAME"
 FILE_SIGNED_PATH="${FILE_PATH}_signed"
+
+echo "Sign file name: $S3_FILE_NAME"
 
 export AWS_ACCESS_KEY_ID=$S3_KEY
 export AWS_SECRET_ACCESS_KEY=$S3_SECRET 


### PR DESCRIPTION
Resolves: broken beta 4 release

Add guid to filenames when uploading to the signing service to prevent mixing up executables for concurrent runs

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
