### PR TITLE
Respect the macOS Qt deployment option

### DIFF
--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -410,20 +410,22 @@ elseif(OS_IS_MAC)
         )
     endif()
 
-    qt_generate_deploy_qml_app_script(
-        TARGET audacity
-        OUTPUT_SCRIPT deploy_script
-        NO_TRANSLATIONS
-        EXCLUDE_PLUGIN_TYPES qmltooling sqldrivers styles
-        DEPLOY_TOOL_OPTIONS
-            -qmldir=${PROJECT_SOURCE_DIR}/src
-            -qmldir=${PROJECT_SOURCE_DIR}/muse/framework
-    )
-    install(SCRIPT ${deploy_script})
+    if(MU_COMPILE_INSTALL_QTQML_FILES)
+        qt_generate_deploy_qml_app_script(
+            TARGET audacity
+            OUTPUT_SCRIPT deploy_script
+            NO_TRANSLATIONS
+            EXCLUDE_PLUGIN_TYPES qmltooling sqldrivers styles
+            DEPLOY_TOOL_OPTIONS
+                -qmldir=${PROJECT_SOURCE_DIR}/src
+                -qmldir=${PROJECT_SOURCE_DIR}/muse/framework
+        )
+        install(SCRIPT ${deploy_script})
 
-    install(SCRIPT
-        "${PROJECT_SOURCE_DIR}/buildscripts/packaging/prune_qt_runtime.cmake"
-    )
+        install(SCRIPT
+            "${PROJECT_SOURCE_DIR}/buildscripts/packaging/prune_qt_runtime.cmake"
+        )
+    endif()
 
 ###########################################
 # Wasm


### PR DESCRIPTION
## Problem
The macOS install rules ignore `MU_COMPILE_INSTALL_QTQML_FILES`. They always run Qt deployment and pruning.

This prevents package managers from retaining shared Qt dependencies outside the application bundle. The Nix build fails in `macdeployqt`.

## Change
Guard macOS Qt deployment and pruning with the existing option. The default remains ON. Application bundle installation is unchanged.

## Validation
A Linux-hosted CMake smoke test exercised the actual macOS install block with a small executable. Before this change, OFF still invoked deployment. After this change, OFF installed the bundle and its executable ran. The default still invoked deployment.

Native Darwin validation is pending through the nixpkgs review workflow.

AI assistance was used to prepare and test this change.