### PR TITLE
Keep macOS deployment targets consistent with explicit linker minimums

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,17 +98,31 @@ if( APPLE )
       set( TARGET_MACOS_VERSION 10.13 )
       set( CMAKE_OSX_ARCHITECTURES x86_64 CACHE INTERNAL "" )
    elseif( MACOS_ARCHITECTURE STREQUAL "arm64" )
-      set( MIN_MACOS_VERSION 10.13 )
+      set( MIN_MACOS_VERSION 11.0 )
       set( TARGET_MACOS_VERSION 10.13 )
       set( CMAKE_OSX_ARCHITECTURES arm64 CACHE INTERNAL "" )
    else()
       message( FATAL_ERROR "MACOS_ARCHITECTURE must be x86_64 or arm64")
    endif()
+
+   # Use the same deployment target for CMake and the explicit linker flags.
+   if( CMAKE_OSX_DEPLOYMENT_TARGET )
+      set( MIN_MACOS_VERSION "${CMAKE_OSX_DEPLOYMENT_TARGET}" )
+   elseif( NOT "$ENV{MACOSX_DEPLOYMENT_TARGET}" STREQUAL "" )
+      set( MIN_MACOS_VERSION "$ENV{MACOSX_DEPLOYMENT_TARGET}" )
+   endif()
+
+   # Apple Silicon is only supported on macOS 11 and newer.
+   if( MACOS_ARCHITECTURE STREQUAL "arm64" AND MIN_MACOS_VERSION VERSION_LESS 11.0 )
+      set( MIN_MACOS_VERSION 11.0 )
+   endif()
+
    # Generate schema files
    set( CMAKE_XCODE_GENERATE_SCHEME ON )
 
    # Define the OSX compatibility parameters
-   set( CMAKE_OSX_DEPLOYMENT_TARGET ${MIN_MACOS_VERSION} CACHE INTERNAL "" )
+   set( CMAKE_OSX_DEPLOYMENT_TARGET "${MIN_MACOS_VERSION}" CACHE INTERNAL "" FORCE )
+   set( CMAKE_OSX_DEPLOYMENT_TARGET "${MIN_MACOS_VERSION}" )
    set( CMAKE_OSX_SYSROOT macosx CACHE INTERNAL "" )
 
    # This prevents a link error when building with the 10.9 or older SDKs


### PR DESCRIPTION
## Summary

The maintenance build currently overwrites externally supplied deployment targets with architecture-specific defaults. MIN_MACOS_VERSION is also passed directly to the linker's -platform_version option, so changing only the CMake target would leave conflicting minimum versions.

- Select MIN_MACOS_VERSION from a nonempty CMAKE_OSX_DEPLOYMENT_TARGET first, then a nonempty MACOSX_DEPLOYMENT_TARGET environment value, before updating the CMake deployment target.
- Preserve the x86_64 default of 10.9.
- Use 11.0 as the arm64 default and floor: Apple Silicon does not support earlier macOS releases. Supplied arm64 targets at or above 11.0 remain unchanged; lower targets are normalized to 11.0 for both CMake and the explicit linker minimum.
- Synchronize the normal CMake variable as well as its existing internal cache entry, so a normal variable retained under CMP0126 does not shadow the effective minimum.
- Preserve TARGET_MACOS_VERSION=10.13 and the SDK-version spoofing/rendering workaround, without changing architecture selection.

The affected deployment-target block is also present in Audacity-3.7.9.

## Verification

Draft: no configure, build, or test commands have been run for this change. Native macOS configuration/build verification and downstream packaging validation are outstanding. Intended configuration coverage: explicit target precedence, environment fallback, x86_64 default, arm64 default/floor, and agreement between the CMake deployment target and MIN_MACOS_VERSION while TARGET_MACOS_VERSION stays 10.13.

## AI disclosure

This change and PR text were prepared with an AI coding assistant at the contributor's request. They require human review; native macOS verification has not been performed.

- [x] I signed the [CLA](https://www.audacityteam.org/cla/) (not verified by the assistant)
- [x] The title describes the issue addressed
- [x] The commit message describes its purpose and effects
- [x] The SDK-version rendering workaround is preserved
- [ ] Each commit compiles and runs on my machine
- [ ] Testflow test cases have been run

## Validation update

Subsequent validation against Audacity 3.7.9 passed: x86_64 default 10.9, arm64 default 11.0, environment-only 14.0, explicit 15.0 over environment 14.0, and an explicitly too-low arm64 target normalized to 11.0. MIN_MACOS_VERSION, normal CMake target, and cached CMake target agree. Nix package flag smoke checks passed at 14.0 and 15.0. Native Darwin build/runtime verification remains outstanding.