### PR TITLE
Use system libdbus to prevent runtime dependency on systemd

### DIFF
--- a/buildscripts/ci/linux/make_appimage.sh
+++ b/buildscripts/ci/linux/make_appimage.sh
@@ -135,6 +135,7 @@ system_libs=(
   libblkid.so.1
   libuuid.so.1
   libsystemd.so.0
+  libdbus-1.so.3
 )
 for lib in "${system_libs[@]}"; do
   rm -f "${appdir}/lib/${lib}"


### PR DESCRIPTION
Resolves:#11915

On systemd systems, including ubuntu 24.04 which is the current github runner, libdbus is linked to systemd. This breaks startup on non-systemd systems. 

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
