### PR TITLE
header fixes for gcc-16.2.0 (disabled unity build)

### DIFF
--- a/src/appshell/appshellmodule.cpp
+++ b/src/appshell/appshellmodule.cpp
@@ -22,7 +22,7 @@
 
 #include "appshellmodule.h"
 
-#include <QQmlEngine>
+#include <QtQml/QQmlEngine>
 
 #include "framework/global/iapplicationeventcontroller.h"
 #include "framework/global/modularity/ioc.h"

--- a/src/appshell/qml/Audacity/AppShell/FirstLaunchSetup/themespagemodel.h
+++ b/src/appshell/qml/Audacity/AppShell/FirstLaunchSetup/themespagemodel.h
@@ -29,6 +29,7 @@
 
 #include "modularity/ioc.h"
 #include "ui/iuiconfiguration.h"
+#include "translation.h"
 
 namespace au::appshell {
 class ThemesPageModel : public QObject, public muse::async::Asyncable

--- a/src/appshell/qml/Audacity/AppShell/welcomedialogmodel.h
+++ b/src/appshell/qml/Audacity/AppShell/welcomedialogmodel.h
@@ -26,7 +26,7 @@
 
 #include <QObject>
 #include <qcontainerfwd.h>
-#include <qqmlintegration.h>
+#include <QtQmlIntegration/qqmlintegration.h>
 
 #include "framework/global/async/asyncable.h"
 #include "framework/global/modularity/ioc.h"

--- a/src/appshell/qml/Audacity/AppShell/windowdroparea.h
+++ b/src/appshell/qml/Audacity/AppShell/windowdroparea.h
@@ -23,7 +23,7 @@
 #ifndef AU_APPSHELL_WINDOWDROPAREA_H
 #define AU_APPSHELL_WINDOWDROPAREA_H
 
-#include <QQuickItem>
+#include <QtQuick/QQuickItem>
 #include <QtQml/qqmlregistration.h>
 
 #include "modularity/ioc.h"

--- a/src/au3cloud/au3cloudmodule.cpp
+++ b/src/au3cloud/au3cloudmodule.cpp
@@ -1,8 +1,8 @@
 /*
 * Audacity: A Digital Audio Editor
 */
-#include <QQmlEngine>
-#include <QtQml>
+#include <QtQml/QQmlEngine>
+#include <QtQml/QtQml>
 
 #include "au3cloudmodule.h"
 

--- a/src/au3cloud/view/accountmodel.cpp
+++ b/src/au3cloud/view/accountmodel.cpp
@@ -6,6 +6,8 @@
 #include "framework/global/io/path.h"
 #include "framework/global/types/retval.h"
 
+#include <QDateTime>
+
 using namespace au::au3cloud;
 
 AccountModel::AccountModel(QObject* parent)

--- a/src/automation/automationmodule.cpp
+++ b/src/automation/automationmodule.cpp
@@ -4,6 +4,8 @@
 
 #include "view/clipgainmodel.h"
 
+#include <QtQml/qqml.h>
+
 using namespace au::automation;
 
 static const std::string mname("automation");

--- a/src/effects/audio_unit/view/audiounitview.cpp
+++ b/src/effects/audio_unit/view/audiounitview.cpp
@@ -3,7 +3,7 @@
  */
 #include "audiounitview.h"
 
-#include <QQuickWindow>
+#include <QtQuick/QQuickWindow>
 
 #include "framework/global/log.h"
 

--- a/src/effects/audio_unit/view/audiounitview.h
+++ b/src/effects/audio_unit/view/audiounitview.h
@@ -3,7 +3,7 @@
  */
 #pragma once
 
-#include <QQuickItem>
+#include <QtQuick/QQuickItem>
 
 #include "global/modularity/ioc.h"
 #include "effects/effects_base/ieffectinstancesregister.h"

--- a/src/effects/builtin/view/builtineffectviewloader.cpp
+++ b/src/effects/builtin/view/builtineffectviewloader.cpp
@@ -23,8 +23,8 @@
 #include "effects/effects_base/effectstypes.h"
 #include "effects/effects_base/internal/abstractviewlauncher.h"
 
-#include <QQmlEngine>
-#include <QQmlContext>
+#include <QtQml/QQmlEngine>
+#include <QtQml/QQmlContext>
 
 #include "au3wrap/internal/wxtypes_convert.h"
 #include "global/types/number.h"

--- a/src/effects/builtin/view/builtineffectviewloader.h
+++ b/src/effects/builtin/view/builtineffectviewloader.h
@@ -4,8 +4,8 @@
 #pragma once
 
 #include <QObject>
-#include <QQmlComponent>
-#include <QQuickItem>
+#include <QtQml/QQmlComponent>
+#include <QtQuick/QQuickItem>
 
 #include "global/async/asyncable.h"
 #include "modularity/ioc.h"

--- a/src/effects/builtin_collection/builtineffectscollectionmodule.cpp
+++ b/src/effects/builtin_collection/builtineffectscollectionmodule.cpp
@@ -10,6 +10,8 @@
 
 #include "effects/effects_base/ieffectviewlaunchregister.h"
 
+#include <QtQml/qqml.h>
+
 using namespace au::effects;
 
 static const std::string mname("builtin_effects_collection");

--- a/src/effects/builtin_collection/common/valuewarper/valuewarper.h
+++ b/src/effects/builtin_collection/common/valuewarper/valuewarper.h
@@ -6,7 +6,7 @@
 #include "valuewarpertypes.h"
 
 #include <QObject>
-#include <QQmlParserStatus>
+#include <QtQml/QQmlParserStatus>
 #include <QVariant>
 
 namespace au::effects {

--- a/src/effects/builtin_collection/dynamics/timeline/dynamicstimeline.cpp
+++ b/src/effects/builtin_collection/dynamics/timeline/dynamicstimeline.cpp
@@ -8,7 +8,7 @@
 #include "global/log.h"
 #include "global/types/number.h"
 
-#include <QSGTransformNode>
+#include <QtQuick/QSGTransformNode>
 #include <QTimer>
 #include <QtQuick/qsgflatcolormaterial.h>
 

--- a/src/effects/builtin_collection/dynamics/timeline/dynamicstimeline.h
+++ b/src/effects/builtin_collection/dynamics/timeline/dynamicstimeline.h
@@ -6,9 +6,9 @@
 #include "dynamicstimelinetypes.h"
 #include "painters/abstractsequencepainter.h"
 
-#include <QQmlParserStatus>
-#include <QQuickItem>
-#include <QSGGeometryNode>
+#include <QtQml/QQmlParserStatus>
+#include <QtQuick/QQuickItem>
+#include <QtQuick/QSGGeometryNode>
 #include <QTimer>
 
 #include <atomic>

--- a/src/effects/builtin_collection/dynamics/timeline/painters/abstractsequencepainter.h
+++ b/src/effects/builtin_collection/dynamics/timeline/painters/abstractsequencepainter.h
@@ -3,7 +3,7 @@
  */
 #pragma once
 
-#include <QSGGeometry>
+#include <QtQuick/QSGGeometry>
 
 #include <atomic>
 

--- a/src/effects/builtin_collection/dynamics/timeline/timelinesourcemodel.cpp
+++ b/src/effects/builtin_collection/dynamics/timeline/timelinesourcemodel.cpp
@@ -8,7 +8,7 @@
 
 #include "global/log.h"
 
-#include <QSGGeometryNode>
+#include <QtQuick/QSGGeometryNode>
 #include <QTimer>
 #include <QtQuick/qsgflatcolormaterial.h>
 

--- a/src/effects/builtin_collection/internal/builtincollectionloader.cpp
+++ b/src/effects/builtin_collection/internal/builtincollectionloader.cpp
@@ -3,7 +3,7 @@
  */
 #include "builtincollectionloader.h"
 
-#include <QtQml>
+#include <QtQml/QtQml>
 
 #include "global/translation.h"
 #include "global/log.h"

--- a/src/effects/effects_base/view/effectsuiengine.cpp
+++ b/src/effects/effects_base/view/effectsuiengine.cpp
@@ -3,8 +3,8 @@
 */
 #include "effectsuiengine.h"
 
-#include <QQmlEngine>
-#include <QQmlContext>
+#include <QtQml/QQmlEngine>
+#include <QtQml/QQmlContext>
 
 using namespace au::effects;
 

--- a/src/effects/effects_base/view/effectsviewutils.h
+++ b/src/effects/effects_base/view/effectsviewutils.h
@@ -7,6 +7,10 @@
 
 #include "framework/uicomponents/qml/Muse/UiComponents/menuitem.h"
 
+#include <QtQml/qqml.h>
+#include <QtQml/QJSEngine>
+#include <QtQml/QQmlEngine>
+
 #define REGISTER_AUDACITY_EFFECTS_SINGLETON_TYPE(Factory) \
     qmlRegisterSingletonType<Factory>("Audacity.Effects", 1, 0, #Factory, \
                                       [] (QQmlEngine*, QJSEngine*) -> QObject* { \

--- a/src/effects/effects_base/view/pluginmanagertableviewmodel.h
+++ b/src/effects/effects_base/view/pluginmanagertableviewmodel.h
@@ -11,7 +11,7 @@
 #include "framework/interactive/iinteractive.h"
 #include "framework/uicomponents/qml/Muse/UiComponents/abstracttableviewmodel.h"
 
-#include <QQmlParserStatus>
+#include <QtQml/QQmlParserStatus>
 #include <QObject>
 
 #include <functional>

--- a/src/effects/extensions/internal/extensioneffect.h
+++ b/src/effects/extensions/internal/extensioneffect.h
@@ -6,7 +6,7 @@
 #include <memory>
 #include <string>
 
-#include <QJSValue>
+#include <QtQml/QJSValue>
 
 #include "au3-effects/StatefulEffect.h"
 

--- a/src/effects/extensions/internal/extensioneffectrunner.h
+++ b/src/effects/extensions/internal/extensioneffectrunner.h
@@ -7,7 +7,7 @@
 #include <memory>
 #include <string>
 
-#include <QJSValue>
+#include <QtQml/QJSValue>
 #include <QObject>
 
 #include "trackedit/api/audiotransform.h"

--- a/src/effects/extensions/internal/extensioneffectruntime.h
+++ b/src/effects/extensions/internal/extensioneffectruntime.h
@@ -7,7 +7,7 @@
 #include <string>
 #include <vector>
 
-#include <QJSValue>
+#include <QtQml/QJSValue>
 #include <QVariantMap>
 
 #include "framework/extensions/iextensionsession.h"

--- a/src/effects/lv2/view/lv2viewmodel.h
+++ b/src/effects/lv2/view/lv2viewmodel.h
@@ -18,7 +18,8 @@
 #include "modularity/ioc.h"
 
 #include <QObject>
-#include <QQuickItem>
+#include <QtQuick/QQuickItem>
+#include <QTimer>
 
 class LV2PortUIStates;
 struct LV2EffectOutputs;

--- a/src/effects/nyquist/nyquistprompt/nyquistpromptloader.cpp
+++ b/src/effects/nyquist/nyquistprompt/nyquistpromptloader.cpp
@@ -2,8 +2,13 @@
  * Audacity: A Digital Audio Editor
  */
 #include "nyquistpromptloader.h"
+#include "nyquistprompteffect.h"
+#include "nyquistpromptviewmodel.h"
 
 #include "au3-effects/LoadEffects.h"
+#include "au3wrap/internal/wxtypes_convert.h"
+
+#include <QtQml/qqml.h>
 
 namespace au::effects {
 void NyquistPromptLoader::preInit()

--- a/src/extensions/api/audiotransformapi.cpp
+++ b/src/extensions/api/audiotransformapi.cpp
@@ -8,7 +8,7 @@
 #include <utility>
 #include <vector>
 
-#include <QJSEngine>
+#include <QtQml/QJSEngine>
 #include <QPointer>
 
 #include "extensions/native/nativeextension.h"

--- a/src/extensions/api/audiotransformapi.h
+++ b/src/extensions/api/audiotransformapi.h
@@ -4,7 +4,7 @@
  */
 #pragma once
 
-#include <QJSValue>
+#include <QtQml/QJSValue>
 #include <QObject>
 #include <QString>
 

--- a/src/extensions/api/nativeapi.cpp
+++ b/src/extensions/api/nativeapi.cpp
@@ -6,7 +6,7 @@
 
 #include <limits>
 
-#include <QJSEngine>
+#include <QtQml/QJSEngine>
 #include <QStringList>
 
 #include "extensions/native/bytebuffer.h"

--- a/src/extensions/native/bytebuffer.cpp
+++ b/src/extensions/native/bytebuffer.cpp
@@ -4,7 +4,7 @@
  */
 #include "bytebuffer.h"
 
-#include <QJSEngine>
+#include <QtQml/QJSEngine>
 
 using namespace muse::extensions;
 

--- a/src/extensions/native/nativelibrary.h
+++ b/src/extensions/native/nativelibrary.h
@@ -10,8 +10,8 @@
 #include <vector>
 
 #include <QByteArray>
-#include <QJSEngine>
-#include <QJSValue>
+#include <QtQml/QJSEngine>
+#include <QtQml/QJSValue>
 #if !defined(Q_OS_WIN)
 #include <QLibrary>
 #endif

--- a/src/importexport/export/exportermodule.cpp
+++ b/src/importexport/export/exportermodule.cpp
@@ -16,6 +16,8 @@
 
 #include "exportermodule.h"
 
+#include <QtQml/qqml.h>
+
 using namespace au::importexport;
 using namespace muse;
 

--- a/src/importexport/labels/labelsmodule.cpp
+++ b/src/importexport/labels/labelsmodule.cpp
@@ -14,6 +14,8 @@
 
 #include "view/exportlabelsmodel.h"
 
+#include <QtQml/qqml.h>
+
 using namespace au::importexport;
 
 static const std::string mname("iex_labels");

--- a/src/playback/internal/meters/dblogmeter.cpp
+++ b/src/playback/internal/meters/dblogmeter.cpp
@@ -4,6 +4,7 @@
 
 #include "dblogmeter.h"
 
+#include <array>
 #include <cmath>
 #include <sstream>
 #include <iomanip>

--- a/src/playback/playbackmodule.cpp
+++ b/src/playback/playbackmodule.cpp
@@ -2,8 +2,8 @@
 * Audacity: A Digital Audio Editor
 */
 
-#include <QQmlEngine>
-#include <QtQml>
+#include <QtQml/QQmlEngine>
+#include <QtQml/QtQml>
 
 #include "framework/interactive/iinteractiveuriregister.h"
 

--- a/src/playback/view/common/volumepressuremeteritembase.h
+++ b/src/playback/view/common/volumepressuremeteritembase.h
@@ -5,7 +5,7 @@
 
 #include <QColor>
 #include <QPointer>
-#include <QQuickPaintedItem>
+#include <QtQuick/QQuickPaintedItem>
 
 #include <vector>
 

--- a/src/preferences/preferencesmodule.cpp
+++ b/src/preferences/preferencesmodule.cpp
@@ -1,6 +1,6 @@
 #include "preferencesmodule.h"
 
-#include <QtQml>
+#include <QtQml/QtQml>
 
 #include "framework/global/modularity/ioc.h"
 

--- a/src/preferences/qml/Audacity/Preferences/preferencesmodel.cpp
+++ b/src/preferences/qml/Audacity/Preferences/preferencesmodel.cpp
@@ -20,6 +20,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 #include <QGuiApplication>
+#include <QCursor>
 
 #include "preferencesmodel.h"
 

--- a/src/project/internal/projectactionscontroller.cpp
+++ b/src/project/internal/projectactionscontroller.cpp
@@ -1,6 +1,7 @@
 #include "projectactionscontroller.h"
 
 #include <QFileDialog>
+#include <QWindow>
 
 #include <variant>
 

--- a/src/project/view/projectthumbnailloader.h
+++ b/src/project/view/projectthumbnailloader.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QObject>
+#include <QPixmap>
 
 #include "framework/global/async/asyncable.h"
 

--- a/src/projectscene/projectscenemodule.cpp
+++ b/src/projectscene/projectscenemodule.cpp
@@ -3,7 +3,7 @@
 */
 #include "projectscenemodule.h"
 
-#include <QtQml>
+#include <QtQml/QtQml>
 
 #include "types/projectscenetypes.h"
 

--- a/src/projectscene/view/common/customcursor.cpp
+++ b/src/projectscene/view/common/customcursor.cpp
@@ -8,7 +8,7 @@
 #include <QScreen>
 #include <QPixmap>
 #include <QWindow>
-#include <QQuickWindow>
+#include <QtQuick/QQuickWindow>
 
 #include "log.h"
 

--- a/src/projectscene/view/common/customcursor.h
+++ b/src/projectscene/view/common/customcursor.h
@@ -6,7 +6,7 @@
 
 #include <QObject>
 #include <QString>
-#include <QQuickItem>
+#include <QtQuick/QQuickItem>
 #include <QCursor>
 
 namespace au::projectscene {

--- a/src/projectscene/view/historypanel/historypanelmodel.h
+++ b/src/projectscene/view/historypanel/historypanelmodel.h
@@ -4,7 +4,7 @@
 #pragma once
 
 #include <QAbstractListModel>
-#include <QQmlParserStatus>
+#include <QtQml/QQmlParserStatus>
 
 #include "async/asyncable.h"
 

--- a/src/projectscene/view/timeline/gridlines.h
+++ b/src/projectscene/view/timeline/gridlines.h
@@ -2,7 +2,7 @@
 * Audacity: A Digital Audio Editor
 */
 
-#include "qquickpainteditem.h"
+#include <QtQuick/qquickpainteditem.h>
 #include "view/timeline/timelineruler.h"
 
 class QPainter;

--- a/src/projectscene/view/timeline/playregioncontroller.h
+++ b/src/projectscene/view/timeline/playregioncontroller.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <QObject>
+#include <QCursor>
 
 #include "modularity/ioc.h"
 #include "context/iuicontextresolver.h"

--- a/src/projectscene/view/trackruler/dblogbaseruler.h
+++ b/src/projectscene/view/trackruler/dblogbaseruler.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "projectscene/view/trackruler/itrackruler.h"
+#include <string>
 
 namespace au::projectscene {
 struct DbLogRulerUiSettings {

--- a/src/projectscene/view/trackruler/itrackruler.h
+++ b/src/projectscene/view/trackruler/itrackruler.h
@@ -2,6 +2,7 @@
 
 #include <cstddef>
 #include <vector>
+#include <string>
 
 namespace au::projectscene {
 enum class IsFullWidthTick : bool {

--- a/src/projectscene/view/trackruler/linearbaseruler.cpp
+++ b/src/projectscene/view/trackruler/linearbaseruler.cpp
@@ -4,6 +4,8 @@
 #include <cassert>
 #include <iomanip>
 #include <sstream>
+#include <array>
+#include <utility>
 
 #include "framework/global/realfn.h"
 

--- a/src/projectscene/view/tracksitemsview/labeleditor/addnewlabeltrackmodel.h
+++ b/src/projectscene/view/tracksitemsview/labeleditor/addnewlabeltrackmodel.h
@@ -3,7 +3,7 @@
 */
 #pragma once
 
-#include <qqmlintegration.h>
+#include <QtQmlIntegration/qqmlintegration.h>
 
 #include "modularity/ioc.h"
 #include "trackedit/itrackeditinteraction.h"

--- a/src/projectscene/view/tracksitemsview/labeleditor/labelstableviewmodel.h
+++ b/src/projectscene/view/tracksitemsview/labeleditor/labelstableviewmodel.h
@@ -3,7 +3,7 @@
 */
 #pragma once
 
-#include <qqmlintegration.h>
+#include <QtQmlIntegration/qqmlintegration.h>
 
 #include "framework/global/modularity/ioc.h"
 #include "framework/interactive/iinteractive.h"

--- a/src/projectscene/view/tracksitemsview/labeleditor/labelstableviewverticalheader.h
+++ b/src/projectscene/view/tracksitemsview/labeleditor/labelstableviewverticalheader.h
@@ -3,7 +3,7 @@
 */
 #pragma once
 
-#include <qqmlintegration.h>
+#include <QtQmlIntegration/qqmlintegration.h>
 
 #include <QObject>
 

--- a/src/projectscene/view/tracksitemsview/mousehelper.h
+++ b/src/projectscene/view/tracksitemsview/mousehelper.h
@@ -3,7 +3,7 @@
  */
 #pragma once
 
-#include <QQuickItem>
+#include <QtQuick/QQuickItem>
 
 namespace au::projectscene {
 class MouseHelper : public QObject

--- a/src/projectscene/view/tracksitemsview/waveview.h
+++ b/src/projectscene/view/tracksitemsview/waveview.h
@@ -3,7 +3,7 @@
 */
 #pragma once
 
-#include <QQuickPaintedItem>
+#include <QtQuick/QQuickPaintedItem>
 
 #include "modularity/ioc.h"
 #include "context/iglobalcontext.h"

--- a/src/record/recordmodule.cpp
+++ b/src/record/recordmodule.cpp
@@ -3,8 +3,8 @@
 */
 #include "recordmodule.h"
 
-#include <QQmlEngine>
-#include <QtQml>
+#include <QtQml/QQmlEngine>
+#include <QtQml/QtQml>
 
 #include "modularity/ioc.h"
 

--- a/src/spectrogram/view/channelspectralselectionmodel.h
+++ b/src/spectrogram/view/channelspectralselectionmodel.h
@@ -13,7 +13,7 @@
 #include "framework/global/async/asyncable.h"
 
 #include <QObject>
-#include <QQmlParserStatus>
+#include <QtQml/QQmlParserStatus>
 
 #include <utility>
 

--- a/src/spectrogram/view/clipchannelspectrogramview.h
+++ b/src/spectrogram/view/clipchannelspectrogramview.h
@@ -11,7 +11,7 @@
 #include "framework/global/async/asyncable.h"
 #include "framework/global/modularity/ioc.h"
 
-#include <QQuickPaintedItem>
+#include <QtQuick/QQuickPaintedItem>
 
 namespace au::spectrogram {
 class ClipChannelSpectrogramView : public QQuickPaintedItem, public muse::async::Asyncable, public muse::Contextable

--- a/src/spectrogram/view/globalspectrogramsettingsmodel.h
+++ b/src/spectrogram/view/globalspectrogramsettingsmodel.h
@@ -9,7 +9,7 @@
 #include "framework/global/async/asyncable.h"
 #include "framework/global/modularity/ioc.h"
 
-#include <QQmlParserStatus>
+#include <QtQml/QQmlParserStatus>
 
 namespace au::spectrogram {
 class GlobalSpectrogramSettingsModel : public AbstractSpectrogramSettingsModel, public muse::async::Asyncable, public QQmlParserStatus

--- a/src/spectrogram/view/scalesectionparameterlistmodel.h
+++ b/src/spectrogram/view/scalesectionparameterlistmodel.h
@@ -9,7 +9,7 @@
 #include "framework/global/modularity/ioc.h"
 #include "framework/global/async/asyncable.h"
 
-#include <QQmlParserStatus>
+#include <QtQml/QQmlParserStatus>
 
 namespace au::spectrogram {
 class AbstractSpectrogramSettingsModel;

--- a/src/spectrogram/view/spectrogramchannelrulermodel.h
+++ b/src/spectrogram/view/spectrogramchannelrulermodel.h
@@ -13,7 +13,7 @@
 #include "framework/ui/iuiconfiguration.h"
 
 #include <QObject>
-#include <QQmlParserStatus>
+#include <QtQml/QQmlParserStatus>
 #include <QVariantList>
 
 namespace au::spectrogram {

--- a/src/spectrogram/view/trackspectrogramsettingsmodel.h
+++ b/src/spectrogram/view/trackspectrogramsettingsmodel.h
@@ -3,7 +3,7 @@
  */
 #pragma once
 
-#include <QQmlParserStatus>
+#include <QtQml/QQmlParserStatus>
 
 #include "spectrogram/view/abstractspectrogramsettingsmodel.h"
 #include "spectrogram/iglobalspectrogramconfiguration.h"

--- a/src/trackedit/api/projectapi.cpp
+++ b/src/trackedit/api/projectapi.cpp
@@ -6,7 +6,7 @@
 #include <algorithm>
 #include <limits>
 
-#include <QJSEngine>
+#include <QtQml/QJSEngine>
 
 #include "au3-project-rate/ProjectRate.h"
 #include "au3-project/Project.h"

--- a/src/trackedit/api/projectapi.h
+++ b/src/trackedit/api/projectapi.h
@@ -3,7 +3,7 @@
  */
 #pragma once
 
-#include <QJSValue>
+#include <QtQml/QJSValue>
 
 #include "api/apiobject.h"
 #include "context/iglobalcontext.h"

--- a/src/trackedit/api/projectedit.cpp
+++ b/src/trackedit/api/projectedit.cpp
@@ -12,7 +12,7 @@
 #include <thread>
 #include <utility>
 
-#include <QJSEngine>
+#include <QtQml/QJSEngine>
 
 #include "au3-label-track/LabelTrack.h"
 #include "au3-project/Project.h"

--- a/src/trackedit/dom/wave.h
+++ b/src/trackedit/dom/wave.h
@@ -3,6 +3,7 @@
 */
 #pragma once
 
+#include <cstdint>
 #include <memory>
 #include <vector>
 

--- a/src/trackedit/tests/tracknavigationmodel_tests.cpp
+++ b/src/trackedit/tests/tracknavigationmodel_tests.cpp
@@ -3,8 +3,8 @@
 */
 #include <gtest/gtest.h>
 
-#include <QQmlEngine>
-#include <QQmlContext>
+#include <QtQml/QQmlEngine>
+#include <QtQml/QQmlContext>
 
 #include "../view/tracknavigationmodel.h"
 

--- a/src/trackedit/trackeditmodule.cpp
+++ b/src/trackedit/trackeditmodule.cpp
@@ -21,7 +21,7 @@
  */
 #include "trackeditmodule.h"
 
-#include <QtQml>
+#include <QtQml/QtQml>
 
 #include "framework/global/modularity/ioc.h"
 

--- a/src/trackedit/view/tracknavigationmodel.h
+++ b/src/trackedit/view/tracknavigationmodel.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <QPointer>
-#include <QQuickItem>
+#include <QtQuick/QQuickItem>
 
 #include "ui/qml/Muse/Ui/navigationsection.h"
 #include "ui/qml/Muse/Ui/navigationpanel.h"

--- a/src/uicomponents/components/internal/numeric/fieldsinteractioncontroller.h
+++ b/src/uicomponents/components/internal/numeric/fieldsinteractioncontroller.h
@@ -3,7 +3,7 @@
 */
 #pragma once
 
-#include <QQuickItem>
+#include <QtQuick/QQuickItem>
 
 #include "timecodeformatter.h"
 

--- a/src/uicomponents/components/internal/numeric/numericviewmodel.h
+++ b/src/uicomponents/components/internal/numeric/numericviewmodel.h
@@ -4,7 +4,7 @@
 #pragma once
 
 #include <QAbstractListModel>
-#include <QQuickItem>
+#include <QtQuick/QQuickItem>
 
 #include "framework/uicomponents/qml/Muse/UiComponents/menuitem.h"
 

--- a/src/uicomponents/uicomponentsmodule.cpp
+++ b/src/uicomponents/uicomponentsmodule.cpp
@@ -2,8 +2,8 @@
 * Audacity: A Digital Audio Editor
 */
 
-#include <QQmlEngine>
-#include <QtQml>
+#include <QtQml/QQmlEngine>
+#include <QtQml/QtQml>
 
 #include "iapplication.h"
 


### PR DESCRIPTION
Resolves: https://gcc.gnu.org/gcc-16/porting_to.html#missing-header-includes

Compiling with gcc-16 fails due to missing headers.
Disabling unity builds (`-DMUSE_COMPILE_USE_UNITY=OFF`) brings further failures, due to incomplete Qt header paths.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [ ] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [x] Testflow test cases have been run
