### PR TITLE
Do not move the playhead when selecting a track by its header

### DIFF
--- a/src/projectscene/view/trackspanel/paneltrackslistmodel.cpp
+++ b/src/projectscene/view/trackspanel/paneltrackslistmodel.cpp
@@ -183,11 +183,6 @@ void PanelTracksListModel::selectAudioData(int row)
         const trackedit::TrackType type = item->trackType();
         if (type == trackedit::TrackType::Mono || type == trackedit::TrackType::Stereo) {
             selectionController()->setSelectedTrackAudioData(item->trackId());
-
-            muse::actions::ActionQuery seek("action://playback/seek");
-            seek.addParam("seekTime", muse::Val(selectionController()->dataSelectedStartTime()));
-            seek.addParam("triggerPlay", muse::Val(false));
-            dispatcher()->dispatch(seek);
         }
     }
 }


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/11972

`PanelTracksListModel::selectAudioData()` dispatched a seek immediately after
setting the selection:

```cpp
selectionController()->setSelectedTrackAudioData(item->trackId());

muse::actions::ActionQuery seek("action://playback/seek");
seek.addParam("seekTime", muse::Val(selectionController()->dataSelectedStartTime()));
seek.addParam("triggerPlay", muse::Val(false));
dispatcher()->dispatch(seek);
```

`setSelectedTrackAudioData` sets the selection to the track's `GetStartTime()`
… `GetEndTime()`, so the seek moved the playhead to the first clip's start, or
to 0 on an empty track. Removing the dispatch leaves the selection behaviour
unchanged.

Verified: builds, `ctest` 5/5, codestyle clean.

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
