### PR TITLE
Keep label selected after track change

### DIFF
--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TrackLabelsContainer.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TrackLabelsContainer.qml
@@ -398,7 +398,13 @@ TrackItemsContainer {
         function onItemMoveRequested(itemKey, completed) {
             root.updateMouseMoveActive(completed)
 
-            labelsModel.moveSelectedLabels(itemKey, completed)
+            let newKey = labelsModel.moveSelectedLabels(itemKey, completed)
+
+            // the label might change its track, we need to update grabbed itemKey
+            if (newKey.trackId() !== itemKey.trackId()) {
+                setHoveredItemKey(newKey)
+                itemKey = newKey
+            }
 
             handleLabelGuideline(itemKey, Direction.Auto, completed)
         }

--- a/src/projectscene/view/tracksitemsview/tracklabelslistmodel.cpp
+++ b/src/projectscene/view/tracksitemsview/tracklabelslistmodel.cpp
@@ -362,23 +362,24 @@ void TrackLabelsListModel::toggleTracksDataSelectionByLabel(const LabelKey& key)
     }
 }
 
-bool TrackLabelsListModel::moveSelectedLabels(const LabelKey& key, bool completed)
+au::projectscene::LabelKey TrackLabelsListModel::moveSelectedLabels(const LabelKey& key, bool completed)
 {
     TrackLabelItem* item = labelItemByKey(key.key);
+    LabelKey labelKey = LabelKey(key);
     if (!item) {
-        return false;
+        return labelKey;
     }
 
     m_pendingToggleDeselect = {};
 
     auto project = globalContext()->currentProject();
     IF_ASSERT_FAILED(project) {
-        return false;
+        return labelKey;
     }
 
     auto vs = project->viewState();
     IF_ASSERT_FAILED(vs) {
-        return false;
+        return labelKey;
     }
 
     bool ok = false;
@@ -391,7 +392,23 @@ bool TrackLabelsListModel::moveSelectedLabels(const LabelKey& key, bool complete
             ok = trackeditInteraction()->moveRangeSelection(moveOffset.timeOffset, completed);
         } else {
             auto selectedLabels = selectionController()->selectedLabels();
-            ok = trackeditInteraction()->moveLabels(selectedLabels, moveOffset.timeOffset, moveOffset.trackOffset, completed).ret;
+            auto result = trackeditInteraction()->moveLabels(selectedLabels, moveOffset.timeOffset, moveOffset.trackOffset, completed);
+            ok = result.ret;
+            auto movedLabelKeys = result.val;
+            if (selectedLabels != movedLabelKeys) {
+                selectionController()->setSelectedLabels(movedLabelKeys, completed);
+
+                if (selectedLabels.size() == movedLabelKeys.size()) {
+                    int currentLabelIndex = 0;
+                    for (int i = 0; i < (int)selectedLabels.size(); ++i) {
+                        if (selectedLabels[i] == labelKey) {
+                            currentLabelIndex = i;
+                            break;
+                        }
+                    }
+                    labelKey = LabelKey(movedLabelKeys[currentLabelIndex]);
+                }
+            }
         }
     }
 
@@ -402,10 +419,13 @@ bool TrackLabelsListModel::moveSelectedLabels(const LabelKey& key, bool complete
     if ((completed && m_autoScrollConnection)) {
         disconnectAutoScroll();
     } else if (!m_autoScrollConnection && !completed) {
-        m_autoScrollConnection = connect(m_context, &TimelineContext::frameTimeChanged, [this, key](){ moveSelectedLabels(key, false); });
+        m_autoScrollConnection = connect(m_context, &TimelineContext::frameTimeChanged,
+            [this, key = labelKey]() mutable {
+                key = moveSelectedLabels(key, false);
+        });
     }
 
-    return ok;
+    return labelKey;
 }
 
 bool TrackLabelsListModel::stretchLabelLeft(const LabelKey& key, const LabelKey& leftLinkedLabel, bool unlink, bool completed)

--- a/src/projectscene/view/tracksitemsview/tracklabelslistmodel.h
+++ b/src/projectscene/view/tracksitemsview/tracklabelslistmodel.h
@@ -21,7 +21,7 @@ public:
 
     Q_INVOKABLE void toggleTracksDataSelectionByLabel(const LabelKey& key);
 
-    Q_INVOKABLE bool moveSelectedLabels(const LabelKey& key, bool completed);
+    Q_INVOKABLE au::projectscene::LabelKey moveSelectedLabels(const LabelKey& key, bool completed);
     Q_INVOKABLE bool stretchLabelLeft(const LabelKey& key, const LabelKey& leftLinkedLabel, bool unlink, bool completed);
     Q_INVOKABLE bool stretchLabelRight(const LabelKey& key, const LabelKey& rightLinkedLabel, bool unlink, bool completed);
 


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/11864

When a label is moved to another track it is destroyed and recreated, so the reference to the focused label is lost. With these changes, the selected labels are updated if any of them change track, keeping them selected.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
