### PR TITLE
Allow extra macdeployqt deployment options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,8 @@ set(AU4_BUILD_MODE "dev" CACHE STRING "Build mode")
 
 set(AU4_REVISION "" CACHE STRING "Build revision")
 
+set(AU4_MACDEPLOYQT_EXTRA_OPTIONS "" CACHE STRING "Semicolon-separated extra arguments for macdeployqt")
+
 # Modules (alphabetical order please)
 option(AU_BUILD_APPSHELL_MODULE "Build appshell module" ON)
 option(AU_BUILD_APPSHELL_TESTS "Build appshell tests" ${MUSE_ENABLE_UNIT_TESTS})

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -418,6 +418,7 @@ elseif(OS_IS_MAC)
         DEPLOY_TOOL_OPTIONS
             -qmldir=${PROJECT_SOURCE_DIR}/src
             -qmldir=${PROJECT_SOURCE_DIR}/muse/framework
+            ${AU4_MACDEPLOYQT_EXTRA_OPTIONS}
     )
     install(SCRIPT ${deploy_script})
 


### PR DESCRIPTION
## Change
Add `AU4_MACDEPLOYQT_EXTRA_OPTIONS`, an empty-default cache string containing semicolon-separated extra macdeployqt arguments. Pass it only to macOS deployment. Default and Windows behavior are unchanged.

## Downstream consumer
https://github.com/NixOS/nixpkgs/pull/559623 uses this option for `-no-strip`, because Nix performs final stripping. This replaces a downstream CMake source substitution.

## Validation
The nixpkgs package fetched this patch, applied it to the Audacity 4.0.0 release archive, and built successfully on an M2 MacBook. The deployment command included `-no-strip`. Native `--long-version` and `--plugin-registration-self-test` passed.

AI assistance was used to prepare and validate this change.