### PR TITLE
Fix VST3 plug-in meters and analysers not updating during playback (#8881)

### DIFF
--- a/au3/libraries/au3-vst3/VST3Wrapper.cpp
+++ b/au3/libraries/au3-vst3/VST3Wrapper.cpp
@@ -990,6 +990,17 @@ size_t VST3Wrapper::Process(const float* const* inBlock, float* const* outBlock,
            ? data.numSamples : 0;
 }
 
+void VST3Wrapper::DeliverPendingUiMessages()
+{
+    //Both proxies are created by this class, so their concrete type is known here.
+    if (mComponentConnectionProxy) {
+        static_cast<internal::ConnectionProxy*>(mComponentConnectionProxy.get())->deliverPendingMessages();
+    }
+    if (mControllerConnectionProxy) {
+        static_cast<internal::ConnectionProxy*>(mControllerConnectionProxy.get())->deliverPendingMessages();
+    }
+}
+
 void VST3Wrapper::SuspendProcessing()
 {
     mAudioProcessor->setProcessing(false);

--- a/au3/libraries/au3-vst3/VST3Wrapper.h
+++ b/au3/libraries/au3-vst3/VST3Wrapper.h
@@ -116,6 +116,13 @@ public:
     //Intialize first, before calling to Process. It's safe to it use from another thread
     size_t Process(const float* const* inBlock, float* const* outBlock, size_t blockLen);
 
+    //!Call periodically from the UI thread (never the audio thread). Plugins whose
+    //!processor and controller are separate objects stream live data to their own editor
+    //!(meters, analyser curves) through IConnectionPoint, from their processing thread.
+    //!Those messages cannot be handed to the controller on that thread, so ConnectionProxy
+    //!queues them; this delivers them here, where controller/editor access is safe.
+    void DeliverPendingUiMessages();
+
     void SuspendProcessing();
     void ResumeProcessing();
 

--- a/au3/libraries/au3-vst3/internal/ConnectionProxy.cpp
+++ b/au3/libraries/au3-vst3/internal/ConnectionProxy.cpp
@@ -21,7 +21,18 @@ internal::ConnectionProxy::ConnectionProxy(Steinberg::Vst::IConnectionPoint* sou
 
 internal::ConnectionProxy::~ConnectionProxy()
 {
+    clearPendingMessages();
     FUNKNOWN_DTOR;
+}
+
+void internal::ConnectionProxy::clearPendingMessages()
+{
+    std::lock_guard<std::mutex> lock(mPendingMutex);
+    for (auto& message : mPending) {
+        message = nullptr;
+    }
+    mPendingHead = 0;
+    mPendingCount = 0;
 }
 
 Steinberg::tresult internal::ConnectionProxy::connect(IConnectionPoint* other)
@@ -52,6 +63,9 @@ Steinberg::tresult internal::ConnectionProxy::disconnect(IConnectionPoint* other
         return Steinberg::kResultFalse;
     }
 
+    //Anything still queued is addressed to a connection point that is going away
+    clearPendingMessages();
+
     auto result = mSource->disconnect(this);
     if (result == Steinberg::kResultOk) {
         mTarget = nullptr;
@@ -61,12 +75,58 @@ Steinberg::tresult internal::ConnectionProxy::disconnect(IConnectionPoint* other
 
 Steinberg::tresult internal::ConnectionProxy::notify(Steinberg::Vst::IMessage* message)
 {
-    if (mTarget.get() == nullptr
-        || std::this_thread::get_id() != mThreadId) {
+    if (mTarget.get() == nullptr || message == nullptr) {
         return Steinberg::kResultFalse;
     }
 
-    return mTarget->notify(message);
+    if (std::this_thread::get_id() == mThreadId) {
+        return mTarget->notify(message);
+    }
+
+    //Off-thread, typically the plug-in's realtime processing thread reporting live
+    //data to its controller. The controller and its editor may only be touched on
+    //the proxy's own thread, so take a reference to the message and hand it over in
+    //deliverPendingMessages(). Everything below is allocation-free and never blocks.
+    std::unique_lock<std::mutex> lock(mPendingMutex, std::try_to_lock);
+    if (!lock.owns_lock()) {
+        return Steinberg::kResultFalse;
+    }
+
+    if (mPendingCount == kPendingCapacity) {
+        //Full: drop this message rather than evicting the oldest, which would release
+        //it - and possibly free it - on a thread that must not be doing either.
+        return Steinberg::kResultFalse;
+    }
+
+    const auto tail = (mPendingHead + mPendingCount) % kPendingCapacity;
+    mPending[tail] = message;
+    ++mPendingCount;
+    return Steinberg::kResultOk;
+}
+
+void internal::ConnectionProxy::deliverPendingMessages()
+{
+    //One at a time, with the message released outside the lock: notify() reaches
+    //plug-in code that may call back into this proxy, and the final release of a
+    //message may free it - neither should happen while holding the lock.
+    for (;;) {
+        Steinberg::IPtr<Steinberg::Vst::IMessage> message;
+        Steinberg::IPtr<Steinberg::Vst::IConnectionPoint> target;
+        {
+            std::lock_guard<std::mutex> lock(mPendingMutex);
+            if (mPendingCount == 0) {
+                return;
+            }
+            message = std::move(mPending[mPendingHead]);
+            mPendingHead = (mPendingHead + 1) % kPendingCapacity;
+            --mPendingCount;
+            target = mTarget;
+        }
+
+        if (target && message) {
+            target->notify(message);
+        }
+    }
 }
 
 IMPLEMENT_FUNKNOWN_METHODS(internal::ConnectionProxy, Steinberg::Vst::IConnectionPoint, Steinberg::Vst::IConnectionPoint::iid);

--- a/au3/libraries/au3-vst3/internal/ConnectionProxy.cpp
+++ b/au3/libraries/au3-vst3/internal/ConnectionProxy.cpp
@@ -106,10 +106,27 @@ Steinberg::tresult internal::ConnectionProxy::notify(Steinberg::Vst::IMessage* m
 
 void internal::ConnectionProxy::deliverPendingMessages()
 {
+    //Bounded by what was already queued when this started, rather than draining
+    //until empty. notify() runs outside the lock, so the sending thread can enqueue
+    //again between iterations; an "until empty" loop therefore need never return if
+    //a plug-in produces faster than its target consumes, and the thread calling this
+    //- the UI thread - would stop repainting and handling input. Anything that
+    //arrives while this is running is delivered on the next call instead.
+    //
+    //The bound is the queued count and not a smaller fixed budget so that a burst is
+    //still delivered in one go: the ring is small and drops the newest message when
+    //full, so a budget below its capacity would leave the newest values waiting
+    //behind older ones and make a meter read late under sustained load.
+    std::size_t budget = 0;
+    {
+        std::lock_guard<std::mutex> lock(mPendingMutex);
+        budget = mPendingCount;
+    }
+
     //One at a time, with the message released outside the lock: notify() reaches
     //plug-in code that may call back into this proxy, and the final release of a
     //message may free it - neither should happen while holding the lock.
-    for (;;) {
+    for (std::size_t delivered = 0; delivered < budget; ++delivered) {
         Steinberg::IPtr<Steinberg::Vst::IMessage> message;
         Steinberg::IPtr<Steinberg::Vst::IConnectionPoint> target;
         {

--- a/au3/libraries/au3-vst3/internal/ConnectionProxy.h
+++ b/au3/libraries/au3-vst3/internal/ConnectionProxy.h
@@ -10,22 +10,48 @@
 
 **********************************************************************/
 
+#include <array>
+#include <cstddef>
+#include <mutex>
+#include <utility>
 #include <thread>
 #include <pluginterfaces/vst/ivstmessage.h>
 
 namespace internal {
 //!Host's proxy object between connection points
 /*! Though it's not necessary to place proxy, it's recommended to do so.
-    * Right now the only "useful" task performed by this proxy is ensuring
-    * that messages are sent on the same thread on which proxy object itself
-    * was created
+    * This proxy makes sure the target connection point is only ever notified
+    * on the thread the proxy object itself was created on (the UI thread).
+    *
+    * A plug-in whose processor and controller are separate objects cannot reach
+    * its own editor directly - it streams live data to the controller (meters,
+    * gain reduction, analyser curves) through IConnectionPoint, and does so from
+    * its processing thread. Those notifications therefore arrive here off the UI
+    * thread; discarding them leaves the plug-in's own GUI frozen. They are queued
+    * instead, and handed over by deliverPendingMessages() on the UI thread.
     */
 class ConnectionProxy final : public Steinberg::Vst::IConnectionPoint
 {
+    //!Bounded on purpose: this carries a continuous stream where only recent data
+    //!matters, and it must not grow while nothing is draining it. Sized to give a
+    //!UI thread refreshing at ~60Hz about a second of slack before messages are lost.
+    static constexpr std::size_t kPendingCapacity = 64;
+
     std::thread::id mThreadId;
 
     Steinberg::IPtr<Steinberg::Vst::IConnectionPoint> mSource;
     Steinberg::IPtr<Steinberg::Vst::IConnectionPoint> mTarget;
+
+    //!Messages received on a thread other than mThreadId, awaiting delivery.
+    //!notify() may be called from a plug-in's realtime processing thread, so this is
+    //!a fixed-size, pre-allocated ring: enqueuing never allocates, frees, or blocks.
+    std::mutex mPendingMutex;
+    std::array<Steinberg::IPtr<Steinberg::Vst::IMessage>, kPendingCapacity> mPending;
+    std::size_t mPendingHead { 0 };
+    std::size_t mPendingCount { 0 };
+
+    void clearPendingMessages();
+
 public:
 
     DECLARE_FUNKNOWN_METHODS;
@@ -38,5 +64,10 @@ public:
     Steinberg::tresult PLUGIN_API disconnect(IConnectionPoint* other) override;
 
     Steinberg::tresult PLUGIN_API notify(Steinberg::Vst::IMessage* message) override;
+
+    //!Delivers everything notify() queued from other threads. Must be called on the
+    //!thread this proxy was created on; call it periodically while a plug-in's editor
+    //!is open, otherwise the plug-in's own GUI never sees its live data.
+    void deliverPendingMessages();
 };
 }

--- a/src/effects/vst/view/vstviewmodel.cpp
+++ b/src/effects/vst/view/vstviewmodel.cpp
@@ -22,6 +22,9 @@ VstViewModel::~VstViewModel()
     m_settingUpdateTimer.stop();
     QObject::disconnect(&m_settingUpdateTimer, &QTimer::timeout, this, &VstViewModel::checkSettingChangesFromUiWhileIdle);
 
+    m_pluginUiUpdateTimer.stop();
+    QObject::disconnect(&m_pluginUiUpdateTimer, &QTimer::timeout, this, &VstViewModel::deliverPendingUiMessages);
+
     // The wrapper is owned by the effect instance and outlives this view model
     // (e.g. when the vendor UI is swapped for the fallback UI). Clear the
     // handler so a later endEdit doesn't invoke a lambda capturing a freed this.
@@ -76,6 +79,20 @@ void VstViewModel::doInit()
 
     // When playback is idle (see VstViewModel::event), no need for setting updates to be low-latency. Every 100ms is plenty.
     m_settingUpdateTimer.start(std::chrono::milliseconds { 100 });
+
+    // Unlike the settings timer above, this runs regardless of idle/active state: it
+    // hands the plugin the live data its own editor draws from. ~60fps, which is what
+    // vendor GUIs expect for smooth meter and analyser animation.
+    QObject::connect(&m_pluginUiUpdateTimer, &QTimer::timeout, this, &VstViewModel::deliverPendingUiMessages);
+    m_pluginUiUpdateTimer.start(std::chrono::milliseconds { 16 });
+}
+
+void VstViewModel::deliverPendingUiMessages()
+{
+    if (!m_auVst3Instance) {
+        return;
+    }
+    m_auVst3Instance->GetWrapper().DeliverPendingUiMessages();
 }
 
 void VstViewModel::checkSettingChangesFromUiWhileIdle()

--- a/src/effects/vst/view/vstviewmodel.h
+++ b/src/effects/vst/view/vstviewmodel.h
@@ -42,10 +42,17 @@ private:
     void settingsFromView();
     void checkSettingChangesFromUiWhileIdle();
     void checkSettingChangesFromUi(bool forceCommitting);
+    void deliverPendingUiMessages();
 
     std::shared_ptr<VST3Instance> m_auVst3Instance;
     std::shared_ptr<EffectSettingsAccess> m_settingsAccess;
     QTimer m_settingUpdateTimer;
+
+    // Unlike m_settingUpdateTimer (which only does anything while inactive/idle), this
+    // runs regardless of active state: it delivers the data a plugin sends to its own
+    // editor while audio is being processed. See VST3Wrapper::DeliverPendingUiMessages
+    // for why it must run on this (UI) thread rather than the audio thread.
+    QTimer m_pluginUiUpdateTimer;
 };
 
 class VstViewModelFactory : public EffectViewModelFactory<VstViewModel>


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/8881

I have tried to track this down properly rather than guess, and the reasoning is below - but I do not know this codebase as well as you do, so please tell me if I have taken a wrong turn anywhere or if you would prefer a different approach.

VST3 plug-in editors never show live data. Meters sit frozen at whatever value they had when the editor was opened, analysers never move, and metering plug-ins look as though no audio reaches them at all — which is how #8881 describes dpMeter5.

### Cause

A VST3 plug-in whose processor and controller are separate objects cannot reach its own editor directly. To drive live displays it sends messages from the processor to the controller over `IConnectionPoint`, and it does so from the thread that processes audio.

`internal::ConnectionProxy::notify()` discarded all of them:

```cpp
if (mTarget.get() == nullptr
    || std::this_thread::get_id() != mThreadId) {
    return Steinberg::kResultFalse;
}

return mTarget->notify(message);
```

`mThreadId` is captured in the proxy's constructor, on the UI thread, so every message a plug-in sends from its processing thread hits that early return and is dropped. The editor only ever renders the state it was opened with.

Measured on the current code with FabFilter Pro-L 2 during playback: **34** messages delivered (all at load time) and **~50/second** discarded, continuously, for as long as audio was playing.

### Fix

Queue those messages rather than discarding them, and hand them to the controller from the UI thread, where touching the controller and its editor is safe. `VstViewModel` drains the queue while a plug-in editor is open — i.e. exactly when the data has somewhere to go.

The thread check itself is kept deliberately: the point of the proxy is still that the controller is only ever notified on the UI thread. What changes is that off-thread messages are now deferred instead of lost.

`notify()` can be called from a realtime thread, so the queue is built to suit that:

- a fixed-size `std::array` ring owned by the proxy — enqueuing never allocates or frees
- `try_lock`, never a blocking lock, so a plug-in's processing thread can't be stalled by the UI thread
- bounded; when full it drops the *newest* message rather than evicting the oldest, because evicting would release (and possibly free) a message on the realtime thread
- cleared in both `disconnect()` and the destructor, so nothing is ever delivered to a connection point that has gone away

Delivery takes one message at a time and calls `notify()` outside the lock, since plug-in code may call back into the proxy, and the final release of a message may free it.

### Notes and trade-offs

- Messages are queued whether or not an editor is open, since the proxy has no way to know. With no editor the ring simply fills and then drops, and the first drain after an editor opens may deliver a few stale values, which the next frame immediately supersedes. Bounded either way, and strictly better than the current behaviour of discarding everything.
- `notify()` returns `kResultOk` once a message is queued rather than once it is delivered. Dropped messages still return `kResultFalse`.
- Both proxies are constructed by `VST3Wrapper`, so it downcasts them to call the drain. The alternative is exposing `internal/ConnectionProxy.h` through `VST3Wrapper.h`; happy to change it if you prefer that.
- The unsynchronised `mTarget` read at the top of `notify()` is unchanged from the existing implementation.
- #8881 was reported against Audacity 3, but the code it blames lives in the shared `au3` layer, so the same fault is present here - the plug-in it names (dpMeter5) reproduces the reported behaviour on master, and works after this change. Note that the drain is wired through `VstViewModel`, so this fixes master; a 3.x branch would need its own place to call `deliverPendingMessages()`.
- Verified on Windows only. The change is platform-neutral, and `VstViewer.qml` is the single entry point for VST3 editors (used by both the realtime and destructive effect dialogs), so all platforms drain through the same path.

### Testing

Three plug-ins from two vendors, with unrelated GUI implementations, all added to a stereo track as realtime effects:

| Plug-in | Before | After |
| --- | --- | --- |
| FabFilter Pro-L 2 | gain-reduction meter static | follows the audio |
| dpMeter5 (the plug-in from #8881) | inert, appears to get no signal | RMS/peak/LUFS update live |
| mvMeter2 | analogue VU needle static | needle tracks the audio |

Built and run against master's current CMake link scoping for the two VST targets, not only against an older configuration.

Message counters over the same playback, before and after: `delivered 34 / dropped 4305 and climbing` → `delivered 6585 and climbing / dropped 4`.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run

I was unable to run the Testflow suite: on my machine `--test-case` crashes during
startup (access violation, before the test script is reached) for every case in
`src/app/testflowscripts`. This reproduces with my changes reverted and rebuilt, so it
looks pre-existing and unrelated to this PR - happy to raise it separately if useful.
None of the current cases open a plug-in editor, so they would not exercise this change
in any event; the plug-in verification above was done by hand.
