### PR TITLE
Fix div by zero in BeatsFormatter when time signature is unset

### DIFF
--- a/src/uicomponents/components/internal/numeric/beatsformatter.cpp
+++ b/src/uicomponents/components/internal/numeric/beatsformatter.cpp
@@ -56,6 +56,13 @@ BeatsFormatter::BeatsFormatter(const QString& formatStr, int fracPart, TimecodeM
 
 void BeatsFormatter::init()
 {
+    if (m_tempo <= 0.0 || m_upperTimeSignature <= 0 || m_lowerTimeSignature <= 0) {
+        m_fields.clear();
+        m_digits.clear();
+        m_fieldLengths.fill(0.0);
+        return;
+    }
+
     const bool formatOk = checkField(1, m_upperTimeSignature) && checkFracField(m_lowerTimeSignature);
 
     // 1/4 = BPM is used for now
@@ -204,7 +211,7 @@ bool BeatsFormatter::checkField(size_t fieldIndex, int value) const
 bool BeatsFormatter::checkFracField(int newLts) const
 {
     if (m_fracPart > newLts) {
-        return checkField(2, m_fracPart / m_lowerTimeSignature);
+        return checkField(2, ticksPerBeat());
     } else {
         return m_fields.size() == 2;
     }
@@ -230,7 +237,7 @@ void BeatsFormatter::updateFields(size_t barsDigits)
     if (hasFracPart) {
         beatsField.label += " ";
         // See the reasoning above about the range
-        m_fields.emplace_back(NumericField::range(std::max(11, m_fracPart / m_lowerTimeSignature + offset)));
+        m_fields.emplace_back(NumericField::range(std::max(11, ticksPerBeat() + offset)));
     }
 
     // Fill the aux m_digits structure
@@ -245,4 +252,9 @@ void BeatsFormatter::updateFields(size_t barsDigits)
 
         pos += m_fields[i].label.length();
     }
+}
+
+int BeatsFormatter::ticksPerBeat() const
+{
+    return m_lowerTimeSignature > 0 ? m_fracPart / m_lowerTimeSignature : 0;
 }

--- a/src/uicomponents/components/internal/numeric/beatsformatter.h
+++ b/src/uicomponents/components/internal/numeric/beatsformatter.h
@@ -28,8 +28,9 @@ private:
     bool checkField(size_t fieldIndex, int value) const;
     bool checkFracField(int newLts) const;
     void updateFields(size_t barsDigits);
+    int ticksPerBeat() const;
 
-    std::array<double, 3> m_fieldLengths;
+    std::array<double, 3> m_fieldLengths {};
     int m_fracPart = 0;
     TimecodeMode m_mode;
 };


### PR DESCRIPTION
Resolves: #11960

Fix UB (crash on `amd64`) division by zero where `BeatsFormatter` divided by `m_lowerTimeSignature`, which is `0` when no project is loaded. Add a `ticksPerBeat()` helper that checks the divisor before dividing, and skip setting up the fields until a valid tempo and time signature are available. Also initialize `m_fieldLengths`.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
