### PR TITLE
Keep the whole file name when exporting over an existing file

### DIFF
--- a/src/importexport/export/view/exportpreferencesmodel.cpp
+++ b/src/importexport/export/view/exportpreferencesmodel.cpp
@@ -477,7 +477,11 @@ void ExportPreferencesModel::setFilePickerPath(const QString& path)
 
     if (info.entryType() == muse::io::EntryType::File) {
         setDirectoryPath(info.absolutePath());
-        setFilename(info.baseName());
+
+        // completeBaseName, not baseName: the latter cuts at the FIRST dot, so
+        // picking "Community Roundup 9.45am 1.45pm.mp3" to overwrite offered
+        // "Community Roundup 9" as the name to export to.
+        setFilename(info.completeBaseName());
         return;
     }
 
@@ -494,7 +498,9 @@ void ExportPreferencesModel::setFileDialogPath(const QString& path)
     }
 
     setDirectoryPath(info.absolutePath());
-    setFilename(info.baseName());
+
+    // See setFilePickerPath: everything after the first dot is not a suffix.
+    setFilename(info.completeBaseName());
 }
 
 void ExportPreferencesModel::updateCurrentSampleRate()

--- a/src/importexport/export/view/exportpreferencesmodel.cpp
+++ b/src/importexport/export/view/exportpreferencesmodel.cpp
@@ -478,9 +478,6 @@ void ExportPreferencesModel::setFilePickerPath(const QString& path)
     if (info.entryType() == muse::io::EntryType::File) {
         setDirectoryPath(info.absolutePath());
 
-        // completeBaseName, not baseName: the latter cuts at the FIRST dot, so
-        // picking "Community Roundup 9.45am 1.45pm.mp3" to overwrite offered
-        // "Community Roundup 9" as the name to export to.
         setFilename(info.completeBaseName());
         return;
     }
@@ -499,7 +496,6 @@ void ExportPreferencesModel::setFileDialogPath(const QString& path)
 
     setDirectoryPath(info.absolutePath());
 
-    // See setFilePickerPath: everything after the first dot is not a suffix.
     setFilename(info.completeBaseName());
 }
 


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/11966

Picking an existing file to overwrite in the export dialog dropped everything
from the first dot onwards, so choosing

```
Community Roundup Spoken 9.45am 1.45pm.mp3
```

offered to export to `Community Roundup Spoken 9`.

### Cause

`muse::io::FileInfo::baseName()` cuts at the **first** dot:

```cpp
size_t firstDot = m_filePath.indexOf(u'.', from);
```

`completeBaseName()` cuts at the last, which is what "the name without its
extension" means here. Both places `ExportPreferencesModel` derives a name from
a chosen path — `setFilePickerPath()` and `setFileDialogPath()` — used the
former. They are the only two `baseName()` calls in `src/`.

### It is not a length limit

The report reasonably reads this as a 26-character cap, because that is where
the truncation lands for this name. It is a coincidence: the cut is at the first
dot wherever that falls. Any name with a dot before its extension loses
everything after it, and names without one were never affected — which is why
short names looked fine.

### Verification

Both functions run against `muse::io::FileInfo` directly. They agree on every
ordinary name and differ only where they should:

| Path | `baseName()` | `completeBaseName()` |
|---|---|---|
| `Community Roundup Spoken 9.45am 1.45pm.mp3` | `Community Roundup Spoken 9` | `Community Roundup Spoken 9.45am 1.45pm` |
| `song.mp3` | `song` | `song` |
| `no_extension` | `no_extension` | `no_extension` |
| `archive.tar.gz` | `archive` | `archive.tar` |
| `/my.folder/track.wav` | `track` | `track` |

The last row matters: a dot in a *directory* name does not confuse
`completeBaseName()`, so paths like that are unaffected.

Because the two agree for names without an interior dot, this cannot change
behaviour for any file name that was already correct.

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [x] Testflow test cases have been run
