### PR TITLE
Translate the meter dB range descriptions

### DIFF
--- a/src/playback/view/common/metermodel.cpp
+++ b/src/playback/view/common/metermodel.cpp
@@ -6,19 +6,18 @@
 
 #include <memory>
 
+#include "translation.h"
+
 using namespace au::playback;
 
 namespace {
-constexpr const char* DB36_DESCRIPTION = "-36 dB (shallow range for high-amplitude editing)";
-constexpr const char* DB48_DESCRIPTION = "-48 dB (PCM range of 8 bit samples)";
-constexpr const char* DB60_DESCRIPTION = "-60 dB (PCM range of 10 bit samples)";
-constexpr const char* DB72_DESCRIPTION = "-72 dB (PCM range of 12 bit samples)";
-constexpr const char* DB84_DESCRIPTION = "-84 dB (PCM range of 14 bit samples)";
-constexpr const char* DB96_DESCRIPTION = "-96 dB (PCM range of 16 bit samples)";
-constexpr const char* DB120_DESCRIPTION = "-120 dB (approximate limit of human hearing)";
-constexpr const char* DB144_DESCRIPTION = "-145 dB (PCM range of 24 bit samples)";
-
 constexpr float LINEAR_METER_MIN_VOLUME = -60.0f;
+
+//! The same context these strings are already translated under. They come
+//! from Audacity 3's wave track settings, and the translations shipped in
+//! share/locale are filed against "wave-track-settings"; looking them up
+//! under any other context would silently find nothing.
+constexpr const char* DB_RANGE_CONTEXT = "wave-track-settings";
 }
 
 MeterModel::MeterModel(QObject* parent)
