### PR TITLE
Add custom recording input selection with mono/stereo grouping

### DIFF
--- a/au3/libraries/au3-audio-devices/AudioIOBase.cpp
+++ b/au3/libraries/au3-audio-devices/AudioIOBase.cpp
@@ -27,8 +27,8 @@ Paul Licameli split from AudioIO.cpp
 #endif
 
 std::map<int, std::vector<long> > AudioIOBase::mCachedPlaybackRates;
-std::map<int, std::vector<long> > AudioIOBase::mCachedCaptureRates;
-std::map<std::pair<int, int>, std::vector<long> > AudioIOBase::mCachedSampleRates;
+std::map<std::pair<int, int>, std::vector<long> > AudioIOBase::mCachedCaptureRates;
+std::map<std::tuple<int, int, int>, std::vector<long> > AudioIOBase::mCachedSampleRates;
 int AudioIOBase::mCurrentPlaybackIndex { -1 };
 int AudioIOBase::mCurrentCaptureIndex { -1 };
 double AudioIOBase::mCachedBestRateIn { 0.0 };
@@ -459,15 +459,20 @@ bool AudioIOBase::IsPlaybackRateSupported(int devIndex, long rate)
     return false;
 }
 
-bool AudioIOBase::IsCaptureRateSupported(int devIndex, long rate)
+bool AudioIOBase::IsCaptureRateSupported(int devIndex, long rate, int captureChannels)
 {
     if (devIndex == -1) { // not given a device, look up in prefs / default
         devIndex = getRecordDevIndex();
     }
 
+    if (captureChannels < 0) {
+        captureChannels = AudioIORecordChannels.ReadWithDefault(1);
+    }
+    const auto cacheKey = std::make_pair(devIndex, captureChannels);
+
     // Check if we can use the cached rate
-    if (mCachedCaptureRates.count(devIndex)
-        && (make_iterator_range(mCachedCaptureRates.at(devIndex)).contains(rate))) {
+    if (mCachedCaptureRates.count(cacheKey)
+        && (make_iterator_range(mCachedCaptureRates.at(cacheKey)).contains(rate))) {
         return true;
     }
 
@@ -479,8 +484,6 @@ bool AudioIOBase::IsCaptureRateSupported(int devIndex, long rate)
     }
 
     auto latencyDuration = AudioIOLatencyDuration.Read();
-    // Why not defaulting to 2 as elsewhere?
-    auto recordChannels = AudioIORecordChannels.ReadWithDefault(1);
 
     // LLL: Remove when a proper method of determining actual supported
     //      DirectSound rate is devised.
@@ -490,7 +493,7 @@ bool AudioIOBase::IsCaptureRateSupported(int devIndex, long rate)
     PaStreamParameters pars;
 
     pars.device = devIndex;
-    pars.channelCount = recordChannels;
+    pars.channelCount = captureChannels;
     pars.sampleFormat = paFloat32;
     pars.suggestedLatency = latencyDuration / 1000.0;
     pars.hostApiSpecificStreamInfo = NULL;
@@ -499,7 +502,7 @@ bool AudioIOBase::IsCaptureRateSupported(int devIndex, long rate)
     //      DirectSound rate is devised.
     if (!(isDirectSound && rate > 200000)) {
         if (Pa_IsFormatSupported(&pars, NULL, rate) == 0) {
-            mCachedCaptureRates[devIndex].push_back(rate);
+            mCachedCaptureRates[cacheKey].push_back(rate);
             return true;
         }
     }
@@ -525,7 +528,7 @@ std::vector<long> AudioIOBase::GetSupportedPlaybackRates(int devIndex)
     return supportedRates;
 }
 
