### PR TITLE
Draw the playhead on whole pixels so it stays crisp while playing

### DIFF
--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TracksItemsView.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TracksItemsView.qml
@@ -356,14 +356,7 @@ Rectangle {
 
             property double displayedPlayCursorX: playCursorController.positionX
 
-            //! Where the playhead is actually drawn. During playback
-            //! displayedPlayCursorX comes from time x zoom and so lands
-            //! between pixels, and a one pixel line drawn on a fraction is
-            //! spread over two - which is why the playhead looks smudged while
-            //! playing but crisp while dragged, where the position comes from
-            //! whole mouse pixels. Rounding gives the dragged appearance in
-            //! both cases. Only the drawing is snapped; the time the playhead
-            //! represents is untouched.
+            //! Snapped to whole pixels so the line does not blur while playing.
             readonly property int playCursorPixelX: Math.round(displayedPlayCursorX)
 
             function updateCursorPosition(x, y) {

--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TracksItemsView.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TracksItemsView.qml
@@ -356,6 +356,16 @@ Rectangle {
 
             property double displayedPlayCursorX: playCursorController.positionX
 
+            //! Where the playhead is actually drawn. During playback
+            //! displayedPlayCursorX comes from time x zoom and so lands
+            //! between pixels, and a one pixel line drawn on a fraction is
+            //! spread over two - which is why the playhead looks smudged while
+            //! playing but crisp while dragged, where the position comes from
+            //! whole mouse pixels. Rounding gives the dragged appearance in
+            //! both cases. Only the drawing is snapped; the time the playhead
+            //! represents is untouched.
+            readonly property int playCursorPixelX: Math.round(displayedPlayCursorX)
+
             function updateCursorPosition(x, y) {
                 const snappedTime = timeline.context.applyDetectedSnap(timeline.context.positionToTime(x))
                 lineCursor.x = timeline.context.timeToPosition(snappedTime)
@@ -407,7 +417,7 @@ Rectangle {
                 property bool dragActive: false
                 property double dragPositionX: timeline.displayedPlayCursorX
 
-                x: timeline.displayedPlayCursorX - (width / 2)
+                x: timeline.playCursorPixelX - Math.round(width / 2)
 
                 MouseArea {
                     anchors.fill: parent
@@ -1261,7 +1271,7 @@ Rectangle {
             anchors.top: tracksItemsViewArea.top
             anchors.bottom: parent.bottom
 
-            x: timeline.displayedPlayCursorX
+            x: timeline.playCursorPixelX
         }
 
         Rectangle {


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/11979

The playhead is a one pixel white line between two one pixel black borders.
While playing it usually landed between pixels, so each of those three lines was
spread across two — the smudge in the report.

### Cause

The drawn position comes from two different places:

| | Source | Value |
|---|---|---|
| Dragging | `mapToItem(...).x` in the head's `MouseArea` | whole mouse pixels |
| Playing | `PlayCursorController::onFrameTimeChanged()` → `timeToPosition(playbackPosition())` | a continuous double, updated every frame |

So the same line is drawn on an integer while dragged and on a fraction while
playing. That accounts for both details in the report: why dragging looks
different, and why it is worst zoomed out — at low zoom a pixel covers more
time, so the fractional part churns continuously, which is the jitter.

### Fix

Round the position that is *drawn*, once, and use it for both the line and the
head so they stay centred on each other. `displayedPlayCursorX` and the time the
playhead represents are untouched, so seeking and the position readout keep
their full precision — only the drawing is snapped.

This gives playback the appearance dragging already had, rather than inventing a
new one.

### Note for the reviewer

The rounding is to whole *logical* pixels, which is exactly what the drag path
already produces. If a display scaling factor ever made that insufficient, the
drag case would look smudged too, and it does not. Snapping to the device pixel
grid via `Screen.devicePixelRatio` would be the stronger version, but it is not
needed to match the behaviour being asked for here.

Not included: `PlaybackSeekLine` takes its `x` from
`timeline.context.lastPlaybackSeekPosition` unrounded and has the same flaw. It
is static, so it does not shimmer and nobody has reported it, but it will be
soft whenever it lands on a fraction. Happy to fold that in if you would prefer
it fixed in the same pass.

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [x] Testflow test cases have been run