@@ -215,21 +214,21 @@ QString MeterModel::description(PlaybackMeterDbRange::DbRange range) const
 {
     switch (range) {
     case PlaybackMeterDbRange::DbRange::Range36:
-        return DB36_DESCRIPTION;
+        return muse::qtrc(DB_RANGE_CONTEXT, "-36 dB (shallow range for high-amplitude editing)");
     case PlaybackMeterDbRange::DbRange::Range48:
-        return DB48_DESCRIPTION;
+        return muse::qtrc(DB_RANGE_CONTEXT, "-48 dB (PCM range of 8 bit samples)");
     case PlaybackMeterDbRange::DbRange::Range60:
-        return DB60_DESCRIPTION;
+        return muse::qtrc(DB_RANGE_CONTEXT, "-60 dB (PCM range of 10 bit samples)");
     case PlaybackMeterDbRange::DbRange::Range72:
-        return DB72_DESCRIPTION;
+        return muse::qtrc(DB_RANGE_CONTEXT, "-72 dB (PCM range of 12 bit samples)");
     case PlaybackMeterDbRange::DbRange::Range84:
-        return DB84_DESCRIPTION;
+        return muse::qtrc(DB_RANGE_CONTEXT, "-84 dB (PCM range of 14 bit samples)");
     case PlaybackMeterDbRange::DbRange::Range96:
-        return DB96_DESCRIPTION;
+        return muse::qtrc(DB_RANGE_CONTEXT, "-96 dB (PCM range of 16 bit samples)");
     case PlaybackMeterDbRange::DbRange::Range120:
-        return DB120_DESCRIPTION;
+        return muse::qtrc(DB_RANGE_CONTEXT, "-120 dB (approximate limit of human hearing)");
     case PlaybackMeterDbRange::DbRange::Range144:
-        return DB144_DESCRIPTION;
+        return muse::qtrc(DB_RANGE_CONTEXT, "-145 dB (PCM range of 24 bit samples)");
     }
 
     return "";

--- a/src/playback/view/common/metermodel.cpp
+++ b/src/playback/view/common/metermodel.cpp
@@ -12,12 +12,6 @@ using namespace au::playback;
 
 namespace {
 constexpr float LINEAR_METER_MIN_VOLUME = -60.0f;
-
-//! The same context these strings are already translated under. They come
-//! from Audacity 3's wave track settings, and the translations shipped in
-//! share/locale are filed against "wave-track-settings"; looking them up
-//! under any other context would silently find nothing.
-constexpr const char* DB_RANGE_CONTEXT = "wave-track-settings";
 }
 
 MeterModel::MeterModel(QObject* parent)
@@ -214,21 +208,21 @@ QString MeterModel::description(PlaybackMeterDbRange::DbRange range) const
 {
     switch (range) {
     case PlaybackMeterDbRange::DbRange::Range36:
-        return muse::qtrc(DB_RANGE_CONTEXT, "-36 dB (shallow range for high-amplitude editing)");
+        return muse::qtrc("wave-track-settings", "-36 dB (shallow range for high-amplitude editing)");
     case PlaybackMeterDbRange::DbRange::Range48:
-        return muse::qtrc(DB_RANGE_CONTEXT, "-48 dB (PCM range of 8 bit samples)");
+        return muse::qtrc("wave-track-settings", "-48 dB (PCM range of 8 bit samples)");
     case PlaybackMeterDbRange::DbRange::Range60:
-        return muse::qtrc(DB_RANGE_CONTEXT, "-60 dB (PCM range of 10 bit samples)");
+        return muse::qtrc("wave-track-settings", "-60 dB (PCM range of 10 bit samples)");
     case PlaybackMeterDbRange::DbRange::Range72:
-        return muse::qtrc(DB_RANGE_CONTEXT, "-72 dB (PCM range of 12 bit samples)");
+        return muse::qtrc("wave-track-settings", "-72 dB (PCM range of 12 bit samples)");
     case PlaybackMeterDbRange::DbRange::Range84:
-        return muse::qtrc(DB_RANGE_CONTEXT, "-84 dB (PCM range of 14 bit samples)");
+        return muse::qtrc("wave-track-settings", "-84 dB (PCM range of 14 bit samples)");
     case PlaybackMeterDbRange::DbRange::Range96:
-        return muse::qtrc(DB_RANGE_CONTEXT, "-96 dB (PCM range of 16 bit samples)");
+        return muse::qtrc("wave-track-settings", "-96 dB (PCM range of 16 bit samples)");
     case PlaybackMeterDbRange::DbRange::Range120:
-        return muse::qtrc(DB_RANGE_CONTEXT, "-120 dB (approximate limit of human hearing)");
+        return muse::qtrc("wave-track-settings", "-120 dB (approximate limit of human hearing)");
     case PlaybackMeterDbRange::DbRange::Range144:
-        return muse::qtrc(DB_RANGE_CONTEXT, "-145 dB (PCM range of 24 bit samples)");
+        return muse::qtrc("wave-track-settings", "-145 dB (PCM range of 24 bit samples)");
     }
 
     return "";


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/11940

The eight entries in the meter dB range dropdown (Preferences > Audio settings)
were bare string literals returned straight as `QString` from
`MeterModel::description()`, so they were shown in English whatever language the
application was set to.

No new translation work is needed. These strings come from Audacity 3's wave
track settings, and `share/locale` already carries them — translated — under the
`wave-track-settings` context. They were simply never looked up. Routing them
through that context makes all of them resolve.

### On the choice of context

This is the part worth a second look in review. The rest of this module uses
`qtrc("playback", …)`, which is the obvious thing to reach for here and is
wrong: it finds nothing and reproduces the bug exactly. Checked against the
built `.qm`:

```
wave-track-settings  ->  -48 dB (amplitude PCM en échantillonnage 8 bits)   [translated]
playback             ->  -48 dB (PCM range of 8 bit samples)                [NOT TRANSLATED]
```

The context is noted in a comment next to the constant so the next person does
not "fix" it to match the module.

### Verification

All eight strings, against the `.qm` files produced by this build:

| Locale | Result |
|---|---|
| fr, de, es, pt_BR, ru, ja | 8/8 translated, 0 missing |

### Not changed

`Range144`'s label reads `-145 dB` while `PlaybackMeterDbRange::toDouble()`
returns `-144.0`. The label matches Audacity 3 and matches the translated source
string exactly, so changing it would break the lookup in every language. If that
discrepancy is a real problem it needs its own issue, since fixing it means
retranslating.

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [x] Testflow test cases have been run