-std::vector<long> AudioIOBase::GetSupportedCaptureRates(int devIndex)
+std::vector<long> AudioIOBase::GetSupportedCaptureRates(int devIndex, int captureChannels)
 {
     if (devIndex == -1) { // weren't given a device index, get the prefs / default one
         devIndex = getRecordDevIndex();
@@ -534,7 +537,7 @@ std::vector<long> AudioIOBase::GetSupportedCaptureRates(int devIndex)
     std::vector<long> supportedRates;
 
     for (const long rate : RatesToTry) {
-        if (IsCaptureRateSupported(devIndex, rate)) {
+        if (IsCaptureRateSupported(devIndex, rate, captureChannels)) {
             supportedRates.push_back(rate);
         }
         Pa_Sleep(10);   // There are ALSA drivers that don't like being probed
@@ -577,7 +580,7 @@ long AudioIOBase::GetClosestSupportedPlaybackRate(int devIndex, long rate)
     return supportedRate;
 }
 
-long AudioIOBase::GetClosestSupportedCaptureRate(int devIndex, long rate)
+long AudioIOBase::GetClosestSupportedCaptureRate(int devIndex, long rate, int captureChannels)
 {
     long supportedRate = 0;
     if (devIndex == -1) { // not given a device, look up in prefs / default
@@ -588,9 +591,14 @@ long AudioIOBase::GetClosestSupportedCaptureRate(int devIndex, long rate)
         return supportedRate;
     }
 
+    if (captureChannels < 0) {
+        captureChannels = AudioIORecordChannels.ReadWithDefault(1);
+    }
+    const auto cacheKey = std::make_pair(devIndex, captureChannels);
+
     // Check if we can use the cached rate
-    if (mCachedCaptureRates.count(devIndex)
-        && (make_iterator_range(mCachedCaptureRates[devIndex]).contains(rate))) {
+    if (mCachedCaptureRates.count(cacheKey)
+        && (make_iterator_range(mCachedCaptureRates[cacheKey]).contains(rate))) {
         supportedRate = rate;
         return supportedRate;
     }
@@ -608,7 +616,7 @@ long AudioIOBase::GetClosestSupportedCaptureRate(int devIndex, long rate)
               std::back_inserter(rates));
 
     for (const long rateToTry : rates) {
-        if (IsCaptureRateSupported(devIndex, rateToTry)) {
+        if (IsCaptureRateSupported(devIndex, rateToTry, captureChannels)) {
             supportedRate = rateToTry;
             break;
         }
@@ -620,7 +628,7 @@ long AudioIOBase::GetClosestSupportedCaptureRate(int devIndex, long rate)
 }
 
 long AudioIOBase::GetClosestSupportedSampleRate(
-    int playDevice, int recDevice, long rate)
+    int playDevice, int recDevice, long rate, int captureChannels)
 {
     long supportedRate = 0;
 
@@ -633,7 +641,10 @@ long AudioIOBase::GetClosestSupportedSampleRate(
     }
 
     // Check if we can use the cached rates
-    std::pair<int, int> devicePair { playDevice, recDevice };
+    if (captureChannels < 0) {
+        captureChannels = AudioIORecordChannels.ReadWithDefault(1);
+    }
+    const auto devicePair = std::make_tuple(playDevice, recDevice, captureChannels);
     if (mCachedSampleRates.count(devicePair)
         && make_iterator_range(mCachedSampleRates.at(devicePair)).contains(rate)) {
         return rate;
@@ -653,7 +664,7 @@ long AudioIOBase::GetClosestSupportedSampleRate(
 
     for (const long rateToTry : rates) {
         if (IsPlaybackRateSupported(playDevice, rateToTry)
-            && IsCaptureRateSupported(recDevice, rateToTry)) {
+            && IsCaptureRateSupported(recDevice, rateToTry, captureChannels)) {
             supportedRate = rateToTry;
             break;
         }
@@ -666,7 +677,7 @@ long AudioIOBase::GetClosestSupportedSampleRate(
     return supportedRate;
 }
 
-std::vector<long> AudioIOBase::GetSupportedSampleRates(int playDevice, int recDevice)
+std::vector<long> AudioIOBase::GetSupportedSampleRates(int playDevice, int recDevice, int captureChannels)
 {
     // Not given device indices, look up prefs
     if (playDevice == -1) {
@@ -677,7 +688,7 @@ std::vector<long> AudioIOBase::GetSupportedSampleRates(int playDevice, int recDe
     }
 
     auto playback = GetSupportedPlaybackRates(playDevice);
-    auto capture = GetSupportedCaptureRates(recDevice);
+    auto capture = GetSupportedCaptureRates(recDevice, captureChannels);
 
     // Return only sample rates which are in both arrays
     std::vector<long> result;

--- a/au3/libraries/au3-audio-devices/AudioIOBase.h
+++ b/au3/libraries/au3-audio-devices/AudioIOBase.h
@@ -78,6 +78,10 @@ struct AudioIOStartStreamOptions
 
     bool loopEnabled{ false };
     bool variableSpeed{ false };
+
+    // Zero-based physical input channels grouped by destination track.  A
+    // one-element group is mono; a two-element group is a stereo pair.
+    std::vector<std::vector<unsigned int> > inputChannelSelection;
 };
 
 struct AudioIODiagnostics {

--- a/au3/libraries/au3-audio-devices/AudioIOBase.h
+++ b/au3/libraries/au3-audio-devices/AudioIOBase.h
@@ -17,6 +17,7 @@ Paul Licameli split from AudioIO.h
 #include <functional>
 #include <map>
 #include <optional>
+#include <tuple>
 #include <vector>
 #include <utility>
 #include <wx/string.h>
@@ -182,7 +183,7 @@ public:
      * give it, the currently selected device from the preferences will be used.
      *
      */
-    static std::vector<long> GetSupportedCaptureRates(int devIndex = -1);
+    static std::vector<long> GetSupportedCaptureRates(int devIndex = -1, int captureChannels = -1);
 
     /** \brief Find the closest supported sample rate for given
      *         recording device.
@@ -199,7 +200,7 @@ public:
      *
      * returns 0 if none is found or the input rate is invalid.
      */
-    static long GetClosestSupportedCaptureRate(int devIndex, long rate);
+    static long GetClosestSupportedCaptureRate(int devIndex, long rate, int captureChannels = -1);
 
     /** \brief Get a list of sample rates the current input/output device
      * combination supports.
@@ -213,7 +214,7 @@ public:
      * If you don't give them, the selected devices from the preferences
      * will be used.
      */
-    static std::vector<long> GetSupportedSampleRates(int playDevice = -1, int recDevice = -1);
+    static std::vector<long> GetSupportedSampleRates(int playDevice = -1, int recDevice = -1, int captureChannels = -1);
 
     /** \brief Find the closest supported sample rate for given
      *         playback and recording devices.
@@ -230,7 +231,7 @@ public:
      *
      * returns 0 if none is found or the input rate is invalid.
      */
-    static long GetClosestSupportedSampleRate(int playDevice, int recDevice, long rate);
+    static long GetClosestSupportedSampleRate(int playDevice, int recDevice, long rate, int captureChannels = -1);
 
     /** \brief Get a supported sample rate which can be used a an optimal
      * default.
@@ -254,7 +255,7 @@ public:
      * Verifies if a recording device supports a given rate.
      * If no device index is specified (devIndex == -1), the preferred device is used.
      */
-    static bool IsCaptureRateSupported(int devIndex, long rate);
+    static bool IsCaptureRateSupported(int devIndex, long rate, int captureChannels = -1);
 
     /** \brief Array of common audio sample rates
      *
@@ -354,8 +355,8 @@ protected:
 
     // For cacheing supported sample rates
     static std::map<int, std::vector<long> > mCachedPlaybackRates;
-    static std::map<int, std::vector<long> > mCachedCaptureRates;
-    static std::map<std::pair<int, int>, std::vector<long> > mCachedSampleRates;
+    static std::map<std::pair<int, int>, std::vector<long> > mCachedCaptureRates;
+    static std::map<std::tuple<int, int, int>, std::vector<long> > mCachedSampleRates;
     static int mCurrentPlaybackIndex;
     static int mCurrentCaptureIndex;
     static double mCachedBestRateIn;

--- a/au3/libraries/au3-audio-io/AudioIO.cpp
+++ b/au3/libraries/au3-audio-io/AudioIO.cpp
@@ -75,6 +75,7 @@ time warp info and AudioIOListener and whether the playback is looped.
 #include <math.h>
 #include <stdlib.h>
 #include <algorithm>
+#include <limits>
 #include <numeric>
 #include <optional>
 
@@ -262,6 +263,7 @@ AudioIO::AudioIO()
 
     mLastRecordingOffset = 0.0;
     mNumCaptureChannels = 0;
+    mNumInputStreamChannels = 0;
     mSilenceLevel = 0.0;
 
     ResetMeters();
@@ -499,8 +501,34 @@ bool AudioIO::StartPortAudioStream(const AudioIOStartStreamOptions& options,
     ResetMeters();
 
     mLastPaError = paNoError;
-    mInputChannelSelection
-        = audacity::audio_io::details::LegacyInputChannelSelection(numCaptureChannels);
+    mInputChannelIndices.clear();
+    mInputChannelSelection = options.inputChannelSelection;
+    if (numCaptureChannels > 0 && mInputChannelSelection.empty()) {
+        mInputChannelSelection
+            = audacity::audio_io::details::LegacyInputChannelSelection(numCaptureChannels);
+    }
+    if (numCaptureChannels > 0
+        && (!audacity::audio_io::details::IsStructurallyValidInputChannelSelection(mInputChannelSelection)
+            || audacity::audio_io::details::InputChannelSelectionCount(mInputChannelSelection)
+            != numCaptureChannels)) {
+        mLastPaError = paInvalidChannelCount;
+        return false;
+    }
+    mInputChannelIndices
+        = audacity::audio_io::details::FlattenInputChannelSelection(mInputChannelSelection);
+    mNumPlaybackChannels = numPlaybackChannels;
+    mNumCaptureChannels = numCaptureChannels;
+    mNumInputStreamChannels = 0;
+    if (numCaptureChannels > 0) {
+        mNumInputStreamChannels
+            = audacity::audio_io::details::InputChannelSelectionStreamWidth(
+            mInputChannelSelection);
+    }
+    if (mNumInputStreamChannels > static_cast<size_t>(std::numeric_limits<int>::max())) {
+        mLastPaError = paInvalidChannelCount;
+        return false;
+    }
+
     // pick a rate to do the audio I/O at, from those available. The project
     // rate is suggested, but we may get something else if it isn't supported
     mRate = 0.0;
@@ -517,7 +545,7 @@ bool AudioIO::StartPortAudioStream(const AudioIOStartStreamOptions& options,
 
     if (mRate == 0.0) {
         mRate = GetBestRate(numCaptureChannels > 0, numPlaybackChannels > 0, sampleRate,
-                            numCaptureChannels);
+                            mNumInputStreamChannels);
     }
 
     // GetBestRate() will return 0.0 for bidirectional streams when there is no
@@ -551,9 +579,6 @@ bool AudioIO::StartPortAudioStream(const AudioIOStartStreamOptions& options,
         // still working (assuming it worked before).
         mCaptureFormat = captureFormat;
     }
-
-    mNumPlaybackChannels = numPlaybackChannels;
-    mNumCaptureChannels = numCaptureChannels;
 
     bool usePlayback = false, useCapture = false;
     PaStreamParameters playbackParameters{};
@@ -647,7 +672,12 @@ bool AudioIO::StartPortAudioStream(const AudioIOStartStreamOptions& options,
             =AudacityToPortAudioSampleFormat(mCaptureFormat);
 
         captureParameters.hostApiSpecificStreamInfo = NULL;
-        captureParameters.channelCount = mNumCaptureChannels;
+        if (mNumInputStreamChannels == 0
+            || mNumInputStreamChannels > static_cast<size_t>(captureDeviceInfo->maxInputChannels)) {
+            mLastPaError = paInvalidChannelCount;
+            return false;
+        }
+        captureParameters.channelCount = static_cast<int>(mNumInputStreamChannels);
 
         if (mSoftwarePlaythrough && !isMME) {
             captureParameters.suggestedLatency
@@ -875,7 +905,15 @@ void AudioIO::StartMonitoring(const AudioIOStartStreamOptions& options)
     }
 
     const auto captureFormat = QualitySettings::SampleFormatChoice();
-    const auto captureChannels = AudioIORecordChannels.Read();
+    auto streamOptions = options;
+    if (streamOptions.inputChannelSelection.empty()) {
+        streamOptions.inputChannelSelection
+            = audacity::audio_io::details::LegacyInputChannelSelection(
+            std::max(1, AudioIORecordChannels.Read()));
+    }
+    const auto captureChannels
+        = audacity::audio_io::details::InputChannelSelectionCount(
+        streamOptions.inputChannelSelection);
     mSoftwarePlaythrough = options.inputMonitoring;
     int playbackChannels = 0;
 
@@ -888,7 +926,7 @@ void AudioIO::StartMonitoring(const AudioIOStartStreamOptions& options)
     mUsingAlsa = false;
     mCaptureFormat = captureFormat;
     mCaptureRate = 44100.0; // Shouldn't matter
-    const bool success = StartPortAudioStream(options,
+    const bool success = StartPortAudioStream(streamOptions,
                                               static_cast<unsigned int>(playbackChannels),
                                               static_cast<unsigned int>(captureChannels));
 
@@ -1073,9 +1111,11 @@ int AudioIO::StartStream(const TransportSequences& sequences,
     }
 
     if (mCaptureSequences.size() > 0) {
-        size_t requestedInputChannels = AudioIORecordChannels.Read();
+        size_t requestedInputChannels
+            = audacity::audio_io::details::InputChannelSelectionCount(
+            options.inputChannelSelection);
         if (requestedInputChannels == 0) {
-            requestedInputChannels = 1;
+            requestedInputChannels = std::max(1, AudioIORecordChannels.Read());
         }
         ConfigureCaptureRouting(requestedInputChannels);
         numCaptureChannels = requestedInputChannels;
@@ -1809,8 +1849,10 @@ void AudioIO::StopStream()
     ResetOwningProject();
 
     mNumCaptureChannels = 0;
+    mNumInputStreamChannels = 0;
     mNumPlaybackChannels = 0;
     mInputChannelSelection.clear();
+    mInputChannelIndices.clear();
 
     mPlaybackSequences.clear();
     mCaptureSequences.clear();
@@ -2447,8 +2489,8 @@ void AudioIO::DrainRecordBuffers()
             || deltat >= mMinCaptureSecsToCopy) {
             // Append captured samples to the end of the RecordableSequences.
             // (WaveTracks have their own buffering for efficiency.)
-            const size_t hardwareChannels = std::min(mNumCaptureChannels, mCaptureBuffers.size());
-            if (hardwareChannels == 0 || mCaptureChannelLayout.empty()) {
+            const size_t logicalChannels = std::min(mNumCaptureChannels, mCaptureBuffers.size());
+            if (logicalChannels == 0 || mCaptureChannelLayout.empty()) {
                 return;
             }
 
@@ -2458,11 +2500,11 @@ void AudioIO::DrainRecordBuffers()
                 sampleFormat format { floatSample };
             };
 
-            std::vector<CapturedChannelData> captured(hardwareChannels);
+            std::vector<CapturedChannelData> captured(logicalChannels);
             const bool forceFloatCapture = mCaptureNeedsMixdown
                                            || !mRecordingSchedule.mCrossfadeData.empty();
 
-            for (size_t i = 0; i < hardwareChannels; ++i) {
+            for (size_t i = 0; i < logicalChannels; ++i) {
                 size_t discarded = 0;
 
                 if (!mRecordingSchedule.mLatencyCorrected) {
@@ -2734,13 +2776,10 @@ void AudioIoCallback::CheckSoundActivatedRecordingLevel(
         return;
     }
 
-    float maxPeak = 0.;
-    for ( unsigned long i = 0, cnt = framesPerBuffer * mNumCaptureChannels; i < cnt; ++i ) {
-        float sample = fabs(*(inputSamples++));
-        if (sample > maxPeak) {
-            maxPeak = sample;
-        }
-    }
+    const float maxPeak
+        = audacity::audio_io::details::InputChannelSelectionPeak(
+        inputSamples, mNumInputStreamChannels, mInputChannelIndices,
+        framesPerBuffer);
 
     bool bShouldBePaused = maxPeak < mSilenceLevel;
     if (bShouldBePaused != IsPaused()) {
@@ -3047,6 +3086,7 @@ unsigned long AudioIoCallback::DrainInputBuffers(
     // possible issues with the (short*) cast.  We'd have a problem if
     // sizeof(short) > sizeof(float) since our buffers are sized for floats.
     for (unsigned t = 0; t < numCaptureChannels; t++) {
+        const auto inputChannel = mInputChannelIndices[t];
         // dmazzoni:
         // Un-interleave.  Ugly special-case code required because the
         // capture channels could be in three different sample formats;
@@ -3056,10 +3096,9 @@ unsigned long AudioIoCallback::DrainInputBuffers(
         switch (mCaptureFormat) {
         case floatSample: {
             auto inputFloats = (const float*)inputBuffer;
-            for (unsigned i = 0; i < len; i++) {
-                tempFloats[i]
-                    =inputFloats[numCaptureChannels * i + t];
-            }
+            audacity::audio_io::details::CopyInputChannel(
+                inputFloats, mNumInputStreamChannels, inputChannel,
+                tempFloats, len);
         } break;
         case int24Sample:
             // We should never get here. Audacity's int24Sample format
@@ -3071,11 +3110,9 @@ unsigned long AudioIoCallback::DrainInputBuffers(
         case int16Sample: {
             auto inputShorts = (const short*)inputBuffer;
             short* tempShorts = (short*)tempFloats;
-            for ( unsigned i = 0; i < len; i++) {
-                float tmp = inputShorts[numCaptureChannels * i + t];
-                tmp = std::clamp(tmp, -32768.0f, 32767.0f);
-                tempShorts[i] = (short)(tmp);
-            }
+            audacity::audio_io::details::CopyInputChannel(
+                inputShorts, mNumInputStreamChannels, inputChannel,
+                tempShorts, len);
         } break;
         } // switch
 
@@ -3148,7 +3185,7 @@ void AudioIoCallback::DoPlaythrough(
 
     if (inputSamples && mSoftwarePlaythrough) {
         audacity::audio_io::details::MixInputChannelSelectionToStereo(
-            inputSamples, mNumCaptureChannels, mInputChannelSelection,
+            inputSamples, mNumInputStreamChannels, mInputChannelSelection,
             outputBuffer, framesPerBuffer);
     }
 
@@ -3221,15 +3258,15 @@ void AudioIoCallback::PushInputMeterValues(const IMeterSenderPtr& sender, const 
                 continue;
             }
             if (sources.size() == 1) {
-                const auto physicalChannel = sources.front();
-                sender->push(ch, { values + physicalChannel, frames, mNumCaptureChannels, dacTime },
+                const auto physicalChannel = mInputChannelIndices[sources.front()];
+                sender->push(ch, { values + physicalChannel, frames, mNumInputStreamChannels, dacTime },
                              IMeterSender::TrackId { id });
             } else {
                 const auto mixed = stackAllocate(float, frames);
                 for (size_t frame = 0; frame < frames; ++frame) {
                     float value = 0.0f;
                     for (const auto source : sources) {
-                        value += values[frame * mNumCaptureChannels + source];
+                        value += values[frame * mNumInputStreamChannels + mInputChannelIndices[source]];
                     }
                     mixed[frame] = value / static_cast<float>(sources.size());
                 }
@@ -3239,22 +3276,28 @@ void AudioIoCallback::PushInputMeterValues(const IMeterSenderPtr& sender, const 
     }
 
     // Update main meter
-    // With one or two inputs, preserve individual levels.
-    if (mNumCaptureChannels <= 2) {
-        for (size_t ch = 0; ch < mNumCaptureChannels; ++ch) {
-            sender->push(ch, { values + ch, frames,
-                              mNumCaptureChannels, dacTime });
+    // With one or two inputs, preserve individual levels regardless of grouping.
+    if (mInputChannelIndices.size() <= 2) {
+        for (size_t ch = 0; ch < mInputChannelIndices.size(); ++ch) {
+            sender->push(ch, { values + mInputChannelIndices[ch], frames,
+                              mNumInputStreamChannels, dacTime });
         }
     } else {
         constexpr size_t mainMeterChannels = 2;
         const auto mainInput = stackAllocate(float, frames * mainMeterChannels);
         std::fill_n(mainInput, frames * mainMeterChannels, 0.0f);
 
-        // Use every input even before recording, and include both sample polarities.
+        // Preserve maximum-based metering without averaging or polarity cancellation.
+        // Use selected inputs even when no recording destination tracks exist yet.
         for (size_t frame = 0; frame < frames; ++frame) {
-            for (size_t inputChannel = 0; inputChannel < mNumCaptureChannels; ++inputChannel) {
-                auto& peak = mainInput[(inputChannel % mainMeterChannels) * frames + frame];
-                peak = std::max(peak, std::fabs(values[frame * mNumCaptureChannels + inputChannel]));
+            for (size_t groupIndex = 0; groupIndex < mInputChannelSelection.size(); ++groupIndex) {
+                const auto& group = mInputChannelSelection[groupIndex];
+                for (size_t ch = 0; ch < group.size(); ++ch) {
+                    // Mono groups alternate bars; stereo groups keep their left/right channels.
+                    const size_t meterChannel = group.size() == 1 ? groupIndex % mainMeterChannels : ch;
+                    auto& peak = mainInput[meterChannel * frames + frame];
+                    peak = std::max(peak, std::fabs(values[frame * mNumInputStreamChannels + group[ch]]));
+                }
             }
         }
 
@@ -3378,7 +3421,7 @@ int AudioIoCallback::AudioCallback(
     const auto numPlaybackChannels = mNumPlaybackChannels;
     const auto numCaptureChannels = mNumCaptureChannels;
     const auto tempFloats = stackAllocate(float,
-                                          framesPerBuffer * std::max(numCaptureChannels, numPlaybackChannels));
+                                          framesPerBuffer * std::max(mNumInputStreamChannels, numPlaybackChannels));
 
     bool bVolEmulationActive
         =(outputBuffer && GetMixerOutputVol() != 1.0);
@@ -3399,7 +3442,7 @@ int AudioIoCallback::AudioCallback(
         if (!mInputMixerWorks) {
             const float gain = GetSoftwareRecordGain();
             if (gain != 1.0f) {
-                const size_t numSamples = framesPerBuffer * numCaptureChannels;
+                const size_t numSamples = framesPerBuffer * mNumInputStreamChannels;
                 const auto scratch = stackAllocate(char, numSamples * SAMPLE_SIZE(mCaptureFormat));
                 inputBuffer = ApplyRecordGain(inputBuffer, gain, numSamples, scratch);
             }
@@ -3409,7 +3452,7 @@ int AudioIoCallback::AudioCallback(
             inputSamples = (float*)inputBuffer;
         } else {
             SamplesToFloats(reinterpret_cast<constSamplePtr>(inputBuffer),
-                            mCaptureFormat, tempFloats, framesPerBuffer * numCaptureChannels);
+                            mCaptureFormat, tempFloats, framesPerBuffer * mNumInputStreamChannels);
             inputSamples = tempFloats;
         }
 

--- a/au3/libraries/au3-audio-io/AudioIO.cpp
+++ b/au3/libraries/au3-audio-io/AudioIO.cpp
@@ -62,6 +62,7 @@ time warp info and AudioIOListener and whether the playback is looped.
 
 #include "AudioIOExt.h"
 #include "AudioIOListener.h"
+#include "internal/AudioIOInputChannelSelection.h"
 
 #include "au3-math/float_cast.h"
 #include "au3-math/Resample.h"
@@ -497,6 +498,8 @@ bool AudioIO::StartPortAudioStream(const AudioIOStartStreamOptions& options,
     ResetMeters();
 
     mLastPaError = paNoError;
+    mInputChannelSelection
+        = audacity::audio_io::details::LegacyInputChannelSelection(numCaptureChannels);
     // pick a rate to do the audio I/O at, from those available. The project
     // rate is suggested, but we may get something else if it isn't supported
     mRate = 0.0;
@@ -1805,6 +1808,7 @@ void AudioIO::StopStream()
 
     mNumCaptureChannels = 0;
     mNumPlaybackChannels = 0;
+    mInputChannelSelection.clear();
 
     mPlaybackSequences.clear();
     mCaptureSequences.clear();
@@ -2698,27 +2702,6 @@ void AudioIoCallback::SetListener(
     mListener = listener;
 }
 
-static void DoSoftwarePlaythrough(constSamplePtr inputBuffer,
-                                  sampleFormat inputFormat,
-                                  unsigned inputChannels,
-                                  float* outputBuffer,
-                                  unsigned long len)
-{
-    for (unsigned int i=0; i < inputChannels; i++) {
-        auto inputPtr = inputBuffer + (i * SAMPLE_SIZE(inputFormat));
-
-        SamplesToFloats(inputPtr, inputFormat,
-                        outputBuffer + i, len, inputChannels, 2);
-    }
-
-    // One mono input channel goes to both output channels...
-    if (inputChannels == 1) {
-        for (int i=0; i < len; i++) {
-            outputBuffer[2 * i + 1] = outputBuffer[2 * i];
-        }
-    }
-}
-
 int audacityAudioCallback(const void* inputBuffer, void* outputBuffer,
                           unsigned long framesPerBuffer,
                           const PaStreamCallbackTimeInfo* timeInfo,
@@ -3139,12 +3122,11 @@ void OldCodeToCalculateLatency()
 // return true, IFF we have fully handled the callback.
 // Prime the output buffer with 0's, optionally adding in the playthrough.
 void AudioIoCallback::DoPlaythrough(
-    constSamplePtr inputBuffer,
+    const float* inputSamples,
     float* outputBuffer,
     unsigned long framesPerBuffer,
     float* outputMeterFloats)
 {
-    const auto numCaptureChannels = mNumCaptureChannels;
     const auto numPlaybackChannels = mNumPlaybackChannels;
 
     // Quick returns if next to nothing to do.
@@ -3160,10 +3142,10 @@ void AudioIoCallback::DoPlaythrough(
         outputFloats[i] = 0.0;
     }
 
-    if (inputBuffer && mSoftwarePlaythrough) {
-        DoSoftwarePlaythrough(inputBuffer, mCaptureFormat,
-                              numCaptureChannels,
-                              outputBuffer, framesPerBuffer);
+    if (inputSamples && mSoftwarePlaythrough) {
+        audacity::audio_io::details::MixInputChannelSelectionToStereo(
+            inputSamples, mNumCaptureChannels, mInputChannelSelection,
+            outputBuffer, framesPerBuffer);
     }
 
     // Copy the results to outputMeterFloats if necessary
@@ -3407,8 +3389,8 @@ int AudioIoCallback::AudioCallback(
     const auto levelDisplayTime = std::chrono::steady_clock::now()
                                   + std::chrono::milliseconds(static_cast<int>(mHardwarePlaybackLatencyMs));
 
+    float* inputSamples = nullptr;
     if (inputBuffer && numCaptureChannels) {
-        float* inputSamples;
 
         if (!mInputMixerWorks) {
             const float gain = GetSoftwareRecordGain();
@@ -3445,7 +3427,7 @@ int AudioIoCallback::AudioCallback(
     // Initialise output buffer to zero or to playthrough data.
     // Initialise output meter values.
     DoPlaythrough(
-        inputBuffer,
+        inputSamples,
         outputBuffer,
         framesPerBuffer,
         outputMeterFloats);

--- a/au3/libraries/au3-audio-io/AudioIO.cpp
+++ b/au3/libraries/au3-audio-io/AudioIO.cpp
@@ -186,6 +186,7 @@ int AudioIoCallback::mNextStreamToken = 0;
 double AudioIoCallback::mCachedBestRateOut;
 bool AudioIoCallback::mCachedBestRatePlaying;
 bool AudioIoCallback::mCachedBestRateCapturing;
+size_t AudioIoCallback::mCachedBestRateInputStreamChannels;
 
 #ifdef __WXGTK__
 // Might #define this for a useful thing on Linux
@@ -515,7 +516,8 @@ bool AudioIO::StartPortAudioStream(const AudioIOStartStreamOptions& options,
     }
 
     if (mRate == 0.0) {
-        mRate = GetBestRate(numCaptureChannels > 0, numPlaybackChannels > 0, sampleRate);
+        mRate = GetBestRate(numCaptureChannels > 0, numPlaybackChannels > 0, sampleRate,
+                            numCaptureChannels);
     }
 
     // GetBestRate() will return 0.0 for bidirectional streams when there is no
@@ -1848,11 +1850,12 @@ void AudioIO::SetPaused(bool state, bool publish)
     }
 }
 
-double AudioIO::GetBestRate(bool capturing, bool playing, double sampleRate)
+double AudioIO::GetBestRate(bool capturing, bool playing, double sampleRate, size_t inputStreamChannels)
 {
     // Check if we can use the cached value
     if (mCachedBestRateIn != 0.0 && mCachedBestRateIn == sampleRate
-        && mCachedBestRatePlaying == playing && mCachedBestRateCapturing == capturing) {
+        && mCachedBestRatePlaying == playing && mCachedBestRateCapturing == capturing
+        && mCachedBestRateInputStreamChannels == inputStreamChannels) {
         return mCachedBestRateOut;
     }
 
@@ -1868,12 +1871,12 @@ double AudioIO::GetBestRate(bool capturing, bool playing, double sampleRate)
     long supportedRate = 0;
 
     if (capturing && !playing) {
-        supportedRate = GetClosestSupportedCaptureRate(-1, sampleRate);
+        supportedRate = GetClosestSupportedCaptureRate(-1, sampleRate, static_cast<int>(inputStreamChannels));
     } else if (playing && !capturing) {
         supportedRate = GetClosestSupportedPlaybackRate(-1, sampleRate);
     } else { // we assume capturing and playing - the alternative would be a
              // bit odd
-        supportedRate = GetClosestSupportedSampleRate(-1, -1, sampleRate);
+        supportedRate = GetClosestSupportedSampleRate(-1, -1, sampleRate, static_cast<int>(inputStreamChannels));
     }
 
     /* if we get here, there is a problem - the project rate isn't supported
@@ -1890,6 +1893,7 @@ double AudioIO::GetBestRate(bool capturing, bool playing, double sampleRate)
     mCachedBestRateOut = supportedRate;
     mCachedBestRatePlaying = playing;
     mCachedBestRateCapturing = capturing;
+    mCachedBestRateInputStreamChannels = inputStreamChannels;
     return supportedRate;
 }
 

--- a/au3/libraries/au3-audio-io/AudioIO.cpp
+++ b/au3/libraries/au3-audio-io/AudioIO.cpp
@@ -69,6 +69,7 @@ time warp info and AudioIOListener and whether the playback is looped.
 #include "au3-audio-devices/DeviceManager.h"
 
 #include <cfloat>
+#include <cmath>
 #include <cstring>
 #include <math.h>
 #include <stdlib.h>
@@ -3221,39 +3222,58 @@ void AudioIoCallback::PushInputMeterValues(const IMeterSenderPtr& sender, const 
     }
 
     // Update meter tracks
-    auto sptr = values;
+    size_t destinationChannel = 0;
     for (const auto& sequence : mCaptureSequences) {
         auto nChannels = sequence->NChannels();
         const int64_t id = sequence->GetRecordableSequenceId();
         for (size_t ch = 0; ch < nChannels; ch++) {
-            // Map track channel to input channel, wrapping if track has more channels than input
-            size_t inputCh = ch % mNumCaptureChannels;
-            sender->push(ch, { sptr + inputCh, frames, mNumCaptureChannels, dacTime }, IMeterSender::TrackId { id });
+            if (destinationChannel >= mTrackChannelSourceMap.size()) {
+                break;
+            }
+            const auto& sources = mTrackChannelSourceMap[destinationChannel++];
+            if (sources.empty()) {
+                continue;
+            }
+            if (sources.size() == 1) {
+                const auto physicalChannel = sources.front();
+                sender->push(ch, { values + physicalChannel, frames, mNumCaptureChannels, dacTime },
+                             IMeterSender::TrackId { id });
+            } else {
+                const auto mixed = stackAllocate(float, frames);
+                for (size_t frame = 0; frame < frames; ++frame) {
+                    float value = 0.0f;
+                    for (const auto source : sources) {
+                        value += values[frame * mNumCaptureChannels + source];
+                    }
+                    mixed[frame] = value / static_cast<float>(sources.size());
+                }
+                sender->push(ch, { mixed, frames, 1, dacTime }, IMeterSender::TrackId { id });
+            }
         }
     }
 
     // Update main meter
-    // If the input source has more than 2 channels it will be splitted on multiple mono sequences
+    // With one or two inputs, preserve individual levels.
     if (mNumCaptureChannels <= 2) {
         for (size_t ch = 0; ch < mNumCaptureChannels; ++ch) {
-            sender->push(ch, { sptr + ch, frames, mNumCaptureChannels, dacTime });
+            sender->push(ch, { values + ch, frames,
+                              mNumCaptureChannels, dacTime });
         }
     } else {
-        constexpr size_t maxMainTrackChannels = 2;
-        const auto mainTrackInput = stackAllocate(float, frames * maxMainTrackChannels);
-        std::memset(mainTrackInput, 0, frames * maxMainTrackChannels * sizeof(float));
+        constexpr size_t mainMeterChannels = 2;
+        const auto mainInput = stackAllocate(float, frames * mainMeterChannels);
+        std::fill_n(mainInput, frames * mainMeterChannels, 0.0f);
 
-        for (size_t i = 0; i < frames; ++i) {
-            for (size_t seqNum = 0; seqNum < mCaptureSequences.size(); seqNum++) {
-                const auto channel = seqNum % maxMainTrackChannels;
-                mainTrackInput[channel * frames + i] = std::max(
-                    mainTrackInput[channel * frames + i], *sptr);
-                sptr++;
+        // Use every input even before recording, and include both sample polarities.
+        for (size_t frame = 0; frame < frames; ++frame) {
+            for (size_t inputChannel = 0; inputChannel < mNumCaptureChannels; ++inputChannel) {
+                auto& peak = mainInput[(inputChannel % mainMeterChannels) * frames + frame];
+                peak = std::max(peak, std::fabs(values[frame * mNumCaptureChannels + inputChannel]));
             }
         }
 
-        for (size_t ch = 0; ch < maxMainTrackChannels; ++ch) {
-            sender->push(ch, { mainTrackInput + ch * frames, frames, 1, dacTime });
+        for (size_t ch = 0; ch < mainMeterChannels; ++ch) {
+            sender->push(ch, { mainInput + ch * frames, frames, 1, dacTime });
         }
     }
 }

--- a/au3/libraries/au3-audio-io/AudioIO.h
+++ b/au3/libraries/au3-audio-io/AudioIO.h
@@ -360,6 +360,7 @@ protected:
     static double mCachedBestRateOut;
     static bool mCachedBestRatePlaying;
     static bool mCachedBestRateCapturing;
+    static size_t mCachedBestRateInputStreamChannels;
 
     // Serialize main thread and PortAudio thread's attempts to pause and change
     // the state used by the third, Audio thread.
@@ -564,7 +565,7 @@ public:
     * audio to be handled, i.e. the currently Project Rate).
     * capturing is true if the stream is capturing one or more audio channels,
     * and playing is true if one or more channels are being played. */
-    double GetBestRate(bool capturing, bool playing, double sampleRate);
+    double GetBestRate(bool capturing, bool playing, double sampleRate, size_t inputStreamChannels);
 
     /** \brief During playback, the sequence time most recently played
      *

--- a/au3/libraries/au3-audio-io/AudioIO.h
+++ b/au3/libraries/au3-audio-io/AudioIO.h
@@ -210,7 +210,7 @@ public:
     void UpdateTimePosition(
         unsigned long framesPerBuffer);
     void DoPlaythrough(
-        constSamplePtr inputBuffer, float* outputBuffer, unsigned long framesPerBuffer, float* outputMeterFloats);
+        const float* inputSamples, float* outputBuffer, unsigned long framesPerBuffer, float* outputMeterFloats);
     void SendVuInputMeterData(const float* inputSamples, unsigned long framesPerBuffer, const TimePoint& dacTime);
     void SendVuOutputMeterData(const float* outputMeterFloats, unsigned long framesPerBuffer, const TimePoint& dacTime);
     void PushMasterOutputMeterValues(const IMeterSenderPtr& sender, const float* values, uint8_t channels, unsigned long frames,
@@ -245,6 +245,7 @@ public:
     std::vector<TrackChannelInfo> mCaptureChannelLayout;
     std::vector<std::vector<size_t> > mTrackChannelSourceMap;
     bool mCaptureNeedsMixdown{ false };
+    std::vector<std::vector<unsigned int> > mInputChannelSelection;
     //!Buffers that hold outcome of transformations applied to each individual sample source.
     //!Number of buffers equals to the sum of number all source channels.
     std::vector<std::vector<float> > mProcessingBuffers;

--- a/au3/libraries/au3-audio-io/AudioIO.h
+++ b/au3/libraries/au3-audio-io/AudioIO.h
@@ -246,6 +246,7 @@ public:
     std::vector<std::vector<size_t> > mTrackChannelSourceMap;
     bool mCaptureNeedsMixdown{ false };
     std::vector<std::vector<unsigned int> > mInputChannelSelection;
+    std::vector<unsigned int> mInputChannelIndices;
     //!Buffers that hold outcome of transformations applied to each individual sample source.
     //!Number of buffers equals to the sum of number all source channels.
     std::vector<std::vector<float> > mProcessingBuffers;
@@ -293,8 +294,11 @@ public:
     /*! Read by a worker thread but unchanging during playback */
     bool mPauseRec;
     float mSilenceLevel;
-    /*! Read by a worker thread but unchanging during playback */
+    /*! Flattened selected logical input count. Read by a worker thread but
+        unchanging during playback. */
     size_t mNumCaptureChannels;
+    /*! Raw interleaved PortAudio input width; may exceed the selected count. */
+    size_t mNumInputStreamChannels{};
     /*! Read by a worker thread but unchanging during playback */
     size_t mNumPlaybackChannels;
     sampleFormat mCaptureFormat;

--- a/au3/libraries/au3-audio-io/CMakeLists.txt
+++ b/au3/libraries/au3-audio-io/CMakeLists.txt
@@ -22,6 +22,7 @@ set( SOURCES
    ProjectAudioIO.h
    RingBuffer.cpp
    RingBuffer.h
+   internal/AudioIOInputChannelSelection.h
 )
 set( LIBRARIES
 PUBLIC

--- a/au3/libraries/au3-audio-io/internal/AudioIOInputChannelSelection.h
+++ b/au3/libraries/au3-audio-io/internal/AudioIOInputChannelSelection.h
@@ -11,6 +11,24 @@
 namespace audacity::audio_io::details {
 using InputChannelSelection = std::vector<std::vector<unsigned int> >;
 
+inline bool IsStructurallyValidInputChannelSelection(
+    const InputChannelSelection& selection)
+{
+    std::vector<unsigned int> usedChannels;
+    for (const auto& group : selection) {
+        if (group.empty() || group.size() > 2) {
+            return false;
+        }
+        for (const auto channel : group) {
+            if (std::find(usedChannels.begin(), usedChannels.end(), channel) != usedChannels.end()) {
+                return false;
+            }
+            usedChannels.push_back(channel);
+        }
+    }
+    return true;
+}
+
 inline InputChannelSelection LegacyInputChannelSelection(size_t channels)
 {
     if (channels == 1) {
@@ -25,6 +43,55 @@ inline InputChannelSelection LegacyInputChannelSelection(size_t channels)
         result.push_back({ static_cast<unsigned int>(channel) });
     }
     return result;
+}
+
+inline size_t InputChannelSelectionCount(const InputChannelSelection& selection)
+{
+    size_t result = 0;
+    for (const auto& group : selection) {
+        result += group.size();
+    }
+    return result;
+}
+
+inline std::vector<unsigned int> FlattenInputChannelSelection(
+    const InputChannelSelection& selection)
+{
+    std::vector<unsigned int> result;
+    result.reserve(InputChannelSelectionCount(selection));
+    for (const auto& group : selection) {
+        result.insert(result.end(), group.begin(), group.end());
+    }
+    return result;
+}
+
+inline size_t InputChannelSelectionStreamWidth(
+    const InputChannelSelection& selection)
+{
+    size_t result = 0;
+    for (const auto& group : selection) {
+        for (const auto channel : group) {
+            result = std::max(result, static_cast<size_t>(channel) + 1);
+        }
+    }
+    return result;
+}
+
+template<typename Sample>
+inline bool CopyInputChannel(
+    const Sample* inputSamples, size_t inputStreamChannels,
+    unsigned int inputChannel, Sample* outputSamples, size_t frames)
+{
+    if (!inputSamples || !outputSamples || inputStreamChannels == 0
+        || inputChannel >= inputStreamChannels) {
+        return false;
+    }
+
+    for (size_t frame = 0; frame < frames; ++frame) {
+        outputSamples[frame]
+            = inputSamples[frame * inputStreamChannels + inputChannel];
+    }
+    return true;
 }
 
 inline void MixInputChannelSelectionToStereo(
@@ -56,4 +123,25 @@ inline void MixInputChannelSelectionToStereo(
     }
 }
 
+inline float InputChannelSelectionPeak(
+    const float* inputSamples, size_t inputStreamChannels,
+    const std::vector<unsigned int>& inputChannelIndices, size_t frames)
+{
+    if (!inputSamples || inputStreamChannels == 0) {
+        return 0.0f;
+    }
+
+    float maxPeak = 0.0f;
+    for (size_t frame = 0; frame < frames; ++frame) {
+        for (const auto channel : inputChannelIndices) {
+            if (channel >= inputStreamChannels) {
+                continue;
+            }
+            maxPeak = std::max(
+                maxPeak,
+                std::fabs(inputSamples[frame * inputStreamChannels + channel]));
+        }
+    }
+    return maxPeak;
+}
 }

--- a/au3/libraries/au3-audio-io/internal/AudioIOInputChannelSelection.h
+++ b/au3/libraries/au3-audio-io/internal/AudioIOInputChannelSelection.h
@@ -1,0 +1,59 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+#pragma once
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <vector>
+
+namespace audacity::audio_io::details {
+using InputChannelSelection = std::vector<std::vector<unsigned int> >;
+
+inline InputChannelSelection LegacyInputChannelSelection(size_t channels)
+{
+    if (channels == 1) {
+        return { { 0 } };
+    }
+    if (channels == 2) {
+        return { { 0, 1 } };
+    }
+
+    InputChannelSelection result;
+    for (size_t channel = 0; channel < channels; ++channel) {
+        result.push_back({ static_cast<unsigned int>(channel) });
+    }
+    return result;
+}
+
+inline void MixInputChannelSelectionToStereo(
+    const float* inputSamples, size_t inputStreamChannels,
+    const InputChannelSelection& selection,
+    float* outputBuffer, size_t frames)
+{
+    if (!inputSamples || inputStreamChannels == 0 || selection.empty()
+        || !outputBuffer) {
+        return;
+    }
+
+    const auto divisor = static_cast<float>(selection.size());
+    for (size_t frame = 0; frame < frames; ++frame) {
+        float left = 0.0f;
+        float right = 0.0f;
+        const auto* frameSamples = inputSamples + frame * inputStreamChannels;
+        for (const auto& group : selection) {
+            if (group.size() == 1) {
+                left += frameSamples[group[0]];
+                right += frameSamples[group[0]];
+            } else if (group.size() == 2) {
+                left += frameSamples[group[0]];
+                right += frameSamples[group[1]];
+            }
+        }
+        outputBuffer[2 * frame] = std::clamp(left / divisor, -1.0f, 1.0f);
+        outputBuffer[2 * frame + 1] = std::clamp(right / divisor, -1.0f, 1.0f);
+    }
+}
+
+}

--- a/docs/recording-input-channel-selection-architecture.md
+++ b/docs/recording-input-channel-selection-architecture.md
@@ -1,0 +1,256 @@
+# ADR: Grouped recording input-channel selection
+
+Date: 2026-09-04
+
+## Status
+
+Proposed
+
+## Context
+
+Audacity previously stored one recording-channel count. Selecting `N` meant
+opening and recording the physical prefix `1..N`, so channels 3 and 4 could not
+be recorded without also recording channels 1 and 2.
+
+One integer was serving several different purposes:
+
+- the user's source selection;
+- PortAudio's input stream width;
+- the number of logical capture buffers; and
+- the number and layout of destination track channels.
+
+Those values diverge as soon as a user selects a high or non-contiguous input.
+For example, mono channel 1 plus stereo channels 3+4 is three logical capture
+channels arranged as two recording groups, while a portable PortAudio stream
+must be four channels wide.
+
+The feature crosses two repository layers. The application configuration, UI,
+recording controller, and AU3 adapter live under `src/`. Device discovery,
+PortAudio stream management, and the real-time capture path live under
+`au3/libraries/`. The `muse` submodule supplies framework primitives but does
+not own Audacity's recording policy, so this feature is implemented in the
+Audacity repository.
+
+Audacity also has one process-wide AudioIO stream. Selection changes therefore
+continue to use the existing driver-controller transaction, stream ownership,
+suspension, rollback, and notification behavior.
+
+## Decision
+
+### Model selected recording groups explicitly
+
+The authoritative configuration value is an ordered collection of groups:
+
+```cpp
+using InputChannelIndex = uint32_t;
+
+struct InputChannelGroup {
+    std::vector<InputChannelIndex> channels;
+};
+
+using InputChannelSelection = std::vector<InputChannelGroup>;
+```
+
+For this increment:
+
+- a one-channel group represents a mono destination;
+- a two-channel group represents a stereo destination;
+- every physical channel is offered as mono;
+- stereo groups are conventional non-overlapping pairs `1+2`, `3+4`, and so
+  on;
+- groups and channels are stored in ascending physical order;
+- a physical channel may occur in only one group; and
+- at least one group remains selected while the device has inputs.
+
+Choosing a group atomically replaces any selected group that overlaps it.
+Thus choosing `1+2` removes mono `1` and mono `2`, while choosing mono `1`
+removes stereo `1+2`.
+
+The logical channel count is derived by flattening the groups. The PortAudio
+stream width is derived separately as `highest selected physical index + 1`.
+Neither is independently writable application configuration.
+
+### Keep policy and persistence in the driver controller
+
+`IAudioDriverController` remains the owner of process-wide audio
+configuration. `Au3AudioDriverController` normalizes selections against the
+resolved device capacity, persists them, emits a typed configuration delta,
+and applies them through the existing stream transaction.
+
+The versioned setting `AudioIO/RecordChannelSelectionV1` stores nested,
+zero-based lists. For example, mono 1 plus stereo 3+4 is stored as
+`[[0], [2, 3]]`.
+
+Legacy `AudioIO/RecordChannels` values are clamped to the available input
+capacity before migrating as follows (zero available inputs yields an empty
+selection):
+
+| Legacy value | Grouped selection | Preserved layout |
+| --- | --- | --- |
+| `1` | `[[0]]` | one mono track |
+| `2` | `[[0, 1]]` | one stereo track |
+| `N > 2` | `[[0], [1], ...]` | `N` mono tracks |
+
+The old setting is mirrored as the flattened logical channel count for legacy
+readers. It is compatibility data, not a second source of truth. The physical
+route and required PortAudio prefix width come from the versioned selection.
+
+On an input-device or capacity change, an exact legacy preset retains its
+count-based behavior: its count is reduced to the available capacity and the
+corresponding preset is selected. For example, four mono inputs reduced to a
+two-input device become stereo 1+2. Increasing capacity does not restore
+discarded inputs.
+
+Custom selections retain groups that remain fully in range, discard invalid
+groups, and fall back to mono channel 1 if nothing valid remains. Separate
+mono groups 1 and 2 remain separate, including previously saved selections;
+they are not the stereo preset. Per-device selection memory is deferred.
+
+### Snapshot the selection at stream startup
+
+Recording and monitoring pass the validated selection through
+`IAudioEngine::StartStreamOptions` (or the explicit monitoring argument) into
+`AudioIOStartStreamOptions`. AudioIO stores that route for the stream lifetime
+and does not reread mutable preferences to decide which samples to use.
+
+The modern application type is converted to a plain nested vector at the AU3
+adapter boundary, keeping the legacy library independent of `src/audio`.
+Application policy limits stereo choices to conventional adjacent pairs in
+this increment. AudioIO validates only executable route structure, uniqueness,
+logical channel count, and device range, so that policy does not leak into the
+engine.
+
+### Separate physical, stream, logical, and destination channels
+
+```mermaid
+flowchart LR
+    D[Physical device channels]
+    P[PortAudio prefix stream]
+    L[Selected logical channels]
+    G[Mono/stereo recording groups]
+    T[Destination tracks]
+
+    D --> P
+    P -->|physical index route| L
+    L --> G
+    G --> T
+```
+
+The portable implementation opens the prefix ending at the highest selected
+physical channel. AudioIO allocates capture buffers only for the flattened
+logical selection and deinterleaves each buffer from its selected physical
+index using the raw PortAudio stride.
+
+For `[[0], [2, 3]]`, PortAudio opens four channels, while AudioIO creates three
+logical capture buffers sourced from stream channels 0, 2, and 3. New-track
+recording creates one mono track followed by one stereo track.
+
+Recording into existing selected tracks preserves the previous total-channel
+compatibility and mono/stereo up/down-mix behavior. Grouping controls the
+layout of newly created tracks; it does not silently redefine existing-track
+selection rules.
+
+### Route every live-input consumer
+
+All consumers use the immutable selected route:
+
+- disk recording receives only flattened selected channels;
+- per-track meters follow the logical-to-track route;
+- the main input meter displays one or two selected logical channels
+  independently, regardless of grouping; larger selections use the maximum
+  sample magnitude contributing to each of its two bars;
+- sound-activated recording inspects only selected physical channels; and
+- software playthrough mixes selected groups to stereo, centering mono groups,
+  preserving stereo left/right, dividing by the number of groups, and
+  clamping the result.
+
+For main metering with three or more inputs, mono groups contribute to the
+left bar at even group indices and the right bar at odd indices. Stereo
+groups always contribute their first and second inputs to the left and right
+bars respectively. Group indices refer to the stored selection order. The
+resulting per-sample magnitude envelopes feed the existing peak/RMS
+calculation without averaging or an additional clamp in AudioIO.
+
+This preserves the legacy maximum-based approach while explicitly correcting
+its missing multichannel meter signal before recording, incorrect source
+indexing when destination-track counts differ, and discarded negative
+samples. Per-track metering also corrects the legacy repeated-first-input
+behavior and reflects the existing stereo-to-mono downmix or mono-to-stereo
+duplication. Ordinary mono/stereo main-meter samples and the downstream
+peak/RMS calculation, clipping, decay, and timing remain unchanged.
+
+### Keep the first release cross-platform
+
+PortAudio is used by Audacity's active desktop audio path on macOS, Windows,
+and Linux. Its generic stream interface reliably accepts a channel count but
+does not expose one universal arbitrary channel-map API. The first increment
+therefore uses prefix-and-route on Core Audio, WASAPI/ASIO, ALSA/JACK, and other
+PortAudio hosts.
+
+Native compact maps remain a later optimization. They may reduce transferred
+channels but must not change the configuration model, group order, track
+layout, or monitor mix.
+
+Sample-rate capability caches include the actual input stream width in their
+keys. This prevents a rate probed for a narrow stream from being reused for a
+wider prefix.
+
+### Use count presets in Audio Setup and edit groups in Preferences
+
+Preferences uses a multi-select popup and retains staged Apply/Cancel
+semantics. It shows numeric mono labels (`1`, `2`, ...) and stereo labels
+(`1+2`, `3+4`, ...), using the shared domain toggle and normalization rules.
+
+The Audio Setup toolbar retains the channel-count presets from `1` through
+the input device's capacity. Choosing a preset replaces the entire selection
+immediately using the legacy mapping: `1` is mono channel 1, `2` is stereo
+1+2, and higher counts select the first N channels as separate mono groups.
+A preset is checked only when the complete selection, including grouping,
+matches it. Choosing the active preset leaves the selection unchanged and
+keeps it checked.
+
+An ordinary, non-checkable `Custom...` command follows the presets after a
+separator and opens the existing Audio settings page without changing the
+selection. A nonempty selection that matches no available preset changes
+the parent submenu label to `Recording channels: Custom`; no preset is
+checked. With no available inputs or an empty selection the label remains
+`Recording channels`.
+A device with no inputs offers only `Custom...`, without a separator.
+
+This keeps custom state separate from the command that opens its editor.
+The toolbar retains the shared menu's normal close-on-activation behavior;
+making it a persistent multi-select editor would require changes to Muse's
+menu lifecycle. The existing Preferences popup already supports editing
+multiple groups without reopening it.
+
+## Consequences
+
+The feature works consistently across supported desktop platforms without
+waiting for host-specific channel maps. Recording channels 3+4 no longer
+creates unwanted tracks for channels 1+2, although a generic backend still
+transfers the lower channels internally as part of the PortAudio prefix.
+
+Channel identity now survives from UI configuration to the real-time callback,
+and count-based callers cannot independently overwrite it. The cost is a
+broader change spanning configuration, persistence, stream startup, real-time
+routing, track creation, meters, and two UI surfaces.
+
+## Deferred work
+
+- remembering selections independently per input endpoint;
+- host-provided channel names;
+- native compact maps for individual host APIs;
+- arbitrary stereo pairs;
+- user-defined group or channel ordering; and
+- a richer multichannel meter presentation.
+
+## Alternatives considered
+
+Keeping a count plus a bit mask was rejected because it preserves two writable
+sources of truth and does not represent destination grouping. Filtering only
+before track writes was rejected because monitoring, meters, and sound
+activation would disagree with the recording. Implementing only on hosts with
+native channel maps was rejected because the feature would not be
+cross-platform. Moving the implementation into `muse` was rejected because
+the framework does not own Audacity's configuration transaction, recording
+track policy, or AU3 PortAudio path.

--- a/src/au3audio/CMakeLists.txt
+++ b/src/au3audio/CMakeLists.txt
@@ -17,6 +17,7 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/internal/au3audioengine.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/au3audiodrivercontroller.cpp
     ${CMAKE_CURRENT_LIST_DIR}/internal/au3audiodrivercontroller.h
+    ${CMAKE_CURRENT_LIST_DIR}/internal/inputchannelselectionsettings.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/au3audioiolistener.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/defaultplaybackpolicy.cpp
     ${CMAKE_CURRENT_LIST_DIR}/internal/defaultplaybackpolicy.h

--- a/src/au3audio/internal/au3audiodrivercontroller.cpp
+++ b/src/au3audio/internal/au3audiodrivercontroller.cpp
@@ -21,6 +21,8 @@
 #include "au3wrap/au3types.h"
 #include "au3wrap/internal/wxtypes_convert.h"
 
+#include "inputchannelselectionsettings.h"
+
 #include "au3-audio-devices/AudioIOBase.h"
 #include "au3-audio-devices/DeviceManager.h"
 #include "au3-project-rate/ProjectRate.h"
@@ -36,6 +38,7 @@ const muse::Settings::Key AUDIO_HOST("au3audio", "AudioIO/Host");
 const muse::Settings::Key PLAYBACK_DEVICE("au3audio", "AudioIO/PlaybackDevice");
 const muse::Settings::Key RECORDING_DEVICE("au3audio", "AudioIO/RecordingDevice");
 const muse::Settings::Key INPUT_CHANNELS("au3audio", "AudioIO/RecordChannels");
+const muse::Settings::Key INPUT_CHANNEL_SELECTION("au3audio", "AudioIO/RecordChannelSelectionV1");
 const muse::Settings::Key AUTOMATIC_LATENCY_COMPENSATION("au3audio", "AudioIO/AutomaticLatencyCompensation");
 const muse::Settings::Key LATENCY_DURATION("au3audio", "AudioIO/LatencyDuration");
 const muse::Settings::Key LATENCY_COMPENSATION("au3audio", "AudioIO/LatencyCompensation");
@@ -176,12 +179,13 @@ void Au3AudioDriverController::init()
     const auto inputDevice = selectionFromSetting(settings()->value(RECORDING_DEVICE).toString());
     refreshInputDeviceSettings(api, inputDevice);
     const auto availableChannels = inputChannelsAvailable(api, inputDevice);
-    const auto inputChannels
-        = availableChannels > 0
-          ? std::clamp(settings()->value(INPUT_CHANNELS).toInt(), 1,
-                       availableChannels)
-          : 0;
-    settings()->setLocalValue(INPUT_CHANNELS, muse::Val(inputChannels));
+    auto inputChannelSelection = details::inputChannelSelectionFromSettings(
+        settings()->value(INPUT_CHANNEL_SELECTION),
+        settings()->value(INPUT_CHANNELS).toInt(), availableChannels);
+    settings()->setLocalValue(
+        INPUT_CHANNEL_SELECTION,
+        details::inputChannelSelectionToVal(inputChannelSelection));
+    settings()->setLocalValue(INPUT_CHANNELS, muse::Val(static_cast<int>(inputChannelCount(inputChannelSelection))));
     m_configuration = configurationFromSettings();
 
     systemAudioDevicesListener()->systemDevicesChanged().onNotify(this, [this]() {
@@ -236,6 +240,7 @@ void Au3AudioDriverController::initDefaults()
     settings()->setDefaultValue(PLAYBACK_DEVICE, muse::Val(std::string()));
     settings()->setDefaultValue(RECORDING_DEVICE, muse::Val(std::string()));
     settings()->setDefaultValue(INPUT_CHANNELS, muse::Val(1));
+    settings()->setDefaultValue(INPUT_CHANNEL_SELECTION, muse::Val(muse::ValList {}));
     settings()->setDefaultValue(LATENCY_DURATION, muse::Val(100.0));
     settings()->setDefaultValue(AUTOMATIC_LATENCY_COMPENSATION, muse::Val(false));
     settings()->setDefaultValue(LATENCY_COMPENSATION, muse::Val(-130.0));
@@ -251,7 +256,10 @@ AudioConfiguration Au3AudioDriverController::configurationFromSettings() const
     result.api = settings()->value(AUDIO_HOST).toString();
     result.outputDevice = selectionFromSetting(settings()->value(PLAYBACK_DEVICE).toString());
     result.inputDevice = selectionFromSetting(settings()->value(RECORDING_DEVICE).toString());
-    result.inputChannels = settings()->value(INPUT_CHANNELS).toInt();
+    const int availableChannels = inputChannelsAvailable(result.api, result.inputDevice);
+    result.inputChannelSelection = details::inputChannelSelectionFromSettings(
+        settings()->value(INPUT_CHANNEL_SELECTION),
+        settings()->value(INPUT_CHANNELS).toInt(), availableChannels);
     result.bufferLength = settings()->value(LATENCY_DURATION).toDouble();
     result.automaticLatencyCompensation = settings()->value(AUTOMATIC_LATENCY_COMPENSATION).toBool();
     result.latencyCompensation = settings()->value(LATENCY_COMPENSATION).toDouble();
@@ -378,11 +386,8 @@ std::optional<AudioConfiguration> Au3AudioDriverController::normalizedConfigurat
     result.inputDevice = change.inputDevice.value_or(result.inputDevice);
 
     const int channels = inputChannelsAvailable(result.api, result.inputDevice);
-    if (channels > 0) {
-        result.inputChannels = std::clamp(change.inputChannels.value_or(result.inputChannels), 1, channels);
-    } else {
-        result.inputChannels = 0;
-    }
+    result.inputChannelSelection = normalizeInputChannelSelection(
+        change.inputChannelSelection.value_or(result.inputChannelSelection), channels);
 
     if (change.bufferLength) {
         result.bufferLength = muse::RealIsEqualOrMore(*change.bufferLength, 0.0)
@@ -428,8 +433,8 @@ AudioConfigurationDelta Au3AudioDriverController::makeDelta(const AudioConfigura
     if (before.inputDevice != after.inputDevice) {
         add(AudioConfigurationField::InputDevice);
     }
-    if (before.inputChannels != after.inputChannels) {
-        add(AudioConfigurationField::InputChannels);
+    if (before.inputChannelSelection != after.inputChannelSelection) {
+        add(AudioConfigurationField::InputChannelSelection);
     }
     if (!muse::RealIsEqual(before.bufferLength, after.bufferLength)) {
         add(AudioConfigurationField::BufferLength);
@@ -484,10 +489,10 @@ bool Au3AudioDriverController::streamNeedsSuspension(
     case AudioStreamKind::Playback:
         return false;
     case AudioStreamKind::Monitoring:
-        return delta.contains(AudioConfigurationField::InputChannels)
+        return delta.contains(AudioConfigurationField::InputChannelSelection)
                || sampleRateChanged;
     case AudioStreamKind::Recording:
-        return delta.contains(AudioConfigurationField::InputChannels)
+        return delta.contains(AudioConfigurationField::InputChannelSelection)
                || delta.contains(AudioConfigurationField::AutomaticLatencyCompensation)
                || delta.contains(AudioConfigurationField::LatencyCompensation)
                || sampleRateChanged;
@@ -567,8 +572,14 @@ void Au3AudioDriverController::writeConfiguration(const AudioConfiguration& valu
     if (delta.contains(AudioConfigurationField::InputDevice)) {
         settings()->setLocalValue(RECORDING_DEVICE, muse::Val(value.inputDevice.value_or(std::string())));
     }
-    if (delta.contains(AudioConfigurationField::InputChannels)) {
-        settings()->setLocalValue(INPUT_CHANNELS, muse::Val(value.inputChannels));
+    if (delta.contains(AudioConfigurationField::InputChannelSelection)) {
+        settings()->setLocalValue(
+            INPUT_CHANNEL_SELECTION,
+            details::inputChannelSelectionToVal(value.inputChannelSelection));
+        // Preserve the logical channel-count meaning for legacy readers. The
+        // physical route and its PortAudio prefix width are carried separately.
+        settings()->setLocalValue(INPUT_CHANNELS,
+                                  muse::Val(static_cast<int>(inputChannelCount(value.inputChannelSelection))));
     }
     if (delta.contains(AudioConfigurationField::BufferLength)) {
         settings()->setLocalValue(LATENCY_DURATION, muse::Val(value.bufferLength));
@@ -792,7 +803,7 @@ ApplyResult Au3AudioDriverController::reload(const muse::modularity::ContextPtr&
     change.api = fromSettings.api;
     change.outputDevice = fromSettings.outputDevice;
     change.inputDevice = fromSettings.inputDevice;
-    change.inputChannels = fromSettings.inputChannels;
+    change.inputChannelSelection = fromSettings.inputChannelSelection;
     change.bufferLength = fromSettings.bufferLength;
     change.automaticLatencyCompensation = fromSettings.automaticLatencyCompensation;
     change.latencyCompensation = fromSettings.latencyCompensation;

--- a/src/au3audio/internal/au3audioengine.cpp
+++ b/src/au3audio/internal/au3audioengine.cpp
@@ -16,6 +16,19 @@
 
 using namespace au::au3audio;
 
+namespace {
+std::vector<std::vector<unsigned int> > toAu3InputChannelSelection(
+    const au::audio::InputChannelSelection& selection)
+{
+    std::vector<std::vector<unsigned int> > result;
+    result.reserve(selection.size());
+    for (const auto& group : selection) {
+        result.emplace_back(group.channels.begin(), group.channels.end());
+    }
+    return result;
+}
+}
+
 std::shared_ptr<Au3AudioIOListener> s_audioIOListener;
 
 static ProjectAudioIO::DefaultOptions::Scope s_defaultOptionsScope {
@@ -121,6 +134,7 @@ int Au3AudioEngine::startStream(const TransportSequences& sequences, const doubl
     au3Options.inputMonitoring = recordConfiguration()->isInputMonitoringOn();
     au3Options.rate = options.sampleRate;
     au3Options.leadInTime = options.leadInTime;
+    au3Options.inputChannelSelection = toAu3InputChannelSelection(options.inputChannelSelection);
     if (options.crossfadeData) {
         au3Options.pCrossfadeData = options.crossfadeData;
     }
@@ -171,10 +185,12 @@ void Au3AudioEngine::seekStream(double time)
     AudioIO::Get()->SeekStream(time - AudioIO::Get()->GetStreamTime());
 }
 
-void Au3AudioEngine::startMonitoring(AudacityProject& project)
+void Au3AudioEngine::startMonitoring(
+    AudacityProject& project, const au::audio::InputChannelSelection& inputChannelSelection)
 {
     AudioIOStartStreamOptions options = ProjectAudioIO::GetDefaultOptions(project);
     options.inputMonitoring = recordConfiguration()->isInputMonitoringOn();
+    options.inputChannelSelection = toAu3InputChannelSelection(inputChannelSelection);
     AudioIO::Get()->StartMonitoring(options);
 }
 

--- a/src/au3audio/internal/au3audioengine.h
+++ b/src/au3audio/internal/au3audioengine.h
@@ -42,7 +42,7 @@ public:
     std::shared_ptr<RealtimeEffectState> replaceRealtimeEffectState(AudacityProject& project, ChannelGroup* group, size_t effectListIndex,
                                                                     const std::string& newEffectId) override;
 
-    void startMonitoring(AudacityProject& project) override;
+    void startMonitoring(AudacityProject& project, const audio::InputChannelSelection& inputChannelSelection) override;
     void stopMonitoring() override;
 
     void setInputVolume(float newInputVolume) override;

--- a/src/au3audio/internal/inputchannelselectionsettings.h
+++ b/src/au3audio/internal/inputchannelselectionsettings.h
@@ -1,0 +1,69 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+#pragma once
+
+#include <algorithm>
+#include <limits>
+#include <utility>
+
+#include "framework/global/types/val.h"
+
+#include "audio/inputchannelselection.h"
+
+namespace au::au3audio::details {
+inline audio::InputChannelSelection inputChannelSelectionFromVal(
+    const muse::Val& value)
+{
+    audio::InputChannelSelection result;
+    for (const auto& groupValue : value.toList()) {
+        audio::InputChannelGroup group;
+        bool valid = true;
+        for (const auto& channelValue : groupValue.toList()) {
+            if (channelValue.type() != muse::Val::Type::Int
+                && channelValue.type() != muse::Val::Type::Int64) {
+                valid = false;
+                break;
+            }
+            const int64_t channel = channelValue.toInt64();
+            if (channel < 0
+                || channel > std::numeric_limits<audio::InputChannelIndex>::max()) {
+                valid = false;
+                break;
+            }
+            group.channels.push_back(
+                static_cast<audio::InputChannelIndex>(channel));
+        }
+        if (valid && !group.channels.empty()) {
+            result.push_back(std::move(group));
+        }
+    }
+    return result;
+}
+
+inline muse::Val inputChannelSelectionToVal(
+    const audio::InputChannelSelection& selection)
+{
+    muse::ValList groups;
+    for (const auto& group : selection) {
+        muse::ValList channels;
+        for (const auto channel : group.channels) {
+            channels.emplace_back(static_cast<int>(channel));
+        }
+        groups.emplace_back(channels);
+    }
+    return muse::Val(groups);
+}
+
+inline audio::InputChannelSelection inputChannelSelectionFromSettings(
+    const muse::Val& value, int legacyChannels, int availableChannels)
+{
+    auto selection = inputChannelSelectionFromVal(value);
+    if (selection.empty()) {
+        return audio::legacyInputChannelSelection(
+            availableChannels > 0 ? std::clamp(legacyChannels, 1, availableChannels) : 0);
+    }
+    return audio::normalizeInputChannelSelection(
+        std::move(selection), availableChannels);
+}
+}

--- a/src/au3audio/internal/platform/linux/linuxsystemaudiodeviceslistener.cpp
+++ b/src/au3audio/internal/platform/linux/linuxsystemaudiodeviceslistener.cpp
@@ -56,7 +56,7 @@ void LinuxSystemAudioDevicesListener::startListening()
         // drain the queued events; what changed does not matter, and bursts
         // (a card exposes several sound devices) collapse into one notification;
         // restarting the timer would let a continuous stream starve it forever
-        while (struct udev_device* device = udev_monitor_receive_device(m_monitor)) {
+        while (udev_device* device = udev_monitor_receive_device(m_monitor)) {
             udev_device_unref(device);
         }
         if (!m_debounceTimer.isActive()) {

--- a/src/au3audio/tests/CMakeLists.txt
+++ b/src/au3audio/tests/CMakeLists.txt
@@ -6,8 +6,10 @@ set(MODULE_TEST au3audio_tests)
 
 set(MODULE_TEST_SRC
     ${CMAKE_CURRENT_LIST_DIR}/au3audiodrivercontroller_tests.cpp
-    ${CMAKE_CURRENT_LIST_DIR}/audioioinputmeter_tests.cpp
     ${CMAKE_CURRENT_LIST_DIR}/audioioinputchannelselection_tests.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/audioioinputmeter_tests.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/inputchannelselection_tests.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/inputchannelselectionsettings_tests.cpp
     ${CMAKE_CURRENT_LIST_DIR}/mocks/audioenginemock.h
     )
 

--- a/src/au3audio/tests/CMakeLists.txt
+++ b/src/au3audio/tests/CMakeLists.txt
@@ -6,12 +6,15 @@ set(MODULE_TEST au3audio_tests)
 
 set(MODULE_TEST_SRC
     ${CMAKE_CURRENT_LIST_DIR}/au3audiodrivercontroller_tests.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/audioioinputmeter_tests.cpp
     ${CMAKE_CURRENT_LIST_DIR}/mocks/audioenginemock.h
     )
 
 set(MODULE_TEST_LINK
     au3audio
     au3wrap
+    au3-audio-io
+    $<$<BOOL:${AU_USE_PORTMIXER}>:portmixer>
     )
 
 set(MODULE_TEST_DATA_ROOT ${CMAKE_CURRENT_LIST_DIR})

--- a/src/au3audio/tests/CMakeLists.txt
+++ b/src/au3audio/tests/CMakeLists.txt
@@ -7,6 +7,7 @@ set(MODULE_TEST au3audio_tests)
 set(MODULE_TEST_SRC
     ${CMAKE_CURRENT_LIST_DIR}/au3audiodrivercontroller_tests.cpp
     ${CMAKE_CURRENT_LIST_DIR}/audioioinputmeter_tests.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/audioioinputchannelselection_tests.cpp
     ${CMAKE_CURRENT_LIST_DIR}/mocks/audioenginemock.h
     )
 

--- a/src/au3audio/tests/au3audiodrivercontroller_tests.cpp
+++ b/src/au3audio/tests/au3audiodrivercontroller_tests.cpp
@@ -110,6 +110,22 @@ public:
         m_controller.m_applying = applying;
     }
 
+    bool streamNeedsSuspension(
+        const audio::AudioConfigurationDelta& delta,
+        const muse::modularity::ContextPtr& requester,
+        const std::optional<audio::AudioStreamDescriptor>& currentStream)
+    {
+        return m_controller.streamNeedsSuspension(
+            delta, 44100, requester, currentStream);
+    }
+
+    audio::AudioConfigurationDelta makeDelta(
+        const audio::AudioConfiguration& before,
+        const audio::AudioConfiguration& after)
+    {
+        return m_controller.makeDelta(before, after);
+    }
+
     Au3AudioDriverController m_controller;
     std::shared_ptr<NiceMock<audio::AudioEngineMock> > m_audioEngine;
     std::shared_ptr<NiceMock<muse::ApplicationMock> > m_application;
@@ -265,5 +281,50 @@ TEST_F(Au3AudioDriverControllerTests, Apply_ReentrantRequestIsRejectedWithoutCha
 
     EXPECT_EQ(result.status, audio::ApplyStatus::Busy);
     EXPECT_EQ(m_controller.configuration().bufferLength, 100.0);
+}
+
+TEST_F(Au3AudioDriverControllerTests, SelectionChangeIsReportedInConfigurationDelta)
+{
+    audio::AudioConfiguration before;
+    before.inputChannelSelection = { { { 0 } } };
+    auto after = before;
+    after.inputChannelSelection = { { { 2, 3 } } };
+
+    const auto delta = makeDelta(before, after);
+
+    EXPECT_TRUE(delta.contains(audio::AudioConfigurationField::InputChannelSelection));
+    EXPECT_EQ(delta.fields,
+              audio::fieldMask(audio::AudioConfigurationField::InputChannelSelection));
+}
+
+TEST_F(Au3AudioDriverControllerTests, SelectionChangeRestartsOwnedMonitoringAndRecording)
+{
+    audio::AudioConfigurationDelta delta;
+    delta.fields
+        = audio::fieldMask(audio::AudioConfigurationField::InputChannelSelection);
+
+    EXPECT_TRUE(streamNeedsSuspension(
+                    delta, m_ownerContext,
+                    stream(audio::AudioStreamKind::Monitoring)));
+    EXPECT_TRUE(streamNeedsSuspension(
+                    delta, m_ownerContext,
+                    stream(audio::AudioStreamKind::Recording)));
+    EXPECT_FALSE(streamNeedsSuspension(
+                     delta, m_ownerContext,
+                     stream(audio::AudioStreamKind::Playback)));
+}
+
+TEST_F(Au3AudioDriverControllerTests, SelectionChangeDoesNotRestartAnotherContextsStream)
+{
+    audio::AudioConfigurationDelta delta;
+    delta.fields
+        = audio::fieldMask(audio::AudioConfigurationField::InputChannelSelection);
+
+    EXPECT_FALSE(streamNeedsSuspension(
+                     delta, m_requesterContext,
+                     stream(audio::AudioStreamKind::Monitoring)));
+    EXPECT_FALSE(streamNeedsSuspension(
+                     delta, m_requesterContext,
+                     stream(audio::AudioStreamKind::Recording)));
 }
 }

--- a/src/au3audio/tests/audioioinputchannelselection_tests.cpp
+++ b/src/au3audio/tests/audioioinputchannelselection_tests.cpp
@@ -10,6 +10,68 @@
 namespace au::au3audio {
 namespace details = audacity::audio_io::details;
 
+TEST(AudioIOInputChannelSelectionTests, AcceptsGenericExecutableRoutes)
+{
+    EXPECT_TRUE(details::IsStructurallyValidInputChannelSelection({ { 1, 2 } }));
+    EXPECT_TRUE(details::IsStructurallyValidInputChannelSelection({ { 3 }, { 1, 2 } }));
+}
+
+TEST(AudioIOInputChannelSelectionTests, RejectsMalformedAndOverlappingRoutes)
+{
+    EXPECT_FALSE(details::IsStructurallyValidInputChannelSelection({ {} }));
+    EXPECT_FALSE(details::IsStructurallyValidInputChannelSelection({ { 0, 1, 2 } }));
+    EXPECT_FALSE(details::IsStructurallyValidInputChannelSelection({ { 0 }, { 0, 1 } }));
+    EXPECT_FALSE(details::IsStructurallyValidInputChannelSelection({ { 2, 2 } }));
+}
+
+TEST(AudioIOInputChannelSelectionTests, DerivesLegacyRouteCountOrderAndStreamWidth)
+{
+    const details::InputChannelSelection selection { { 0 }, { 2, 3 }, { 7 } };
+
+    EXPECT_EQ(details::LegacyInputChannelSelection(0), details::InputChannelSelection {});
+    EXPECT_EQ(details::LegacyInputChannelSelection(1), details::InputChannelSelection({ { 0 } }));
+    EXPECT_EQ(details::LegacyInputChannelSelection(2), details::InputChannelSelection({ { 0, 1 } }));
+    EXPECT_EQ(details::LegacyInputChannelSelection(3),
+              details::InputChannelSelection({ { 0 }, { 1 }, { 2 } }));
+    EXPECT_EQ(details::InputChannelSelectionCount(selection), 4u);
+    EXPECT_EQ(details::FlattenInputChannelSelection(selection),
+              std::vector<unsigned int>({ 0, 2, 3, 7 }));
+    EXPECT_EQ(details::InputChannelSelectionStreamWidth(selection), 8u);
+}
+
+TEST(AudioIOInputChannelSelectionTests, CopiesOnlyTheRequestedPhysicalInputChannel)
+{
+    const float input[] {
+        10.0f, 11.0f, 12.0f, 13.0f,
+        20.0f, 21.0f, 22.0f, 23.0f,
+        30.0f, 31.0f, 32.0f, 33.0f,
+    };
+    float output[] { -1.0f, -1.0f, -1.0f };
+
+    EXPECT_TRUE(details::CopyInputChannel(input, 4, 2, output, 3));
+    EXPECT_EQ(std::vector<float>(std::begin(output), std::end(output)),
+              std::vector<float>({ 12.0f, 22.0f, 32.0f }));
+}
+
+TEST(AudioIOInputChannelSelectionTests, CopiesIntegerInputWithoutChangingSampleValues)
+{
+    const short input[] { -32768, 3, 32767, 7 };
+    short output[] { 0, 0 };
+
+    EXPECT_TRUE(details::CopyInputChannel(input, 2, 0, output, 2));
+    EXPECT_EQ(std::vector<short>(std::begin(output), std::end(output)),
+              std::vector<short>({ -32768, 32767 }));
+}
+
+TEST(AudioIOInputChannelSelectionTests, RejectsCopyOutsideTheInputStream)
+{
+    const float input[] { 1.0f, 2.0f };
+    float output = 99.0f;
+
+    EXPECT_FALSE(details::CopyInputChannel(input, 2, 2, &output, 1));
+    EXPECT_FLOAT_EQ(output, 99.0f);
+}
+
 TEST(AudioIOInputChannelSelectionTests, MixesMonoAndStereoGroupsForMonitoring)
 {
     const float input[] {
@@ -37,5 +99,16 @@ TEST(AudioIOInputChannelSelectionTests, MonitoringMixClampsEachOutputChannel)
 
     EXPECT_FLOAT_EQ(output[0], 1.0f);
     EXPECT_FLOAT_EQ(output[1], -1.0f);
+}
+
+TEST(AudioIOInputChannelSelectionTests, PeakIgnoresUnselectedPrefixChannels)
+{
+    const float input[] {
+        0.1f, 0.99f, 0.3f, -0.7f,
+        0.2f, -1.0f, -0.6f, 0.4f,
+    };
+
+    EXPECT_FLOAT_EQ(details::InputChannelSelectionPeak(
+                        input, 4, { 2, 3 }, 2), 0.7f);
 }
 }

--- a/src/au3audio/tests/audioioinputchannelselection_tests.cpp
+++ b/src/au3audio/tests/audioioinputchannelselection_tests.cpp
@@ -1,0 +1,41 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+#include <iterator>
+
+#include <gtest/gtest.h>
+
+#include "au3-audio-io/internal/AudioIOInputChannelSelection.h"
+
+namespace au::au3audio {
+namespace details = audacity::audio_io::details;
+
+TEST(AudioIOInputChannelSelectionTests, MixesMonoAndStereoGroupsForMonitoring)
+{
+    const float input[] {
+        0.9f, 0.2f, -0.4f, 0.8f,
+        -0.6f, 0.1f, 0.4f, -0.2f,
+    };
+    float output[] { 0.0f, 0.0f, 0.0f, 0.0f };
+
+    details::MixInputChannelSelectionToStereo(
+        input, 4, { { 0 }, { 2, 3 } }, output, 2);
+
+    EXPECT_FLOAT_EQ(output[0], 0.25f);
+    EXPECT_FLOAT_EQ(output[1], 0.85f);
+    EXPECT_FLOAT_EQ(output[2], -0.1f);
+    EXPECT_FLOAT_EQ(output[3], -0.4f);
+}
+
+TEST(AudioIOInputChannelSelectionTests, MonitoringMixClampsEachOutputChannel)
+{
+    const float input[] { 2.0f, -2.0f };
+    float output[] { 0.0f, 0.0f };
+
+    details::MixInputChannelSelectionToStereo(
+        input, 2, { { 0, 1 } }, output, 1);
+
+    EXPECT_FLOAT_EQ(output[0], 1.0f);
+    EXPECT_FLOAT_EQ(output[1], -1.0f);
+}
+}

--- a/src/au3audio/tests/audioioinputmeter_tests.cpp
+++ b/src/au3audio/tests/audioioinputmeter_tests.cpp
@@ -11,12 +11,14 @@
 #include <gtest/gtest.h>
 
 #include "au3-audio-io/AudioIO.h"
+#include "au3-audio-io/internal/AudioIOInputChannelSelection.h"
 #include "au3-mixer/AudioIOSequences.h"
 
 using ::testing::_;
 using ::testing::NiceMock;
 
 namespace au::au3audio {
+namespace details = audacity::audio_io::details;
 
 namespace {
 class TestAudioIoCallback : public AudioIoCallback
@@ -83,6 +85,7 @@ public:
     void setInputChannelCount(size_t channels)
     {
         m_callback.mNumCaptureChannels = channels;
+        m_callback.mInputChannelSelection = details::LegacyInputChannelSelection(channels);
     }
 
     void setTracks(const std::vector<size_t>& channelCounts, const std::vector<std::vector<size_t> >& sourceMap)
@@ -240,5 +243,24 @@ TEST_F(AudioIOInputMeterTests, StereoTrackDuplicatesTheSelectedMonoInput)
     ASSERT_EQ(m_submissions.size(), 3u);
     expectMainMeter({ { 0.4f, -0.6f } }, 1);
     expectMeter({ { 0.4f, -0.6f }, { 0.4f, -0.6f } }, 1, 100);
+}
+
+TEST_F(AudioIOInputMeterTests, MultichannelMeterLevelsDoNotChangeCancellingSoftwarePlaythrough)
+{
+    setInputChannelCount(3);
+    const std::vector<float> input { 0.8f, -0.8f, 0.0f, -0.6f, 0.3f, 0.3f };
+    ASSERT_NO_FATAL_FAILURE(pushInput(input));
+    expectMainMeter({ { 0.8f, 0.6f }, { 0.8f, 0.3f } }, 1);
+
+    m_callback.mSoftwarePlaythrough = true;
+    m_callback.mNumPlaybackChannels = 2;
+    float output[4] {};
+    float outputMeter[4] {};
+    m_callback.DoPlaythrough(input.data(), output, 2, outputMeter);
+
+    for (size_t sample = 0; sample < 4; ++sample) {
+        EXPECT_FLOAT_EQ(output[sample], 0.0f);
+        EXPECT_FLOAT_EQ(outputMeter[sample], 0.0f);
+    }
 }
 }

--- a/src/au3audio/tests/audioioinputmeter_tests.cpp
+++ b/src/au3audio/tests/audioioinputmeter_tests.cpp
@@ -82,10 +82,12 @@ public:
         });
     }
 
-    void setInputChannelCount(size_t channels)
+    void setSelection(const details::InputChannelSelection& selection)
     {
-        m_callback.mNumCaptureChannels = channels;
-        m_callback.mInputChannelSelection = details::LegacyInputChannelSelection(channels);
+        m_callback.mInputChannelSelection = selection;
+        m_callback.mInputChannelIndices = details::FlattenInputChannelSelection(selection);
+        m_callback.mNumCaptureChannels = m_callback.mInputChannelIndices.size();
+        m_callback.mNumInputStreamChannels = details::InputChannelSelectionStreamWidth(selection);
     }
 
     void setTracks(const std::vector<size_t>& channelCounts, const std::vector<std::vector<size_t> >& sourceMap)
@@ -99,10 +101,10 @@ public:
 
     void pushInput(const std::vector<float>& input)
     {
-        ASSERT_GT(m_callback.mNumCaptureChannels, 0u);
-        ASSERT_EQ(input.size() % m_callback.mNumCaptureChannels, 0u);
+        ASSERT_GT(m_callback.mNumInputStreamChannels, 0u);
+        ASSERT_EQ(input.size() % m_callback.mNumInputStreamChannels, 0u);
         m_submissions.clear();
-        m_callback.PushInputMeterValues(m_sender, input.data(), input.size() / m_callback.mNumCaptureChannels, m_dacTime);
+        m_callback.PushInputMeterValues(m_sender, input.data(), input.size() / m_callback.mNumInputStreamChannels, m_dacTime);
     }
 
     void expectMainMeter(const std::vector<std::vector<float> >& expected, size_t stride)
@@ -140,9 +142,55 @@ public:
     std::vector<MeterSubmission> m_submissions;
 };
 
+struct InputMeterCase {
+    const char* name;
+    details::InputChannelSelection selection;
+    std::vector<float> input;
+    std::vector<std::vector<float> > expected;
+};
+
+class AudioIOInputMeterRoutesTests : public AudioIOInputMeterTests, public ::testing::WithParamInterface<InputMeterCase>
+{
+};
+
+TEST_P(AudioIOInputMeterRoutesTests, PreservesEachSelectedInputIndependently)
+{
+    const auto& testCase = GetParam();
+    setSelection(testCase.selection);
+
+    ASSERT_NO_FATAL_FAILURE(pushInput(testCase.input));
+
+    expectMainMeter(testCase.expected, m_callback.mNumInputStreamChannels);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    SelectedInputs,
+    AudioIOInputMeterRoutesTests,
+    ::testing::Values(
+        InputMeterCase { "NonAdjacentMonos", { { 0 }, { 2 } },
+                        { 0.8f, 0.99f, 0.0f, -0.4f, -0.99f, 0.2f, 0.6f, 0.99f, -0.6f },
+                        { { 0.8f, -0.4f, 0.6f }, { 0.0f, 0.2f, -0.6f } } },
+        InputMeterCase { "AdjacentMonos", { { 0 }, { 1 } },
+                        { 0.8f, 0.0f, -0.4f, 0.2f, 0.6f, -0.6f },
+                        { { 0.8f, -0.4f, 0.6f }, { 0.0f, 0.2f, -0.6f } } },
+        InputMeterCase { "FirstStereoPair", { { 0, 1 } },
+                        { 0.8f, 0.0f, -0.4f, 0.2f, 0.6f, -0.6f },
+                        { { 0.8f, -0.4f, 0.6f }, { 0.0f, 0.2f, -0.6f } } },
+        InputMeterCase { "HigherStereoPair", { { 2, 3 } },
+                        { 0.99f, -0.99f, 0.8f, 0.0f, -0.99f, 0.99f, -0.4f, 0.2f, 0.99f, -0.99f, 0.6f, -0.6f },
+                        { { 0.8f, -0.4f, 0.6f }, { 0.0f, 0.2f, -0.6f } } },
+        InputMeterCase { "FirstMono", { { 0 } },
+                        { 0.4f, -0.5f, 0.6f }, { { 0.4f, -0.5f, 0.6f } } },
+        InputMeterCase { "HigherMono", { { 3 } },
+                        { 0.99f, -0.99f, 0.75f, 0.4f, -0.99f, 0.99f, 0.2f, -0.5f, 0.99f, -0.99f, 0.3f, 0.6f },
+                        { { 0.4f, -0.5f, 0.6f } } }),
+    [](const ::testing::TestParamInfo<InputMeterCase>& info) {
+    return info.param.name;
+});
+
 TEST_F(AudioIOInputMeterTests, PassesUnclampedSamplesToTheMeter)
 {
-    setInputChannelCount(2);
+    setSelection({ { 0, 1 } });
 
     ASSERT_NO_FATAL_FAILURE(pushInput({ 1.5f, 0.0f, -1.5f, 0.5f }));
 
@@ -151,7 +199,7 @@ TEST_F(AudioIOInputMeterTests, PassesUnclampedSamplesToTheMeter)
 
 TEST_F(AudioIOInputMeterTests, ZeroFramesProduceNoUpdates)
 {
-    setInputChannelCount(2);
+    setSelection({ { 0 }, { 2 } });
     const float input[] { 0.8f, 0.99f, 0.0f };
     EXPECT_CALL(*m_sender, push(_, _, _)).Times(0);
 
@@ -160,16 +208,35 @@ TEST_F(AudioIOInputMeterTests, ZeroFramesProduceNoUpdates)
 
 TEST_F(AudioIOInputMeterTests, EmptySelectionProducesNoUpdates)
 {
-    setInputChannelCount(0);
+    setSelection({});
     const float input[] { 0.8f };
     EXPECT_CALL(*m_sender, push(_, _, _)).Times(0);
 
     m_callback.PushInputMeterValues(m_sender, input, 1, m_dacTime);
 }
 
+TEST_F(AudioIOInputMeterTests, ThreeMonoInputsUseSelectedSampleMagnitudes)
+{
+    setSelection({ { 0 }, { 2 }, { 4 } });
+
+    ASSERT_NO_FATAL_FAILURE(pushInput({ 0.75f, 1.0f, -0.375f, -1.0f, 0.375f,
+                                       -0.75f, 1.0f, 0.375f, -1.0f, -0.375f }));
+
+    expectMainMeter({ { 0.75f, 0.75f }, { 0.375f, 0.375f } }, 1);
+}
+
+TEST_F(AudioIOInputMeterTests, StereoGroupAfterMonoKeepsItsLeftAndRightChannels)
+{
+    setSelection({ { 0 }, { 2, 3 } });
+
+    ASSERT_NO_FATAL_FAILURE(pushInput({ 0.9f, 0.2f, -0.4f, 0.8f, -0.6f, 0.1f, 0.4f, -0.2f }));
+
+    expectMainMeter({ { 0.9f, 0.6f }, { 0.8f, 0.2f } }, 1);
+}
+
 TEST_F(AudioIOInputMeterTests, LegacyThreeInputPresetMetersBeforeRecordingWithoutPolarityCancellation)
 {
-    setInputChannelCount(3);
+    setSelection(details::LegacyInputChannelSelection(3));
 
     ASSERT_NO_FATAL_FAILURE(pushInput({ 0.75f, -0.25f, -0.75f, -0.6f, -0.4f, -0.2f, 0.2f, 0.9f, 0.4f }));
 
@@ -178,16 +245,26 @@ TEST_F(AudioIOInputMeterTests, LegacyThreeInputPresetMetersBeforeRecordingWithou
 
 TEST_F(AudioIOInputMeterTests, LegacyFourInputPresetUsesMaximumMagnitudeInEachBar)
 {
-    setInputChannelCount(4);
+    setSelection(details::LegacyInputChannelSelection(4));
 
     ASSERT_NO_FATAL_FAILURE(pushInput({ 0.8f, 0.2f, -0.8f, -0.7f, -0.25f, -0.5f, -0.75f, -0.1f }));
 
     expectMainMeter({ { 0.8f, 0.75f }, { 0.7f, 0.5f } }, 1);
 }
 
+TEST_F(AudioIOInputMeterTests, MixedGroupsKeepStereoSidesAndAlternateMonosByGroupIndex)
+{
+    setSelection({ { 0, 1 }, { 2 }, { 4 }, { 6, 7 } });
+
+    ASSERT_NO_FATAL_FAILURE(pushInput({ -0.2f, 0.1f, -0.7f, 0.99f, -0.8f, -0.99f, 0.4f, -0.3f,
+                                       0.9f, -0.8f, 0.1f, -0.99f, 0.2f, 0.99f, -0.3f, 0.4f }));
+
+    expectMainMeter({ { 0.8f, 0.9f }, { 0.7f, 0.8f } }, 1);
+}
+
 TEST_F(AudioIOInputMeterTests, MultichannelSummaryDoesNotClampSamples)
 {
-    setInputChannelCount(3);
+    setSelection(details::LegacyInputChannelSelection(3));
 
     ASSERT_NO_FATAL_FAILURE(pushInput({ 1.5f, -1.25f, -1.75f }));
 
@@ -196,7 +273,7 @@ TEST_F(AudioIOInputMeterTests, MultichannelSummaryDoesNotClampSamples)
 
 TEST_F(AudioIOInputMeterTests, MainMeterDoesNotDependOnRecordingDestinationCount)
 {
-    setInputChannelCount(4);
+    setSelection(details::LegacyInputChannelSelection(4));
     const std::vector<float> input { 0.8f, 0.2f, -0.8f, -0.7f, -0.25f, -0.5f, -0.75f, -0.1f };
     ASSERT_NO_FATAL_FAILURE(pushInput(input));
     expectMainMeter({ { 0.8f, 0.75f }, { 0.7f, 0.5f } }, 1);
@@ -212,7 +289,7 @@ TEST_F(AudioIOInputMeterTests, MainMeterDoesNotDependOnRecordingDestinationCount
 
 TEST_F(AudioIOInputMeterTests, SeparateMonoTracksReceiveIndependentSelectedInputs)
 {
-    setInputChannelCount(2);
+    setSelection(details::LegacyInputChannelSelection(2));
     setTracks({ 1, 1 }, { { 0 }, { 1 } });
     ASSERT_NO_FATAL_FAILURE(pushInput({ 0.8f, 0.2f, -0.6f, 0.4f }));
 
@@ -221,11 +298,29 @@ TEST_F(AudioIOInputMeterTests, SeparateMonoTracksReceiveIndependentSelectedInput
     expectMeter({ { 0.8f, -0.6f } }, 2, 100);
     expectMeter({ { 0.2f, 0.4f } }, 2, 101);
 
+    setSelection({ { 0 }, { 2 } });
+    ASSERT_NO_FATAL_FAILURE(pushInput({ 0.8f, 0.99f, 0.2f, -0.6f, -0.99f, 0.4f }));
+
+    ASSERT_EQ(m_submissions.size(), 4u);
+    expectMainMeter({ { 0.8f, -0.6f }, { 0.2f, 0.4f } }, 3);
+    expectMeter({ { 0.8f, -0.6f } }, 3, 100);
+    expectMeter({ { 0.2f, 0.4f } }, 3, 101);
+}
+
+TEST_F(AudioIOInputMeterTests, StereoTrackReceivesNonAdjacentInputsIndependently)
+{
+    setSelection({ { 0 }, { 2 } });
+    setTracks({ 2 }, { { 0 }, { 1 } });
+    ASSERT_NO_FATAL_FAILURE(pushInput({ 0.8f, 0.99f, 0.2f, -0.6f, -0.99f, 0.4f }));
+
+    ASSERT_EQ(m_submissions.size(), 4u);
+    expectMainMeter({ { 0.8f, -0.6f }, { 0.2f, 0.4f } }, 3);
+    expectMeter({ { 0.8f, -0.6f }, { 0.2f, 0.4f } }, 3, 100);
 }
 
 TEST_F(AudioIOInputMeterTests, MonoTrackMetersTheRecordedStereoDownmix)
 {
-    setInputChannelCount(2);
+    setSelection(details::LegacyInputChannelSelection(2));
     setTracks({ 1 }, { { 0, 1 } });
     ASSERT_NO_FATAL_FAILURE(pushInput({ 0.8f, -0.8f, -0.4f, 0.2f }));
 
@@ -236,18 +331,18 @@ TEST_F(AudioIOInputMeterTests, MonoTrackMetersTheRecordedStereoDownmix)
 
 TEST_F(AudioIOInputMeterTests, StereoTrackDuplicatesTheSelectedMonoInput)
 {
-    setInputChannelCount(1);
+    setSelection({ { 3 } });
     setTracks({ 2 }, { { 0 }, { 0 } });
-    ASSERT_NO_FATAL_FAILURE(pushInput({ 0.4f, -0.6f }));
+    ASSERT_NO_FATAL_FAILURE(pushInput({ 0.99f, -0.99f, 0.75f, 0.4f, -0.99f, 0.99f, 0.2f, -0.6f }));
 
     ASSERT_EQ(m_submissions.size(), 3u);
-    expectMainMeter({ { 0.4f, -0.6f } }, 1);
-    expectMeter({ { 0.4f, -0.6f }, { 0.4f, -0.6f } }, 1, 100);
+    expectMainMeter({ { 0.4f, -0.6f } }, 4);
+    expectMeter({ { 0.4f, -0.6f }, { 0.4f, -0.6f } }, 4, 100);
 }
 
 TEST_F(AudioIOInputMeterTests, MultichannelMeterLevelsDoNotChangeCancellingSoftwarePlaythrough)
 {
-    setInputChannelCount(3);
+    setSelection(details::LegacyInputChannelSelection(3));
     const std::vector<float> input { 0.8f, -0.8f, 0.0f, -0.6f, 0.3f, 0.3f };
     ASSERT_NO_FATAL_FAILURE(pushInput(input));
     expectMainMeter({ { 0.8f, 0.6f }, { 0.8f, 0.3f } }, 1);
@@ -261,6 +356,26 @@ TEST_F(AudioIOInputMeterTests, MultichannelMeterLevelsDoNotChangeCancellingSoftw
     for (size_t sample = 0; sample < 4; ++sample) {
         EXPECT_FLOAT_EQ(output[sample], 0.0f);
         EXPECT_FLOAT_EQ(outputMeter[sample], 0.0f);
+    }
+}
+
+TEST_F(AudioIOInputMeterTests, IndependentInputMetersDoNotChangeSoftwarePlaythrough)
+{
+    setSelection({ { 0 }, { 2 } });
+    const std::vector<float> input { 0.8f, 0.99f, 0.0f, -0.6f, -0.99f, 0.2f };
+    ASSERT_NO_FATAL_FAILURE(pushInput(input));
+    expectMainMeter({ { 0.8f, -0.6f }, { 0.0f, 0.2f } }, 3);
+
+    m_callback.mSoftwarePlaythrough = true;
+    m_callback.mNumPlaybackChannels = 2;
+    float output[4] {};
+    float outputMeter[4] {};
+    m_callback.DoPlaythrough(input.data(), output, 2, outputMeter);
+
+    const float expected[] { 0.4f, 0.4f, -0.2f, -0.2f };
+    for (size_t sample = 0; sample < 4; ++sample) {
+        EXPECT_FLOAT_EQ(output[sample], expected[sample]);
+        EXPECT_FLOAT_EQ(outputMeter[sample], expected[sample]);
     }
 }
 }

--- a/src/au3audio/tests/audioioinputmeter_tests.cpp
+++ b/src/au3audio/tests/audioioinputmeter_tests.cpp
@@ -1,0 +1,244 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+#include <chrono>
+#include <memory>
+#include <optional>
+#include <utility>
+#include <vector>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "au3-audio-io/AudioIO.h"
+#include "au3-mixer/AudioIOSequences.h"
+
+using ::testing::_;
+using ::testing::NiceMock;
+
+namespace au::au3audio {
+
+namespace {
+class TestAudioIoCallback : public AudioIoCallback
+{
+public:
+    void StopStream() override {}
+    void StopMonitoring() override {}
+};
+
+class MeterSenderMock : public IMeterSender
+{
+public:
+    MOCK_METHOD(void, push, (uint8_t, const InterleavedSampleData&, const std::optional<TrackId>&), (override));
+    void start(double) override {}
+    void stop() override {}
+};
+
+class RecordableSequenceStub final : public RecordableSequence
+{
+public:
+    RecordableSequenceStub(size_t channels, int64_t id)
+        : m_channels(channels), m_id(id) {}
+
+    sampleFormat GetSampleFormat() const override { return floatSample; }
+    double GetRate() const override { return 44100.0; }
+    size_t NChannels() const override { return m_channels; }
+    int64_t GetRecordableSequenceId() const override { return m_id; }
+    bool Append(size_t, constSamplePtr, sampleFormat, size_t, unsigned int, sampleFormat) override { return false; }
+    void Flush() override {}
+    void RepairChannels() override {}
+    void InsertSilence(double, double) override {}
+
+private:
+    size_t m_channels;
+    int64_t m_id;
+};
+
+struct MeterSubmission {
+    uint8_t channel;
+    size_t stride;
+    TimePoint dacTime;
+    std::optional<IMeterSender::TrackId> trackId;
+    std::vector<float> samples;
+};
+}
+
+class AudioIOInputMeterTests : public ::testing::Test
+{
+public:
+    void SetUp() override
+    {
+        ON_CALL(*m_sender, push(_, _, _))
+        .WillByDefault([this](uint8_t channel, const IMeterSender::InterleavedSampleData& data,
+                              const std::optional<IMeterSender::TrackId>& trackId) {
+            MeterSubmission submission { channel, data.nChannels, data.dacTime, trackId, {} };
+            // The callback may submit temporary buffers, so copy samples during push().
+            for (size_t frame = 0; frame < data.frames; ++frame) {
+                submission.samples.push_back(data.buffer[frame * data.nChannels]);
+            }
+            m_submissions.push_back(std::move(submission));
+        });
+    }
+
+    void setInputChannelCount(size_t channels)
+    {
+        m_callback.mNumCaptureChannels = channels;
+    }
+
+    void setTracks(const std::vector<size_t>& channelCounts, const std::vector<std::vector<size_t> >& sourceMap)
+    {
+        m_callback.mCaptureSequences.clear();
+        for (size_t track = 0; track < channelCounts.size(); ++track) {
+            m_callback.mCaptureSequences.push_back(std::make_shared<RecordableSequenceStub>(channelCounts[track], 100 + track));
+        }
+        m_callback.mTrackChannelSourceMap = sourceMap;
+    }
+
+    void pushInput(const std::vector<float>& input)
+    {
+        ASSERT_GT(m_callback.mNumCaptureChannels, 0u);
+        ASSERT_EQ(input.size() % m_callback.mNumCaptureChannels, 0u);
+        m_submissions.clear();
+        m_callback.PushInputMeterValues(m_sender, input.data(), input.size() / m_callback.mNumCaptureChannels, m_dacTime);
+    }
+
+    void expectMainMeter(const std::vector<std::vector<float> >& expected, size_t stride)
+    {
+        expectMeter(expected, stride, std::nullopt);
+    }
+
+    void expectMeter(const std::vector<std::vector<float> >& expected, size_t stride, std::optional<int64_t> trackId)
+    {
+        std::vector<const MeterSubmission*> submissions;
+        for (const auto& submission : m_submissions) {
+            const auto id = submission.trackId ? std::make_optional(submission.trackId->value) : std::nullopt;
+            if (id == trackId) {
+                submissions.push_back(&submission);
+            }
+        }
+        ASSERT_EQ(submissions.size(), expected.size());
+        for (size_t channel = 0; channel < expected.size(); ++channel) {
+            SCOPED_TRACE(channel);
+            const auto& submission = *submissions[channel];
+            EXPECT_EQ(submission.channel, channel);
+            EXPECT_EQ(submission.stride, stride);
+            EXPECT_EQ(submission.dacTime, m_dacTime);
+            ASSERT_EQ(submission.samples.size(), expected[channel].size());
+            for (size_t frame = 0; frame < expected[channel].size(); ++frame) {
+                SCOPED_TRACE(frame);
+                EXPECT_FLOAT_EQ(submission.samples[frame], expected[channel][frame]);
+            }
+        }
+    }
+
+    TestAudioIoCallback m_callback;
+    std::shared_ptr<NiceMock<MeterSenderMock> > m_sender = std::make_shared<NiceMock<MeterSenderMock> >();
+    const TimePoint m_dacTime { std::chrono::milliseconds(123) };
+    std::vector<MeterSubmission> m_submissions;
+};
+
+TEST_F(AudioIOInputMeterTests, PassesUnclampedSamplesToTheMeter)
+{
+    setInputChannelCount(2);
+
+    ASSERT_NO_FATAL_FAILURE(pushInput({ 1.5f, 0.0f, -1.5f, 0.5f }));
+
+    expectMainMeter({ { 1.5f, -1.5f }, { 0.0f, 0.5f } }, 2);
+}
+
+TEST_F(AudioIOInputMeterTests, ZeroFramesProduceNoUpdates)
+{
+    setInputChannelCount(2);
+    const float input[] { 0.8f, 0.99f, 0.0f };
+    EXPECT_CALL(*m_sender, push(_, _, _)).Times(0);
+
+    m_callback.PushInputMeterValues(m_sender, input, 0, m_dacTime);
+}
+
+TEST_F(AudioIOInputMeterTests, EmptySelectionProducesNoUpdates)
+{
+    setInputChannelCount(0);
+    const float input[] { 0.8f };
+    EXPECT_CALL(*m_sender, push(_, _, _)).Times(0);
+
+    m_callback.PushInputMeterValues(m_sender, input, 1, m_dacTime);
+}
+
+TEST_F(AudioIOInputMeterTests, LegacyThreeInputPresetMetersBeforeRecordingWithoutPolarityCancellation)
+{
+    setInputChannelCount(3);
+
+    ASSERT_NO_FATAL_FAILURE(pushInput({ 0.75f, -0.25f, -0.75f, -0.6f, -0.4f, -0.2f, 0.2f, 0.9f, 0.4f }));
+
+    expectMainMeter({ { 0.75f, 0.6f, 0.4f }, { 0.25f, 0.4f, 0.9f } }, 1);
+}
+
+TEST_F(AudioIOInputMeterTests, LegacyFourInputPresetUsesMaximumMagnitudeInEachBar)
+{
+    setInputChannelCount(4);
+
+    ASSERT_NO_FATAL_FAILURE(pushInput({ 0.8f, 0.2f, -0.8f, -0.7f, -0.25f, -0.5f, -0.75f, -0.1f }));
+
+    expectMainMeter({ { 0.8f, 0.75f }, { 0.7f, 0.5f } }, 1);
+}
+
+TEST_F(AudioIOInputMeterTests, MultichannelSummaryDoesNotClampSamples)
+{
+    setInputChannelCount(3);
+
+    ASSERT_NO_FATAL_FAILURE(pushInput({ 1.5f, -1.25f, -1.75f }));
+
+    expectMainMeter({ { 1.75f }, { 1.25f } }, 1);
+}
+
+TEST_F(AudioIOInputMeterTests, MainMeterDoesNotDependOnRecordingDestinationCount)
+{
+    setInputChannelCount(4);
+    const std::vector<float> input { 0.8f, 0.2f, -0.8f, -0.7f, -0.25f, -0.5f, -0.75f, -0.1f };
+    ASSERT_NO_FATAL_FAILURE(pushInput(input));
+    expectMainMeter({ { 0.8f, 0.75f }, { 0.7f, 0.5f } }, 1);
+
+    setTracks({ 1, 1 }, { { 0 }, { 1 } });
+    ASSERT_NO_FATAL_FAILURE(pushInput(input));
+
+    ASSERT_EQ(m_submissions.size(), 4u);
+    expectMainMeter({ { 0.8f, 0.75f }, { 0.7f, 0.5f } }, 1);
+    expectMeter({ { 0.8f, -0.25f } }, 4, 100);
+    expectMeter({ { 0.2f, -0.5f } }, 4, 101);
+}
+
+TEST_F(AudioIOInputMeterTests, SeparateMonoTracksReceiveIndependentSelectedInputs)
+{
+    setInputChannelCount(2);
+    setTracks({ 1, 1 }, { { 0 }, { 1 } });
+    ASSERT_NO_FATAL_FAILURE(pushInput({ 0.8f, 0.2f, -0.6f, 0.4f }));
+
+    ASSERT_EQ(m_submissions.size(), 4u);
+    expectMainMeter({ { 0.8f, -0.6f }, { 0.2f, 0.4f } }, 2);
+    expectMeter({ { 0.8f, -0.6f } }, 2, 100);
+    expectMeter({ { 0.2f, 0.4f } }, 2, 101);
+
+}
+
+TEST_F(AudioIOInputMeterTests, MonoTrackMetersTheRecordedStereoDownmix)
+{
+    setInputChannelCount(2);
+    setTracks({ 1 }, { { 0, 1 } });
+    ASSERT_NO_FATAL_FAILURE(pushInput({ 0.8f, -0.8f, -0.4f, 0.2f }));
+
+    ASSERT_EQ(m_submissions.size(), 3u);
+    expectMainMeter({ { 0.8f, -0.4f }, { -0.8f, 0.2f } }, 2);
+    expectMeter({ { 0.0f, -0.1f } }, 1, 100);
+}
+
+TEST_F(AudioIOInputMeterTests, StereoTrackDuplicatesTheSelectedMonoInput)
+{
+    setInputChannelCount(1);
+    setTracks({ 2 }, { { 0 }, { 0 } });
+    ASSERT_NO_FATAL_FAILURE(pushInput({ 0.4f, -0.6f }));
+
+    ASSERT_EQ(m_submissions.size(), 3u);
+    expectMainMeter({ { 0.4f, -0.6f } }, 1);
+    expectMeter({ { 0.4f, -0.6f }, { 0.4f, -0.6f } }, 1, 100);
+}
+}

--- a/src/au3audio/tests/audioioinputmeter_tests.cpp
+++ b/src/au3audio/tests/audioioinputmeter_tests.cpp
@@ -168,22 +168,22 @@ INSTANTIATE_TEST_SUITE_P(
     AudioIOInputMeterRoutesTests,
     ::testing::Values(
         InputMeterCase { "NonAdjacentMonos", { { 0 }, { 2 } },
-                        { 0.8f, 0.99f, 0.0f, -0.4f, -0.99f, 0.2f, 0.6f, 0.99f, -0.6f },
-                        { { 0.8f, -0.4f, 0.6f }, { 0.0f, 0.2f, -0.6f } } },
+                         { 0.8f, 0.99f, 0.0f, -0.4f, -0.99f, 0.2f, 0.6f, 0.99f, -0.6f },
+                         { { 0.8f, -0.4f, 0.6f }, { 0.0f, 0.2f, -0.6f } } },
         InputMeterCase { "AdjacentMonos", { { 0 }, { 1 } },
-                        { 0.8f, 0.0f, -0.4f, 0.2f, 0.6f, -0.6f },
-                        { { 0.8f, -0.4f, 0.6f }, { 0.0f, 0.2f, -0.6f } } },
+                         { 0.8f, 0.0f, -0.4f, 0.2f, 0.6f, -0.6f },
+                         { { 0.8f, -0.4f, 0.6f }, { 0.0f, 0.2f, -0.6f } } },
         InputMeterCase { "FirstStereoPair", { { 0, 1 } },
-                        { 0.8f, 0.0f, -0.4f, 0.2f, 0.6f, -0.6f },
-                        { { 0.8f, -0.4f, 0.6f }, { 0.0f, 0.2f, -0.6f } } },
+                         { 0.8f, 0.0f, -0.4f, 0.2f, 0.6f, -0.6f },
+                         { { 0.8f, -0.4f, 0.6f }, { 0.0f, 0.2f, -0.6f } } },
         InputMeterCase { "HigherStereoPair", { { 2, 3 } },
-                        { 0.99f, -0.99f, 0.8f, 0.0f, -0.99f, 0.99f, -0.4f, 0.2f, 0.99f, -0.99f, 0.6f, -0.6f },
-                        { { 0.8f, -0.4f, 0.6f }, { 0.0f, 0.2f, -0.6f } } },
+                         { 0.99f, -0.99f, 0.8f, 0.0f, -0.99f, 0.99f, -0.4f, 0.2f, 0.99f, -0.99f, 0.6f, -0.6f },
+                         { { 0.8f, -0.4f, 0.6f }, { 0.0f, 0.2f, -0.6f } } },
         InputMeterCase { "FirstMono", { { 0 } },
-                        { 0.4f, -0.5f, 0.6f }, { { 0.4f, -0.5f, 0.6f } } },
+                         { 0.4f, -0.5f, 0.6f }, { { 0.4f, -0.5f, 0.6f } } },
         InputMeterCase { "HigherMono", { { 3 } },
-                        { 0.99f, -0.99f, 0.75f, 0.4f, -0.99f, 0.99f, 0.2f, -0.5f, 0.99f, -0.99f, 0.3f, 0.6f },
-                        { { 0.4f, -0.5f, 0.6f } } }),
+                         { 0.99f, -0.99f, 0.75f, 0.4f, -0.99f, 0.99f, 0.2f, -0.5f, 0.99f, -0.99f, 0.3f, 0.6f },
+                         { { 0.4f, -0.5f, 0.6f } } }),
     [](const ::testing::TestParamInfo<InputMeterCase>& info) {
     return info.param.name;
 });
@@ -220,7 +220,7 @@ TEST_F(AudioIOInputMeterTests, ThreeMonoInputsUseSelectedSampleMagnitudes)
     setSelection({ { 0 }, { 2 }, { 4 } });
 
     ASSERT_NO_FATAL_FAILURE(pushInput({ 0.75f, 1.0f, -0.375f, -1.0f, 0.375f,
-                                       -0.75f, 1.0f, 0.375f, -1.0f, -0.375f }));
+                                        -0.75f, 1.0f, 0.375f, -1.0f, -0.375f }));
 
     expectMainMeter({ { 0.75f, 0.75f }, { 0.375f, 0.375f } }, 1);
 }
@@ -257,7 +257,7 @@ TEST_F(AudioIOInputMeterTests, MixedGroupsKeepStereoSidesAndAlternateMonosByGrou
     setSelection({ { 0, 1 }, { 2 }, { 4 }, { 6, 7 } });
 
     ASSERT_NO_FATAL_FAILURE(pushInput({ -0.2f, 0.1f, -0.7f, 0.99f, -0.8f, -0.99f, 0.4f, -0.3f,
-                                       0.9f, -0.8f, 0.1f, -0.99f, 0.2f, 0.99f, -0.3f, 0.4f }));
+                                        0.9f, -0.8f, 0.1f, -0.99f, 0.2f, 0.99f, -0.3f, 0.4f }));
 
     expectMainMeter({ { 0.8f, 0.9f }, { 0.7f, 0.8f } }, 1);
 }

--- a/src/au3audio/tests/inputchannelselection_tests.cpp
+++ b/src/au3audio/tests/inputchannelselection_tests.cpp
@@ -1,0 +1,176 @@
+/*
+* Audacity: A Digital Audio Editor
+*/
+
+#include <gtest/gtest.h>
+
+#include "audio/inputchannelselection.h"
+
+using namespace au::audio;
+
+TEST(InputChannelSelectionTests, OffersEveryMonoAndConventionalStereoGroup)
+{
+    const InputChannelSelection expected {
+        { { 0 } }, { { 1 } }, { { 2 } }, { { 3 } },
+        { { 0, 1 } }, { { 2, 3 } },
+    };
+    EXPECT_EQ(availableInputChannelGroups(4), expected);
+}
+
+TEST(InputChannelSelectionTests, AvailableGroupsHandleZeroOneAndOddCapacities)
+{
+    EXPECT_TRUE(availableInputChannelGroups(0).empty());
+    EXPECT_EQ(availableInputChannelGroups(1),
+              InputChannelSelection({ { { 0 } } }));
+    EXPECT_EQ(availableInputChannelGroups(3),
+              InputChannelSelection({ { { 0 } }, { { 1 } }, { { 2 } },
+                                        { { 0, 1 } } }));
+}
+
+TEST(InputChannelSelectionTests, ApplicationPolicyRejectsNonConventionalStereoPairs)
+{
+    EXPECT_TRUE(isValidInputChannelGroup({ { 3 } }, 4));
+    EXPECT_TRUE(isValidInputChannelGroup({ { 0, 1 } }, 4));
+    EXPECT_FALSE(isValidInputChannelGroup({ { 1, 2 } }, 4));
+    EXPECT_FALSE(isValidInputChannelGroup({ { 3, 4 } }, 4));
+    EXPECT_FALSE(isValidInputChannelGroup({ { 0, 0 } }, 4));
+    EXPECT_FALSE(isValidInputChannelGroup({}, 4));
+}
+
+TEST(InputChannelSelectionTests, SelectingStereoPairAtomicallyReplacesOverlappingMonos)
+{
+    const InputChannelSelection selection { { { 0 } }, { { 1 } }, { { 3 } } };
+    const InputChannelSelection expected { { { 0, 1 } }, { { 3 } } };
+    EXPECT_EQ(toggleInputChannelGroup(selection, { { 0, 1 } }, 4), expected);
+}
+
+TEST(InputChannelSelectionTests, SelectingMonoAtomicallyReplacesOverlappingStereoPair)
+{
+    const InputChannelSelection selection { { { 0, 1 } }, { { 2, 3 } } };
+    const InputChannelSelection expected { { { 0 } }, { { 2, 3 } } };
+    EXPECT_EQ(toggleInputChannelGroup(selection, { { 0 } }, 4), expected);
+}
+
+TEST(InputChannelSelectionTests, CannotRemoveLastGroup)
+{
+    const InputChannelSelection selection { { { 2 } } };
+    EXPECT_EQ(toggleInputChannelGroup(selection, { { 2 } }, 4), selection);
+}
+
+TEST(InputChannelSelectionTests, CanRemoveOneOfSeveralGroups)
+{
+    const InputChannelSelection selection { { { 0 } }, { { 2, 3 } } };
+    EXPECT_EQ(toggleInputChannelGroup(selection, { { 0 } }, 4),
+              InputChannelSelection({ { { 2, 3 } } }));
+}
+
+TEST(InputChannelSelectionTests, InvalidToggleLeavesNormalizedSelectionUnchanged)
+{
+    const InputChannelSelection selection { { { 2, 3 } }, { { 0 } } };
+    EXPECT_EQ(toggleInputChannelGroup(selection, { { 1, 2 } }, 4),
+              InputChannelSelection({ { { 0 } }, { { 2, 3 } } }));
+}
+
+TEST(InputChannelSelectionTests, NormalizationOrdersGroupsAndDropsOutOfRangeOnDeviceChange)
+{
+    const InputChannelSelection selection { { { 4 } }, { { 2, 3 } }, { { 0 } } };
+    const InputChannelSelection expected { { { 0 } }, { { 2, 3 } } };
+    EXPECT_EQ(normalizeInputChannelSelection(selection, 4), expected);
+}
+
+TEST(InputChannelSelectionTests, CapacityReductionPreservesLegacyPresetLayouts)
+{
+    const struct {
+        int preset;
+        int capacity;
+        InputChannelSelection expected;
+    } cases[] {
+        { 3, 2, { { { 0, 1 } } } },
+        { 4, 2, { { { 0, 1 } } } },
+        { 4, 3, { { { 0 } }, { { 1 } }, { { 2 } } } },
+        { 4, 1, { { { 0 } } } },
+        { 2, 1, { { { 0 } } } },
+        { 4, 0, {} },
+    };
+
+    for (const auto& testCase : cases) {
+        SCOPED_TRACE(::testing::Message() << "preset " << testCase.preset << ", capacity " << testCase.capacity);
+        EXPECT_EQ(normalizeInputChannelSelection(legacyInputChannelSelection(testCase.preset), testCase.capacity),
+                  testCase.expected);
+    }
+}
+
+TEST(InputChannelSelectionTests, CapacityChangesDoNotExpandPresetsOrRestoreDiscardedInputs)
+{
+    const auto preset = legacyInputChannelSelection(4);
+    EXPECT_EQ(normalizeInputChannelSelection(preset, 4), preset);
+    EXPECT_EQ(normalizeInputChannelSelection(preset, 8), preset);
+
+    const auto reduced = normalizeInputChannelSelection(preset, 2);
+    EXPECT_EQ(normalizeInputChannelSelection(reduced, 2),
+              InputChannelSelection({ { { 0, 1 } } }));
+    EXPECT_EQ(normalizeInputChannelSelection(reduced, 4),
+              InputChannelSelection({ { { 0, 1 } } }));
+}
+
+TEST(InputChannelSelectionTests, CapacityReductionPreservesCustomGrouping)
+{
+    const struct {
+        InputChannelSelection selection;
+        int capacity;
+        InputChannelSelection expected;
+    } cases[] {
+        { { { { 0 } }, { { 1 } } }, 2, { { { 0 } }, { { 1 } } } },
+        { { { { 0 } }, { { 1 } }, { { 4 } } }, 2, { { { 0 } }, { { 1 } } } },
+        { { { { 2, 3 } } }, 2, { { { 0 } } } },
+        { { { { 0 } }, { { 2, 3 } }, { { 6 } } }, 4, { { { 0 } }, { { 2, 3 } } } },
+    };
+
+    for (const auto& testCase : cases) {
+        SCOPED_TRACE(::testing::PrintToString(testCase.selection));
+        EXPECT_EQ(normalizeInputChannelSelection(testCase.selection, testCase.capacity), testCase.expected);
+    }
+}
+
+TEST(InputChannelSelectionTests, NormalizationFallsBackToFirstMonoWhenNothingRemains)
+{
+    EXPECT_EQ(normalizeInputChannelSelection({ { { 6 } } }, 2),
+              InputChannelSelection({ { { 0 } } }));
+    EXPECT_TRUE(normalizeInputChannelSelection({ { { 0 } } }, 0).empty());
+}
+
+TEST(InputChannelSelectionTests, NormalizationRejectsMalformedGroupsAndResolvesOverlap)
+{
+    const InputChannelSelection selection {
+        { { 1, 2 } }, // not a conventional stereo pair
+        { { 0, 1 } },
+        { { 0 } },
+        { { 2, 3, 4 } },
+        { { 3 } },
+    };
+    const InputChannelSelection expected { { { 0 } }, { { 3 } } };
+    EXPECT_EQ(normalizeInputChannelSelection(selection, 4), expected);
+}
+
+TEST(InputChannelSelectionTests, LegacyChannelCountsPreserveTrackLayout)
+{
+    EXPECT_TRUE(legacyInputChannelSelection(-1).empty());
+    EXPECT_TRUE(legacyInputChannelSelection(0).empty());
+    EXPECT_EQ(legacyInputChannelSelection(1), InputChannelSelection({ { { 0 } } }));
+    EXPECT_EQ(legacyInputChannelSelection(2), InputChannelSelection({ { { 0, 1 } } }));
+    EXPECT_EQ(legacyInputChannelSelection(4),
+              InputChannelSelection({ { { 0 } }, { { 1 } }, { { 2 } }, { { 3 } } }));
+}
+
+TEST(InputChannelSelectionTests, ComputesLogicalCountFlatteningAndPortAudioPrefixWidth)
+{
+    const InputChannelSelection selection { { { 0 } }, { { 2, 3 } } };
+    EXPECT_EQ(inputChannelCount(selection), 3u);
+    EXPECT_EQ(flattenInputChannelSelection(selection),
+              std::vector<InputChannelIndex>({ 0, 2, 3 }));
+    EXPECT_EQ(inputChannelStreamWidth(selection), 4u);
+
+    EXPECT_EQ(inputChannelCount({}), 0u);
+    EXPECT_TRUE(flattenInputChannelSelection({}).empty());
+    EXPECT_EQ(inputChannelStreamWidth({}), 0u);
+}

--- a/src/au3audio/tests/inputchannelselectionsettings_tests.cpp
+++ b/src/au3audio/tests/inputchannelselectionsettings_tests.cpp
@@ -1,0 +1,93 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+#include <gtest/gtest.h>
+
+#include "../internal/inputchannelselectionsettings.h"
+
+namespace au::au3audio {
+TEST(InputChannelSelectionSettingsTests, RoundTripsNestedChannelGroups)
+{
+    const audio::InputChannelSelection selection {
+        { { 0 } }, { { 2, 3 } }, { { 7 } },
+    };
+
+    EXPECT_EQ(details::inputChannelSelectionFromVal(
+                  details::inputChannelSelectionToVal(selection)), selection);
+}
+
+TEST(InputChannelSelectionSettingsTests, DropsMalformedGroupsWithoutThrowing)
+{
+    const muse::Val value(muse::ValList {
+            muse::Val(muse::ValList { muse::Val(-1) }),
+            muse::Val(muse::ValList {}),
+            muse::Val(muse::ValList { muse::Val("not a channel") }),
+            muse::Val(muse::ValList { muse::Val(2), muse::Val(3) }),
+        });
+
+    EXPECT_EQ(details::inputChannelSelectionFromVal(value),
+              audio::InputChannelSelection({ { { 2, 3 } } }));
+}
+
+TEST(InputChannelSelectionSettingsTests, EmptyNewSettingMigratesLegacyCount)
+{
+    EXPECT_EQ(details::inputChannelSelectionFromSettings(
+                  muse::Val(muse::ValList {}), 2, 4),
+              audio::InputChannelSelection({ { { 0, 1 } } }));
+}
+
+TEST(InputChannelSelectionSettingsTests, CapacityReductionClampsLegacyCountBeforeMigration)
+{
+    const muse::Val emptySelection(muse::ValList {});
+    for (const int legacyCount : { -1, 0, 1, 2, 3, 4 }) {
+        SCOPED_TRACE(legacyCount);
+        const audio::InputChannelSelection expected = legacyCount <= 1
+                                                     ? audio::InputChannelSelection { { { 0 } } }
+                                                     : audio::InputChannelSelection { { { 0, 1 } } };
+        EXPECT_EQ(details::inputChannelSelectionFromSettings(emptySelection, legacyCount, 2), expected);
+        EXPECT_EQ(details::inputChannelSelectionFromSettings(emptySelection, legacyCount, 1),
+                  audio::InputChannelSelection({ { { 0 } } }));
+        EXPECT_TRUE(details::inputChannelSelectionFromSettings(emptySelection, legacyCount, 0).empty());
+    }
+}
+
+TEST(InputChannelSelectionSettingsTests, CapacityReductionClampsPersistedPreset)
+{
+    const auto value = details::inputChannelSelectionToVal(audio::legacyInputChannelSelection(4));
+
+    EXPECT_EQ(details::inputChannelSelectionFromSettings(value, 1, 2),
+              audio::InputChannelSelection({ { { 0, 1 } } }));
+}
+
+TEST(InputChannelSelectionSettingsTests, CapacityReductionKeepsPersistedCustomMonosSeparate)
+{
+    const audio::InputChannelSelection twoMonos { { { 0 } }, { { 1 } } };
+    const auto savedTwoMonos = details::inputChannelSelectionToVal(twoMonos);
+    EXPECT_EQ(details::inputChannelSelectionFromSettings(savedTwoMonos, 2, 2), twoMonos);
+
+    const auto savedCustomRoute = details::inputChannelSelectionToVal(
+        audio::InputChannelSelection { { { 0 } }, { { 1 } }, { { 4 } } });
+    const auto reduced = details::inputChannelSelectionFromSettings(savedCustomRoute, 3, 2);
+    EXPECT_EQ(reduced, twoMonos);
+    EXPECT_EQ(details::inputChannelSelectionFromSettings(details::inputChannelSelectionToVal(reduced), 2, 2), twoMonos);
+}
+
+TEST(InputChannelSelectionSettingsTests, NewSettingTakesPrecedenceOverLegacyCount)
+{
+    const auto value = details::inputChannelSelectionToVal(
+        audio::InputChannelSelection({ { { 2, 3 } } }));
+
+    EXPECT_EQ(details::inputChannelSelectionFromSettings(value, 1, 4),
+              audio::InputChannelSelection({ { { 2, 3 } } }));
+}
+
+TEST(InputChannelSelectionSettingsTests, NormalizesPersistedSelectionForDeviceCapacity)
+{
+    const auto value = details::inputChannelSelectionToVal(
+        audio::InputChannelSelection({ { { 0 } }, { { 4, 5 } } }));
+
+    EXPECT_EQ(details::inputChannelSelectionFromSettings(value, 6, 4),
+              audio::InputChannelSelection({ { { 0 } } }));
+    EXPECT_TRUE(details::inputChannelSelectionFromSettings(value, 6, 0).empty());
+}
+}

--- a/src/au3audio/tests/inputchannelselectionsettings_tests.cpp
+++ b/src/au3audio/tests/inputchannelselectionsettings_tests.cpp
@@ -42,8 +42,8 @@ TEST(InputChannelSelectionSettingsTests, CapacityReductionClampsLegacyCountBefor
     for (const int legacyCount : { -1, 0, 1, 2, 3, 4 }) {
         SCOPED_TRACE(legacyCount);
         const audio::InputChannelSelection expected = legacyCount <= 1
-                                                     ? audio::InputChannelSelection { { { 0 } } }
-                                                     : audio::InputChannelSelection { { { 0, 1 } } };
+                                                      ? audio::InputChannelSelection { { { 0 } } }
+        : audio::InputChannelSelection { { { 0, 1 } } };
         EXPECT_EQ(details::inputChannelSelectionFromSettings(emptySelection, legacyCount, 2), expected);
         EXPECT_EQ(details::inputChannelSelectionFromSettings(emptySelection, legacyCount, 1),
                   audio::InputChannelSelection({ { { 0 } } }));

--- a/src/au3audio/tests/mocks/audioenginemock.h
+++ b/src/au3audio/tests/mocks/audioenginemock.h
@@ -34,7 +34,7 @@ public:
     MOCK_METHOD(std::shared_ptr<RealtimeEffectState>, replaceRealtimeEffectState,
                 (AudacityProject&, ChannelGroup*, size_t, const std::string&), (override));
 
-    MOCK_METHOD(void, startMonitoring, (AudacityProject & project), (override));
+    MOCK_METHOD(void, startMonitoring, (AudacityProject & project, const InputChannelSelection& inputChannelSelection), (override));
     MOCK_METHOD(void, stopMonitoring, (), (override));
     MOCK_METHOD(void, setInputVolume, (float newInputVolume), (override));
     MOCK_METHOD(float, getInputVolume, (), (const, override));

--- a/src/audio/CMakeLists.txt
+++ b/src/audio/CMakeLists.txt
@@ -13,6 +13,7 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/audiotypes.h
     ${CMAKE_CURRENT_LIST_DIR}/iaudioengine.h
     ${CMAKE_CURRENT_LIST_DIR}/iaudiometer.h
+    ${CMAKE_CURRENT_LIST_DIR}/inputchannelselection.h
 
     ${CMAKE_CURRENT_LIST_DIR}/internal/audiometer.cpp
     ${CMAKE_CURRENT_LIST_DIR}/internal/audiometer.h

--- a/src/audio/audioconfigurationtypes.h
+++ b/src/audio/audioconfigurationtypes.h
@@ -7,6 +7,8 @@
 #include <optional>
 #include <string>
 
+#include "inputchannelselection.h"
+
 class AudacityProject;
 
 namespace au::audio {
@@ -16,7 +18,7 @@ struct AudioConfiguration {
     std::string api;
     AudioDeviceSelection outputDevice;
     AudioDeviceSelection inputDevice;
-    int inputChannels = 1;
+    InputChannelSelection inputChannelSelection { { { 0 } } };
     double bufferLength = 0.0;
     bool automaticLatencyCompensation = false;
     double latencyCompensation = 0.0;
@@ -29,7 +31,7 @@ struct AudioConfigurationChange {
     std::optional<std::string> api;
     std::optional<AudioDeviceSelection> outputDevice;
     std::optional<AudioDeviceSelection> inputDevice;
-    std::optional<int> inputChannels;
+    std::optional<InputChannelSelection> inputChannelSelection;
     std::optional<double> bufferLength;
     std::optional<bool> automaticLatencyCompensation;
     std::optional<double> latencyCompensation;
@@ -43,7 +45,7 @@ enum class AudioConfigurationField : uint32_t {
     Api = 1 << 0,
     OutputDevice = 1 << 1,
     InputDevice = 1 << 2,
-    InputChannels = 1 << 3,
+    InputChannelSelection = 1 << 3,
     BufferLength = 1 << 4,
     AutomaticLatencyCompensation = 1 << 5,
     LatencyCompensation = 1 << 6,

--- a/src/audio/iaudioengine.h
+++ b/src/audio/iaudioengine.h
@@ -52,6 +52,7 @@ public:
         std::vector<std::vector<float> >* crossfadeData = nullptr;
         //! Does not change the play region.
         std::optional<double> streamStartTime;
+        InputChannelSelection inputChannelSelection;
     };
 
     //! Returns a positive stream token on success, 0 otherwise.
@@ -70,7 +71,7 @@ public:
     virtual std::shared_ptr<RealtimeEffectState> replaceRealtimeEffectState(AudacityProject& project, ChannelGroup* group,
                                                                             size_t effectListIndex, const std::string& newEffectId) = 0;
 
-    virtual void startMonitoring(AudacityProject& project) = 0;
+    virtual void startMonitoring(AudacityProject& project, const InputChannelSelection& inputChannelSelection) = 0;
     virtual void stopMonitoring() = 0;
 
     virtual void setInputVolume(float newInputVolume) = 0;

--- a/src/audio/inputchannelselection.h
+++ b/src/audio/inputchannelselection.h
@@ -1,0 +1,180 @@
+/*
+* Audacity: A Digital Audio Editor
+*/
+#pragma once
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <vector>
+
+namespace au::audio {
+using InputChannelIndex = uint32_t;
+
+struct InputChannelGroup {
+    std::vector<InputChannelIndex> channels;
+};
+
+inline bool operator==(const InputChannelGroup& lhs, const InputChannelGroup& rhs)
+{
+    return lhs.channels == rhs.channels;
+}
+
+inline bool operator!=(const InputChannelGroup& lhs, const InputChannelGroup& rhs)
+{
+    return !(lhs == rhs);
+}
+
+using InputChannelSelection = std::vector<InputChannelGroup>;
+
+inline size_t inputChannelCount(const InputChannelSelection& selection)
+{
+    size_t result = 0;
+    for (const auto& group : selection) {
+        result += group.channels.size();
+    }
+    return result;
+}
+
+inline InputChannelSelection legacyInputChannelSelection(int channels)
+{
+    if (channels <= 0) {
+        return {};
+    }
+    if (channels == 1) {
+        return { { { 0 } } };
+    }
+    if (channels == 2) {
+        return { { { 0, 1 } } };
+    }
+
+    InputChannelSelection result;
+    for (int channel = 0; channel < channels; ++channel) {
+        result.push_back({ { static_cast<InputChannelIndex>(channel) } });
+    }
+    return result;
+}
+
+inline bool isValidInputChannelGroup(const InputChannelGroup& group, int availableChannels)
+{
+    if (availableChannels <= 0 || group.channels.empty() || group.channels.size() > 2) {
+        return false;
+    }
+
+    if (group.channels.size() == 2
+        && (group.channels[0] % 2 != 0 || group.channels[1] != group.channels[0] + 1)) {
+        return false;
+    }
+
+    return std::all_of(group.channels.begin(), group.channels.end(), [availableChannels](InputChannelIndex channel) {
+        return channel < static_cast<InputChannelIndex>(availableChannels);
+    });
+}
+
+inline InputChannelSelection normalizeInputChannelSelection(InputChannelSelection selection, int availableChannels)
+{
+    if (availableChannels <= 0) {
+        return {};
+    }
+
+    // Clamp exact count presets before discarding groups, so reducing N > 2
+    // inputs to two preserves the legacy stereo layout. Custom groups stay separate.
+    const auto selectedChannels = inputChannelCount(selection);
+    if (selectedChannels > static_cast<size_t>(availableChannels)
+        && selectedChannels <= static_cast<size_t>(std::numeric_limits<int>::max())
+        && selection == legacyInputChannelSelection(static_cast<int>(selectedChannels))) {
+        return legacyInputChannelSelection(availableChannels);
+    }
+
+    selection.erase(std::remove_if(selection.begin(), selection.end(), [availableChannels](const InputChannelGroup& group) {
+        return !isValidInputChannelGroup(group, availableChannels);
+    }), selection.end());
+    std::sort(selection.begin(), selection.end(), [](const InputChannelGroup& lhs, const InputChannelGroup& rhs) {
+        if (lhs.channels.front() != rhs.channels.front()) {
+            return lhs.channels.front() < rhs.channels.front();
+        }
+        return lhs.channels.size() < rhs.channels.size();
+    });
+
+    InputChannelSelection result;
+    std::vector<bool> used(static_cast<size_t>(availableChannels));
+    for (auto& group : selection) {
+        const bool overlaps = std::any_of(group.channels.begin(), group.channels.end(), [&used](InputChannelIndex channel) {
+            return used[channel];
+        });
+        if (overlaps) {
+            continue;
+        }
+        for (const auto channel : group.channels) {
+            used[channel] = true;
+        }
+        result.push_back(std::move(group));
+    }
+
+    if (result.empty()) {
+        result.push_back({ { 0 } });
+    }
+    return result;
+}
+
+inline InputChannelSelection availableInputChannelGroups(int availableChannels)
+{
+    InputChannelSelection result;
+    for (int channel = 0; channel < availableChannels; ++channel) {
+        result.push_back({ { static_cast<InputChannelIndex>(channel) } });
+    }
+    for (int channel = 0; channel + 1 < availableChannels; channel += 2) {
+        result.push_back({ { static_cast<InputChannelIndex>(channel), static_cast<InputChannelIndex>(channel + 1) } });
+    }
+    return result;
+}
+
+inline InputChannelSelection toggleInputChannelGroup(
+    const InputChannelSelection& selection, const InputChannelGroup& group, int availableChannels)
+{
+    auto result = normalizeInputChannelSelection(selection, availableChannels);
+    if (!isValidInputChannelGroup(group, availableChannels)) {
+        return result;
+    }
+
+    const auto exact = std::find(result.begin(), result.end(), group);
+    if (exact != result.end()) {
+        if (result.size() == 1) {
+            return result;
+        }
+        result.erase(exact);
+        return normalizeInputChannelSelection(std::move(result), availableChannels);
+    }
+
+    result.erase(std::remove_if(result.begin(), result.end(), [&group](const InputChannelGroup& candidate) {
+        return std::any_of(candidate.channels.begin(), candidate.channels.end(), [&group](InputChannelIndex channel) {
+            return std::find(group.channels.begin(), group.channels.end(), channel) != group.channels.end();
+        });
+    }), result.end());
+    result.push_back(group);
+    return normalizeInputChannelSelection(std::move(result), availableChannels);
+}
+
+inline std::vector<InputChannelIndex> flattenInputChannelSelection(const InputChannelSelection& selection)
+{
+    std::vector<InputChannelIndex> result;
+    for (const auto& group : selection) {
+        result.insert(result.end(), group.channels.begin(), group.channels.end());
+    }
+    return result;
+}
+
+inline size_t inputChannelStreamWidth(const InputChannelSelection& selection)
+{
+    InputChannelIndex highest = 0;
+    bool found = false;
+    for (const auto& group : selection) {
+        for (const auto channel : group.channels) {
+            highest = std::max(highest, channel);
+            found = true;
+        }
+    }
+    return found ? static_cast<size_t>(highest) + 1 : 0;
+}
+}

--- a/src/extensions/native/nativeextension.h
+++ b/src/extensions/native/nativeextension.h
@@ -51,11 +51,7 @@ typedef struct ext_value {
 typedef int32_t (* ext_dispatch_fn)(const char* call, const ext_value* args, uint32_t arg_count, ext_value* result);
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
 #endif
 
 EXT_EXPORT int32_t extension_dispatch_v0(const char* call, const ext_value* args, uint32_t arg_count, ext_value* result);
-
-#ifdef __cplusplus
-}
-#endif

--- a/src/playback/internal/playbackcontroller.cpp
+++ b/src/playback/internal/playbackcontroller.cpp
@@ -699,7 +699,8 @@ AudioStreamRestorer PlaybackController::suspendForAudioConfiguration(AudioStream
                     return true;
                 }
 
-                audioEngine()->startMonitoring(*au3Project);
+                audioEngine()->startMonitoring(
+                    *au3Project, audioDriverController()->configuration().inputChannelSelection);
                 return audioEngine()->isMonitoring();
             };
     }
@@ -938,15 +939,24 @@ void PlaybackController::setAudioInputDevice(const muse::actions::ActionQuery& q
 
 void PlaybackController::setInputChannels(const muse::actions::ActionQuery& q)
 {
-    IF_ASSERT_FAILED(q.contains("input-channels_index")) {
+    if (!q.contains("input-channels_index")) {
         return;
     }
 
-    const int channels = q.param("input-channels_index").toInt();
+    bool validCount = false;
+    const int channelCount = QString::fromStdString(q.param("input-channels_index").toString()).toInt(&validCount);
+    const int availableChannels = audioDriverController()->inputChannelsAvailable();
+    if (!validCount || channelCount <= 0 || channelCount > availableChannels) {
+        return;
+    }
     AudioConfigurationChange change;
-    change.inputChannels = channels;
-    handleAudioConfigurationResult(audioDriverController()->apply(iocContext(), change),
-                                   PLAYBACK_CHANGE_INPUT_CHANNELS_QUERY.toString());
+    change.inputChannelSelection = audio::legacyInputChannelSelection(channelCount);
+    const auto result = audioDriverController()->apply(iocContext(), change);
+    if (result.status == ApplyStatus::NoChange) {
+        // A selected preset cannot be unchecked, even when no configuration change is needed.
+        notifyActionCheckedChanged(PLAYBACK_CHANGE_INPUT_CHANNELS_QUERY.toString());
+    }
+    handleAudioConfigurationResult(result, PLAYBACK_CHANGE_INPUT_CHANNELS_QUERY.toString());
 }
 
 void PlaybackController::rescanAudioDevices()

--- a/src/playback/internal/playbackuiactions.cpp
+++ b/src/playback/internal/playbackuiactions.cpp
@@ -362,7 +362,7 @@ void PlaybackUiActions::init()
         if (delta.contains(AudioConfigurationField::InputDevice)) {
             actions.push_back(PLAYBACK_CHANGE_RECORDING_DEVICE_QUERY.toString());
         }
-        if (delta.contains(AudioConfigurationField::InputChannels)) {
+        if (delta.contains(AudioConfigurationField::InputChannelSelection)) {
             actions.push_back(PLAYBACK_CHANGE_INPUT_CHANNELS_QUERY.toString());
         }
         if (!actions.empty()) {

--- a/src/playback/tests/playbackcontroller_tests.cpp
+++ b/src/playback/tests/playbackcontroller_tests.cpp
@@ -191,6 +191,18 @@ public:
         m_controller->setAudioInputDevice(q);
     }
 
+    void changeInputChannels(int channelCount)
+    {
+        muse::actions::ActionQuery q("action://playback/change-input-channels");
+        q.addParam("input-channels_index", muse::Val(channelCount));
+        changeInputChannels(q);
+    }
+
+    void changeInputChannels(const muse::actions::ActionQuery& q)
+    {
+        m_controller->setInputChannels(q);
+    }
+
     void playFromCurrentState()
     {
         m_controller->doPlay(false);
@@ -1376,12 +1388,17 @@ TEST_F(PlaybackControllerTests, SuspendMonitoring_RestoresTheOwningProject)
     .WillByDefault(Return(std::vector<std::string> { "Built-in microphone" }));
     ON_CALL(*m_audioDriverController, inputChannelsAvailable())
     .WillByDefault(Return(2));
+    audio::AudioConfiguration configuration;
+    configuration.inputChannelSelection = { { { 1 } } };
+    ON_CALL(*m_audioDriverController, configuration())
+    .WillByDefault(Return(configuration));
 
     EXPECT_CALL(*m_audioEngine, stopMonitoring()).Times(1);
     auto restoreStream = suspend(audio::AudioStreamKind::Monitoring);
 
     ASSERT_TRUE(restoreStream);
-    EXPECT_CALL(*m_audioEngine, startMonitoring(_)).Times(1);
+    EXPECT_CALL(*m_audioEngine, startMonitoring(
+                    _, configuration.inputChannelSelection)).Times(1);
     EXPECT_TRUE(restoreStream());
 }
 
@@ -1398,7 +1415,7 @@ TEST_F(PlaybackControllerTests, SuspendMonitoring_WithoutRecordDevice_DoesNotRes
     auto restoreStream = suspend(audio::AudioStreamKind::Monitoring);
 
     ASSERT_TRUE(restoreStream);
-    EXPECT_CALL(*m_audioEngine, startMonitoring(_)).Times(0);
+    EXPECT_CALL(*m_audioEngine, startMonitoring(_, _)).Times(0);
     EXPECT_TRUE(restoreStream());
 }
 
@@ -1442,6 +1459,118 @@ TEST_F(PlaybackControllerTests, ChangeInputDevice_RejectedChangeRestoresMenuStat
     changeInputDevice(1);
 
     EXPECT_THAT(changedActions, ::testing::ElementsAre("action://playback/change-recording-device"));
+}
+
+TEST_F(PlaybackControllerTests, ChangeInputChannelsReplacesCustomSelectionWithTheCountPreset)
+{
+    audio::AudioConfiguration configuration;
+    configuration.inputChannelSelection = { { { 0 } }, { { 2, 3 } } };
+    ON_CALL(*m_audioDriverController, configuration())
+    .WillByDefault(Return(configuration));
+    ON_CALL(*m_audioDriverController, inputChannelsAvailable())
+    .WillByDefault(Return(4));
+
+    const std::vector<audio::InputChannelSelection> presets {
+        { { { 0 } } },
+        { { { 0, 1 } } },
+        { { { 0 } }, { { 1 } }, { { 2 } } },
+        { { { 0 } }, { { 1 } }, { { 2 } }, { { 3 } } }
+    };
+    for (size_t index = 0; index < presets.size(); ++index) {
+        SCOPED_TRACE(index);
+        EXPECT_CALL(*m_audioDriverController, apply(muse::modularity::globalCtx(), _))
+        .WillOnce([&presets, index](const muse::modularity::ContextPtr&,
+                                    const audio::AudioConfigurationChange& change) {
+            EXPECT_EQ(change.inputChannelSelection, std::optional<audio::InputChannelSelection>(presets[index]));
+            EXPECT_FALSE(change.api.has_value());
+            EXPECT_FALSE(change.inputDevice.has_value());
+            EXPECT_FALSE(change.outputDevice.has_value());
+            return audio::ApplyResult { audio::ApplyStatus::Applied };
+        });
+
+        changeInputChannels(static_cast<int>(index + 1));
+    }
+}
+
+TEST_F(PlaybackControllerTests, ChangeInputChannelsKeepsTheActivePresetCheckedWhenUnchanged)
+{
+    ON_CALL(*m_audioDriverController, inputChannelsAvailable()).WillByDefault(Return(4));
+    EXPECT_CALL(*m_audioDriverController, apply(muse::modularity::globalCtx(), _))
+    .WillOnce([](const muse::modularity::ContextPtr&, const audio::AudioConfigurationChange& change) {
+        EXPECT_EQ(change.inputChannelSelection, std::optional<audio::InputChannelSelection>({ { { 0, 1 } } }));
+        return audio::ApplyResult { audio::ApplyStatus::NoChange };
+    });
+    EXPECT_CALL(*m_interactive, error(_, _, _, _, _, _)).Times(0);
+
+    std::vector<muse::actions::ActionCode> changedActions;
+    m_controller->actionCheckedChanged().onReceive(nullptr, [&changedActions](const muse::actions::ActionCode& code) {
+        changedActions.push_back(code);
+    });
+
+    changeInputChannels(2);
+
+    EXPECT_THAT(changedActions, ::testing::ElementsAre("action://playback/change-input-channels"));
+}
+
+TEST_F(PlaybackControllerTests, ChangeInputChannelsRejectedChangeRestoresMenuStateAndReportsError)
+{
+    ON_CALL(*m_audioDriverController, inputChannelsAvailable()).WillByDefault(Return(4));
+    EXPECT_CALL(*m_audioDriverController, apply(muse::modularity::globalCtx(), _))
+    .WillOnce(Return(audio::ApplyResult { audio::ApplyStatus::OwnerUnavailable }));
+    EXPECT_CALL(*m_interactive, error(_, _, _, _, _, _))
+    .WillOnce(Return(muse::async::make_promise<muse::IInteractive::Result>(
+                         [](const auto& resolve) { return resolve(muse::IInteractive::Result {}); },
+                         muse::async::PromiseType::AsyncByBody)));
+
+    std::vector<muse::actions::ActionCode> changedActions;
+    m_controller->actionCheckedChanged().onReceive(nullptr, [&changedActions](const muse::actions::ActionCode& code) {
+        changedActions.push_back(code);
+    });
+
+    changeInputChannels(2);
+
+    EXPECT_THAT(changedActions, ::testing::ElementsAre("action://playback/change-input-channels"));
+}
+
+TEST_F(PlaybackControllerTests, ChangeInputChannelsRejectsMalformedOrOutOfRangeQueries)
+{
+    ON_CALL(*m_audioDriverController, inputChannelsAvailable())
+    .WillByDefault(Return(4));
+    EXPECT_CALL(*m_audioDriverController, apply(_, _)).Times(0);
+
+    changeInputChannels(-1);
+    changeInputChannels(0);
+    changeInputChannels(5);
+
+    for (const auto* count : { "", "not-a-number", "2.5", "2tail", "999999999999999999999" }) {
+        SCOPED_TRACE(count);
+        muse::actions::ActionQuery q("action://playback/change-input-channels");
+        q.addParam("input-channels_index", muse::Val(count));
+        changeInputChannels(q);
+    }
+
+    changeInputChannels(muse::actions::ActionQuery("action://playback/change-input-channels"));
+    changeInputChannels(muse::actions::ActionQuery("action://playback/change-input-channels?first-channel-index=0&channel-count=2"));
+}
+
+TEST_F(PlaybackControllerTests, ChangeInputChannelsAcceptsSerializedCountQuery)
+{
+    ON_CALL(*m_audioDriverController, inputChannelsAvailable()).WillByDefault(Return(4));
+    EXPECT_CALL(*m_audioDriverController, apply(muse::modularity::globalCtx(), _))
+    .WillOnce([](const muse::modularity::ContextPtr&, const audio::AudioConfigurationChange& change) {
+        EXPECT_EQ(change.inputChannelSelection, std::optional<audio::InputChannelSelection>({ { { 0, 1 } } }));
+        return audio::ApplyResult { audio::ApplyStatus::Applied };
+    });
+
+    changeInputChannels(muse::actions::ActionQuery("action://playback/change-input-channels?input-channels_index=2"));
+}
+
+TEST_F(PlaybackControllerTests, ChangeInputChannelsRejectsCountWhenNoInputsAreAvailable)
+{
+    ON_CALL(*m_audioDriverController, inputChannelsAvailable()).WillByDefault(Return(0));
+    EXPECT_CALL(*m_audioDriverController, apply(_, _)).Times(0);
+
+    changeInputChannels(1);
 }
 
 TEST_F(PlaybackControllerTests, RescanAudioDevices_DelegatesToGlobalController)

--- a/src/preferences/qml/Audacity/Preferences/CMakeLists.txt
+++ b/src/preferences/qml/Audacity/Preferences/CMakeLists.txt
@@ -85,6 +85,7 @@ qt_add_qml_module(preferences_qml
         internal/PreferencesMenu.qml
         internal/ProgramStartSection.qml
         internal/RecordingBehaviorSection.qml
+        internal/RecordingChannelListModel.qml
         internal/RemoteControlSection.qml
         internal/SampleRateSection.qml
         internal/SaveBehaviorSection.qml

--- a/src/preferences/qml/Audacity/Preferences/commonaudioapiconfigurationmodel.cpp
+++ b/src/preferences/qml/Audacity/Preferences/commonaudioapiconfigurationmodel.cpp
@@ -37,15 +37,12 @@ QString toSampleRateName(uint64_t sampleRate)
     return QString::number(sampleRate) + " Hz";
 }
 
-QString channelName(int channelNumber)
+QString channelGroupName(const au::audio::InputChannelGroup& group)
 {
-    return channelNumber == 1
-           //: %1 is the recording channel number
-           ? muse::qtrc("preferences", "%1 (Mono) Recording channel").arg(channelNumber)
-           : channelNumber == 2
-           //: %1 is the recording channel number
-           ? muse::qtrc("preferences", "%1 (Stereo) Recording channels").arg(channelNumber)
-           : QString::number(channelNumber);
+    if (group.channels.size() == 1) {
+        return QString::number(group.channels.front() + 1);
+    }
+    return QString("%1+%2").arg(group.channels[0] + 1).arg(group.channels[1] + 1);
 }
 
 QString failureMessage(au::audio::ApplyStatus status)
@@ -220,8 +217,7 @@ void CommonAudioApiConfigurationModel::notifyDeviceContextChanged()
     emit longestDeviceNameLengthChanged();
     emit currentOutputDeviceIndexChanged();
     emit currentInputDeviceIndexChanged();
-    emit inputChannelsListChanged();
-    emit currentInputChannelsSelectedChanged();
+    emit inputChannelSelectionChanged();
 }
 
 bool CommonAudioApiConfigurationModel::isAsio() const
@@ -415,8 +411,7 @@ void CommonAudioApiConfigurationModel::inputDeviceSelected(int index)
     }
     m_pending.inputChannelSelection.reset();
     emit currentInputDeviceIndexChanged();
-    emit inputChannelsListChanged();
-    emit currentInputChannelsSelectedChanged();
+    emit inputChannelSelectionChanged();
 }
 
 double CommonAudioApiConfigurationModel::bufferLength() const
@@ -480,38 +475,51 @@ void CommonAudioApiConfigurationModel::latencyCompensationSelected(
     emit latencyCompensationChanged();
 }
 
-QString CommonAudioApiConfigurationModel::currentInputChannelsSelected() const
+QString CommonAudioApiConfigurationModel::inputChannelSelectionSummary() const
 {
-    const auto selection = effectiveInputChannelSelection();
-    const int channels = static_cast<int>(audio::inputChannelCount(selection));
-    return selection == audio::legacyInputChannelSelection(channels)
-           ? channelName(channels) : QStringLiteral("\u2014");
+    QStringList groups;
+    for (const auto& group : effectiveInputChannelSelection()) {
+        groups.push_back(channelGroupName(group));
+    }
+    return groups.empty() ? QStringLiteral("\u2014") : groups.join(", ");
 }
 
-QVariantList CommonAudioApiConfigurationModel::inputChannelsList() const
+QVariantList CommonAudioApiConfigurationModel::inputChannelGroups() const
 {
     QVariantList result;
-
-    for (int i = 0; i < effectiveInputChannelsAvailable(); i++) {
-        result << channelName(i + 1);
+    const auto selection = effectiveInputChannelSelection();
+    for (const auto& group : audio::availableInputChannelGroups(effectiveInputChannelsAvailable())) {
+        result.push_back(QVariantMap {
+            { "title", channelGroupName(group) },
+            { "firstChannel", static_cast<int>(group.channels.front()) },
+            { "channelCount", static_cast<int>(group.channels.size()) },
+            { "sectionStart", group.channels.front() == 0 },
+            { "checked", std::find(selection.begin(), selection.end(), group) != selection.end() },
+        });
     }
-
     return result;
 }
 
-void CommonAudioApiConfigurationModel::inputChannelsSelected(const int index)
+void CommonAudioApiConfigurationModel::toggleInputChannelGroup(int firstChannel, int channelCount)
 {
-    if (index < 0 || index >= effectiveInputChannelsAvailable()) {
+    const int availableChannels = effectiveInputChannelsAvailable();
+    if (firstChannel < 0 || (channelCount != 1 && channelCount != 2)
+        || firstChannel > availableChannels - channelCount) {
         return;
     }
-    const auto value = audio::legacyInputChannelSelection(index + 1);
+    audio::InputChannelGroup group;
+    for (int channel = 0; channel < channelCount; ++channel) {
+        group.channels.push_back(static_cast<audio::InputChannelIndex>(firstChannel + channel));
+    }
+    const auto value = audio::toggleInputChannelGroup(
+        effectiveInputChannelSelection(), group, availableChannels);
     if (!m_pending.api && !m_pending.inputDevice
         && value == audioDriverController()->configuration().inputChannelSelection) {
         m_pending.inputChannelSelection.reset();
     } else {
         m_pending.inputChannelSelection = value;
     }
-    emit currentInputChannelsSelectedChanged();
+    emit inputChannelSelectionChanged();
 }
 
 QString CommonAudioApiConfigurationModel::defaultSampleRate() const

--- a/src/preferences/qml/Audacity/Preferences/commonaudioapiconfigurationmodel.cpp
+++ b/src/preferences/qml/Audacity/Preferences/commonaudioapiconfigurationmodel.cpp
@@ -107,7 +107,7 @@ void CommonAudioApiConfigurationModel::load()
         if (delta.contains(audio::AudioConfigurationField::Api)
             || delta.contains(audio::AudioConfigurationField::OutputDevice)
             || delta.contains(audio::AudioConfigurationField::InputDevice)
-            || delta.contains(audio::AudioConfigurationField::InputChannels)) {
+            || delta.contains(audio::AudioConfigurationField::InputChannelSelection)) {
             notifyDeviceContextChanged();
         }
         if (delta.contains(audio::AudioConfigurationField::BufferLength)) {
@@ -205,11 +205,11 @@ int CommonAudioApiConfigurationModel::effectiveInputChannelsAvailable() const
     return audioDriverController()->inputChannelsAvailable(effectiveApi(), effectiveInputDevice());
 }
 
-int CommonAudioApiConfigurationModel::effectiveInputChannels() const
+au::audio::InputChannelSelection CommonAudioApiConfigurationModel::effectiveInputChannelSelection() const
 {
-    int channels = m_pending.inputChannels.value_or(audioDriverController()->configuration().inputChannels);
     const int available = effectiveInputChannelsAvailable();
-    return available > 0 ? std::min(channels, available) : 0;
+    return audio::normalizeInputChannelSelection(
+        m_pending.inputChannelSelection.value_or(audioDriverController()->configuration().inputChannelSelection), available);
 }
 
 void CommonAudioApiConfigurationModel::notifyDeviceContextChanged()
@@ -302,7 +302,7 @@ void CommonAudioApiConfigurationModel::setCurrentAudioApiIndex(int index)
     }
     m_pending.outputDevice.reset();
     m_pending.inputDevice.reset();
-    m_pending.inputChannels.reset();
+    m_pending.inputChannelSelection.reset();
     notifyDeviceContextChanged();
 }
 
@@ -413,7 +413,7 @@ void CommonAudioApiConfigurationModel::inputDeviceSelected(int index)
     } else {
         m_pending.inputDevice = value;
     }
-    m_pending.inputChannels.reset();
+    m_pending.inputChannelSelection.reset();
     emit currentInputDeviceIndexChanged();
     emit inputChannelsListChanged();
     emit currentInputChannelsSelectedChanged();
@@ -482,7 +482,10 @@ void CommonAudioApiConfigurationModel::latencyCompensationSelected(
 
 QString CommonAudioApiConfigurationModel::currentInputChannelsSelected() const
 {
-    return channelName(effectiveInputChannels());
+    const auto selection = effectiveInputChannelSelection();
+    const int channels = static_cast<int>(audio::inputChannelCount(selection));
+    return selection == audio::legacyInputChannelSelection(channels)
+           ? channelName(channels) : QStringLiteral("\u2014");
 }
 
 QVariantList CommonAudioApiConfigurationModel::inputChannelsList() const
@@ -498,12 +501,15 @@ QVariantList CommonAudioApiConfigurationModel::inputChannelsList() const
 
 void CommonAudioApiConfigurationModel::inputChannelsSelected(const int index)
 {
-    const int value = index + 1;
+    if (index < 0 || index >= effectiveInputChannelsAvailable()) {
+        return;
+    }
+    const auto value = audio::legacyInputChannelSelection(index + 1);
     if (!m_pending.api && !m_pending.inputDevice
-        && value == audioDriverController()->configuration().inputChannels) {
-        m_pending.inputChannels.reset();
+        && value == audioDriverController()->configuration().inputChannelSelection) {
+        m_pending.inputChannelSelection.reset();
     } else {
-        m_pending.inputChannels = value;
+        m_pending.inputChannelSelection = value;
     }
     emit currentInputChannelsSelectedChanged();
 }

--- a/src/preferences/qml/Audacity/Preferences/commonaudioapiconfigurationmodel.h
+++ b/src/preferences/qml/Audacity/Preferences/commonaudioapiconfigurationmodel.h
@@ -53,8 +53,8 @@ class CommonAudioApiConfigurationModel : public QObject, public muse::async::Asy
     Q_PROPERTY(bool automaticCompensationEnabled READ automaticCompensationEnabled NOTIFY automaticCompensationEnabledChanged)
     Q_PROPERTY(double latencyCompensation READ latencyCompensation NOTIFY latencyCompensationChanged)
 
-    Q_PROPERTY(QString currentInputChannelsSelected READ currentInputChannelsSelected NOTIFY currentInputChannelsSelectedChanged)
-    Q_PROPERTY(QVariantList inputChannelsList READ inputChannelsList NOTIFY inputChannelsListChanged)
+    Q_PROPERTY(QString inputChannelSelectionSummary READ inputChannelSelectionSummary NOTIFY inputChannelSelectionChanged)
+    Q_PROPERTY(QVariantList inputChannelGroups READ inputChannelGroups NOTIFY inputChannelSelectionChanged)
 
     Q_PROPERTY(QString defaultSampleRate READ defaultSampleRate NOTIFY defaultSampleRateChanged)
     Q_PROPERTY(uint64_t defaultSampleRateValue READ defaultSampleRateValue NOTIFY defaultSampleRateValueChanged)
@@ -102,9 +102,9 @@ public:
     double latencyCompensation() const;
     Q_INVOKABLE void latencyCompensationSelected(const QString& latencyCompensationStr);
 
-    QString currentInputChannelsSelected() const;
-    QVariantList inputChannelsList() const;
-    Q_INVOKABLE void inputChannelsSelected(const int index);
+    QString inputChannelSelectionSummary() const;
+    QVariantList inputChannelGroups() const;
+    Q_INVOKABLE void toggleInputChannelGroup(int firstChannel, int channelCount);
 
     // used for dropdown
     QString defaultSampleRate() const;
@@ -143,8 +143,7 @@ signals:
     void latencyCompensationChanged();
     void automaticCompensationEnabledChanged();
 
-    void currentInputChannelsSelectedChanged();
-    void inputChannelsListChanged();
+    void inputChannelSelectionChanged();
 
     void defaultSampleRateChanged();
     void defaultSampleRateValueChanged();

--- a/src/preferences/qml/Audacity/Preferences/commonaudioapiconfigurationmodel.h
+++ b/src/preferences/qml/Audacity/Preferences/commonaudioapiconfigurationmodel.h
@@ -163,7 +163,7 @@ private:
     audio::AudioDeviceSelection effectiveOutputDevice() const;
     audio::AudioDeviceSelection effectiveInputDevice() const;
     int effectiveInputChannelsAvailable() const;
-    int effectiveInputChannels() const;
+    audio::InputChannelSelection effectiveInputChannelSelection() const;
     void setPendingSampleRate(uint64_t rateValue);
     void clearPendingValues();
     void notifyDeviceContextChanged();

--- a/src/preferences/qml/Audacity/Preferences/internal/AudioApiSection.qml
+++ b/src/preferences/qml/Audacity/Preferences/internal/AudioApiSection.qml
@@ -178,7 +178,9 @@ BaseSection {
                                 CheckBox {
                                     id: channelCheckBox
                                     anchors.left: parent.left
+                                    anchors.right: parent.right
                                     anchors.leftMargin: 8
+                                    anchors.rightMargin: 8
                                     anchors.bottom: parent.bottom
                                     text: channelDelegate.model.title
                                     checked: channelDelegate.model.checked

--- a/src/preferences/qml/Audacity/Preferences/internal/AudioApiSection.qml
+++ b/src/preferences/qml/Audacity/Preferences/internal/AudioApiSection.qml
@@ -21,6 +21,7 @@
  */
 import QtQuick 2.15
 
+import Muse.Ui
 import Muse.UiComponents
 
 import Audacity.UiComponents 1.0
@@ -101,20 +102,102 @@ BaseSection {
                 }
             }
 
-            ComboBoxWithTitle {
-                title: qsTrc("preferences", "Recording channels")
-                columnWidth: root.columnWidth
+            Column {
+                width: root.columnWidth
+                spacing: 6
 
-                currentIndex: indexOfValue(apiModel.currentInputChannelsSelected)
-                model: apiModel.inputChannelsList
+                StyledTextLabel {
+                    width: parent.width
+                    text: qsTrc("preferences", "Recording channels")
+                    horizontalAlignment: Text.AlignLeft
+                }
 
-                navigation.name: "RecordingChannelsBox"
-                navigation.panel: root.navigation
-                navigation.row: 2
-                navigation.column: 1
+                FlatButton {
+                    id: recordingChannelsButton
+                    width: parent.width
+                    text: apiModel.inputChannelSelectionSummary
+                    orientation: Qt.Horizontal
 
-                onValueEdited: function (newIndex, newValue) {
-                    apiModel.inputChannelsSelected(newIndex)
+                    navigation.name: "RecordingChannelsBox"
+                    navigation.panel: root.navigation
+                    navigation.row: 2
+                    navigation.column: 1
+                    navigation.accessible.name: qsTrc("preferences", "Recording channels") + " " + text
+
+                    onClicked: recordingChannelsPopup.toggleOpened()
+
+                    StyledPopupView {
+                        id: recordingChannelsPopup
+                        objectName: "RecordingChannelsPopup"
+                        contentWidth: recordingChannelsList.width
+                        contentHeight: recordingChannelsList.height
+                        navigationSection.name: objectName
+
+                        NavigationPanel {
+                            id: recordingChannelsNavigation
+                            name: "RecordingChannelsPopup"
+                            order: 1
+                            enabled: recordingChannelsPopup.isOpened
+                            direction: NavigationPanel.Vertical
+                            section: recordingChannelsPopup.navigationSection
+                        }
+
+                        StyledListView {
+                            id: recordingChannelsList
+                            objectName: "RecordingChannelsList"
+                            width: root.columnWidth
+                            height: Math.min(contentHeight, 400)
+                            clip: true
+                            spacing: 8
+                            model: RecordingChannelListModel {
+                                groups: apiModel.inputChannelGroups
+                            }
+
+                            delegate: Item {
+                                id: channelDelegate
+
+                                required property var model
+                                required property int index
+
+                                readonly property bool hasSectionHeader: model.sectionStart
+
+                                width: recordingChannelsList.width
+                                height: channelCheckBox.implicitHeight + (hasSectionHeader ? sectionHeader.implicitHeight + 8 : 0)
+
+                                StyledTextLabel {
+                                    id: sectionHeader
+                                    visible: hasSectionHeader
+                                    anchors.top: parent.top
+                                    anchors.left: parent.left
+                                    anchors.leftMargin: 8
+                                    text: channelDelegate.model.channelCount === 1 ? qsTrc("preferences", "Mono channels") : qsTrc("preferences", "Stereo channels")
+                                    font: ui.theme.bodyBoldFont
+                                    horizontalAlignment: Text.AlignLeft
+                                }
+
+                                CheckBox {
+                                    id: channelCheckBox
+                                    anchors.left: parent.left
+                                    anchors.leftMargin: 8
+                                    anchors.bottom: parent.bottom
+                                    text: channelDelegate.model.title
+                                    checked: channelDelegate.model.checked
+
+                                    navigation.name: "RecordingChannel" + channelDelegate.model.title
+                                    navigation.panel: recordingChannelsNavigation
+                                    navigation.row: index
+                                    navigation.column: 0
+                                    navigation.onActiveChanged: {
+                                        if (navigation.active) {
+                                            recordingChannelsList.positionViewAtIndex(index, ListView.Contain)
+                                        }
+                                    }
+
+                                    onClicked: apiModel.toggleInputChannelGroup(channelDelegate.model.firstChannel, channelDelegate.model.channelCount)
+                                }
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/src/preferences/qml/Audacity/Preferences/internal/RecordingChannelListModel.qml
+++ b/src/preferences/qml/Audacity/Preferences/internal/RecordingChannelListModel.qml
@@ -1,0 +1,23 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+import QtQuick 2.15
+
+ListModel {
+    property var groups: []
+
+    onGroupsChanged: {
+        // Update existing rows instead of replacing the view's model on each toggle.
+        // This preserves its delegates, scroll position, and keyboard focus.
+        if (count > groups.length) {
+            remove(groups.length, count - groups.length)
+        }
+        for (let i = 0; i < groups.length; ++i) {
+            if (i < count) {
+                set(i, groups[i])
+            } else {
+                append(groups[i])
+            }
+        }
+    }
+}

--- a/src/preferences/tests/CMakeLists.txt
+++ b/src/preferences/tests/CMakeLists.txt
@@ -8,10 +8,18 @@ set(MODULE_TEST_SRC
     ${CMAKE_CURRENT_LIST_DIR}/commonaudioapiconfigurationmodel_tests.cpp
     ${CMAKE_CURRENT_LIST_DIR}/../qml/Audacity/Preferences/commonaudioapiconfigurationmodel.cpp
     ${CMAKE_CURRENT_LIST_DIR}/../qml/Audacity/Preferences/commonaudioapiconfigurationmodel.h
+    ${MUSE_FRAMEWORK_PATH}/framework/stubs/accessibility/accessibilitycontrollerstub.cpp
+    ${MUSE_FRAMEWORK_PATH}/framework/stubs/languages/languagesservicestub.cpp
     )
 
 set(MODULE_TEST_LINK
     audio
+    uicomponents
+    muse_actions
+    muse_rcommand
+    muse::graphicaleffects_qml
+    muse::ui_qml
+    muse::uicomponents_qml
     Qt6::Qml
     Qt6::Quick
     )

--- a/src/preferences/tests/commonaudioapiconfigurationmodel_tests.cpp
+++ b/src/preferences/tests/commonaudioapiconfigurationmodel_tests.cpp
@@ -5,6 +5,7 @@
 #include <gtest/gtest.h>
 
 #include <QAbstractItemModel>
+#include <QFontMetricsF>
 #include <QPointer>
 #include <QQmlComponent>
 #include <QQmlContext>
@@ -302,6 +303,43 @@ TEST_F(RecordingChannelPopupTests, TriggerTogglesPendingSelectionWithoutClosing)
         EXPECT_EQ(m_model->inputChannelGroups().at(1).toMap().value("checked").toBool(), checked);
         EXPECT_EQ(m_applied.inputChannelSelection, (audio::InputChannelSelection { { { 0 } } }));
     }
+}
+
+TEST_F(RecordingChannelPopupTests, DeviceChangeKeepsReusedStereoLabelVisible)
+{
+    ON_CALL(*m_controller, inputChannelsAvailable()).WillByDefault(Return(4));
+    ON_CALL(*m_controller, inputChannelsAvailable("Core Audio", _)).WillByDefault(Return(2));
+    m_applied.inputChannelSelection = { { { 2, 3 } } };
+    ASSERT_EQ(m_model->inputChannelSelectionSummary(), "3+4");
+    ASSERT_NO_FATAL_FAILURE(createView());
+    ASSERT_NO_FATAL_FAILURE(openPopup());
+    dispatch(muse::ui::DOWN_COMMAND);
+    dispatch(muse::ui::DOWN_COMMAND);
+    ASSERT_NO_FATAL_FAILURE(expectChannelFocus(2, "3"));
+
+    const QPointer<QQuickItem> checkBox = m_navigation->activeControl()->visualItem();
+    ASSERT_TRUE(QTest::qWaitFor([checkBox]() { return checkBox->width() > 20; }));
+
+    // The third row changes from mono 3 to stereo 1+2 without recreating its checkbox.
+    m_model->inputDeviceSelected(2);
+    ASSERT_TRUE(QMetaObject::invokeMethod(m_list, "forceLayout"));
+    ASSERT_FALSE(checkBox.isNull());
+    ASSERT_EQ(checkBox->property("text").toString(), "1+2");
+
+    QQuickItem* label = nullptr;
+    for (auto* item : checkBox->findChildren<QQuickItem*>()) {
+        if (item->property("text").toString() == "1+2"
+            && item->property("truncated").isValid()) {
+            label = item;
+            break;
+        }
+    }
+    ASSERT_NE(label, nullptr);
+    const qreal textWidth = QFontMetricsF(label->property("font").value<QFont>()).horizontalAdvance("1+2");
+    EXPECT_TRUE(QTest::qWaitFor([label, textWidth]() {
+        return label->isVisible() && label->width() >= textWidth
+               && !label->property("truncated").toBool();
+    })) << "label width=" << label->width() << ", text width=" << textWidth;
 }
 
 TEST_F(RecordingChannelPopupTests, KeyboardNavigationScrollsToOffscreenMonoAndStereoGroups)

--- a/src/preferences/tests/commonaudioapiconfigurationmodel_tests.cpp
+++ b/src/preferences/tests/commonaudioapiconfigurationmodel_tests.cpp
@@ -29,7 +29,7 @@ public:
         m_applied.api = "Core Audio";
         m_applied.outputDevice = "Built-in Output";
         m_applied.inputDevice = "Built-in Mic";
-        m_applied.inputChannels = 1;
+        m_applied.inputChannelSelection = audio::legacyInputChannelSelection(1);
         m_applied.bufferLength = 100.0;
         m_applied.defaultSampleRate = 44100;
         m_applied.defaultSampleFormat = "32-bit float";
@@ -97,7 +97,8 @@ TEST_F(CommonAudioApiConfigurationModelTests, Apply_SubmitsAllPendingFieldsInOne
     EXPECT_CALL(*m_controller, apply(_, _))
     .WillOnce([](const muse::modularity::ContextPtr&, const audio::AudioConfigurationChange& change) {
         EXPECT_EQ(change.outputDevice, std::optional<std::string>("Headphones"));
-        EXPECT_EQ(change.inputChannels, std::optional<int>(2));
+        EXPECT_EQ(change.inputChannelSelection,
+                  std::optional<audio::InputChannelSelection>(audio::legacyInputChannelSelection(2)));
         EXPECT_EQ(change.bufferLength, std::optional<double>(50.0));
         EXPECT_FALSE(change.api.has_value());
         EXPECT_FALSE(change.inputDevice.has_value());
@@ -127,7 +128,7 @@ TEST_F(CommonAudioApiConfigurationModelTests, ApplySuccess_ClearsFieldsThatNorma
         EXPECT_FALSE(change.api);
         EXPECT_FALSE(change.outputDevice);
         EXPECT_FALSE(change.inputDevice);
-        EXPECT_FALSE(change.inputChannels);
+        EXPECT_FALSE(change.inputChannelSelection);
         EXPECT_FALSE(change.bufferLength);
         EXPECT_FALSE(change.automaticLatencyCompensation);
         EXPECT_FALSE(change.latencyCompensation);
@@ -165,7 +166,7 @@ TEST_F(CommonAudioApiConfigurationModelTests, EditingBackToAppliedStateProducesA
         EXPECT_FALSE(change.api);
         EXPECT_FALSE(change.outputDevice);
         EXPECT_FALSE(change.inputDevice);
-        EXPECT_FALSE(change.inputChannels);
+        EXPECT_FALSE(change.inputChannelSelection);
         EXPECT_FALSE(change.bufferLength);
         EXPECT_FALSE(change.automaticLatencyCompensation);
         EXPECT_FALSE(change.latencyCompensation);

--- a/src/preferences/tests/commonaudioapiconfigurationmodel_tests.cpp
+++ b/src/preferences/tests/commonaudioapiconfigurationmodel_tests.cpp
@@ -4,13 +4,37 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <QAbstractItemModel>
+#include <QPointer>
+#include <QQmlComponent>
+#include <QQmlContext>
+#include <QQmlEngine>
+#include <QQmlIncubationController>
+#include <QQuickItem>
+#include <QQuickWindow>
+#include <QtGui/qtestsupport_gui.h>
+
+#include "actions/internal/actionsdispatcher.h"
 #include "audio/tests/mocks/audiodrivercontrollermock.h"
+#include "interactive/tests/mocks/interactivemock.h"
+#include "rcommand/internal/commanddispatcher.h"
+#include "stubs/accessibility/accessibilitycontrollerstub.h"
+#include "stubs/languages/languagesservicestub.h"
+#include "ui/api/themeapi.h"
+#include "ui/internal/navigationcontroller.h"
+#include "ui/internal/uiengine.h"
+#include "ui/navigationcommands.h"
+#include "ui/tests/mocks/mainwindowmock.h"
+#include "ui/tests/mocks/uiconfigurationmock.h"
+#include "uicomponents/qml/Muse/UiComponents/popupview.h"
+#include "uicomponents/uicomponentsmodule.h"
 
 #include "../qml/Audacity/Preferences/commonaudioapiconfigurationmodel.h"
 
 using ::testing::_;
 using ::testing::NiceMock;
 using ::testing::Return;
+using ::testing::ReturnRef;
 
 namespace au::appshell {
 constexpr const char* SYSTEM_DEFAULT = "System default";
@@ -29,7 +53,7 @@ public:
         m_applied.api = "Core Audio";
         m_applied.outputDevice = "Built-in Output";
         m_applied.inputDevice = "Built-in Mic";
-        m_applied.inputChannelSelection = audio::legacyInputChannelSelection(1);
+        m_applied.inputChannelSelection = { { { 0 } } };
         m_applied.bufferLength = 100.0;
         m_applied.defaultSampleRate = 44100;
         m_applied.defaultSampleFormat = "32-bit float";
@@ -75,30 +99,456 @@ public:
     muse::async::Notification m_deviceListChanged;
 };
 
+class RecordingChannelListModelTests : public CommonAudioApiConfigurationModelTests
+{
+public:
+    std::unique_ptr<QObject> createView()
+    {
+        m_engine.rootContext()->setContextProperty("apiModel", m_model.get());
+        QQmlComponent component(&m_engine, QUrl::fromLocalFile(
+                                    QStringLiteral(preferences_tests_DATA_ROOT "/data/RecordingChannelListView.qml")));
+        auto view = std::unique_ptr<QObject>(component.create());
+        EXPECT_FALSE(component.isError()) << component.errorString().toStdString();
+        return view;
+    }
+
+    QQuickItem* scrollToGroup(QObject* view, int index)
+    {
+        QVariant result;
+        EXPECT_TRUE(QMetaObject::invokeMethod(view, "scrollToGroup", Q_RETURN_ARG(QVariant, result), Q_ARG(QVariant, index)));
+        return qobject_cast<QQuickItem*>(result.value<QObject*>());
+    }
+
+    QQmlEngine m_engine;
+};
+
+class RecordingChannelPopupTests : public CommonAudioApiConfigurationModelTests
+{
+public:
+    static void SetUpTestSuite()
+    {
+        uicomponents::UiComponentsModule module;
+        module.registerResources();
+        module.registerUiTypes();
+    }
+
+    void SetUp() override
+    {
+        CommonAudioApiConfigurationModelTests::SetUp();
+#ifdef Q_OS_MAC
+        // Muse popups observe the parent NSWindow, which requires the Cocoa platform plugin.
+        if (QGuiApplication::platformName() != "cocoa") {
+            GTEST_SKIP() << "Popup navigation tests require QT_QPA_PLATFORM=cocoa on macOS";
+        }
+#endif
+
+        m_uiConfiguration = std::make_shared<NiceMock<muse::ui::UiConfigurationMock> >();
+        ON_CALL(*m_uiConfiguration, currentTheme()).WillByDefault(ReturnRef(m_themeInfo));
+        ON_CALL(*m_uiConfiguration, fontFamily()).WillByDefault(Return(QGuiApplication::font().family().toStdString()));
+        ON_CALL(*m_uiConfiguration, fontSize(_)).WillByDefault(Return(12));
+        ON_CALL(*m_uiConfiguration, iconsFontSize(_)).WillByDefault(Return(16));
+        ON_CALL(*m_uiConfiguration, musicalFontSize()).WillByDefault(Return(16));
+        ON_CALL(*m_uiConfiguration, musicalTextFontSize()).WillByDefault(Return(16));
+        ON_CALL(*m_uiConfiguration, flickableMaxVelocity()).WillByDefault(Return(2500));
+        auto* globalIoc = muse::modularity::globalIoc();
+        globalIoc->registerExport<muse::ui::IUiConfiguration>("preferences_tests", m_uiConfiguration);
+        globalIoc->registerExport<muse::languages::ILanguagesService>("preferences_tests", new muse::languages::LanguagesServiceStub());
+
+        auto* ioc = muse::modularity::ioc(m_context);
+        auto mainWindow = std::make_shared<NiceMock<muse::ui::MainWindowMock> >();
+        ON_CALL(*mainWindow, qWindow()).WillByDefault(Return(&m_window));
+        ioc->registerExport<muse::ui::IMainWindow>("preferences_tests", mainWindow);
+        auto interactive = std::make_shared<NiceMock<muse::InteractiveMock> >();
+        ON_CALL(*interactive, topWindow()).WillByDefault(Return(&m_window));
+        ioc->registerExport<muse::IInteractive>("preferences_tests", interactive);
+        ioc->registerExport<muse::accessibility::IAccessibilityController>(
+            "preferences_tests", new muse::accessibility::AccessibilityControllerStub());
+        ioc->registerExport<muse::actions::IActionsDispatcher>(
+            "preferences_tests", new muse::actions::ActionsDispatcher(m_context));
+        m_dispatcher = std::make_shared<muse::rcommand::CommandDispatcher>();
+        ioc->registerExport<muse::rcommand::ICommandDispatcher>("preferences_tests", m_dispatcher);
+        m_navigation = std::make_shared<muse::ui::NavigationController>(m_context);
+        ioc->registerExport<muse::ui::INavigationController>("preferences_tests", m_navigation);
+        m_navigation->init();
+
+        m_theme = std::make_unique<muse::api::ThemeApi>(nullptr);
+        m_theme->init();
+        m_uiEngine = std::make_shared<muse::ui::UiEngine>(m_context);
+        ioc->registerExport<muse::ui::IUiEngine>("preferences_tests", m_uiEngine);
+        m_uiEngine->setTheme(m_theme.get());
+        m_uiEngine->init();
+        m_uiEngine->qmlEngine()->rootContext()->setContextProperty("recordingApiModel", m_model.get());
+    }
+
+    void TearDown() override
+    {
+        if (m_popup) {
+            m_popup->close();
+        }
+        m_view.reset();
+        m_window.close();
+        if (m_uiEngine) {
+            m_uiEngine->quit();
+        }
+        m_uiEngine.reset();
+        m_theme.reset();
+        CommonAudioApiConfigurationModelTests::TearDown();
+        m_navigation.reset();
+        m_dispatcher.reset();
+        if (m_uiConfiguration) {
+            muse::modularity::globalIoc()->unregister<muse::ui::IUiConfiguration>("preferences_tests");
+            muse::modularity::globalIoc()->unregister<muse::languages::ILanguagesService>("preferences_tests");
+        }
+    }
+
+    void createView()
+    {
+        QQmlComponent component(m_uiEngine->qmlEngine(), QUrl::fromLocalFile(
+                                    QStringLiteral(preferences_tests_DATA_ROOT "/data/RecordingChannelPopupView.qml")));
+        m_view.reset(qobject_cast<QQuickItem*>(component.create()));
+        ASSERT_FALSE(component.isError()) << component.errorString().toStdString();
+        ASSERT_TRUE(m_view);
+        m_popup = m_view->findChild<muse::uicomponents::PopupView*>("RecordingChannelsPopup");
+        ASSERT_TRUE(m_popup);
+        m_list = m_view->findChild<QQuickItem*>("RecordingChannelsList");
+        ASSERT_TRUE(m_list);
+
+        m_window.resize(m_view->width(), m_view->height());
+        m_view->setParentItem(m_window.contentItem());
+        m_uiEngine->setRootItem(m_view.get());
+        m_window.show();
+        ASSERT_TRUE(QTest::qWaitForWindowExposed(&m_window));
+    }
+
+    void dispatch(const muse::rcommand::Command& command)
+    {
+        m_dispatcher->dispatch(command);
+        QCoreApplication::processEvents();
+        // Finish the ListView's cached delegates before sending the next command.
+        ASSERT_TRUE(QMetaObject::invokeMethod(m_list, "forceLayout"));
+        if (auto* incubation = m_uiEngine->qmlEngine()->incubationController()) {
+            ASSERT_TRUE(QTest::qWaitFor([incubation]() {
+                incubation->incubateFor(10);
+                return incubation->incubatingObjectCount() == 0;
+            }));
+        }
+    }
+
+    void openPopup()
+    {
+        ASSERT_TRUE(m_navigation->requestActivateByName("PreferencesTestWindow", "AudioApiSection", "RecordingChannelsBox"));
+        dispatch(muse::ui::TRIGGER_CONTROL_COMMAND);
+        ASSERT_TRUE(m_popup->isOpened());
+        ASSERT_NO_FATAL_FAILURE(expectChannelFocus(0, "1"));
+    }
+
+    void expectChannelFocus(int row, const QString& title)
+    {
+        ASSERT_NE(m_navigation->activeSection(), nullptr);
+        ASSERT_EQ(m_navigation->activeSection()->name(), "RecordingChannelsPopup");
+        ASSERT_NE(m_navigation->activeControl(), nullptr);
+        ASSERT_EQ(m_navigation->activeControl()->name().toStdString(), ("RecordingChannel" + title).toStdString());
+        ASSERT_EQ(m_navigation->activeControl()->index().row, row);
+        // Check focus within the QML scope even when the test window is not the foreground app.
+        EXPECT_TRUE(m_navigation->activeControl()->visualItem()->hasFocus());
+    }
+
+    muse::ui::ThemeInfo m_themeInfo;
+    std::shared_ptr<NiceMock<muse::ui::UiConfigurationMock> > m_uiConfiguration;
+    std::unique_ptr<muse::api::ThemeApi> m_theme;
+    std::shared_ptr<muse::ui::UiEngine> m_uiEngine;
+    std::shared_ptr<muse::ui::NavigationController> m_navigation;
+    std::shared_ptr<muse::rcommand::CommandDispatcher> m_dispatcher;
+    QQuickWindow m_window;
+    std::unique_ptr<QQuickItem> m_view;
+    QPointer<muse::uicomponents::PopupView> m_popup;
+    QPointer<QQuickItem> m_list;
+};
+
+TEST_F(RecordingChannelPopupTests, OpeningAndDirectionalNavigationStayInsidePopup)
+{
+    ASSERT_NO_FATAL_FAILURE(createView());
+    ASSERT_NO_FATAL_FAILURE(openPopup());
+
+    dispatch(muse::ui::DOWN_COMMAND);
+    ASSERT_NO_FATAL_FAILURE(expectChannelFocus(1, "2"));
+    dispatch(muse::ui::DOWN_COMMAND);
+    ASSERT_NO_FATAL_FAILURE(expectChannelFocus(2, "1+2"));
+    dispatch(muse::ui::UP_COMMAND);
+    ASSERT_NO_FATAL_FAILURE(expectChannelFocus(1, "2"));
+    dispatch(muse::ui::UP_COMMAND);
+    ASSERT_NO_FATAL_FAILURE(expectChannelFocus(0, "1"));
+
+    for (const auto& command : { muse::ui::NEXT_PANEL_COMMAND, muse::ui::NEXT_SECTION_COMMAND }) {
+        dispatch(command);
+        ASSERT_NO_FATAL_FAILURE(expectChannelFocus(0, "1"));
+        EXPECT_TRUE(m_popup->isOpened());
+    }
+}
+
+TEST_F(RecordingChannelPopupTests, TriggerTogglesPendingSelectionWithoutClosing)
+{
+    EXPECT_CALL(*m_controller, apply(_, _)).Times(0);
+    ASSERT_NO_FATAL_FAILURE(createView());
+    ASSERT_NO_FATAL_FAILURE(openPopup());
+    dispatch(muse::ui::DOWN_COMMAND);
+    ASSERT_NO_FATAL_FAILURE(expectChannelFocus(1, "2"));
+
+    for (const bool checked : { true, false }) {
+        dispatch(muse::ui::TRIGGER_CONTROL_COMMAND);
+        ASSERT_NO_FATAL_FAILURE(expectChannelFocus(1, "2"));
+        EXPECT_TRUE(m_popup->isOpened());
+        EXPECT_EQ(m_navigation->activeControl()->visualItem()->property("checked").toBool(), checked);
+        EXPECT_EQ(m_model->inputChannelGroups().at(1).toMap().value("checked").toBool(), checked);
+        EXPECT_EQ(m_applied.inputChannelSelection, (audio::InputChannelSelection { { { 0 } } }));
+    }
+}
+
+TEST_F(RecordingChannelPopupTests, KeyboardNavigationScrollsToOffscreenMonoAndStereoGroups)
+{
+    ON_CALL(*m_controller, inputChannelsAvailable()).WillByDefault(Return(20));
+    ASSERT_NO_FATAL_FAILURE(createView());
+    ASSERT_NO_FATAL_FAILURE(openPopup());
+    int currentRow = 0;
+
+    for (const int targetRow : { 16, 28 }) {
+        SCOPED_TRACE(targetRow);
+        while (currentRow < targetRow) {
+            dispatch(muse::ui::DOWN_COMMAND);
+            ++currentRow;
+            const auto group = m_model->inputChannelGroups().at(currentRow).toMap();
+            ASSERT_NO_FATAL_FAILURE(expectChannelFocus(currentRow, group.value("title").toString()));
+        }
+
+        const QPointer<QQuickItem> checkBox = m_navigation->activeControl()->visualItem();
+        const qreal contentY = m_list->property("contentY").toReal();
+        ASSERT_GT(contentY, 0.0);
+        const qreal top = checkBox->mapToItem(m_list, QPointF()).y();
+        EXPECT_GE(top, 0.0);
+        EXPECT_LE(top + checkBox->height(), m_list->height());
+
+        for (const bool checked : { true, false }) {
+            dispatch(muse::ui::TRIGGER_CONTROL_COMMAND);
+            EXPECT_TRUE(m_popup->isOpened());
+            ASSERT_FALSE(checkBox.isNull());
+            EXPECT_EQ(m_navigation->activeControl()->visualItem(), checkBox.data());
+            EXPECT_TRUE(checkBox->hasFocus());
+            EXPECT_EQ(checkBox->property("checked").toBool(), checked);
+            EXPECT_DOUBLE_EQ(m_list->property("contentY").toReal(), contentY);
+        }
+    }
+}
+
+TEST_F(RecordingChannelPopupTests, EscapeRestoresButtonFocusAndPopupCanReopen)
+{
+    ASSERT_NO_FATAL_FAILURE(createView());
+    ASSERT_NO_FATAL_FAILURE(openPopup());
+
+    for (int attempt = 0; attempt < 2; ++attempt) {
+        dispatch(muse::ui::DOWN_COMMAND);
+        ASSERT_NO_FATAL_FAILURE(expectChannelFocus(1, "2"));
+        dispatch(muse::ui::ESCAPE_COMMAND);
+        ASSERT_FALSE(m_popup->isOpened());
+        EXPECT_TRUE(m_window.isVisible());
+        EXPECT_FALSE(m_view->property("closeRequested").toBool());
+        ASSERT_NE(m_navigation->activeControl(), nullptr);
+        EXPECT_EQ(m_navigation->activeSection()->name(), "PreferencesTestWindow");
+        EXPECT_EQ(m_navigation->activeControl()->name(), "RecordingChannelsBox");
+
+        dispatch(muse::ui::TRIGGER_CONTROL_COMMAND);
+        ASSERT_TRUE(m_popup->isOpened());
+        ASSERT_NO_FATAL_FAILURE(expectChannelFocus(0, "1"));
+    }
+}
+
+TEST_F(RecordingChannelListModelTests, TogglingScrolledGroupsPreservesScrollPositionAndDelegates)
+{
+    ON_CALL(*m_controller, inputChannelsAvailable()).WillByDefault(Return(20));
+    const auto view = createView();
+    ASSERT_TRUE(view);
+    auto* listModel = qobject_cast<QAbstractItemModel*>(view->property("model").value<QObject*>());
+    ASSERT_NE(listModel, nullptr);
+    int resets = 0;
+    QObject::connect(listModel, &QAbstractItemModel::modelReset, view.get(), [&resets]() { ++resets; });
+
+    for (const int channelCount : { 1, 2 }) {
+        SCOPED_TRACE(channelCount);
+        // Mono 17 and stereo 17+18 are both below the initial viewport.
+        const int row = channelCount == 1 ? 16 : 28;
+        const QPointer<QQuickItem> delegate = scrollToGroup(view.get(), row);
+        ASSERT_FALSE(delegate.isNull());
+        const double contentY = view->property("contentY").toDouble();
+        ASSERT_GT(contentY, 0.0);
+        delegate->forceActiveFocus();
+        ASSERT_TRUE(delegate->hasFocus());
+
+        for (const bool checked : { true, false }) {
+            m_model->toggleInputChannelGroup(16, channelCount);
+            ASSERT_TRUE(QMetaObject::invokeMethod(view.get(), "forceLayout"));
+
+            EXPECT_DOUBLE_EQ(view->property("contentY").toDouble(), contentY);
+            EXPECT_EQ(view->property("model").value<QObject*>(), listModel);
+            EXPECT_EQ(resets, 0);
+            ASSERT_FALSE(delegate.isNull());
+            EXPECT_EQ(scrollToGroup(view.get(), row), delegate.data());
+            EXPECT_EQ(delegate->property("checked").toBool(), checked);
+            EXPECT_TRUE(delegate->hasFocus());
+        }
+    }
+}
+
+TEST_F(RecordingChannelListModelTests, OverlapReplacementUpdatesAllAffectedCheckmarksInPlace)
+{
+    ON_CALL(*m_controller, inputChannelsAvailable()).WillByDefault(Return(20));
+    m_applied.inputChannelSelection = { { { 16 } }, { { 17 } } };
+    const auto view = createView();
+    ASSERT_TRUE(view);
+    auto* listModel = qobject_cast<QAbstractItemModel*>(view->property("model").value<QObject*>());
+    ASSERT_NE(listModel, nullptr);
+    const int checkedRole = listModel->roleNames().key("checked");
+    ASSERT_TRUE(listModel->data(listModel->index(16, 0), checkedRole).toBool());
+    ASSERT_TRUE(listModel->data(listModel->index(17, 0), checkedRole).toBool());
+
+    const QPointer<QQuickItem> delegate = scrollToGroup(view.get(), 28);
+    ASSERT_FALSE(delegate.isNull());
+    const double contentY = view->property("contentY").toDouble();
+    m_model->toggleInputChannelGroup(16, 2);
+    ASSERT_TRUE(QMetaObject::invokeMethod(view.get(), "forceLayout"));
+
+    EXPECT_FALSE(listModel->data(listModel->index(16, 0), checkedRole).toBool());
+    EXPECT_FALSE(listModel->data(listModel->index(17, 0), checkedRole).toBool());
+    EXPECT_TRUE(listModel->data(listModel->index(28, 0), checkedRole).toBool());
+    EXPECT_DOUBLE_EQ(view->property("contentY").toDouble(), contentY);
+    ASSERT_FALSE(delegate.isNull());
+    EXPECT_EQ(scrollToGroup(view.get(), 28), delegate.data());
+}
+
+TEST_F(RecordingChannelListModelTests, DeviceCapacityChangesResizeTheListAndRefreshSections)
+{
+    const auto view = createView();
+    ASSERT_TRUE(view);
+    auto* listModel = qobject_cast<QAbstractItemModel*>(view->property("model").value<QObject*>());
+    ASSERT_NE(listModel, nullptr);
+    ASSERT_EQ(listModel->rowCount(), 3);
+    const int titleRole = listModel->roleNames().key("title");
+    const int sectionRole = listModel->roleNames().key("sectionStart");
+
+    for (const int capacity : { 20, 4, 1, 0, 2 }) {
+        SCOPED_TRACE(capacity);
+        ON_CALL(*m_controller, inputChannelsAvailable()).WillByDefault(Return(capacity));
+        m_deviceListChanged.notify();
+
+        EXPECT_EQ(listModel->rowCount(), capacity + capacity / 2);
+        for (int row = 0; row < listModel->rowCount(); ++row) {
+            EXPECT_EQ(listModel->data(listModel->index(row, 0), sectionRole).toBool(), row == 0 || row == capacity);
+        }
+        if (capacity >= 2) {
+            EXPECT_EQ(listModel->data(listModel->index(capacity, 0), titleRole).toString(), "1+2");
+        }
+    }
+}
+
 TEST_F(CommonAudioApiConfigurationModelTests, EditingValues_IsPendingUntilApply)
 {
     EXPECT_CALL(*m_controller, apply(_, _)).Times(0);
 
     m_model->outputDeviceSelected(2);
-    m_model->inputChannelsSelected(1);
+    m_model->toggleInputChannelGroup(0, 2);
     m_model->bufferLengthSelected("50");
 
     EXPECT_EQ(m_model->currentOutputDeviceIndex(), 2);
-    EXPECT_TRUE(m_model->currentInputChannelsSelected().startsWith("2"));
+    EXPECT_EQ(m_model->inputChannelSelectionSummary(), "1+2");
     EXPECT_DOUBLE_EQ(m_model->bufferLength(), 50.0);
+}
+
+TEST_F(CommonAudioApiConfigurationModelTests, InputChannelGroupsExposeSectionAndSelectionRoles)
+{
+    ON_CALL(*m_controller, inputChannelsAvailable()).WillByDefault(Return(4));
+    m_applied.inputChannelSelection = { { { 0 } }, { { 2, 3 } } };
+
+    const QVariantList groups = m_model->inputChannelGroups();
+
+    ASSERT_EQ(groups.size(), 6);
+    const QStringList expectedTitles { "1", "2", "3", "4", "1+2", "3+4" };
+    for (int index = 0; index < groups.size(); ++index) {
+        const QVariantMap group = groups.at(index).toMap();
+        EXPECT_EQ(group.value("title").toString(), expectedTitles.at(index));
+        EXPECT_EQ(group.value("sectionStart").toBool(), index == 0 || index == 4);
+        EXPECT_EQ(group.value("channelCount").toInt(), index < 4 ? 1 : 2);
+    }
+    EXPECT_TRUE(groups.at(0).toMap().value("checked").toBool());
+    EXPECT_FALSE(groups.at(1).toMap().value("checked").toBool());
+    EXPECT_FALSE(groups.at(2).toMap().value("checked").toBool());
+    EXPECT_FALSE(groups.at(3).toMap().value("checked").toBool());
+    EXPECT_FALSE(groups.at(4).toMap().value("checked").toBool());
+    EXPECT_TRUE(groups.at(5).toMap().value("checked").toBool());
+}
+
+TEST_F(CommonAudioApiConfigurationModelTests, MixedSelectionSummaryAndApplyPreserveGroups)
+{
+    ON_CALL(*m_controller, inputChannelsAvailable()).WillByDefault(Return(4));
+
+    m_model->toggleInputChannelGroup(2, 2);
+
+    EXPECT_EQ(m_model->inputChannelSelectionSummary(), "1, 3+4");
+    EXPECT_CALL(*m_controller, apply(_, _))
+    .WillOnce([](const muse::modularity::ContextPtr&,
+                 const audio::AudioConfigurationChange& change) {
+        EXPECT_EQ(change.inputChannelSelection,
+                  std::optional<audio::InputChannelSelection>(
+                      { { { 0 } }, { { 2, 3 } } }));
+        return audio::ApplyResult { audio::ApplyStatus::Applied };
+    });
+    EXPECT_TRUE(m_model->apply());
+}
+
+TEST_F(CommonAudioApiConfigurationModelTests, StereoToggleAtomicallyReplacesOverlappingMonos)
+{
+    ON_CALL(*m_controller, inputChannelsAvailable()).WillByDefault(Return(4));
+    m_applied.inputChannelSelection = { { { 0 } }, { { 1 } }, { { 2, 3 } } };
+
+    m_model->toggleInputChannelGroup(0, 2);
+
+    EXPECT_EQ(m_model->inputChannelSelectionSummary(), "1+2, 3+4");
+    EXPECT_CALL(*m_controller, apply(_, _))
+    .WillOnce([](const muse::modularity::ContextPtr&,
+                 const audio::AudioConfigurationChange& change) {
+        EXPECT_EQ(change.inputChannelSelection,
+                  std::optional<audio::InputChannelSelection>(
+                      { { { 0, 1 } }, { { 2, 3 } } }));
+        return audio::ApplyResult { audio::ApplyStatus::Applied };
+    });
+    EXPECT_TRUE(m_model->apply());
+}
+
+TEST_F(CommonAudioApiConfigurationModelTests, InvalidTogglesAreIgnoredAndLastGroupCannotBeRemoved)
+{
+    m_model->toggleInputChannelGroup(-1, 1);
+    m_model->toggleInputChannelGroup(0, 3);
+    m_model->toggleInputChannelGroup(1, 2);
+    m_model->toggleInputChannelGroup(0, 1);
+
+    EXPECT_EQ(m_model->inputChannelSelectionSummary(), "1");
+    EXPECT_CALL(*m_controller, apply(_, _))
+    .WillOnce([](const muse::modularity::ContextPtr&,
+                 const audio::AudioConfigurationChange& change) {
+        EXPECT_FALSE(change.inputChannelSelection);
+        return audio::ApplyResult { audio::ApplyStatus::NoChange };
+    });
+    EXPECT_TRUE(m_model->apply());
 }
 
 TEST_F(CommonAudioApiConfigurationModelTests, Apply_SubmitsAllPendingFieldsInOneChangeSet)
 {
     m_model->outputDeviceSelected(2);
-    m_model->inputChannelsSelected(1);
+    m_model->toggleInputChannelGroup(0, 2);
     m_model->bufferLengthSelected("50");
 
     EXPECT_CALL(*m_controller, apply(_, _))
     .WillOnce([](const muse::modularity::ContextPtr&, const audio::AudioConfigurationChange& change) {
         EXPECT_EQ(change.outputDevice, std::optional<std::string>("Headphones"));
         EXPECT_EQ(change.inputChannelSelection,
-                  std::optional<audio::InputChannelSelection>(audio::legacyInputChannelSelection(2)));
+                  std::optional<audio::InputChannelSelection>({ { { 0, 1 } } }));
         EXPECT_EQ(change.bufferLength, std::optional<double>(50.0));
         EXPECT_FALSE(change.api.has_value());
         EXPECT_FALSE(change.inputDevice.has_value());
@@ -153,7 +603,53 @@ TEST_F(CommonAudioApiConfigurationModelTests, ApiEdit_PreviewsTheSelectedApisDev
     EXPECT_EQ(m_model->currentOutputDeviceIndex(), 0);
     EXPECT_EQ(m_model->currentInputDeviceIndex(), 0);
     EXPECT_EQ(m_model->outputDeviceList().size(), 3);
-    EXPECT_EQ(m_model->inputChannelsList().size(), 4);
+    EXPECT_EQ(m_model->inputChannelGroups().size(), 6);
+}
+
+TEST_F(CommonAudioApiConfigurationModelTests, InputDeviceEditPreviewsItsChannelCapacity)
+{
+    ON_CALL(*m_controller, inputChannelsAvailable()).WillByDefault(Return(4));
+    ON_CALL(*m_controller, inputChannelsAvailable("Core Audio", _))
+    .WillByDefault(Return(2));
+    m_applied.inputChannelSelection = { { { 2, 3 } } };
+
+    m_model->inputDeviceSelected(2);
+
+    EXPECT_EQ(m_model->currentInputDeviceIndex(), 2);
+    EXPECT_EQ(m_model->inputChannelGroups().size(), 3);
+    EXPECT_EQ(m_model->inputChannelSelectionSummary(), "1");
+    EXPECT_CALL(*m_controller, apply(_, _))
+    .WillOnce([](const muse::modularity::ContextPtr&,
+                 const audio::AudioConfigurationChange& change) {
+        EXPECT_EQ(change.inputDevice,
+                  std::optional<audio::AudioDeviceSelection>("USB Mic"));
+        EXPECT_FALSE(change.inputChannelSelection);
+        return audio::ApplyResult { audio::ApplyStatus::Applied };
+    });
+    EXPECT_TRUE(m_model->apply());
+}
+
+TEST_F(CommonAudioApiConfigurationModelTests, CapacityReductionPreviewsStereoPresetAndCancelRestoresSelection)
+{
+    ON_CALL(*m_controller, inputChannelsAvailable()).WillByDefault(Return(4));
+    ON_CALL(*m_controller, inputChannelsAvailable("Core Audio", _)).WillByDefault(Return(2));
+    m_applied.inputChannelSelection = audio::legacyInputChannelSelection(4);
+    EXPECT_CALL(*m_controller, apply(_, _)).Times(0);
+
+    m_model->inputDeviceSelected(2);
+
+    EXPECT_EQ(m_model->inputChannelSelectionSummary(), "1+2");
+    const auto groups = m_model->inputChannelGroups();
+    ASSERT_EQ(groups.size(), 3);
+    EXPECT_FALSE(groups[0].toMap()["checked"].toBool());
+    EXPECT_FALSE(groups[1].toMap()["checked"].toBool());
+    EXPECT_TRUE(groups[2].toMap()["checked"].toBool());
+
+    m_model->reset();
+
+    EXPECT_EQ(m_model->currentInputDeviceIndex(), 1);
+    EXPECT_EQ(m_model->inputChannelSelectionSummary(), "1, 2, 3, 4");
+    EXPECT_EQ(m_applied.inputChannelSelection, audio::legacyInputChannelSelection(4));
 }
 
 TEST_F(CommonAudioApiConfigurationModelTests, EditingBackToAppliedStateProducesAnEmptyChange)
@@ -214,6 +710,35 @@ TEST_F(CommonAudioApiConfigurationModelTests, ResetDiscardsPendingEdits)
         return audio::ApplyResult { audio::ApplyStatus::NoChange };
     });
     EXPECT_TRUE(m_model->apply());
+}
+
+TEST_F(CommonAudioApiConfigurationModelTests, ResetDiscardsPendingInputSelection)
+{
+    m_model->toggleInputChannelGroup(0, 2);
+
+    m_model->reset();
+
+    EXPECT_EQ(m_model->inputChannelSelectionSummary(), "1");
+    EXPECT_CALL(*m_controller, apply(_, _))
+    .WillOnce([](const muse::modularity::ContextPtr&,
+                 const audio::AudioConfigurationChange& change) {
+        EXPECT_FALSE(change.inputChannelSelection);
+        return audio::ApplyResult { audio::ApplyStatus::NoChange };
+    });
+    EXPECT_TRUE(m_model->apply());
+}
+
+TEST_F(CommonAudioApiConfigurationModelTests, ExternalSelectionChangeUpdatesTheSummary)
+{
+    ON_CALL(*m_controller, inputChannelsAvailable()).WillByDefault(Return(4));
+    m_applied.inputChannelSelection = { { { 2, 3 } } };
+    audio::AudioConfigurationDelta delta;
+    delta.fields
+        = audio::fieldMask(audio::AudioConfigurationField::InputChannelSelection);
+
+    m_configurationChanged.send(delta);
+
+    EXPECT_EQ(m_model->inputChannelSelectionSummary(), "3+4");
 }
 
 TEST_F(CommonAudioApiConfigurationModelTests, ExternalSampleRateChangeUpdatesOtherRateState)

--- a/src/preferences/tests/data/RecordingChannelListView.qml
+++ b/src/preferences/tests/data/RecordingChannelListView.qml
@@ -1,0 +1,30 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+import QtQuick 2.15
+import "../../qml/Audacity/Preferences/internal"
+
+ListView {
+    width: 200
+    height: 180
+    spacing: 8
+
+    model: RecordingChannelListModel {
+        groups: apiModel.inputChannelGroups
+    }
+
+    delegate: Item {
+        required property var model
+        required property int index
+
+        readonly property bool checked: model.checked
+        height: model.sectionStart ? 60 : 32
+        width: ListView.view.width
+    }
+
+    function scrollToGroup(index) {
+        positionViewAtIndex(index, ListView.Center)
+        forceLayout()
+        return itemAtIndex(index)
+    }
+}

--- a/src/preferences/tests/data/RecordingChannelPopupView.qml
+++ b/src/preferences/tests/data/RecordingChannelPopupView.qml
@@ -17,7 +17,7 @@ Item {
         name: "PreferencesTestWindow"
         order: 1
         type: NavigationSection.Exclusive
-        onNavigationEvent: function(event) {
+        onNavigationEvent: function (event) {
             if (event.type === NavigationEvent.Escape) {
                 root.closeRequested = true
             }

--- a/src/preferences/tests/data/RecordingChannelPopupView.qml
+++ b/src/preferences/tests/data/RecordingChannelPopupView.qml
@@ -1,0 +1,35 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+import QtQuick
+import Muse.Ui
+
+import "../../qml/Audacity/Preferences/internal"
+
+Item {
+    id: root
+    width: 640
+    height: 640
+    property bool closeRequested: false
+
+    NavigationSection {
+        id: preferencesNavigation
+        name: "PreferencesTestWindow"
+        order: 1
+        type: NavigationSection.Exclusive
+        onNavigationEvent: function(event) {
+            if (event.type === NavigationEvent.Escape) {
+                root.closeRequested = true
+            }
+        }
+    }
+
+    AudioApiSection {
+        apiModel: recordingApiModel
+        audioApiList: recordingApiModel.audioApiList()
+
+        navigation.name: "AudioApiSection"
+        navigation.section: preferencesNavigation
+        navigation.order: 1
+    }
+}

--- a/src/projectscene/tests/CMakeLists.txt
+++ b/src/projectscene/tests/CMakeLists.txt
@@ -14,6 +14,7 @@ set(MODULE_TEST_SRC
     ${CMAKE_CURRENT_LIST_DIR}/findguideline_tests.cpp
     ${CMAKE_CURRENT_LIST_DIR}/playcursorcontroller_tests.cpp
     ${CMAKE_CURRENT_LIST_DIR}/playpositionactioncontroller_tests.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/audiosetupcontextmenumodel_tests.cpp
 
     ${CMAKE_CURRENT_LIST_DIR}/snaptestaccess.h
     ${CMAKE_CURRENT_LIST_DIR}/mocks/globalcontextmock.h

--- a/src/projectscene/tests/audiosetupcontextmenumodel_tests.cpp
+++ b/src/projectscene/tests/audiosetupcontextmenumodel_tests.cpp
@@ -117,6 +117,25 @@ public:
     muse::shortcuts::Shortcut m_shortcut;
 };
 
+TEST_F(AudioSetupContextMenuModelTests, InputChannelsMenuOffersCountPresetsAndCustomCommand)
+{
+    const auto* menu = inputChannelsMenu();
+    const auto items = menu->subitems();
+
+    EXPECT_EQ(menu->translatedTitle(), "Recording channels: Custom");
+    ASSERT_EQ(items.size(), 6);
+    const QStringList expectedTitles { "1 (Mono) Recording channel", "2 (Stereo) Recording channels", "3", "4", "", "Custom..." };
+    for (int index = 0; index < items.size(); ++index) {
+        EXPECT_EQ(items.at(index)->translatedTitle(), expectedTitles.at(index));
+        EXPECT_FALSE(items.at(index)->checked());
+        EXPECT_EQ(items.at(index)->checkable(), index < 4);
+    }
+
+    EXPECT_FALSE(items.at(4)->isValid());
+    EXPECT_EQ(items.last()->actionCode(), "audio-settings");
+    EXPECT_EQ(items.last()->id(), "customInputChannels");
+}
+
 TEST_F(AudioSetupContextMenuModelTests, InputChannelsMenuEncodesOneBasedCountInActionQuery)
 {
     const auto items = inputChannelsMenu()->subitems();
@@ -151,7 +170,7 @@ TEST_F(AudioSetupContextMenuModelTests, ExactPresetSelectionChecksOnlyTheMatchin
     }
 }
 
-TEST_F(AudioSetupContextMenuModelTests, NonPresetChannelsOrGroupingDoNotCheckAPreset)
+TEST_F(AudioSetupContextMenuModelTests, NonPresetChannelsOrGroupingShowCustomState)
 {
     const std::vector<audio::InputChannelSelection> selections {
         { { { 2 } } },
@@ -164,11 +183,37 @@ TEST_F(AudioSetupContextMenuModelTests, NonPresetChannelsOrGroupingDoNotCheckAPr
         SCOPED_TRACE(::testing::PrintToString(selection));
         setSelection(selection);
         const auto* menu = inputChannelsMenu();
-        EXPECT_EQ(menu->translatedTitle(), "Recording channels");
+        EXPECT_EQ(menu->translatedTitle(), "Recording channels: Custom");
         for (const auto* item : menu->subitems()) {
             EXPECT_FALSE(item->checked());
         }
     }
+}
+
+TEST_F(AudioSetupContextMenuModelTests, NoInputsOffersOnlyCustomWithoutASeparator)
+{
+    setSelection({}, 0);
+    const auto* menu = inputChannelsMenu();
+
+    EXPECT_EQ(menu->translatedTitle(), "Recording channels");
+    ASSERT_EQ(menu->subitems().size(), 1);
+    const auto* item = menu->subitems().first();
+    EXPECT_EQ(item->translatedTitle(), "Custom...");
+    EXPECT_EQ(item->actionCode(), "audio-settings");
+    EXPECT_TRUE(item->isValid());
+    EXPECT_TRUE(item->enabled());
+    EXPECT_FALSE(item->checkable());
+    EXPECT_FALSE(item->checked());
+}
+
+TEST_F(AudioSetupContextMenuModelTests, NoInputsDoesNotDescribeAnUnavailableSelectionAsCustom)
+{
+    setSelection({ { { 2, 3 } } }, 0);
+    const auto* menu = inputChannelsMenu();
+
+    EXPECT_EQ(menu->translatedTitle(), "Recording channels");
+    ASSERT_EQ(menu->subitems().size(), 1);
+    EXPECT_EQ(menu->subitems().first()->actionCode(), "audio-settings");
 }
 
 TEST_F(AudioSetupContextMenuModelTests, EmptySelectionDoesNotCheckAPresetOrShowCustomState)
@@ -179,6 +224,37 @@ TEST_F(AudioSetupContextMenuModelTests, EmptySelectionDoesNotCheckAPresetOrShowC
     EXPECT_EQ(menu->translatedTitle(), "Recording channels");
     for (const auto* item : menu->subitems()) {
         EXPECT_FALSE(item->checked());
+    }
+}
+
+TEST_F(AudioSetupContextMenuModelTests, MonoDeviceOffersOnlyMonoPresetAndCustom)
+{
+    setSelection({ { { 0 } } }, 1);
+    const auto* menu = inputChannelsMenu();
+
+    EXPECT_EQ(menu->translatedTitle(), "Recording channels");
+    ASSERT_EQ(menu->subitems().size(), 3);
+    EXPECT_TRUE(menu->subitems().first()->checked());
+    EXPECT_FALSE(menu->subitems().at(1)->isValid());
+    EXPECT_EQ(menu->subitems().last()->translatedTitle(), "Custom...");
+}
+
+TEST_F(AudioSetupContextMenuModelTests, CustomDispatchesAudioSettingsWithoutChangingSelection)
+{
+    EXPECT_CALL(*m_dispatcher, dispatch(testing::Matcher<const muse::actions::ActionQuery&>(testing::_))).Times(0);
+    EXPECT_CALL(*m_dispatcher, dispatch(testing::Matcher<const muse::actions::ActionCode&>(testing::_))).Times(0);
+    for (const auto& selection : { audio::InputChannelSelection { { { 0, 1 } } }, audio::InputChannelSelection { { { 2, 3 } } } }) {
+        setSelection(selection);
+        const auto* item = inputChannelsMenu()->subitems().last();
+
+        EXPECT_FALSE(item->checkable());
+        EXPECT_FALSE(item->checked());
+        EXPECT_CALL(*m_controller, apply(testing::_, testing::_)).Times(0);
+        EXPECT_CALL(*m_dispatcher, dispatch(muse::actions::ActionCode("audio-settings"), testing::_)).Times(1);
+
+        m_model.handleMenuItem(item->id());
+
+        EXPECT_EQ(m_controller->configuration().inputChannelSelection, selection);
     }
 }
 

--- a/src/projectscene/tests/audiosetupcontextmenumodel_tests.cpp
+++ b/src/projectscene/tests/audiosetupcontextmenumodel_tests.cpp
@@ -1,0 +1,195 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "actions/tests/mocks/actionsdispatchermock.h"
+#include "audio/tests/mocks/audiodrivercontrollermock.h"
+#include "projectscene/view/toolbars/audiosetupcontextmenumodel.h"
+#include "testing/testcontext.h"
+
+using ::testing::NiceMock;
+using ::testing::Return;
+using ::testing::ReturnRef;
+
+namespace au::projectscene {
+class ShortcutsRegisterMock : public muse::shortcuts::IShortcutsRegister
+{
+public:
+    MOCK_METHOD(const muse::shortcuts::ShortcutList&, shortcuts, (), (const, override));
+    MOCK_METHOD(muse::Ret, setShortcuts, (const muse::shortcuts::ShortcutList&), (override));
+    MOCK_METHOD(void, resetShortcuts, (), (override));
+    MOCK_METHOD(muse::async::Notification, shortcutsChanged, (), (const, override));
+    MOCK_METHOD(muse::Ret, setAdditionalShortcuts, (const std::string&, const muse::shortcuts::ShortcutList&), (override));
+    MOCK_METHOD(const muse::shortcuts::Shortcut&, shortcut, (const std::string&), (const, override));
+    MOCK_METHOD(const muse::shortcuts::Shortcut&, defaultShortcut, (const std::string&), (const, override));
+    MOCK_METHOD(bool, isRegistered, (const std::string&), (const, override));
+    MOCK_METHOD(muse::shortcuts::ShortcutList, shortcutsForSequence, (const std::string&), (const, override));
+    MOCK_METHOD(muse::Ret, importFromFile, (const muse::io::path_t&), (override));
+    MOCK_METHOD(muse::Ret, exportToFile, (const muse::io::path_t&), (const, override));
+    MOCK_METHOD(bool, active, (), (override));
+    MOCK_METHOD(void, setActive, (bool), (override));
+    MOCK_METHOD(muse::async::Notification, activeChanged, (), (const, override));
+    MOCK_METHOD(void, reload, (bool), (override));
+};
+
+class UiActionsRegisterMock : public muse::ui::IUiActionsRegister
+{
+public:
+    MOCK_METHOD(void, reg, (const muse::ui::IUiActionsModulePtr&), (override));
+    MOCK_METHOD(void, unreg, (const muse::ui::IUiActionsModulePtr&), (override));
+    MOCK_METHOD(std::vector<muse::ui::UiAction>, actionList, (), (const, override));
+    MOCK_METHOD(const muse::ui::UiAction&, action,
+                (const muse::actions::ActionCode&), (const, override));
+    MOCK_METHOD(const muse::actions::ActionCode&, parentActionCode,
+                (const muse::actions::ActionCode&), (const, override));
+    MOCK_METHOD(muse::async::Channel<muse::ui::UiActionList>, actionsChanged,
+                (), (const, override));
+    MOCK_METHOD(muse::ui::UiActionState, actionState,
+                (const muse::actions::ActionCode&), (const, override));
+    MOCK_METHOD(muse::async::Channel<muse::actions::ActionCodeList>,
+                actionStateChanged, (), (const, override));
+};
+
+class AudioSetupContextMenuModelTests : public ::testing::Test
+{
+public:
+    void SetUp() override
+    {
+        m_context = au::testutils::makeTestContext();
+        m_model.setContext(m_context);
+        m_controller
+            = std::make_shared<NiceMock<audio::AudioDriverControllerMock> >();
+        m_uiActionsRegister
+            = std::make_shared<NiceMock<UiActionsRegisterMock> >();
+        m_shortcutsRegister = std::make_shared<NiceMock<ShortcutsRegisterMock> >();
+        m_dispatcher = std::make_shared<NiceMock<muse::actions::ActionsDispatcherMock> >();
+        m_model.audioDriverController.set(m_controller);
+        m_model.uiActionsRegister.set(m_uiActionsRegister);
+        m_model.shortcutsRegister.set(m_shortcutsRegister);
+        m_model.dispatcher.set(m_dispatcher);
+
+        ON_CALL(*m_shortcutsRegister, shortcut(testing::_))
+        .WillByDefault(ReturnRef(m_shortcut));
+
+        m_inputChannelsAction.code
+            = "action://playback/change-input-channels";
+        m_audioSettingsAction.code = "audio-settings";
+        ON_CALL(*m_uiActionsRegister, action(testing::_))
+        .WillByDefault(ReturnRef(m_inputChannelsAction));
+        ON_CALL(*m_uiActionsRegister, action("audio-settings"))
+        .WillByDefault(ReturnRef(m_audioSettingsAction));
+        ON_CALL(*m_uiActionsRegister, actionState(testing::_))
+        .WillByDefault(Return(muse::ui::UiActionState::make_enabled()));
+
+        setSelection({ { { 0 } }, { { 2, 3 } } });
+    }
+
+    void TearDown() override
+    {
+        muse::modularity::removeIoC(m_context);
+    }
+
+    void setSelection(const audio::InputChannelSelection& selection, int availableChannels = 4)
+    {
+        audio::AudioConfiguration configuration;
+        configuration.inputChannelSelection = selection;
+        ON_CALL(*m_controller, configuration()).WillByDefault(Return(configuration));
+        ON_CALL(*m_controller, inputChannelsAvailable()).WillByDefault(Return(availableChannels));
+    }
+
+    muse::uicomponents::MenuItem* inputChannelsMenu()
+    {
+        auto* menu = m_model.makeInputChannelsMenu();
+        m_model.setItems({ menu });
+        return menu;
+    }
+
+    AudioSetupContextMenuModel m_model;
+    muse::modularity::ContextPtr m_context;
+    std::shared_ptr<NiceMock<audio::AudioDriverControllerMock> > m_controller;
+    std::shared_ptr<NiceMock<UiActionsRegisterMock> > m_uiActionsRegister;
+    std::shared_ptr<NiceMock<ShortcutsRegisterMock> > m_shortcutsRegister;
+    std::shared_ptr<NiceMock<muse::actions::ActionsDispatcherMock> > m_dispatcher;
+    muse::ui::UiAction m_inputChannelsAction;
+    muse::ui::UiAction m_audioSettingsAction;
+    muse::shortcuts::Shortcut m_shortcut;
+};
+
+TEST_F(AudioSetupContextMenuModelTests, InputChannelsMenuEncodesOneBasedCountInActionQuery)
+{
+    const auto items = inputChannelsMenu()->subitems();
+
+    for (int index = 0; index < 4; ++index) {
+        const auto query = items.at(index)->query();
+        EXPECT_EQ(query.uri().toString(), "action://playback/change-input-channels");
+        EXPECT_EQ(query.param("input-channels_index").toInt(), index + 1);
+        EXPECT_FALSE(query.contains("first-channel-index"));
+        EXPECT_FALSE(query.contains("channel-count"));
+        EXPECT_EQ(items.at(index)->id(), QString::fromStdString(query.toString()));
+    }
+}
+
+TEST_F(AudioSetupContextMenuModelTests, ExactPresetSelectionChecksOnlyTheMatchingCount)
+{
+    const std::vector<audio::InputChannelSelection> presets {
+        { { { 0 } } },
+        { { { 0, 1 } } },
+        { { { 0 } }, { { 1 } }, { { 2 } } },
+        { { { 0 } }, { { 1 } }, { { 2 } }, { { 3 } } }
+    };
+    for (size_t presetIndex = 0; presetIndex < presets.size(); ++presetIndex) {
+        SCOPED_TRACE(presetIndex);
+        setSelection(presets[presetIndex]);
+        const auto* menu = inputChannelsMenu();
+        EXPECT_EQ(menu->translatedTitle(), "Recording channels");
+        const auto items = menu->subitems();
+        for (int index = 0; index < items.size(); ++index) {
+            EXPECT_EQ(items.at(index)->checked(), index == static_cast<int>(presetIndex));
+        }
+    }
+}
+
+TEST_F(AudioSetupContextMenuModelTests, NonPresetChannelsOrGroupingDoNotCheckAPreset)
+{
+    const std::vector<audio::InputChannelSelection> selections {
+        { { { 2 } } },
+        { { { 2, 3 } } },
+        { { { 0 } }, { { 1 } } },
+        { { { 0, 1 } }, { { 2 } } },
+        { { { 0, 1 } }, { { 2, 3 } } }
+    };
+    for (const auto& selection : selections) {
+        SCOPED_TRACE(::testing::PrintToString(selection));
+        setSelection(selection);
+        const auto* menu = inputChannelsMenu();
+        EXPECT_EQ(menu->translatedTitle(), "Recording channels");
+        for (const auto* item : menu->subitems()) {
+            EXPECT_FALSE(item->checked());
+        }
+    }
+}
+
+TEST_F(AudioSetupContextMenuModelTests, EmptySelectionDoesNotCheckAPresetOrShowCustomState)
+{
+    setSelection({});
+    const auto* menu = inputChannelsMenu();
+
+    EXPECT_EQ(menu->translatedTitle(), "Recording channels");
+    for (const auto* item : menu->subitems()) {
+        EXPECT_FALSE(item->checked());
+    }
+}
+
+TEST_F(AudioSetupContextMenuModelTests, PresetDispatchesTheCountQuery)
+{
+    const auto* item = inputChannelsMenu()->subitems().at(1);
+    EXPECT_CALL(*m_dispatcher, dispatch(testing::Matcher<const muse::actions::ActionQuery&>(
+                                            testing::Property(&muse::actions::ActionQuery::toString,
+                                                              "action://playback/change-input-channels?input-channels_index=2"))))
+    .Times(1);
+
+    m_model.handleMenuItem(item->id());
+}
+}

--- a/src/projectscene/view/toolbars/audiosetupcontextmenumodel.cpp
+++ b/src/projectscene/view/toolbars/audiosetupcontextmenumodel.cpp
@@ -59,7 +59,7 @@ void AudioSetupContextMenuModel::makeMenuItems()
         makeMenu(muse::TranslatableString("audio setup", "Host"), makeHostItems(), "hostMenu"),
         makeMenu(muse::TranslatableString("audio setup", "Playback device"), makePlaybackDevicesItems(), "playbackDeviceMenu"),
         makeMenu(muse::TranslatableString("audio setup", "Recording device"), makeRecordingDevicesItems(), "recordingDeviceMenu"),
-        makeMenu(muse::TranslatableString("audio setup", "Recording channels"), makeInputChannelsItems(), "inputChannelsMenu"),
+        makeInputChannelsMenu(),
         makeMenuItem("rescan-devices"),
         makeMenuItem("audio-settings")
     };
@@ -191,40 +191,38 @@ MenuItemList AudioSetupContextMenuModel::makeRecordingDevicesItems()
     return items;
 }
 
-MenuItemList AudioSetupContextMenuModel::makeInputChannelsItems()
+MenuItem* AudioSetupContextMenuModel::makeInputChannelsMenu()
 {
     MenuItemList items;
-    int inputChannelsSelected = audioDriverController()->configuration().inputChannels;
-    int inputChannelsAvailable = audioDriverController()->inputChannelsAvailable();
+    const auto& selection = audioDriverController()->configuration().inputChannelSelection;
+    const int inputChannelsAvailable = audioDriverController()->inputChannelsAvailable();
 
-    auto makeChangeInputChannelsAction = [](int index) -> ActionQuery {
+    auto makeChangeInputChannelsAction = [](int channelCount) -> ActionQuery {
         ActionQuery q = PLAYBACK_CHANGE_INPUT_CHANNELS_QUERY;
-        q.addParam("input-channels_index", muse::Val(index));
+        q.addParam("input-channels_index", muse::Val(channelCount));
         return q;
     };
 
-    auto channelName = [](int channelNumber) -> QString {
-        return channelNumber == 1
-               //: %1 is the recording channel number
-               ? muse::qtrc("projectscene/toolbars", "%1 (Mono) Recording channel").arg(channelNumber)
-               : channelNumber == 2
-               //: %1 is the recording channel number
-               ? muse::qtrc("projectscene/toolbars", "%1 (Stereo) Recording channels").arg(channelNumber)
-               : QString::number(channelNumber);
+    auto channelName = [](int channelCount) -> muse::TranslatableString {
+        if (channelCount == 1) {
+            //: %1 is the recording channel count
+            return muse::TranslatableString("projectscene/toolbars", "%1 (Mono) Recording channel").arg(channelCount);
+        }
+        if (channelCount == 2) {
+            //: %1 is the recording channel count
+            return muse::TranslatableString("projectscene/toolbars", "%1 (Stereo) Recording channels").arg(channelCount);
+        }
+        return muse::TranslatableString::untranslatable(QString::number(channelCount));
     };
 
-    for (int i = 0; i < inputChannelsAvailable; ++i) {
-        int channelNumber = i + 1;
-        MenuItem* item = makeMenuItem(makeChangeInputChannelsAction(channelNumber).toString(),
-                                      muse::TranslatableString::untranslatable(channelName(channelNumber)));
+    for (int channelCount = 1; channelCount <= inputChannelsAvailable; ++channelCount) {
+        MenuItem* item = makeMenuItem(makeChangeInputChannelsAction(channelCount).toString(), channelName(channelCount));
 
         item->setId(QString::fromStdString(item->query().toString()));
-
-        if (inputChannelsSelected == (channelNumber)) {
-            item->setChecked(true);
-        }
+        item->setCheckable(true);
+        item->setChecked(selection == audio::legacyInputChannelSelection(channelCount));
         items << item;
     }
 
-    return items;
+    return makeMenu(muse::TranslatableString("audio setup", "Recording channels"), items, "inputChannelsMenu");
 }

--- a/src/projectscene/view/toolbars/audiosetupcontextmenumodel.cpp
+++ b/src/projectscene/view/toolbars/audiosetupcontextmenumodel.cpp
@@ -215,14 +215,28 @@ MenuItem* AudioSetupContextMenuModel::makeInputChannelsMenu()
         return muse::TranslatableString::untranslatable(QString::number(channelCount));
     };
 
+    bool hasCheckedPreset = false;
     for (int channelCount = 1; channelCount <= inputChannelsAvailable; ++channelCount) {
         MenuItem* item = makeMenuItem(makeChangeInputChannelsAction(channelCount).toString(), channelName(channelCount));
 
         item->setId(QString::fromStdString(item->query().toString()));
         item->setCheckable(true);
         item->setChecked(selection == audio::legacyInputChannelSelection(channelCount));
+        hasCheckedPreset = hasCheckedPreset || item->checked();
         items << item;
     }
 
-    return makeMenu(muse::TranslatableString("audio setup", "Recording channels"), items, "inputChannelsMenu");
+    if (!items.empty()) {
+        items << makeSeparator();
+    }
+    MenuItem* customItem = makeMenuItem("audio-settings", muse::TranslatableString("audio setup", "Custom..."));
+    customItem->setId("customInputChannels");
+    customItem->setCheckable(false);
+    customItem->setChecked(false);
+    items << customItem;
+
+    const auto title = inputChannelsAvailable > 0 && !selection.empty() && !hasCheckedPreset
+                       ? muse::TranslatableString("audio setup", "Recording channels: Custom")
+                       : muse::TranslatableString("audio setup", "Recording channels");
+    return makeMenu(title, items, "inputChannelsMenu");
 }

--- a/src/projectscene/view/toolbars/audiosetupcontextmenumodel.h
+++ b/src/projectscene/view/toolbars/audiosetupcontextmenumodel.h
@@ -12,6 +12,8 @@ class AudioSetupContextMenuModel : public muse::uicomponents::AbstractMenuModel
 {
     Q_OBJECT
 
+    friend class AudioSetupContextMenuModelTests;
+
     muse::GlobalInject<audio::IAudioDriverController> audioDriverController;
 
     muse::ContextInject<context::IGlobalContext> globalContext{ this };
@@ -29,6 +31,6 @@ private:
     muse::uicomponents::MenuItemList makeHostItems();
     muse::uicomponents::MenuItemList makePlaybackDevicesItems();
     muse::uicomponents::MenuItemList makeRecordingDevicesItems();
-    muse::uicomponents::MenuItemList makeInputChannelsItems();
+    muse::uicomponents::MenuItem* makeInputChannelsMenu();
 };
 }

--- a/src/projectscene/view/trackspanel/wavetrackitem.cpp
+++ b/src/projectscene/view/trackspanel/wavetrackitem.cpp
@@ -53,10 +53,11 @@ void WaveTrackItem::init(const trackedit::Track& track)
     }, muse::async::Asyncable::Mode::SetReplace);
 
     audioDriverController()->configurationChanged().onReceive(this, [this](const audio::AudioConfigurationDelta& delta) {
-        if (!delta.contains(audio::AudioConfigurationField::InputChannels)) {
+        if (!delta.contains(audio::AudioConfigurationField::InputChannelSelection)) {
             return;
         }
-        const int inputChannelsCount = audioDriverController()->configuration().inputChannels;
+        const int inputChannelsCount = static_cast<int>(audio::inputChannelCount(
+                                                            audioDriverController()->configuration().inputChannelSelection));
         m_recordStreamChannelsMatch = (trackType() == trackedit::TrackType::Mono && inputChannelsCount == 1)
                                       || (trackType() == trackedit::TrackType::Stereo && inputChannelsCount == 2);
         checkMainAudioInput();
@@ -80,7 +81,8 @@ void WaveTrackItem::init(const trackedit::Track& track)
         muteOrSoloChanged();
     }, muse::async::Asyncable::Mode::SetReplace);
 
-    const int inputChannelsCount = audioDriverController()->configuration().inputChannels;
+    const int inputChannelsCount = static_cast<int>(audio::inputChannelCount(
+                                                        audioDriverController()->configuration().inputChannelSelection));
     m_recordStreamChannelsMatch = (trackType() == trackedit::TrackType::Mono && inputChannelsCount == 1)
                                   || (trackType() == trackedit::TrackType::Stereo && inputChannelsCount == 2);
 

--- a/src/record/internal/au3/au3audioinput.cpp
+++ b/src/record/internal/au3/au3audioinput.cpp
@@ -29,7 +29,8 @@ Au3AudioInput::Au3AudioInput(const muse::modularity::ContextPtr& ctx)
             return;
         }
 
-        m_inputChannelsCount = audioDriverController()->configuration().inputChannels;
+        m_inputChannelsCount = static_cast<int>(audio::inputChannelCount(
+                                                    audioDriverController()->configuration().inputChannelSelection));
         m_focusedTrackChannels = getFocusedTrackChannels();
 
         initMeter();
@@ -57,8 +58,9 @@ Au3AudioInput::Au3AudioInput(const muse::modularity::ContextPtr& ctx)
         }, muse::async::Asyncable::Mode::SetReplace);
 
         audioDriverController()->configurationChanged().onReceive(this, [this](const audio::AudioConfigurationDelta& delta) {
-            if (delta.contains(audio::AudioConfigurationField::InputChannels)) {
-                m_inputChannelsCount = audioDriverController()->configuration().inputChannels;
+            if (delta.contains(audio::AudioConfigurationField::InputChannelSelection)) {
+                m_inputChannelsCount = static_cast<int>(audio::inputChannelCount(
+                                                            audioDriverController()->configuration().inputChannelSelection));
                 updateAudioEngineMonitoring();
             }
         }, muse::async::Asyncable::Mode::SetReplace);
@@ -128,7 +130,8 @@ void Au3AudioInput::startAudioEngineMonitoring() const
         if (!project) {
             return;
         }
-        audioEngine()->startMonitoring(*project);
+        audioEngine()->startMonitoring(
+            *project, audioDriverController()->configuration().inputChannelSelection);
     });
 }
 

--- a/src/record/internal/au3/au3record.cpp
+++ b/src/record/internal/au3/au3record.cpp
@@ -385,7 +385,8 @@ muse::Ret Au3Record::start()
     }
 
     if (appendRecord) {
-        const int recordingChannels = std::max(0, audioDriverController()->configuration().inputChannels);
+        const int recordingChannels = static_cast<int>(audio::inputChannelCount(
+                                                           audioDriverController()->configuration().inputChannelSelection));
 
         // Try to find wave tracks to record into.  (If any are selected,
         // try to choose only from them; else if wave tracks exist, may record into any.)
@@ -512,7 +513,8 @@ muse::Ret Au3Record::leadInRecording()
     }
 
     // Find tracks to record into (must be selected)
-    const int recordingChannels = std::max(0, audioDriverController()->configuration().inputChannels);
+    const int recordingChannels = static_cast<int>(audio::inputChannelCount(
+                                                       audioDriverController()->configuration().inputChannelSelection));
     auto tracks = ChooseExistingRecordingTracks(project, true, rateOfSelected, recordingChannels);
     if (tracks.empty()) {
         return make_ret(Err::LeadInRecordingNoTracksSelected);
@@ -829,7 +831,7 @@ Ret Au3Record::doRecord(Au3Project& project,
         // Count the tracks.
         auto numTracks = trackList.Any<const Au3WaveTrack>().size();
 
-        const auto recordingChannels = std::max(1, audioDriverController()->configuration().inputChannels);
+        const auto& inputChannelSelection = audioDriverController()->configuration().inputChannelSelection;
 
         const RecordingTrackNameOptions nameOptions = recordConfiguration()->recordingTrackNameOptions();
         const wxString defaultTrackName = trackList.MakeUniqueTrackName(Au3WaveTrack::GetDefaultAudioTrackNamePreference());
@@ -838,12 +840,8 @@ Ret Au3Record::doRecord(Au3Project& project,
                                        : defaultTrackName;
 
         std::vector<WaveTrack::Holder> newTracks;
-        if (recordingChannels == 2) {
-            newTracks.push_back(WaveTrackFactory::Get(*p).Create(2));
-        } else {
-            for (int i = 0; i < recordingChannels; ++i) {
-                newTracks.push_back(WaveTrackFactory::Get(*p).Create(1));
-            }
+        for (const auto& group : inputChannelSelection) {
+            newTracks.push_back(WaveTrackFactory::Get(*p).Create(group.channels.size()));
         }
 
         std::vector<std::pair<WaveTrack::Holder, Au3WaveTrack::IntervalHolder> > newTrackHolders;
@@ -940,6 +938,7 @@ Ret Au3Record::doRecord(Au3Project& project,
     options.sampleRate = audioStreamSampleRate;
     options.leadInTime = leadInTime;
     options.crossfadeData = crossfadeData;
+    options.inputChannelSelection = audioDriverController()->configuration().inputChannelSelection;
 
     int token = audioEngine()->startStream(transportSequences, t0, t1, t1, project, options);
 

--- a/src/record/internal/recordcontroller.cpp
+++ b/src/record/internal/recordcontroller.cpp
@@ -5,6 +5,8 @@
 
 #include "framework/global/translation.h"
 
+#include "record/recorderrors.h"
+
 using namespace muse;
 using namespace au::record;
 using namespace muse::async;
@@ -130,15 +132,15 @@ void RecordController::startWithNewTrack()
 
     stopPlaybackIfPaused();
 
-    const int recordingChannels = std::max(1, audioDriverController()->configuration().inputChannels);
+    const auto& inputChannelSelection = audioDriverController()->configuration().inputChannelSelection;
+    if (inputChannelSelection.empty()) {
+        interactive()->error(muse::trc("record", "Recording error"), make_ret(Err::NoRecordingDevice).text());
+        return;
+    }
 
     au::trackedit::TrackIdList newTracks;
-    if (recordingChannels == 2) {
-        newTracks.push_back(tracksInteraction()->addWaveTrack(2));
-    } else {
-        for (int i = 0; i < recordingChannels; ++i) {
-            newTracks.push_back(tracksInteraction()->addWaveTrack(1));
-        }
+    for (const auto& group : inputChannelSelection) {
+        newTracks.push_back(tracksInteraction()->addWaveTrack(static_cast<int>(group.channels.size())));
     }
 
     selectionController()->setSelectedTracks(newTracks);

--- a/src/record/tests/CMakeLists.txt
+++ b/src/record/tests/CMakeLists.txt
@@ -9,6 +9,7 @@ set(MODULE_TEST_SRC
 
     ${CMAKE_CURRENT_LIST_DIR}/../../au3audio/tests/mocks/audioenginemock.h
     ${CMAKE_CURRENT_LIST_DIR}/../../audio/tests/mocks/audiodrivercontrollermock.h
+    ${CMAKE_CURRENT_LIST_DIR}/../../trackedit/tests/mocks/tracksinteractionmock.h
     ${CMAKE_CURRENT_LIST_DIR}/mocks/recordconfigurationmock.h
     ${CMAKE_CURRENT_LIST_DIR}/mocks/recordcontrollermock.h
     ${CMAKE_CURRENT_LIST_DIR}/mocks/recordmock.h

--- a/src/record/tests/au3record_tests.cpp
+++ b/src/record/tests/au3record_tests.cpp
@@ -88,7 +88,7 @@ public:
         .WillByDefault(Return(2));
 
         audio::AudioConfiguration audioConfiguration;
-        audioConfiguration.inputChannels = 2;
+        audioConfiguration.inputChannelSelection = { { { 0, 1 } } };
         ON_CALL(*m_audioDriverController, configuration())
         .WillByDefault(Return(audioConfiguration));
 
@@ -138,14 +138,20 @@ public:
         return *reinterpret_cast<Au3Project*>(m_au3ProjectAccessor->au3ProjectPtr());
     }
 
-    Au3WaveTrack* addSelectedMonoTrack()
+    Au3WaveTrack* addSelectedTrack(size_t channels = 1)
     {
         auto& trackFactory = Au3WaveTrackFactory::Get(projectRef());
-        auto track = trackFactory.Create(sampleFormat::floatSample, TEST_SAMPLE_RATE);
+        auto track = trackFactory.Create(
+            channels, sampleFormat::floatSample, TEST_SAMPLE_RATE);
         Au3TrackList::Get(projectRef()).Add(track, ::TrackList::DoAssignId::Yes,
                                             ::TrackList::EventPublicationSynchrony::Synchronous);
         track->SetSelected(true);
         return track.get();
+    }
+
+    Au3WaveTrack* addSelectedMonoTrack()
+    {
+        return addSelectedTrack();
     }
 
     std::shared_ptr<Au3Record> m_record;
@@ -239,6 +245,96 @@ TEST_F(Au3RecordTests, RecordingToNewTrackUsesConfiguredTrackName)
     ASSERT_EQ(tracks.size(), 1u);
     EXPECT_EQ((*tracks.begin())->NChannels(), 2u);
     EXPECT_EQ((*tracks.begin())->GetName(), wxString("MyTake_1"));
+}
+
+struct ChannelSelectionCase {
+    const char* name;
+    audio::InputChannelSelection selection;
+    std::vector<size_t> trackChannels;
+    int availableChannels;
+};
+
+class Au3RecordChannelSelectionTests : public Au3RecordTests, public ::testing::WithParamInterface<ChannelSelectionCase>
+{
+};
+
+TEST_P(Au3RecordChannelSelectionTests, CreatesMatchingTracksAndPassesExactRouteToEngine)
+{
+    const auto& testCase = GetParam();
+    audio::AudioConfiguration configuration;
+    configuration.inputChannelSelection = testCase.selection;
+    ON_CALL(*m_audioDriverController, configuration()).WillByDefault(Return(configuration));
+    ON_CALL(*m_audioDriverController, inputChannelsAvailable())
+    .WillByDefault(Return(testCase.availableChannels));
+
+    audio::IAudioEngine::StartStreamOptions streamOptions;
+    EXPECT_CALL(*m_audioEngine, startStream(_, _, _, _, _, _))
+    .WillOnce(DoAll(SaveArg<5>(&streamOptions), Return(1)));
+
+    ASSERT_TRUE(m_record->start());
+
+    const auto tracks = Au3TrackList::Get(projectRef()).Any<Au3WaveTrack>();
+    ASSERT_EQ(tracks.size(), testCase.trackChannels.size());
+    auto track = tracks.begin();
+    for (const auto channels : testCase.trackChannels) {
+        ASSERT_NE(track, tracks.end());
+        EXPECT_EQ((*track++)->NChannels(), channels);
+    }
+    EXPECT_EQ(streamOptions.inputChannelSelection, configuration.inputChannelSelection);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    RecordingRoutes,
+    Au3RecordChannelSelectionTests,
+    ::testing::Values(
+        ChannelSelectionCase { "HighMono", { { { 2 } } }, { 1 }, 4 },
+        ChannelSelectionCase { "HighStereo", { { { 2, 3 } } }, { 2 }, 4 },
+        ChannelSelectionCase { "MultipleMonos", { { { 0 } }, { { 2 } } },
+                               { 1, 1 }, 4 },
+        ChannelSelectionCase { "MixedMonoAndStereo", { { { 0 } }, { { 2, 3 } } },
+                               { 1, 2 }, 4 },
+        ChannelSelectionCase { "MultipleStereoPairs", { { { 0, 1 } }, { { 2, 3 } } },
+                               { 2, 2 }, 4 },
+        ChannelSelectionCase { "HighestConventionalPair", { { { 6, 7 } } },
+                               { 2 }, 8 }),
+    [](const ::testing::TestParamInfo<ChannelSelectionCase>& info) {
+    return info.param.name;
+});
+
+TEST_F(Au3RecordTests, ExistingTrackCompatibilityUsesLogicalChannelCount)
+{
+    addSelectedTrack(2);
+    audio::AudioConfiguration configuration;
+    configuration.inputChannelSelection = { { { 0 } }, { { 2 } } };
+    ON_CALL(*m_audioDriverController, configuration()).WillByDefault(Return(configuration));
+    ON_CALL(*m_audioDriverController, inputChannelsAvailable()).WillByDefault(Return(4));
+
+    audio::IAudioEngine::StartStreamOptions streamOptions;
+    EXPECT_CALL(*m_audioEngine, startStream(_, _, _, _, _, _))
+    .WillOnce(DoAll(SaveArg<5>(&streamOptions), Return(1)));
+
+    ASSERT_TRUE(m_record->start());
+
+    EXPECT_EQ(Au3TrackList::Get(projectRef()).Any<Au3WaveTrack>().size(), 1u);
+    EXPECT_EQ(streamOptions.inputChannelSelection, configuration.inputChannelSelection);
+}
+
+TEST_F(Au3RecordTests, CapacityReducedPresetCreatesOneStereoTrack)
+{
+    audio::AudioConfiguration configuration;
+    configuration.inputChannelSelection = audio::normalizeInputChannelSelection(audio::legacyInputChannelSelection(4), 2);
+    ON_CALL(*m_audioDriverController, configuration()).WillByDefault(Return(configuration));
+
+    audio::IAudioEngine::StartStreamOptions streamOptions;
+    EXPECT_CALL(*m_audioEngine, startStream(_, _, _, _, _, _))
+    .WillOnce(DoAll(SaveArg<5>(&streamOptions), Return(1)));
+
+    ASSERT_TRUE(m_record->start());
+
+    const auto tracks = Au3TrackList::Get(projectRef()).Any<Au3WaveTrack>();
+    ASSERT_EQ(tracks.size(), 1u);
+    EXPECT_EQ((*tracks.begin())->NChannels(), 2u);
+    EXPECT_EQ(streamOptions.inputChannelSelection, audio::InputChannelSelection({ { { 0, 1 } } }));
 }
 
 TEST_F(Au3RecordTests, RecordingWithBusyEngineStartsUnpausedAtPlayhead)

--- a/src/record/tests/recordcontroller_tests.cpp
+++ b/src/record/tests/recordcontroller_tests.cpp
@@ -6,11 +6,16 @@
 
 #include "../internal/recordcontroller.h"
 
+#include "audio/tests/mocks/audiodrivercontrollermock.h"
 #include "context/tests/mocks/globalcontextmock.h"
 #include "context/tests/mocks/playbackstatemock.h"
-#include "playback/tests/mocks/playbackcontrollermock.h"
-#include "trackedit/tests/mocks/selectioncontrollermock.h"
 #include "interactive/tests/mocks/interactivemock.h"
+#include "playback/tests/mocks/playbackcontrollermock.h"
+#include "record/recorderrors.h"
+#include "trackedit/tests/mocks/selectioncontrollermock.h"
+#include "trackedit/tests/mocks/trackeditinteractionmock.h"
+#include "trackedit/tests/mocks/tracknavigationcontrollermock.h"
+#include "trackedit/tests/mocks/tracksinteractionmock.h"
 
 #include "mocks/recordmock.h"
 
@@ -33,12 +38,24 @@ public:
         m_selectionController = std::make_shared<NiceMock<trackedit::SelectionControllerMock> >();
         m_interactive = std::make_shared<NiceMock<muse::InteractiveMock> >();
         m_record = std::make_shared<NiceMock<RecordMock> >();
+        m_audioDriverController
+            = std::make_shared<NiceMock<audio::AudioDriverControllerMock> >();
+        m_tracksInteraction
+            = std::make_shared<NiceMock<trackedit::TracksInteractionMock> >();
+        m_trackeditInteraction
+            = std::make_shared<NiceMock<trackedit::TrackeditInteractionMock> >();
+        m_trackNavigationController
+            = std::make_shared<NiceMock<trackedit::TrackNavigationControllerMock> >();
 
         m_controller->globalContext.set(m_globalContext);
         m_controller->playbackController.set(m_playbackController);
         m_controller->selectionController.set(m_selectionController);
         m_controller->interactive.set(m_interactive);
         m_controller->record.set(m_record);
+        m_controller->audioDriverController.set(m_audioDriverController);
+        m_controller->tracksInteraction.set(m_tracksInteraction);
+        m_controller->trackeditInteraction.set(m_trackeditInteraction);
+        m_controller->trackNavigationController.set(m_trackNavigationController);
 
         ON_CALL(*m_globalContext, playbackState())
         .WillByDefault(Return(m_playbackState));
@@ -66,6 +83,11 @@ public:
         m_controller->pause();
     }
 
+    void startWithNewTrack()
+    {
+        m_controller->startWithNewTrack();
+    }
+
     bool recordStatusIsRunning() const
     {
         return m_controller->m_currentRecordStatus == RecordController::RecordStatus::Running;
@@ -79,6 +101,10 @@ public:
     std::shared_ptr<trackedit::SelectionControllerMock> m_selectionController;
     std::shared_ptr<muse::InteractiveMock> m_interactive;
     std::shared_ptr<RecordMock> m_record;
+    std::shared_ptr<NiceMock<audio::AudioDriverControllerMock> > m_audioDriverController;
+    std::shared_ptr<NiceMock<trackedit::TracksInteractionMock> > m_tracksInteraction;
+    std::shared_ptr<NiceMock<trackedit::TrackeditInteractionMock> > m_trackeditInteraction;
+    std::shared_ptr<NiceMock<trackedit::TrackNavigationControllerMock> > m_trackNavigationController;
 };
 
 TEST_F(RecordControllerTests, LeadInRecordingStartsFromPlayheadNotSelectionStart)
@@ -187,5 +213,93 @@ TEST_F(RecordControllerTests, PauseWhilePausedResumesRecording)
 
     //! [THEN] The recording is running again
     EXPECT_TRUE(recordStatusIsRunning());
+}
+
+class RecordOnNewTrackWithoutInputsTests : public RecordControllerTests, public ::testing::WithParamInterface<bool>
+{
+};
+
+TEST_P(RecordOnNewTrackWithoutInputsTests, ReportsErrorWithoutChangingTracksOrStartingRecording)
+{
+    const bool playbackPaused = GetParam();
+    audio::AudioConfiguration configuration;
+    configuration.inputChannelSelection.clear();
+    ON_CALL(*m_audioDriverController, configuration())
+    .WillByDefault(Return(configuration));
+    ON_CALL(*m_playbackController, isPaused())
+    .WillByDefault(Return(playbackPaused));
+
+    EXPECT_CALL(*m_tracksInteraction, addWaveTrack(_)).Times(0);
+    EXPECT_CALL(*m_trackeditInteraction, deleteTracks(_)).Times(0);
+    EXPECT_CALL(*m_selectionController, setSelectedTracks(_, _)).Times(0);
+    EXPECT_CALL(*m_trackNavigationController, setFocusedTrack(_, _)).Times(0);
+    EXPECT_CALL(*m_record, start()).Times(0);
+
+    InSequence sequence;
+    EXPECT_CALL(*m_playbackController, stop()).Times(playbackPaused ? 1 : 0);
+    EXPECT_CALL(*m_interactive, error(muse::trc("record", "Recording error"),
+                                    ::testing::Field(&muse::IInteractive::Text::text, make_ret(Err::NoRecordingDevice).text()),
+                                    _, _, _, _))
+    .WillOnce(Return(muse::async::make_promise<muse::IInteractive::Result>(
+                         [](const auto& resolve) {
+        return resolve(muse::IInteractive::Result {});
+    }, muse::async::PromiseType::AsyncByBody)));
+
+    startWithNewTrack();
+
+    EXPECT_FALSE(m_controller->isRecording());
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    PlaybackStates,
+    RecordOnNewTrackWithoutInputsTests,
+    ::testing::Values(false, true),
+    [](const ::testing::TestParamInfo<bool>& info) {
+    return info.param ? "Paused" : "Stopped";
+});
+
+TEST_F(RecordControllerTests, RecordOnNewTrackCreatesOneTrackPerInputGroup)
+{
+    audio::AudioConfiguration configuration;
+    configuration.inputChannelSelection = { { { 0 } }, { { 2, 3 } } };
+    ON_CALL(*m_audioDriverController, configuration())
+    .WillByDefault(Return(configuration));
+
+    InSequence sequence;
+    EXPECT_CALL(*m_tracksInteraction, addWaveTrack(1)).WillOnce(Return(101));
+    EXPECT_CALL(*m_tracksInteraction, addWaveTrack(2)).WillOnce(Return(102));
+    EXPECT_CALL(*m_selectionController,
+                setSelectedTracks(trackedit::TrackIdList { 101, 102 }, true));
+    EXPECT_CALL(*m_trackNavigationController, setFocusedTrack(101, false));
+    EXPECT_CALL(*m_record, start()).WillOnce(Return(muse::make_ok()));
+
+    startWithNewTrack();
+
+    EXPECT_TRUE(recordStatusIsRunning());
+}
+
+TEST_F(RecordControllerTests, RecordOnNewTrackFailureDeletesEveryCreatedTrack)
+{
+    audio::AudioConfiguration configuration;
+    configuration.inputChannelSelection = { { { 0 } }, { { 2, 3 } } };
+    ON_CALL(*m_audioDriverController, configuration())
+    .WillByDefault(Return(configuration));
+    ON_CALL(*m_tracksInteraction, addWaveTrack(1)).WillByDefault(Return(101));
+    ON_CALL(*m_tracksInteraction, addWaveTrack(2)).WillByDefault(Return(102));
+    ON_CALL(*m_record, start())
+    .WillByDefault(Return(muse::make_ret(muse::Ret::Code::UnknownError)));
+
+    EXPECT_CALL(*m_trackeditInteraction,
+                deleteTracks(trackedit::TrackIdList { 101, 102 }))
+    .WillOnce(Return(true));
+    EXPECT_CALL(*m_interactive, error(_, _, _, _, _, _))
+    .WillOnce(Return(muse::async::make_promise<muse::IInteractive::Result>(
+                         [](const auto& resolve) {
+        return resolve(muse::IInteractive::Result {});
+    }, muse::async::PromiseType::AsyncByBody)));
+
+    startWithNewTrack();
+
+    EXPECT_FALSE(recordStatusIsRunning());
 }
 }

--- a/src/record/tests/recordcontroller_tests.cpp
+++ b/src/record/tests/recordcontroller_tests.cpp
@@ -238,8 +238,8 @@ TEST_P(RecordOnNewTrackWithoutInputsTests, ReportsErrorWithoutChangingTracksOrSt
     InSequence sequence;
     EXPECT_CALL(*m_playbackController, stop()).Times(playbackPaused ? 1 : 0);
     EXPECT_CALL(*m_interactive, error(muse::trc("record", "Recording error"),
-                                    ::testing::Field(&muse::IInteractive::Text::text, make_ret(Err::NoRecordingDevice).text()),
-                                    _, _, _, _))
+                                      ::testing::Field(&muse::IInteractive::Text::text, make_ret(Err::NoRecordingDevice).text()),
+                                      _, _, _, _))
     .WillOnce(Return(muse::async::make_promise<muse::IInteractive::Result>(
                          [](const auto& resolve) {
         return resolve(muse::IInteractive::Result {});

--- a/src/record/view/toolbars/playbacktoolbarrecordlevelitem.cpp
+++ b/src/record/view/toolbars/playbacktoolbarrecordlevelitem.cpp
@@ -25,7 +25,7 @@ PlaybackToolBarRecordLevelItem::PlaybackToolBarRecordLevelItem(const muse::ui::U
     });
 
     audioDriverController()->configurationChanged().onReceive(this, [this](const audio::AudioConfigurationDelta& delta) {
-        if (delta.contains(audio::AudioConfigurationField::InputChannels)) {
+        if (delta.contains(audio::AudioConfigurationField::InputChannelSelection)) {
             recordingChannelsCountChanged();
         }
     });
@@ -162,7 +162,8 @@ void PlaybackToolBarRecordLevelItem::setRightMaxPeak(const float newRightMaxPeak
 
 int PlaybackToolBarRecordLevelItem::recordingChannelsCount() const
 {
-    return audioDriverController()->configuration().inputChannels;
+    return static_cast<int>(audio::inputChannelCount(
+                                audioDriverController()->configuration().inputChannelSelection));
 }
 
 bool PlaybackToolBarRecordLevelItem::isInputMonitoringOn() const

--- a/src/trackedit/tests/mocks/tracksinteractionmock.h
+++ b/src/trackedit/tests/mocks/tracksinteractionmock.h
@@ -1,0 +1,67 @@
+/*
+ * Audacity: A Digital Audio Editor
+ */
+#pragma once
+
+#include <gmock/gmock.h>
+
+#include "trackedit/itracksinteraction.h"
+
+namespace au::trackedit {
+class TracksInteractionMock : public ITracksInteraction
+{
+public:
+    MOCK_METHOD(bool, trimTracksData, (const TrackIdList&, secs_t, secs_t), (override));
+    MOCK_METHOD(bool, silenceTracksData, (const TrackIdList&, secs_t, secs_t), (override));
+    MOCK_METHOD(bool, tracksDataIsSilent, (const TrackIdList&, secs_t, secs_t), (const, override));
+    MOCK_METHOD(bool, changeTrackTitle, (TrackId, const muse::String&), (override));
+    MOCK_METHOD(bool, changeTracksColor, (const TrackIdList&, ClipColorIndex), (override));
+    MOCK_METHOD(muse::Ret, paste,
+                (const std::vector<ITrackDataPtr>&, secs_t, bool, bool, bool, bool&),
+                (override));
+    MOCK_METHOD(ITrackDataPtr, cutTrackData, (TrackId, secs_t, secs_t, bool), (override));
+    MOCK_METHOD(ITrackDataPtr, copyNonContinuousTrackData,
+                (TrackId, const TrackItemKeyList&, secs_t), (override));
+    MOCK_METHOD(ITrackDataPtr, copyContinuousTrackData,
+                (TrackId, secs_t, secs_t), (override));
+    MOCK_METHOD(bool, removeTracksData,
+                (const TrackIdList&, secs_t, secs_t, bool), (override));
+    MOCK_METHOD(bool, splitTracksAt,
+                (const TrackIdList&, std::vector<secs_t>), (override));
+    MOCK_METHOD(bool, splitRangeSelectionAtSilences,
+                (const TrackIdList&, secs_t, secs_t), (override));
+    MOCK_METHOD(bool, splitRangeSelectionIntoNewTracks,
+                (const TrackIdList&, secs_t, secs_t), (override));
+    MOCK_METHOD(bool, mergeSelectedOnTracks,
+                (const TrackIdList&, secs_t, secs_t), (override));
+    MOCK_METHOD(bool, duplicateSelectedOnTracks,
+                (const TrackIdList&, secs_t, secs_t), (override));
+    MOCK_METHOD(std::vector<ITrackDataPtr>, splitCutSelectedOnTracks,
+                (const TrackIdList, secs_t, secs_t), (override));
+    MOCK_METHOD(bool, splitDeleteSelectedOnTracks,
+                (const TrackIdList, secs_t, secs_t), (override));
+    MOCK_METHOD(bool, newMonoTrack, (), (override));
+    MOCK_METHOD(bool, newStereoTrack, (), (override));
+    MOCK_METHOD(muse::RetVal<TrackId>, newLabelTrack,
+                (const muse::String&), (override));
+    MOCK_METHOD(bool, deleteTracks, (const TrackIdList&), (override));
+    MOCK_METHOD(bool, duplicateTracks, (const TrackIdList&), (override));
+    MOCK_METHOD(bool, moveTracks,
+                (const TrackIdList&, TrackMoveDirection), (override));
+    MOCK_METHOD(bool, moveTracksTo, (const TrackIdList&, int), (override));
+    MOCK_METHOD(bool, insertSilence,
+                (const TrackIdList&, secs_t, secs_t, secs_t), (override));
+    MOCK_METHOD(bool, changeTracksFormat,
+                (const TrackIdList&, TrackFormat), (override));
+    MOCK_METHOD(bool, changeTracksRate, (const TrackIdList&, int), (override));
+    MOCK_METHOD(bool, swapStereoChannels, (const TrackIdList&), (override));
+    MOCK_METHOD(bool, splitStereoTracksToLRMono, (const TrackIdList&), (override));
+    MOCK_METHOD(bool, splitStereoTracksToCenterMono, (const TrackIdList&), (override));
+    MOCK_METHOD(bool, makeStereoTrack, (TrackId, TrackId), (override));
+    MOCK_METHOD(bool, resampleTracks, (const TrackIdList&, int), (override));
+    MOCK_METHOD(double, nearestZeroCrossing, (double), (const, override));
+    MOCK_METHOD(TrackId, addWaveTrack, (int), (override));
+    MOCK_METHOD(void, removeDragAddedTracks, (size_t, bool), (override));
+    MOCK_METHOD(muse::Progress, progress, (), (const, override));
+};
+}


### PR DESCRIPTION
Resolves: [#11912](https://github.com/audacity/audacity/issues/11912)

Audacity’s recording-channel setting currently selects the first N inputs on a device. This PR allows selecting individual mono inputs and adjacent stereo pairs, including mixed selections. For example, inputs 3+4 can be recorded directly into one stereo track without creating unwanted tracks for inputs 1+2. Selecting mono input 1 and stereo inputs 3+4 creates one mono track and one stereo track.

<img width="618" height="367" alt="Screenshot 2026-09-06 at 13 56 02" src="https://github.com/user-attachments/assets/c173d067-17fe-4ffb-a7a9-5e7d77e18cea" />


Changes:

  - Add a recording-channel selector in Preferences
  - Preserve the channel-count presets in Audio Setup and add a "Custom..." command that opens Preferences
  - Persist grouped selections and migrate existing channel-count settings while preserving their track layouts
  - Apply the selected inputs consistently to recording, input meters, sound-activated recording, and software playthrough
  - Include the required input stream width in sample-rate capability queries and caches
  - Add regression coverage for selection rules, settings migration, channel routing, meters, recording controllers, and UI behavior

The PortAudio stream opens enough physical channels to reach the highest selected input. Only selected channels enter the logical capture buffers. For example, mono 1 plus stereo 3+4 uses a four-channel input stream, three logical capture channels, and two destination tracks.

Stereo choices are currently only odd-even pairs, 1+2, 3+4, and so on.

The design is documented in `docs/recording-input-channel-selection-architecture.md`.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [ ] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
