### PR TITLE
Declare the MUSE_COMPILE_USE_PCH option app-side

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,6 +155,7 @@ set(APP_BUILTIN_WORKSPACES_DIR "${CMAKE_CURRENT_LIST_DIR}/share/workspaces")
 # === Compile ===
 option(MU_COMPILE_INSTALL_QTQML_FILES "Whether to bundle qml files along with the installation (relevant on MacOS only)" ON)
 option(MUSE_COMPILE_USE_UNITY "Use unity build." ON) # many AU4 modules still disable unity per-module; re-enabling is tracked in https://github.com/audacity/audacity/issues/11805
+option(MUSE_COMPILE_USE_PCH "Use precompiled headers." ON) # the app owns this option, see https://github.com/musescore/muse_framework/pull/254
 option(MUSE_COMPILE_USE_CCACHE "Try use ccache" ON)
 
 ###########################################


### PR DESCRIPTION
Closes #11898.

musescore/muse_framework#254 removes the `MUSE_COMPILE_USE_PCH` declaration from the framework so applications own it (`MUSE_COMPILE_USE_UNITY` is already declared app-side). Declaring it here is safe before that PR merges (same ON default, first declaration wins) and required after it (otherwise PCH silently turns off).

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run