### PR TITLE
11865 batch track list notification

### DIFF
--- a/src/effects/effects_base/internal/effectexecutionscenario.cpp
+++ b/src/effects/effects_base/internal/effectexecutionscenario.cpp
@@ -32,9 +32,9 @@
 
 #include "au3wrap/au3types.h"
 #include "au3wrap/internal/domaccessor.h"
-#include "au3wrap/internal/domconverter.h"
 #include "au3wrap/internal/progressdialog.h"
 #include "trackedit/trackeditutils.h"
+#include "trackedit/tracklistchangeguard.h"
 
 #include "../effecterrors.h"
 using namespace muse;
@@ -586,41 +586,12 @@ muse::Ret EffectExecutionScenario::previewEffect(const EffectInstanceId& effectI
     return doPreviewEffect(effectId, settings);
 }
 
-namespace {
-std::vector<au::trackedit::Track> trackListDifference(const std::vector<au::trackedit::Track>& a,
-                                                      const std::vector<au::trackedit::Track>& b)
-{
-    std::vector<au::trackedit::Track> result;
-    for (const au::trackedit::Track& item : a) {
-        if (std::find_if(b.begin(), b.end(), [&item](const au::trackedit::Track& other) { return item.id == other.id; }) == b.end()) {
-            result.push_back(item);
-        }
-    }
-    return result;
-}
-
-void notifyIfTracksWereAdded(au::au3::Au3Project& au3Prj, const std::vector<au::trackedit::Track>& before,
-                             au::trackedit::ITrackeditProject& trackeditPrj)
-{
-    const auto& trackList = ::TrackList::Get(au3Prj);
-    std::vector<au::trackedit::Track> tracksAfter;
-    auto it = trackList.begin();
-    while (it != trackList.end()) {
-        tracksAfter.push_back(au::au3::DomConverter::track(*it));
-        ++it;
-    }
-
-    const std::vector<au::trackedit::Track> addedTracks = trackListDifference(tracksAfter, before);
-    for (const auto& track : addedTracks) {
-        trackeditPrj.notifyAboutTrackAdded(track);
-    }
-}
-}
-
 muse::Ret EffectExecutionScenario::performEffectInternal(au3::Au3Project& project, Effect* effect,
                                                          std::shared_ptr<EffectInstance> pInstanceEx,
                                                          EffectSettings& settings)
 {
+    const trackedit::TrackListChangeGuard guard(globalContext()->currentTrackeditProject());
+
     //! ============================================================================
     //! NOTE Step 1 - add new a track if need
     //! ============================================================================
@@ -638,7 +609,6 @@ muse::Ret EffectExecutionScenario::performEffectInternal(au3::Au3Project& projec
                 track, TrackList::DoAssignId::Yes,
                 TrackList::EventPublicationSynchrony::Synchronous);
             newTrack->SetSelected(true);
-            globalContext()->currentTrackeditProject()->notifyAboutTrackAdded(au3::DomConverter::track(newTrack));
         }
     }
 
@@ -673,9 +643,6 @@ muse::Ret EffectExecutionScenario::performEffectInternal(au3::Au3Project& projec
 
             assert(pInstanceEx); // null check above
             try {
-                // Get tracklist now and compare it with after to see if some tracks were added (such as a label track being added by the beat finder analyzer).
-                const auto prj = globalContext()->currentTrackeditProject();
-                const std::vector<trackedit::Track> tracksBefore = prj->trackList();
                 if (pInstanceEx->Process(settings) == false) {
                     if (progress.Cancelled()) {
                         success = make_ret(Err::EffectProcessCancelled);
@@ -683,7 +650,6 @@ muse::Ret EffectExecutionScenario::performEffectInternal(au3::Au3Project& projec
                         success = make_ret(Err::EffectProcessFailed, pInstanceEx->GetLastError());
                     }
                 }
-                notifyIfTracksWereAdded(project, tracksBefore, *prj);
             } catch (::AudacityException& e) {
                 success = make_ret(Err::EffectProcessFailed);
                 if (const auto box = dynamic_cast<MessageBoxException*>(&e)) {
@@ -707,10 +673,8 @@ muse::Ret EffectExecutionScenario::performEffectInternal(au3::Au3Project& projec
 
     {
         if (!success && newTrack) {
-            const auto au4Track = au3::DomConverter::track(newTrack);
             // This decreases the reference count of the track, so it may be deleted.
             effect->mTracks->Remove(*newTrack);
-            globalContext()->currentTrackeditProject()->notifyAboutTrackRemoved(au4Track);
         }
     }
 

--- a/src/importexport/import/internal/au3/au3importer.cpp
+++ b/src/importexport/import/internal/au3/au3importer.cpp
@@ -25,6 +25,7 @@
 #include "au3wrap/internal/domconverter.h"
 #include "projectscene/view/tracksitemsview/dropcontroller.h"
 #include "trackedit/internal/au3/au3trackdata.h"
+#include "trackedit/tracklistchangeguard.h"
 
 #include "tempodetection.h"
 using au::trackedit::ITrackDataPtr;
@@ -225,6 +226,8 @@ bool au::importexport::Au3Importer::importLegacyAup(const muse::io::path_t& file
     auto& tracks = Au3TrackList::Get(*project);
     const auto trackeditProject = globalContext()->currentTrackeditProject();
 
+    const trackedit::TrackListChangeGuard guard(trackeditProject);
+
     for (const LegacyAupImporter::LabelTrack& track : legacyProject.labelTracks) {
         Au3LabelTrack* labelTrack = !track.title.empty()
                                     ? ::LabelTrack::Create(tracks, wxFromString(muse::String::fromUtf8(track.title)))
@@ -236,8 +239,6 @@ bool au::importexport::Au3Importer::importLegacyAup(const muse::io::path_t& file
         }
 
         if (trackeditProject) {
-            trackeditProject->notifyAboutTrackAdded(DomConverter::labelTrack(labelTrack));
-
             const auto& labels = labelTrack->GetLabels();
             for (size_t i = 0; i < labels.size(); ++i) {
                 trackeditProject->notifyAboutLabelAdded(DomConverter::label(labelTrack, &labels[i]));
@@ -435,9 +436,10 @@ bool au::importexport::Au3Importer::isProjectEmpty() const
 void au::importexport::Au3Importer::addImportedTracks(const muse::io::path_t& fileName, TrackHolders&& newTracks,
                                                       std::vector<WaveTrack*>* outWaveTracks)
 {
+    const trackedit::TrackListChangeGuard guard(globalContext()->currentTrackeditProject());
+
     Au3Project* project = reinterpret_cast<Au3Project*>(globalContext()->currentProject()->au3ProjectPtr());
     auto& tracks = TrackList::Get(*project);
-    auto& projectFileIO = ProjectFileIO::Get(*project);
 
     std::vector<Track*> results;
 
@@ -507,7 +509,6 @@ void au::importexport::Au3Importer::addImportedTracks(const muse::io::path_t& fi
     }
 
     for (const auto& newTrack : results) {
-        prj->notifyAboutTrackAdded(DomConverter::track(newTrack));
         for (const auto& clip : prj->clipList(newTrack->GetId())) {
             prj->notifyAboutClipAdded(clip);
         }

--- a/src/importexport/labels/internal/au3/au3labelsimporter.cpp
+++ b/src/importexport/labels/internal/au3/au3labelsimporter.cpp
@@ -11,6 +11,8 @@
 #include "au3wrap/internal/wxtypes_convert.h"
 #include "au3wrap/internal/domconverter.h"
 
+#include "trackedit/tracklistchangeguard.h"
+
 #include "labelsutils.h"
 
 using namespace au::au3;
@@ -29,6 +31,8 @@ muse::Ret Au3LabelsImporter::importData(const muse::io::path_t& filePath)
         return muse::make_ret(muse::Ret::Code::InternalError);
     }
 
+    const trackedit::TrackListChangeGuard guard(globalContext()->currentTrackeditProject());
+
     LabelFormat format = au3labelFormatFromSuffix(filePath);
 
     auto& tracks = Au3TrackList::Get(*project);
@@ -41,11 +45,8 @@ muse::Ret Au3LabelsImporter::importData(const muse::io::path_t& filePath)
 
     textFile.Close();
 
-    // Notify project about the new track
     const auto prj = globalContext()->currentTrackeditProject();
     if (prj) {
-        prj->notifyAboutTrackAdded(DomConverter::labelTrack(labelTrack));
-
         // Notify about each imported label
         const auto& labels = labelTrack->GetLabels();
         for (size_t i = 0; i < labels.size(); ++i) {

--- a/src/projectscene/internal/projectviewstate.cpp
+++ b/src/projectscene/internal/projectviewstate.cpp
@@ -213,24 +213,17 @@ void ProjectViewState::init(const std::shared_ptr<au3::IAu3Project>& project)
             return;
         }
 
-        prj->trackRemoved().onReceive(this, [this](const trackedit::Track& track) {
+        prj->trackListChanged().onReceive(this, [this](const trackedit::TrackListChange& change) {
             recomputeTotalTrackHeight();
             m_verticalRulerWidth.set(calculateVerticalRulerWidth());
-            m_tracks.erase(track.id);
+            for (const trackedit::TrackId& trackId : change.removed()) {
+                m_tracks.erase(trackId);
+            }
+            updateItemsBoundaries(false);
         });
 
         updateItemsBoundaries(false);
         prj->trackChanged().onReceive(this, [this](const trackedit::Track&) {
-            updateItemsBoundaries(false);
-        });
-
-        prj->trackAdded().onReceive(this, [this](const trackedit::Track&) {
-            recomputeTotalTrackHeight();
-            updateItemsBoundaries(false);
-        });
-
-        prj->trackInserted().onReceive(this, [this](const trackedit::Track&, int) {
-            recomputeTotalTrackHeight();
             updateItemsBoundaries(false);
         });
 
@@ -242,7 +235,7 @@ void ProjectViewState::init(const std::shared_ptr<au3::IAu3Project>& project)
             frequencySelectionController()->setShowsSpectrogram(trackId, hasSpectrogram);
         }
 
-        // Tracks already present on open don't trigger trackAdded / trackInserted
+        // Tracks already present on open don't trigger trackListChanged
         // So the total height must be computed here
         recomputeTotalTrackHeight();
     });

--- a/src/projectscene/internal/realtimeeffectpaneltrackselection.cpp
+++ b/src/projectscene/internal/realtimeeffectpaneltrackselection.cpp
@@ -30,32 +30,26 @@ void RealtimeEffectPanelTrackSelection::init()
 
 void RealtimeEffectPanelTrackSelection::setupCallbacks(trackedit::ITrackeditProject& project)
 {
-    project.trackAdded().onReceive(this, [this](trackedit::Track track) { onTrackAdded(track); });
-    project.trackRemoved().onReceive(this, [this](trackedit::Track track) { onTrackRemoved(track.id); });
+    project.trackListChanged().onReceive(this, [this](const trackedit::TrackListChange& change) { onTrackListChanged(change); });
     project.tracksChanged().onReceive(this, [this](std::vector<trackedit::Track> tracks) {
         onTracksChanged(tracks);
     });
 }
 
-void RealtimeEffectPanelTrackSelection::onTrackAdded(const trackedit::Track& track)
+void RealtimeEffectPanelTrackSelection::onTrackListChanged(const trackedit::TrackListChange& change)
 {
-    if (m_trackId.has_value()) {
+    if (!m_trackId.has_value()) {
+        const trackedit::TrackIdList added = change.added();
+        if (!added.empty()) {
+            setTrackId(added.front());
+        }
         return;
     }
-    setTrackId(track.id);
-}
 
-void RealtimeEffectPanelTrackSelection::onTrackRemoved(const trackedit::TrackId& trackId)
-{
-    const trackedit::ITrackeditProjectPtr project = globalContext()->currentTrackeditProject();
-    IF_ASSERT_FAILED(project) {
-        return;
-    }
-    const std::vector<trackedit::TrackId> tracks = project->trackIdList();
-    if (tracks.empty()) {
+    if (change.after().empty()) {
         setTrackId(std::nullopt);
-    } else if (m_trackId == trackId) {
-        setTrackId(tracks.front());
+    } else if (change.wasRemoved(m_trackId.value())) {
+        setTrackId(change.after().front());
     }
 }
 

--- a/src/projectscene/internal/realtimeeffectpaneltrackselection.h
+++ b/src/projectscene/internal/realtimeeffectpaneltrackselection.h
@@ -27,8 +27,7 @@ public:
 private:
     void setTrackId(std::optional<au::trackedit::TrackId>);
     void setupCallbacks(trackedit::ITrackeditProject&);
-    void onTrackAdded(const trackedit::Track&);
-    void onTrackRemoved(const trackedit::TrackId&);
+    void onTrackListChanged(const trackedit::TrackListChange& change);
     void onTracksChanged(const std::vector<trackedit::Track>&);
     std::optional<au::trackedit::TrackId> m_trackId;
     muse::async::Notification m_selectedTrackIdChanged;

--- a/src/projectscene/view/tracksitemsview/trackitemslistmodel.cpp
+++ b/src/projectscene/view/tracksitemsview/trackitemslistmodel.cpp
@@ -596,8 +596,8 @@ void TrackItemsListModel::reload()
         }
     }, muse::async::Asyncable::Mode::SetReplace);
 
-    prj->trackRemoved().onReceive(this, [this](const au::trackedit::Track& track) {
-        if (track.id == m_trackId) {
+    prj->trackListChanged().onReceive(this, [this](const au::trackedit::TrackListChange& change) {
+        if (change.wasRemoved(m_trackId)) {
             m_trackId = -1;
         }
     }, muse::async::Asyncable::Mode::SetReplace);

--- a/src/projectscene/view/tracksitemsview/viewtrackslistmodel.cpp
+++ b/src/projectscene/view/tracksitemsview/viewtrackslistmodel.cpp
@@ -163,23 +163,6 @@ void ViewTracksListModel::load()
         });
     }, muse::async::Asyncable::Mode::SetReplace);
 
-    prj->trackAdded().onReceive(this, [this](const trackedit::Track& track) {
-        const int size = static_cast<int>(m_trackList.size());
-        beginInsertRows(QModelIndex(), size, size);
-        m_trackList.push_back(track);
-        endInsertRows();
-    }, muse::async::Asyncable::Mode::SetReplace);
-
-    prj->trackInserted().onReceive(this, [this](const trackedit::Track& track, const int pos) {
-        const int size = static_cast<int>(m_trackList.size());
-        const int index = ((pos >= 0) && (pos <= size)) ? pos : size;
-
-        beginInsertRows(QModelIndex(), index, index);
-        m_trackList.insert(m_trackList.begin() + index, track);
-
-        endInsertRows();
-    }, muse::async::Asyncable::Mode::SetReplace);
-
     prj->trackMoved().onReceive(this, [this](const trackedit::Track& track, const int pos) {
         const auto iterator = std::find_if(m_trackList.begin(), m_trackList.end(), [&track](const trackedit::Track& it)
         {
@@ -199,14 +182,35 @@ void ViewTracksListModel::load()
         endMoveRows();
     }, muse::async::Asyncable::Mode::SetReplace);
 
-    prj->trackRemoved().onReceive(this, [this](const trackedit::Track& track) {
-        for (size_t i = 0; i < m_trackList.size(); ++i) {
-            if (m_trackList.at(i).id == track.id) {
-                beginRemoveRows(QModelIndex(), i, i);
-                m_trackList.erase(m_trackList.begin() + i);
-                endRemoveRows();
-                break;
+    prj->trackListChanged().onReceive(this, [this](const trackedit::TrackListChange& change) {
+        for (const trackedit::TrackId& trackId : change.removed()) {
+            for (size_t i = 0; i < m_trackList.size(); ++i) {
+                if (m_trackList.at(i).id == trackId) {
+                    beginRemoveRows(QModelIndex(), i, i);
+                    m_trackList.erase(m_trackList.begin() + i);
+                    endRemoveRows();
+                    break;
+                }
             }
+        }
+
+        const auto currentPrj = globalContext()->currentTrackeditProject();
+        if (!currentPrj) {
+            return;
+        }
+
+        for (const trackedit::TrackId& trackId : change.added()) {
+            const std::optional<trackedit::Track> track = currentPrj->track(trackId);
+            if (!track) {
+                continue;
+            }
+
+            const int size = static_cast<int>(m_trackList.size());
+            const int index = std::min(static_cast<int>(change.indexAfter(trackId).value_or(m_trackList.size())), size);
+
+            beginInsertRows(QModelIndex(), index, index);
+            m_trackList.insert(m_trackList.begin() + index, track.value());
+            endInsertRows();
         }
     }, muse::async::Asyncable::Mode::SetReplace);
 

--- a/src/projectscene/view/trackspanel/paneltrackslistmodel.cpp
+++ b/src/projectscene/view/trackspanel/paneltrackslistmodel.cpp
@@ -81,20 +81,12 @@ void PanelTracksListModel::load()
         onTracksChanged(tracks);
     }, muse::async::Asyncable::Mode::SetReplace);
 
-    prj->trackAdded().onReceive(this, [this](const Track& track) {
-        onTrackAdded(track);
-    }, muse::async::Asyncable::Mode::SetReplace);
-
-    prj->trackRemoved().onReceive(this, [this](const Track& track) {
-        onTrackRemoved(track);
+    prj->trackListChanged().onReceive(this, [this](const TrackListChange& change) {
+        onTrackListChanged(change);
     }, muse::async::Asyncable::Mode::SetReplace);
 
     prj->trackChanged().onReceive(this, [this](const Track& track) {
         onTrackChanged(track);
-    }, muse::async::Asyncable::Mode::SetReplace);
-
-    prj->trackInserted().onReceive(this, [this](const Track& track, int pos) {
-        onTrackInserted(track, pos);
     }, muse::async::Asyncable::Mode::SetReplace);
 
     prj->trackMoved().onReceive(this, [this](const Track& track, int pos) {
@@ -671,27 +663,40 @@ void PanelTracksListModel::onTracksChanged(const std::vector<au::trackedit::Trac
     });
 }
 
-void PanelTracksListModel::onTrackAdded(const trackedit::Track& track)
+void PanelTracksListModel::onTrackListChanged(const trackedit::TrackListChange& change)
 {
-    const int size = static_cast<int>(m_trackList.size());
-    beginInsertRows(QModelIndex(), size, size);
-    m_trackList.push_back(buildTrackItem(track));
-    onTrackChanged(track);
-    endInsertRows();
-}
-
-void PanelTracksListModel::onTrackRemoved(const trackedit::Track& track)
-{
-    for (int i = 0; i < m_trackList.size(); ++i) {
-        if (m_trackList.at(i)->trackId() == track.id) {
-            beginRemoveRows(QModelIndex(), i, i);
-            const auto it = m_trackList.begin() + i;
-            const auto item = *it;
-            m_trackList.erase(it);
-            delete item;
-            endRemoveRows();
-            break;
+    for (const trackedit::TrackId& trackId : change.removed()) {
+        for (int i = 0; i < m_trackList.size(); ++i) {
+            if (m_trackList.at(i)->trackId() == trackId) {
+                beginRemoveRows(QModelIndex(), i, i);
+                const auto it = m_trackList.begin() + i;
+                const auto item = *it;
+                m_trackList.erase(it);
+                delete item;
+                endRemoveRows();
+                break;
+            }
         }
+    }
+
+    const auto prj = globalContext()->currentTrackeditProject();
+    if (!prj) {
+        return;
+    }
+
+    for (const trackedit::TrackId& trackId : change.added()) {
+        const std::optional<trackedit::Track> track = prj->track(trackId);
+        if (!track) {
+            continue;
+        }
+
+        const int size = static_cast<int>(m_trackList.size());
+        const int index = std::min(static_cast<int>(change.indexAfter(trackId).value_or(m_trackList.size())), size);
+
+        beginInsertRows(QModelIndex(), index, index);
+        m_trackList.insert(index, buildTrackItem(track.value()));
+        onTrackChanged(track.value());
+        endInsertRows();
     }
 }
 
@@ -704,18 +709,6 @@ void PanelTracksListModel::onTrackChanged(const trackedit::Track& track)
 
     trackItem->init(track);
     updateRemovingAvailability();
-}
-
-void PanelTracksListModel::onTrackInserted(const trackedit::Track& track, int pos)
-{
-    int index = pos >= 0 && pos <= m_trackList.size() ? pos : m_trackList.size();
-
-    beginInsertRows(QModelIndex(), index, index);
-
-    m_trackList.insert(index, buildTrackItem(track));
-    onTrackChanged(track);
-
-    endInsertRows();
 }
 
 void PanelTracksListModel::onTrackMoved(const trackedit::Track& track, int pos)

--- a/src/projectscene/view/trackspanel/paneltrackslistmodel.h
+++ b/src/projectscene/view/trackspanel/paneltrackslistmodel.h
@@ -111,10 +111,8 @@ private:
     void onSelectedTracks(const trackedit::TrackIdList& tracksIds);
     void onFocusedTrack(const trackedit::TrackId& trackId);
     void onTracksChanged(const std::vector<trackedit::Track>& tracks);
-    void onTrackAdded(const trackedit::Track& track);
-    void onTrackRemoved(const trackedit::Track& track);
+    void onTrackListChanged(const trackedit::TrackListChange& change);
     void onTrackChanged(const trackedit::Track& track);
-    void onTrackInserted(const trackedit::Track& track, int pos);
     void onTrackMoved(const trackedit::Track& track, int pos);
 
     TrackItem* buildTrackItem(const trackedit::Track& track);

--- a/src/record/internal/au3/au3record.cpp
+++ b/src/record/internal/au3/au3record.cpp
@@ -25,6 +25,8 @@
 #include "au3wrap/internal/wxtypes_convert.h"
 #include "au3wrap/au3types.h"
 
+#include "trackedit/tracklistchangeguard.h"
+
 #include "au3audioinput.h"
 #include "../../recorderrors.h"
 
@@ -900,7 +902,12 @@ Ret Au3Record::doRecord(Au3Project& project,
         for (auto& w : newTracks) {
             list->Add(std::static_pointer_cast<Track>(std::move(w)));
         }
-        pendingTracks.RegisterPendingNewTracks(*list);
+
+        {
+            const trackedit::TrackListChangeGuard guard(globalContext()->currentTrackeditProject());
+
+            pendingTracks.RegisterPendingNewTracks(*list);
+        }
 
         for (auto& [newTrack, newClip] : newTrackHolders) {
             auto updater = [this, trackId = newTrack->GetId(), clipId = newClip->GetId()](Au3Track& d, const Au3Track& s){
@@ -929,7 +936,6 @@ Ret Au3Record::doRecord(Au3Project& project,
             rebuildRecordingClipKeys();
 
             trackedit::ITrackeditProjectPtr prj = globalContext()->currentTrackeditProject();
-            prj->notifyAboutTrackAdded(DomConverter::track(newTrack.get()));
             prj->notifyAboutClipAdded(DomConverter::clip(newTrack.get(), newClip.get()));
         }
         pendingTracks.UpdatePendingTracks();

--- a/src/trackedit/CMakeLists.txt
+++ b/src/trackedit/CMakeLists.txt
@@ -31,6 +31,7 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/trackeditutils.h
 
     ${CMAKE_CURRENT_LIST_DIR}/dom/track.h
+    ${CMAKE_CURRENT_LIST_DIR}/tracklistchange.h
     ${CMAKE_CURRENT_LIST_DIR}/dom/clip.cpp
     ${CMAKE_CURRENT_LIST_DIR}/dom/clip.h
     ${CMAKE_CURRENT_LIST_DIR}/dom/label.h

--- a/src/trackedit/CMakeLists.txt
+++ b/src/trackedit/CMakeLists.txt
@@ -32,6 +32,7 @@ set(MODULE_SRC
 
     ${CMAKE_CURRENT_LIST_DIR}/dom/track.h
     ${CMAKE_CURRENT_LIST_DIR}/tracklistchange.h
+    ${CMAKE_CURRENT_LIST_DIR}/tracklistchangeguard.h
     ${CMAKE_CURRENT_LIST_DIR}/dom/clip.cpp
     ${CMAKE_CURRENT_LIST_DIR}/dom/clip.h
     ${CMAKE_CURRENT_LIST_DIR}/dom/label.h

--- a/src/trackedit/internal/au3/au3clipsinteraction.cpp
+++ b/src/trackedit/internal/au3/au3clipsinteraction.cpp
@@ -32,6 +32,7 @@
 #include "defer.h"
 #include "log.h"
 #include "trackediterrors.h"
+#include "tracklistchangeguard.h"
 #include "translation.h"
 
 using namespace au::trackedit;
@@ -533,6 +534,8 @@ bool Au3ClipsInteraction::splitClipsAtSilences(const ClipKeyList& clipKeyList)
 
 bool Au3ClipsInteraction::splitClipsIntoNewTracks(const ClipKeyList& clipKeyList)
 {
+    const TrackListChangeGuard guard(globalContext()->currentTrackeditProject());
+
     std::map<TrackId, std::vector<ClipKey> > clipsPerTrack;
     for (const auto& clipKey : clipKeyList) {
         clipsPerTrack[clipKey.trackId].push_back(clipKey);
@@ -564,7 +567,6 @@ bool Au3ClipsInteraction::splitClipsIntoNewTracks(const ClipKeyList& clipKeyList
         prj->notifyAboutTrackChanged(DomConverter::track(waveTrack));
 
         projectTracks.Add(newTrack);
-        prj->notifyAboutTrackAdded(DomConverter::track(newTrack.get()));
         for (const auto& clip : prj->clipList(newTrack->GetId())) {
             prj->notifyAboutClipAdded(clip);
         }
@@ -597,6 +599,8 @@ bool Au3ClipsInteraction::duplicateClips(const ClipKeyList& clipKeyList)
     if (selectedTracks.empty()) {
         return false;
     }
+
+    const TrackListChangeGuard guard(prj);
 
     //Get only the selected tracks but keeping the UI order
     std::vector<Au3WaveTrack*> waveTracks;
@@ -645,7 +649,6 @@ bool Au3ClipsInteraction::duplicateClips(const ClipKeyList& clipKeyList)
 
     for (const auto& newTrack : newTracks) {
         projectTracks.Add(newTrack);
-        prj->notifyAboutTrackAdded(DomConverter::track(newTrack.get()));
         for (const auto& clip : prj->clipList(newTrack->GetId())) {
             prj->notifyAboutClipAdded(clip);
         }
@@ -1009,8 +1012,9 @@ NeedsDownmixing Au3ClipsInteraction::moveSelectedClipsUpOrDown(ClipKeyList& clip
         if (!origWaveTrack) {
             // This must be a new track created 'cos the user dragged clips down.
             assert(offset > 0);
+            const TrackListChangeGuard guard(prj);
+
             origWaveTrack = utils::appendWaveTrack(mutOrig, newWaveTrack->NChannels());
-            prj->notifyAboutTrackAdded(DomConverter::track(origWaveTrack));
         }
 
         if (utils::clipIdSetsAreEqual(*origWaveTrack, *newWaveTrack)) {

--- a/src/trackedit/internal/au3/au3labelsinteraction.cpp
+++ b/src/trackedit/internal/au3/au3labelsinteraction.cpp
@@ -16,6 +16,7 @@
 #include "au3trackdata.h"
 
 #include "trackediterrors.h"
+#include "tracklistchangeguard.h"
 
 #include "defer.h"
 #include "log.h"
@@ -85,10 +86,9 @@ muse::RetVal<LabelKey> Au3LabelsInteraction::addLabelToSelection()
 
     // If no label track exists, create a new one
     if (!labelTrack) {
-        labelTrack = ::LabelTrack::Create(tracks);
+        const TrackListChangeGuard guard(globalContext()->currentTrackeditProject());
 
-        const auto prj = globalContext()->currentTrackeditProject();
-        prj->notifyAboutTrackAdded(DomConverter::labelTrack(labelTrack));
+        labelTrack = ::LabelTrack::Create(tracks);
     }
 
     wxString title = wxEmptyString;

--- a/src/trackedit/internal/au3/au3trackeditproject.cpp
+++ b/src/trackedit/internal/au3/au3trackeditproject.cpp
@@ -288,24 +288,17 @@ void Au3TrackeditProject::reload()
     m_tracksChanged.send(trackList());
 }
 
-void Au3TrackeditProject::notifyAboutTrackAdded(const Track& track)
-{
-    m_trackAdded.send(track);
-}
-
 void Au3TrackeditProject::notifyAboutTrackChanged(const Track& track)
 {
     m_trackChanged.send(track);
 }
 
-void Au3TrackeditProject::notifyAboutTrackRemoved(const Track& track)
+void Au3TrackeditProject::notifyAboutTrackListChanged(const TrackListChange& change)
 {
-    m_trackRemoved.send(track);
-}
-
-void Au3TrackeditProject::notifyAboutTrackInserted(const Track& track, int pos)
-{
-    m_trackInserted.send(track, pos);
+    if (!change.hasChanges()) {
+        return;
+    }
+    m_trackListChanged.send(change);
 }
 
 void Au3TrackeditProject::notifyAboutTrackMoved(const Track& track, int pos)
@@ -433,9 +426,9 @@ muse::async::Channel<std::vector<au::trackedit::Track> > Au3TrackeditProject::tr
     return m_tracksChanged;
 }
 
-muse::async::Channel<au::trackedit::Track> Au3TrackeditProject::trackAdded() const
+muse::async::Channel<au::trackedit::TrackListChange> Au3TrackeditProject::trackListChanged() const
 {
-    return m_trackAdded;
+    return m_trackListChanged;
 }
 
 muse::async::Channel<au::trackedit::Track> Au3TrackeditProject::trackChanged() const
@@ -446,16 +439,6 @@ muse::async::Channel<au::trackedit::Track> Au3TrackeditProject::trackChanged() c
 muse::async::Channel<au::trackedit::Track> Au3TrackeditProject::trackClipListChanged() const
 {
     return m_trackClipListChanged;
-}
-
-muse::async::Channel<au::trackedit::Track> Au3TrackeditProject::trackRemoved() const
-{
-    return m_trackRemoved;
-}
-
-muse::async::Channel<au::trackedit::Track, int> Au3TrackeditProject::trackInserted() const
-{
-    return m_trackInserted;
 }
 
 muse::async::Channel<au::trackedit::Track, int> Au3TrackeditProject::trackMoved() const

--- a/src/trackedit/internal/au3/au3trackeditproject.h
+++ b/src/trackedit/internal/au3/au3trackeditproject.h
@@ -37,10 +37,8 @@ public:
 
     void reload() override;
 
-    void notifyAboutTrackAdded(const Track& track) override;
     void notifyAboutTrackChanged(const Track& track) override;
-    void notifyAboutTrackRemoved(const Track& track) override;
-    void notifyAboutTrackInserted(const Track& track, int pos) override;
+    void notifyAboutTrackListChanged(const TrackListChange& change) override;
     void notifyAboutTrackMoved(const Track& track, int pos) override;
 
     void notifyAboutTrackClipListChanged(const Track& track) override;
@@ -58,11 +56,9 @@ public:
     muse::async::Channel<TimeSignature> timeSignatureChanged() const override;
 
     muse::async::Channel<std::vector<au::trackedit::Track> > tracksChanged() const override;
-    muse::async::Channel<Track> trackAdded() const override;
+    muse::async::Channel<TrackListChange> trackListChanged() const override;
     muse::async::Channel<Track> trackChanged() const override;
     muse::async::Channel<Track> trackClipListChanged() const override;
-    muse::async::Channel<Track> trackRemoved() const override;
-    muse::async::Channel<Track, int> trackInserted() const override;
     muse::async::Channel<Track, int> trackMoved() const override;
 
     secs_t totalTime() const override;
@@ -88,11 +84,9 @@ private:
     mutable muse::async::Channel<au::trackedit::TimeSignature> m_timeSignatureChanged;
 
     mutable muse::async::Channel<trackedit::TrackList> m_tracksChanged;
-    mutable muse::async::Channel<trackedit::Track> m_trackAdded;
+    mutable muse::async::Channel<TrackListChange> m_trackListChanged;
     mutable muse::async::Channel<trackedit::Track> m_trackChanged;
     mutable muse::async::Channel<trackedit::Track> m_trackClipListChanged;
-    mutable muse::async::Channel<trackedit::Track> m_trackRemoved;
-    mutable muse::async::Channel<trackedit::Track, int> m_trackInserted;
     mutable muse::async::Channel<trackedit::Track, int> m_trackMoved;
 
     muse::ValCh<bool> m_hasAudioContent;

--- a/src/trackedit/internal/au3/au3tracksinteraction.cpp
+++ b/src/trackedit/internal/au3/au3tracksinteraction.cpp
@@ -32,6 +32,7 @@
 #include "playback/playbacktypes.h"
 #include "thirdparty/kors_logger/src/log_base.h"
 #include "trackediterrors.h"
+#include "tracklistchangeguard.h"
 
 #include "au3interactionutils.h"
 #include "trackeditutils.h"
@@ -188,6 +189,8 @@ muse::Ret Au3TracksInteraction::paste(const std::vector<ITrackDataPtr>& data, se
     if (data.empty()) {
         return make_ret(trackedit::Err::TrackEmpty);
     }
+
+    const TrackListChangeGuard guard(globalContext()->currentTrackeditProject());
 
     std::vector<std::shared_ptr<Au3TrackData> > copiedData(data.size());
     for (size_t i = 0; i < data.size(); ++i) {
@@ -414,7 +417,6 @@ muse::Ret Au3TracksInteraction::pasteLabels(const std::vector<Au3TrackDataPtr>& 
 
         if (!targetLabelTrack) {
             targetLabelTrack = ::LabelTrack::Create(tracks);
-            prj->notifyAboutTrackAdded(DomConverter::labelTrack(targetLabelTrack));
         }
 
         const auto trackToPaste = std::static_pointer_cast<Au3LabelTrack>(copiedData.at(i)->track());
@@ -626,6 +628,8 @@ bool Au3TracksInteraction::splitRangeSelectionAtSilences(const TrackIdList& trac
 
 bool Au3TracksInteraction::splitRangeSelectionIntoNewTracks(const TrackIdList& tracksIds, secs_t begin, secs_t end)
 {
+    const TrackListChangeGuard guard(globalContext()->currentTrackeditProject());
+
     for (const auto& trackId : tracksIds) {
         Au3WaveTrack* waveTrack = DomAccessor::findWaveTrack(projectRef(), Au3TrackId(trackId));
         IF_ASSERT_FAILED(waveTrack) {
@@ -657,7 +661,6 @@ bool Au3TracksInteraction::splitRangeSelectionIntoNewTracks(const TrackIdList& t
         projectTracks.Add(newTrack);
 
         prj->notifyAboutTrackChanged(DomConverter::track(waveTrack));
-        prj->notifyAboutTrackAdded(DomConverter::track(newTrack.get()));
         for (const auto& clip : prj->clipList(newTrack->GetId())) {
             prj->notifyAboutClipAdded(clip);
         }
@@ -683,6 +686,7 @@ bool Au3TracksInteraction::duplicateSelectedOnTracks(const TrackIdList& tracksId
     auto& tracks = Au3TrackList::Get(projectRef());
 
     trackedit::ITrackeditProjectPtr prj = globalContext()->currentTrackeditProject();
+    const TrackListChangeGuard guard(prj);
 
     std::vector<std::shared_ptr<Au3Track> > copies;
     copies.reserve(tracksIds.size());
@@ -713,8 +717,6 @@ bool Au3TracksInteraction::duplicateSelectedOnTracks(const TrackIdList& tracksId
 
     for (const auto& dest : copies) {
         tracks.Add(dest);
-
-        prj->notifyAboutTrackAdded(DomConverter::track(dest.get()));
 
         if (dynamic_cast<Au3WaveTrack*>(dest.get())) {
             for (const auto& clip : prj->clipList(dest->GetId())) {
@@ -773,11 +775,10 @@ bool Au3TracksInteraction::newStereoTrack()
 
 muse::RetVal<au::trackedit::TrackId> Au3TracksInteraction::newLabelTrack(const muse::String& title)
 {
+    const TrackListChangeGuard guard(globalContext()->currentTrackeditProject());
+
     auto& tracks = Au3TrackList::Get(projectRef());
     Au3LabelTrack* track = !title.empty() ? ::LabelTrack::Create(tracks, wxFromString(title)) : ::LabelTrack::Create(tracks);
-
-    const auto prj = globalContext()->currentTrackeditProject();
-    prj->notifyAboutTrackAdded(DomConverter::labelTrack(track));
 
     selectionController()->setSelectedTracks({ track->GetId() });
     trackNavigationController()->setFocusedTrack(track->GetId());
@@ -792,6 +793,7 @@ bool Au3TracksInteraction::deleteTracks(const TrackIdList& trackIds)
 
     TrackId focusedTrack = trackNavigationController()->focusedTrack();
     const auto prj = globalContext()->currentTrackeditProject();
+    const TrackListChangeGuard guard(prj);
     const auto indexFocusedTrack = muse::indexOf(prj->trackIdList(), focusedTrack);
 
     for (const auto& trackId : trackIds) {
@@ -799,14 +801,12 @@ bool Au3TracksInteraction::deleteTracks(const TrackIdList& trackIds)
         IF_ASSERT_FAILED(au3Track) {
             continue;
         }
-        auto track = DomConverter::track(au3Track);
         const auto clips = prj->clipList(trackId);
 
         tracks.Remove(*au3Track);
         for (const auto& clip : clips) {
             prj->notifyAboutClipRemoved(clip);
         }
-        prj->notifyAboutTrackRemoved(track);
     }
 
     if (!muse::contains(trackIds, focusedTrack)) {
@@ -843,6 +843,7 @@ bool Au3TracksInteraction::duplicateTracks(const TrackIdList& trackIds)
     auto& tracks = Au3TrackList::Get(project);
 
     trackedit::ITrackeditProjectPtr prj = globalContext()->currentTrackeditProject();
+    const TrackListChangeGuard guard(prj);
 
     std::vector<std::shared_ptr<Au3Track> > clones;
     clones.reserve(trackIds.size());
@@ -869,10 +870,6 @@ bool Au3TracksInteraction::duplicateTracks(const TrackIdList& trackIds)
 
     for (const auto& au3Clone : clones) {
         tracks.Add(au3Clone, ::TrackList::DoAssignId::Yes);
-
-        auto clone = DomConverter::track(au3Clone.get());
-
-        prj->notifyAboutTrackInserted(clone, static_cast<int>(utils::getTrackIndex(tracks, *au3Clone)));
 
         if (dynamic_cast<Au3WaveTrack*>(au3Clone.get())) {
             for (const auto& clip : prj->clipList(au3Clone->GetId())) {
@@ -938,8 +935,9 @@ bool Au3TracksInteraction::moveTracksTo(const TrackIdList& trackIds, int to)
 
 bool Au3TracksInteraction::insertSilence(const TrackIdList& trackIds, secs_t begin, secs_t end, secs_t duration)
 {
+    const TrackListChangeGuard guard(globalContext()->currentTrackeditProject());
+
     if (trackIds.empty()) {
-        const auto prj = globalContext()->currentTrackeditProject();
         auto& tracks = Au3TrackList::Get(projectRef());
         auto& trackFactory = ::WaveTrackFactory::Get(projectRef());
 
@@ -950,7 +948,6 @@ bool Au3TracksInteraction::insertSilence(const TrackIdList& trackIds, secs_t beg
         track->SetName(tracks.MakeUniqueTrackName(Au3WaveTrack::GetDefaultAudioTrackNamePreference()));
         tracks.Add(track, ::TrackList::DoAssignId::Yes,
                    ::TrackList::EventPublicationSynchrony::Synchronous);
-        prj->notifyAboutTrackAdded(DomConverter::track(track.get()));
         doInsertSilence({ track->GetId() }, begin, end, duration);
     } else {
         doInsertSilence(trackIds, begin, end, duration);
@@ -1064,6 +1061,8 @@ bool Au3TracksInteraction::swapStereoChannels(const TrackIdList& tracksIds)
 
 bool Au3TracksInteraction::splitStereoTracksToLRMono(const TrackIdList& tracksIds)
 {
+    const TrackListChangeGuard guard(globalContext()->currentTrackeditProject());
+
     for (const TrackId& trackId : tracksIds) {
         Au3WaveTrack* waveTrack = DomAccessor::findWaveTrack(projectRef(), ::TrackId(trackId));
         IF_ASSERT_FAILED(waveTrack) {
@@ -1085,11 +1084,9 @@ bool Au3TracksInteraction::splitStereoTracksToLRMono(const TrackIdList& tracksId
         unlinkedTracks[1]->SetPan(1.0f);
 
         trackedit::ITrackeditProjectPtr prj = globalContext()->currentTrackeditProject();
-        prj->notifyAboutTrackAdded(DomConverter::track(unlinkedTracks[0].get()));
         for (const auto& clip : prj->clipList(unlinkedTracks[0]->GetId())) {
             prj->notifyAboutClipAdded(clip);
         }
-        prj->notifyAboutTrackAdded(DomConverter::track(unlinkedTracks[1].get()));
         for (const auto& clip : prj->clipList(unlinkedTracks[1]->GetId())) {
             prj->notifyAboutClipAdded(clip);
         }
@@ -1105,14 +1102,12 @@ bool Au3TracksInteraction::splitStereoTracksToLRMono(const TrackIdList& tracksId
 
         moveTracksTo({ unlinkedTracks[0]->GetId(), unlinkedTracks[1]->GetId() }, trackPosition(trackId));
 
-        const auto originalTrack = DomConverter::track(waveTrack);
         const auto originalClips = prj->clipList(trackId);
         auto& tracks = Au3TrackList::Get(projectRef());
         tracks.Remove(*waveTrack);
         for (const auto& clip : originalClips) {
             prj->notifyAboutClipRemoved(clip);
         }
-        prj->notifyAboutTrackRemoved(originalTrack);
     }
 
     return true;
@@ -1120,6 +1115,8 @@ bool Au3TracksInteraction::splitStereoTracksToLRMono(const TrackIdList& tracksId
 
 bool Au3TracksInteraction::splitStereoTracksToCenterMono(const TrackIdList& tracksIds)
 {
+    const TrackListChangeGuard guard(globalContext()->currentTrackeditProject());
+
     for (const TrackId& trackId : tracksIds) {
         Au3WaveTrack* waveTrack = DomAccessor::findWaveTrack(projectRef(), ::TrackId(trackId));
         IF_ASSERT_FAILED(waveTrack) {
@@ -1138,11 +1135,9 @@ bool Au3TracksInteraction::splitStereoTracksToCenterMono(const TrackIdList& trac
         }
 
         trackedit::ITrackeditProjectPtr prj = globalContext()->currentTrackeditProject();
-        prj->notifyAboutTrackAdded(DomConverter::track(unlinkedTracks[0].get()));
         for (const auto& clip : prj->clipList(unlinkedTracks[0]->GetId())) {
             prj->notifyAboutClipAdded(clip);
         }
-        prj->notifyAboutTrackAdded(DomConverter::track(unlinkedTracks[1].get()));
         for (const auto& clip : prj->clipList(unlinkedTracks[1]->GetId())) {
             prj->notifyAboutClipAdded(clip);
         }
@@ -1159,13 +1154,11 @@ bool Au3TracksInteraction::splitStereoTracksToCenterMono(const TrackIdList& trac
         moveTracksTo({ unlinkedTracks[0]->GetId(), unlinkedTracks[1]->GetId() }, trackPosition(trackId));
 
         auto& tracks = Au3TrackList::Get(projectRef());
-        const auto originalTrack = DomConverter::track(waveTrack);
         const auto originalClips = prj->clipList(trackId);
         tracks.Remove(*waveTrack);
         for (const auto& clip : originalClips) {
             prj->notifyAboutClipRemoved(clip);
         }
-        prj->notifyAboutTrackRemoved(originalTrack);
     }
 
     return true;
@@ -1173,6 +1166,8 @@ bool Au3TracksInteraction::splitStereoTracksToCenterMono(const TrackIdList& trac
 
 bool Au3TracksInteraction::makeStereoTrack(const TrackId left, const TrackId right)
 {
+    const TrackListChangeGuard guard(globalContext()->currentTrackeditProject());
+
     const auto au3LeftTrack = DomAccessor::findWaveTrack(projectRef(), ::TrackId(left));
     IF_ASSERT_FAILED(au3LeftTrack) {
         return false;
@@ -1225,15 +1220,11 @@ bool Au3TracksInteraction::makeStereoTrack(const TrackId left, const TrackId rig
     const projectscene::IProjectViewStatePtr viewState = globalContext()->currentProject()->viewState();
     const int newTrackHeight = viewState->trackHeight(left).val + viewState->trackHeight(right).val;
 
-    const Track leftTrack = DomConverter::track(au3LeftTrack);
-    const Track rightTrack = DomConverter::track(au3RightTrack);
-
     ITrackeditProjectPtr prj = globalContext()->currentTrackeditProject();
     const auto leftClips = prj->clipList(left);
     const auto rightClips = prj->clipList(right);
 
     tracks.Append(mix, true);
-    prj->notifyAboutTrackAdded(DomConverter::track(mix.get()));
     for (const auto& clip : prj->clipList(mix->GetId())) {
         prj->notifyAboutClipAdded(clip);
     }
@@ -1248,11 +1239,9 @@ bool Au3TracksInteraction::makeStereoTrack(const TrackId left, const TrackId rig
     for (const auto& clip : leftClips) {
         prj->notifyAboutClipRemoved(clip);
     }
-    prj->notifyAboutTrackRemoved(leftTrack);
     for (const auto& clip : rightClips) {
         prj->notifyAboutClipRemoved(clip);
     }
-    prj->notifyAboutTrackRemoved(rightTrack);
 
     return true;
 }
@@ -1413,6 +1402,9 @@ void Au3TracksInteraction::removeDragAddedTracks(size_t numTracksWhenDragStarted
 {
     trackedit::ITrackeditProjectPtr prj = globalContext()->currentTrackeditProject();
     const auto tracks = prj->trackList();
+
+    const TrackListChangeGuard guard(prj);
+
     for (auto i = numTracksWhenDragStarted; i < tracks.size(); ++i) {
         const auto& track = tracks[i];
         Au3WaveTrack* const waveTrack = DomAccessor::findWaveTrack(projectRef(), Au3TrackId(track.id));
@@ -1422,7 +1414,6 @@ void Au3TracksInteraction::removeDragAddedTracks(size_t numTracksWhenDragStarted
             for (const auto& clip : clips) {
                 prj->notifyAboutClipRemoved(clip);
             }
-            prj->notifyAboutTrackRemoved(track);
         }
     }
 }
@@ -1443,9 +1434,6 @@ TrackIdList Au3TracksInteraction::pasteIntoNewTracks(const std::vector<Au3TrackD
             pFirstNewTrack = pNewTrack.get();
         }
 
-        auto newTrack = DomConverter::track(pNewTrack.get());
-        prj->notifyAboutTrackAdded(newTrack);
-
         // Handle wave track clips
         if (dynamic_cast<Au3WaveTrack*>(pNewTrack.get())) {
             for (const auto& clip : prj->clipList(pNewTrack->GetId())) {
@@ -1460,7 +1448,7 @@ TrackIdList Au3TracksInteraction::pasteIntoNewTracks(const std::vector<Au3TrackD
             }
         }
 
-        tracksIdsPastedInto.push_back(newTrack.id);
+        tracksIdsPastedInto.push_back(pNewTrack->GetId());
     }
 
     return tracksIdsPastedInto;
@@ -1973,10 +1961,9 @@ void Au3TracksInteraction::moveTrackTo(const TrackId trackId, int to)
 
 au::trackedit::TrackId Au3TracksInteraction::addWaveTrack(int numChannels)
 {
-    const auto track = utils::appendWaveTrack(Au3TrackList::Get(projectRef()), numChannels);
+    const TrackListChangeGuard guard(globalContext()->currentTrackeditProject());
 
-    const auto prj = globalContext()->currentTrackeditProject();
-    prj->notifyAboutTrackAdded(DomConverter::track(track));
+    const auto track = utils::appendWaveTrack(Au3TrackList::Get(projectRef()), numChannels);
 
     return track->GetId();
 }

--- a/src/trackedit/internal/au3/au3tracksinteraction.cpp
+++ b/src/trackedit/internal/au3/au3tracksinteraction.cpp
@@ -791,10 +791,8 @@ bool Au3TracksInteraction::deleteTracks(const TrackIdList& trackIds)
     auto& project = projectRef();
     auto& tracks = Au3TrackList::Get(project);
 
-    TrackId focusedTrack = trackNavigationController()->focusedTrack();
     const auto prj = globalContext()->currentTrackeditProject();
     const TrackListChangeGuard guard(prj);
-    const auto indexFocusedTrack = muse::indexOf(prj->trackIdList(), focusedTrack);
 
     for (const auto& trackId : trackIds) {
         Au3Track* au3Track = DomAccessor::findTrack(project, Au3TrackId(trackId));
@@ -807,27 +805,6 @@ bool Au3TracksInteraction::deleteTracks(const TrackIdList& trackIds)
         for (const auto& clip : clips) {
             prj->notifyAboutClipRemoved(clip);
         }
-    }
-
-    if (!muse::contains(trackIds, focusedTrack)) {
-        return true;
-    }
-
-    if (indexFocusedTrack == muse::nidx) {
-        return true;
-    }
-
-    const auto notRemovedTracks = prj->trackIdList();
-    if (notRemovedTracks.empty()) {
-        trackNavigationController()->setFocusedTrack(-1);
-        return true;
-    }
-
-    const auto maxIndex = notRemovedTracks.size() - 1;
-    if (maxIndex < indexFocusedTrack) {
-        trackNavigationController()->setFocusedTrack(notRemovedTracks.back());
-    } else {
-        trackNavigationController()->setFocusedTrack(notRemovedTracks[indexFocusedTrack]);
     }
 
     return true;

--- a/src/trackedit/internal/changedetection.cpp
+++ b/src/trackedit/internal/changedetection.cpp
@@ -1,5 +1,8 @@
 #include "changedetection.h"
 
+#include <algorithm>
+#include <iterator>
+
 #include "log.h"
 
 using namespace au::trackedit;
@@ -225,30 +228,43 @@ void notifyOfUndoRedo(const TracksAndItems& before,
         }
     }
 
-    //! Checking for Track addition:
+    const auto toId = [](const Track& track) { return track.id; };
+    TrackIdList idsBefore;
+    idsBefore.reserve(before.tracks.size());
+    std::transform(before.tracks.begin(), before.tracks.end(), std::back_inserter(idsBefore), toId);
+    TrackIdList idsAfter;
+    idsAfter.reserve(after.tracks.size());
+    std::transform(after.tracks.begin(), after.tracks.end(), std::back_inserter(idsAfter), toId);
+    const TrackListChange listChange(std::move(idsBefore), std::move(idsAfter));
+
+    //! Clips of removed tracks go away before the track event:
     notifier<Track>(
-        before.tracks,
         after.tracks,
-        [&](Track track, int index) {
+        before.tracks,
+        [&](Track, int index) {
         changed = true;
-        trackeditProject->trackInserted().send(track, index);
-        for (const Clip& clip : after.clips[index]) {
-            trackeditProject->notifyAboutClipAdded(clip);
+        for (const Clip& clip : before.clips[index]) {
+            trackeditProject->notifyAboutClipRemoved(clip);
         }
     },
         trackIdCheck
         );
 
-    //! Checking for Track removal:
-    notifier<Track>(
-        after.tracks,
-        before.tracks,
-        [&](Track track, int index) {
+    //! Checking for Track addition/removal:
+    if (listChange.hasChanges()) {
         changed = true;
-        for (const Clip& clip : before.clips[index]) {
-            trackeditProject->notifyAboutClipRemoved(clip);
+        trackeditProject->trackListChanged().send(listChange);
+    }
+
+    //! Clips of added tracks arrive after the track event:
+    notifier<Track>(
+        before.tracks,
+        after.tracks,
+        [&](Track, int index) {
+        changed = true;
+        for (const Clip& clip : after.clips[index]) {
+            trackeditProject->notifyAboutClipAdded(clip);
         }
-        trackeditProject->trackRemoved().send(track);
     },
         trackIdCheck
         );

--- a/src/trackedit/internal/trackeditinteraction.h
+++ b/src/trackedit/internal/trackeditinteraction.h
@@ -3,7 +3,7 @@
 #include "itrackeditinteraction.h"
 #include "trackedit/trackediterrors.h"
 
-#include "playback/iplayer.h"
+#include "context/iglobalcontext.h"
 #include "global/types/secs.h"
 #include "modularity/ioc.h"
 #include "record/irecordcontroller.h"
@@ -15,6 +15,7 @@ class TrackeditInteraction : public ITrackeditInteraction, public muse::Contexta
 {
     muse::ContextInject<au::record::IRecordController> recordController { this };
     muse::ContextInject<au::playback::IPlaybackController> playbackController { this };
+    muse::ContextInject<au::context::IGlobalContext> globalContext { this };
 
 public:
     TrackeditInteraction(const muse::modularity::ContextPtr& ctx, std::unique_ptr<ITrackeditInteraction> interaction);

--- a/src/trackedit/internal/tracknavigationcontroller.cpp
+++ b/src/trackedit/internal/tracknavigationcontroller.cpp
@@ -89,8 +89,8 @@ void TrackNavigationController::init()
                     setFocusedTrack(trackList.front().id);
                 }
 
-                prj->trackListChanged().onReceive(this, [this](const TrackListChange&) {
-                    revalidateFocusedTrack();
+                prj->trackListChanged().onReceive(this, [this](const TrackListChange& change) {
+                    onTrackListChanged(change);
                 });
             }
         });
@@ -840,17 +840,23 @@ void TrackNavigationController::au3SetTrackFocused(const TrackId& trackId)
     }
 }
 
-void TrackNavigationController::revalidateFocusedTrack()
+void TrackNavigationController::onTrackListChanged(const TrackListChange& change)
 {
     const TrackId focused = focusedTrack();
-    const TrackIdList tracks = selectionController()->orderedTrackList();
-    const bool focusedExists = std::any_of(tracks.begin(), tracks.end(),
-                                           [focused](const TrackId& t) { return t == focused; });
+    const TrackIdList& after = change.after();
 
-    if (focusedExists) {
+    if (change.wasRemoved(focused)) {
+        if (after.empty()) {
+            setFocusedTrack(INVALID_TRACK);
+            return;
+        }
+
+        const auto index = muse::indexOf(change.before(), focused);
+        setFocusedTrack(index < after.size() ? after[index] : after.back());
         return;
     }
 
-    const TrackId trackId = tracks.empty() ? INVALID_TRACK : tracks.front();
-    setFocusedTrack(trackId);
+    if (!muse::contains(after, focused)) {
+        setFocusedTrack(after.empty() ? INVALID_TRACK : after.front());
+    }
 }

--- a/src/trackedit/internal/tracknavigationcontroller.cpp
+++ b/src/trackedit/internal/tracknavigationcontroller.cpp
@@ -89,15 +89,7 @@ void TrackNavigationController::init()
                     setFocusedTrack(trackList.front().id);
                 }
 
-                prj->trackAdded().onReceive(this, [this](const Track&) {
-                    revalidateFocusedTrack();
-                });
-
-                prj->trackInserted().onReceive(this, [this](const Track&, int) {
-                    revalidateFocusedTrack();
-                });
-
-                prj->trackRemoved().onReceive(this, [this](const Track&) {
+                prj->trackListChanged().onReceive(this, [this](const TrackListChange&) {
                     revalidateFocusedTrack();
                 });
             }

--- a/src/trackedit/internal/tracknavigationcontroller.h
+++ b/src/trackedit/internal/tracknavigationcontroller.h
@@ -102,7 +102,7 @@ private:
 
     void au3SetTrackFocused(const TrackId& trackId);
 
-    void revalidateFocusedTrack();
+    void onTrackListChanged(const TrackListChange& change);
 
     bool m_isNavigationActive = false;
     muse::async::Notification m_isNavigationActiveChannel;

--- a/src/trackedit/itrackeditproject.h
+++ b/src/trackedit/itrackeditproject.h
@@ -15,6 +15,7 @@
 #include "trackedittypes.h"
 #include "dom/track.h"
 #include "dom/label.h"
+#include "tracklistchange.h"
 
 namespace au::au3 {
 class IAu3Project;
@@ -47,10 +48,8 @@ public:
 
     virtual void reload() = 0;
 
-    virtual void notifyAboutTrackAdded(const Track& track) = 0;
     virtual void notifyAboutTrackChanged(const Track& track) = 0;
-    virtual void notifyAboutTrackRemoved(const Track& track) = 0;
-    virtual void notifyAboutTrackInserted(const Track& track, int pos) = 0;
+    virtual void notifyAboutTrackListChanged(const TrackListChange& change) = 0;
     virtual void notifyAboutTrackMoved(const Track& track, int pos) = 0;
 
     virtual void notifyAboutTrackClipListChanged(const Track& track) = 0;
@@ -68,11 +67,9 @@ public:
     virtual muse::async::Channel<TimeSignature> timeSignatureChanged() const = 0;
 
     virtual muse::async::Channel<std::vector<au::trackedit::Track> > tracksChanged() const = 0;
-    virtual muse::async::Channel<trackedit::Track> trackAdded() const = 0;
+    virtual muse::async::Channel<TrackListChange> trackListChanged() const = 0;
     virtual muse::async::Channel<trackedit::Track> trackChanged() const = 0;
     virtual muse::async::Channel<trackedit::Track> trackClipListChanged() const = 0;
-    virtual muse::async::Channel<trackedit::Track> trackRemoved() const = 0;
-    virtual muse::async::Channel<trackedit::Track, int> trackInserted() const = 0;
     virtual muse::async::Channel<trackedit::Track, int> trackMoved() const = 0;
 
     virtual secs_t totalTime() const = 0;

--- a/src/trackedit/tests/au3clipsinteraction_tests.cpp
+++ b/src/trackedit/tests/au3clipsinteraction_tests.cpp
@@ -394,7 +394,7 @@ TEST_F(Au3ClipsInteractionTests, DuplicateClipsOnEmptyList)
     ASSERT_EQ(projectTracks.Size(), 0) << "Precondition failed: The number of tracks is not 0";
 
     //! [EXPECT] Notify about track inserted is not called
-    EXPECT_CALL(*m_trackEditProject, notifyAboutTrackInserted(_, _)).Times(0);
+    EXPECT_CALL(*m_trackEditProject, notifyAboutTrackListChanged(_)).Times(0);
 
     //! [WHEN] Duplicate the clips with an empty list
     EXPECT_EQ(m_clipsInteraction->duplicateClips({}), false);
@@ -415,10 +415,10 @@ TEST_F(Au3ClipsInteractionTests, DuplicateSingleClip)
     ASSERT_EQ(projectTracks.Size(), 1) << "Precondition failed: The number of tracks is not 1";
 
     //! [EXPECT] The trackList is requested
-    EXPECT_CALL(*m_trackEditProject, trackIdList()).Times(1).WillOnce(Return(std::vector<trackedit::TrackId> { track->GetId() }));
+    EXPECT_CALL(*m_trackEditProject, trackIdList()).Times(3).WillRepeatedly(Return(std::vector<trackedit::TrackId> { track->GetId() }));
 
     //! [EXPECT] Notify about track added
-    EXPECT_CALL(*m_trackEditProject, notifyAboutTrackAdded(_)).Times(1);
+    EXPECT_CALL(*m_trackEditProject, notifyAboutTrackListChanged(_)).Times(1);
 
     //! [WHEN] Duplicate the clip
     m_clipsInteraction->duplicateClip({ track->GetId(), clip->GetId() });

--- a/src/trackedit/tests/au3labelsinteractions_tests.cpp
+++ b/src/trackedit/tests/au3labelsinteractions_tests.cpp
@@ -84,7 +84,7 @@ TEST_F(Au3LabelsInteractionsTests, AddLabelToSelectionCreatesLabelTrackWhenNoneE
     .WillByDefault(Return(INVALID_TRACK));
 
     //! [EXPECT] The project is notified about a new track and a new label being added
-    EXPECT_CALL(*m_trackEditProject, notifyAboutTrackAdded(_)).Times(1);
+    EXPECT_CALL(*m_trackEditProject, notifyAboutTrackListChanged(_)).Times(1);
     EXPECT_CALL(*m_trackEditProject, notifyAboutLabelAdded(_)).Times(1);
     EXPECT_CALL(*m_selectionController, setSelectedLabels(_, _)).Times(1);
 
@@ -128,7 +128,7 @@ TEST_F(Au3LabelsInteractionsTests, AddLabelToSelectionUsesExistingLabelTrack)
     .WillByDefault(Return(INVALID_TRACK));
 
     //! [EXPECT] The project is notified about a new label being added but NOT about a new track
-    EXPECT_CALL(*m_trackEditProject, notifyAboutTrackAdded(_)).Times(0);
+    EXPECT_CALL(*m_trackEditProject, notifyAboutTrackListChanged(_)).Times(0);
     EXPECT_CALL(*m_trackEditProject, notifyAboutLabelAdded(_)).Times(1);
     EXPECT_CALL(*m_selectionController, setSelectedLabels(_, _)).Times(1);
 
@@ -175,7 +175,7 @@ TEST_F(Au3LabelsInteractionsTests, AddLabelToSelectionUsesFocusedLabelTrack)
     .WillByDefault(Return(selectionEnd));
 
     //! [EXPECT] The project is notified about a new label being added
-    EXPECT_CALL(*m_trackEditProject, notifyAboutTrackAdded(_)).Times(0);
+    EXPECT_CALL(*m_trackEditProject, notifyAboutTrackListChanged(_)).Times(0);
     EXPECT_CALL(*m_trackEditProject, notifyAboutLabelAdded(_)).Times(1);
     EXPECT_CALL(*m_selectionController, setSelectedLabels(_, _)).Times(1);
 
@@ -212,7 +212,7 @@ TEST_F(Au3LabelsInteractionsTests, AddLabelToSelectionWithZeroLengthSelection)
     .WillByDefault(Return(INVALID_TRACK));
 
     //! [EXPECT] The project is notified about a new track and a new label being added
-    EXPECT_CALL(*m_trackEditProject, notifyAboutTrackAdded(_)).Times(1);
+    EXPECT_CALL(*m_trackEditProject, notifyAboutTrackListChanged(_)).Times(1);
     EXPECT_CALL(*m_trackEditProject, notifyAboutLabelAdded(_)).Times(1);
     EXPECT_CALL(*m_selectionController, setSelectedLabels(_, _)).Times(1);
 
@@ -247,7 +247,7 @@ TEST_F(Au3LabelsInteractionsTests, AddMultipleLabelsToSameLabelTrack)
     .WillByDefault(Return(INVALID_TRACK));
 
     //! [EXPECT] Notifications for track and labels
-    EXPECT_CALL(*m_trackEditProject, notifyAboutTrackAdded(_)).Times(1);
+    EXPECT_CALL(*m_trackEditProject, notifyAboutTrackListChanged(_)).Times(1);
     EXPECT_CALL(*m_trackEditProject, notifyAboutLabelAdded(_)).Times(3);
     EXPECT_CALL(*m_selectionController, setSelectedLabels(_, _)).Times(AtLeast(1));
 
@@ -314,7 +314,7 @@ TEST_F(Au3LabelsInteractionsTests, AddLabelToSelectionWithAudioTrackPresent)
     .WillByDefault(Return(INVALID_TRACK));
 
     //! [EXPECT] The project is notified about a new label track and a new label being added
-    EXPECT_CALL(*m_trackEditProject, notifyAboutTrackAdded(_)).Times(1);
+    EXPECT_CALL(*m_trackEditProject, notifyAboutTrackListChanged(_)).Times(1);
     EXPECT_CALL(*m_trackEditProject, notifyAboutLabelAdded(_)).Times(1);
     EXPECT_CALL(*m_selectionController, setSelectedLabels(_, _)).Times(1);
 
@@ -370,7 +370,7 @@ TEST_F(Au3LabelsInteractionsTests, AddLabelToSelectionWhenPlaybackIsActive)
     .WillByDefault(Return(playbackPosition));
 
     //! [EXPECT] The project is notified about a new label being added but NOT about a new track
-    EXPECT_CALL(*m_trackEditProject, notifyAboutTrackAdded(_)).Times(0);
+    EXPECT_CALL(*m_trackEditProject, notifyAboutTrackListChanged(_)).Times(0);
     EXPECT_CALL(*m_trackEditProject, notifyAboutLabelAdded(_)).Times(1);
     EXPECT_CALL(*m_selectionController, setSelectedLabels(_, _)).Times(1);
 
@@ -425,7 +425,7 @@ TEST_F(Au3LabelsInteractionsTests, AddLabelToSelectionWhenRecordingIsActive)
     .WillByDefault(Return(recordPosition));
 
     //! [EXPECT] The project is notified about a new label being added but NOT about a new track
-    EXPECT_CALL(*m_trackEditProject, notifyAboutTrackAdded(_)).Times(0);
+    EXPECT_CALL(*m_trackEditProject, notifyAboutTrackListChanged(_)).Times(0);
     EXPECT_CALL(*m_trackEditProject, notifyAboutLabelAdded(_)).Times(1);
     EXPECT_CALL(*m_selectionController, setSelectedLabels(_, _)).Times(1);
 

--- a/src/trackedit/tests/au3tracksinteraction_tests.cpp
+++ b/src/trackedit/tests/au3tracksinteraction_tests.cpp
@@ -536,7 +536,7 @@ TEST_F(Au3TracksInteractionTests, SplitTracksAtEmptyList)
     //! [EXPECT] The project is not notified about track changed
     EXPECT_CALL(*m_trackEditProject, notifyAboutTrackChanged(_)).Times(0);
     EXPECT_CALL(*m_trackEditProject, notifyAboutClipChanged(_)).Times(0);
-    EXPECT_CALL(*m_trackEditProject, notifyAboutTrackAdded(_)).Times(0);
+    EXPECT_CALL(*m_trackEditProject, notifyAboutTrackListChanged(_)).Times(0);
 
     //! [WHEN] Split an empty list
     m_tracksInteraction->splitTracksAt({}, { 0.0 });
@@ -722,7 +722,7 @@ TEST_F(Au3TracksInteractionTests, DuplicateTracksOnEmptyList)
     ASSERT_EQ(projectTracks.Size(), 0) << "Precondition failed: The number of tracks is not 0";
 
     //! [EXPECT] Notify about track inserted is not called
-    EXPECT_CALL(*m_trackEditProject, notifyAboutTrackInserted(_, _)).Times(0);
+    EXPECT_CALL(*m_trackEditProject, notifyAboutTrackListChanged(_)).Times(0);
 
     //! [WHEN] Duplicate the tracks with an empty list
     EXPECT_EQ(m_tracksInteraction->duplicateTracks({}), false);
@@ -740,7 +740,7 @@ TEST_F(Au3TracksInteractionTests, DuplicateTracks)
     ASSERT_EQ(projectTracks.Size(), 1) << "Precondition failed: The number of tracks is not 1";
 
     //! [EXPECT] Notify about track added
-    EXPECT_CALL(*m_trackEditProject, notifyAboutTrackInserted(_, _)).Times(1);
+    EXPECT_CALL(*m_trackEditProject, notifyAboutTrackListChanged(_)).Times(1);
 
     //! [WHEN] Duplicate the track
     const TrackIdList trackList { trackId };
@@ -997,7 +997,7 @@ TEST_F(Au3TracksInteractionTests, DuplicateRangeSelectionOnNewTrack)
     ASSERT_EQ(projectTracks.Size(), 1) << "Precondition failed: The number of tracks is not 1";
 
     //! [EXPECT] Notify about track added
-    EXPECT_CALL(*m_trackEditProject, notifyAboutTrackAdded(_)).Times(1);
+    EXPECT_CALL(*m_trackEditProject, notifyAboutTrackListChanged(_)).Times(1);
 
     //! [WHEN] Duplicate the range selection
     m_tracksInteraction->duplicateSelectedOnTracks({ track->GetId() }, TRACK_THREE_CLIPS_CLIP2_START, TRACK_THREE_CLIPS_CLIP2_END);
@@ -1268,7 +1268,7 @@ TEST_F(Au3TracksInteractionTests, MoveTrackToSameIndexDoNothing)
 TEST_F(Au3TracksInteractionTests, InsertSilenceWithEmptyTrackCreatesNewTrack)
 {
     //! [EXPECT] The project is notified about track changed
-    EXPECT_CALL(*m_trackEditProject, notifyAboutTrackAdded(_)).Times(1);
+    EXPECT_CALL(*m_trackEditProject, notifyAboutTrackListChanged(_)).Times(1);
 
     //! [WHEN] Insert silence on the empty track
     const secs_t begin = 0;
@@ -1542,7 +1542,7 @@ TEST_F(Au3TracksInteractionTests, PasteLabelTrackCreatesNewTrack)
     EXPECT_CALL(*m_playbackState, playbackPosition()).Times(1).WillOnce(Return(5.0));
 
     //! [EXPECT] The project is notified about track added
-    EXPECT_CALL(*m_trackEditProject, notifyAboutTrackAdded(_)).Times(1);
+    EXPECT_CALL(*m_trackEditProject, notifyAboutTrackListChanged(_)).Times(1);
 
     //! [WHEN] Paste from clipboard
     constexpr auto moveClips = false;
@@ -1582,7 +1582,7 @@ TEST_F(Au3TracksInteractionTests, AddNewMonoTrack)
     ASSERT_EQ(projectTracks.Size(), 0) << "The number of tracks before the add new mono track operation is not 0";
 
     //! [EXPECT] The project is notified about track added
-    EXPECT_CALL(*m_trackEditProject, notifyAboutTrackAdded(_)).Times(1);
+    EXPECT_CALL(*m_trackEditProject, notifyAboutTrackListChanged(_)).Times(1);
 
     //! [EXPECT] The new track is selected
     EXPECT_CALL(*m_selectionController, setSelectedTracks(_, true)).Times(1);
@@ -1609,7 +1609,7 @@ TEST_F(Au3TracksInteractionTests, AddNewStereoTrack)
     ASSERT_EQ(projectTracks.Size(), 0) << "The number of tracks before the add new stereo track operation is not 0";
 
     //! [EXPECT] The project is notified about track added
-    EXPECT_CALL(*m_trackEditProject, notifyAboutTrackAdded(_)).Times(1);
+    EXPECT_CALL(*m_trackEditProject, notifyAboutTrackListChanged(_)).Times(1);
 
     //! [EXPECT] The new track is selected
     EXPECT_CALL(*m_selectionController, setSelectedTracks(_, true)).Times(1);

--- a/src/trackedit/tests/changedetection_tests.cpp
+++ b/src/trackedit/tests/changedetection_tests.cpp
@@ -126,8 +126,7 @@ TEST_F(ChangeDetectionTests, TestNotificationsWhenTheresNoChanges)
 
     EXPECT_EQ(before.tracks.size(), after.tracks.size());
 
-    EXPECT_CALL(*m_trackEditProject, trackInserted()).Times(0);
-    EXPECT_CALL(*m_trackEditProject, trackRemoved()).Times(0);
+    EXPECT_CALL(*m_trackEditProject, trackListChanged()).Times(0);
     EXPECT_CALL(*m_trackEditProject, trackChanged()).Times(0);
 
     //! If there are no changes detected,
@@ -158,8 +157,7 @@ TEST_F(ChangeDetectionTests, TestTrackNotificationsForAddingOneTrack)
 
     EXPECT_NE(before.tracks.size(), after.tracks.size());
 
-    EXPECT_CALL(*m_trackEditProject, trackInserted()).Times(1);
-    EXPECT_CALL(*m_trackEditProject, trackRemoved()).Times(0);
+    EXPECT_CALL(*m_trackEditProject, trackListChanged()).Times(1);
     EXPECT_CALL(*m_trackEditProject, trackChanged()).Times(0);
     EXPECT_CALL(*m_trackEditProject, reload()).Times(0);
 
@@ -184,8 +182,7 @@ TEST_F(ChangeDetectionTests, TestTrackNotificationsForAddingTwoTracks)
 
     EXPECT_NE(before.tracks.size(), after.tracks.size());
 
-    EXPECT_CALL(*m_trackEditProject, trackInserted()).Times(2);
-    EXPECT_CALL(*m_trackEditProject, trackRemoved()).Times(0);
+    EXPECT_CALL(*m_trackEditProject, trackListChanged()).Times(1);
     EXPECT_CALL(*m_trackEditProject, trackChanged()).Times(0);
     EXPECT_CALL(*m_trackEditProject, reload()).Times(0);
 
@@ -213,8 +210,7 @@ TEST_F(ChangeDetectionTests, TestTrackNotificationsForRemovingOneTrack)
 
     EXPECT_NE(before.tracks.size(), after.tracks.size());
 
-    EXPECT_CALL(*m_trackEditProject, trackInserted()).Times(0);
-    EXPECT_CALL(*m_trackEditProject, trackRemoved()).Times(1);
+    EXPECT_CALL(*m_trackEditProject, trackListChanged()).Times(1);
     EXPECT_CALL(*m_trackEditProject, trackChanged()).Times(0);
     EXPECT_CALL(*m_trackEditProject, reload()).Times(0);
 
@@ -246,8 +242,7 @@ TEST_F(ChangeDetectionTests, TestTrackNotificationsForRemovingTwoTracks)
 
     EXPECT_NE(before.tracks.size(), after.tracks.size());
 
-    EXPECT_CALL(*m_trackEditProject, trackInserted()).Times(0);
-    EXPECT_CALL(*m_trackEditProject, trackRemoved()).Times(2);
+    EXPECT_CALL(*m_trackEditProject, trackListChanged()).Times(1);
     EXPECT_CALL(*m_trackEditProject, trackChanged()).Times(0);
     EXPECT_CALL(*m_trackEditProject, reload()).Times(0);
 
@@ -283,8 +278,7 @@ TEST_F(ChangeDetectionTests, TestTrackNotificationsForReordering)
     }
 
     // Reordering is detected indirectly, as removal and addition.
-    EXPECT_CALL(*m_trackEditProject, trackInserted()).Times(0);
-    EXPECT_CALL(*m_trackEditProject, trackRemoved()).Times(0);
+    EXPECT_CALL(*m_trackEditProject, trackListChanged()).Times(0);
     EXPECT_CALL(*m_trackEditProject, trackChanged()).Times(0);
     EXPECT_CALL(*m_trackEditProject, reload()).Times(1);
 
@@ -310,8 +304,7 @@ TEST_F(ChangeDetectionTests, TestTrackNotificationForTitleChange)
 
     before.tracks.back().title = "new title";
 
-    EXPECT_CALL(*m_trackEditProject, trackInserted()).Times(0);
-    EXPECT_CALL(*m_trackEditProject, trackRemoved()).Times(0);
+    EXPECT_CALL(*m_trackEditProject, trackListChanged()).Times(0);
     EXPECT_CALL(*m_trackEditProject, trackChanged()).Times(1);
     EXPECT_CALL(*m_trackEditProject, reload()).Times(0);
 
@@ -337,8 +330,7 @@ TEST_F(ChangeDetectionTests, TestClipNotificationAddingOne)
 
     addClipToTrack(after, after.tracks.back().id, static_cast<int>(after.clips.back().size()));
 
-    EXPECT_CALL(*m_trackEditProject, trackInserted()).Times(0);
-    EXPECT_CALL(*m_trackEditProject, trackRemoved()).Times(0);
+    EXPECT_CALL(*m_trackEditProject, trackListChanged()).Times(0);
     EXPECT_CALL(*m_trackEditProject, trackChanged()).Times(0);
     EXPECT_CALL(*m_trackEditProject, reload()).Times(0);
 
@@ -361,8 +353,7 @@ TEST_F(ChangeDetectionTests, TestClipNotificationAddingTwo)
     addClipToTrack(after, after.tracks.front().id, static_cast<int>(after.clips.front().size()));
     addClipToTrack(after, after.tracks.back().id, static_cast<int>(after.clips.back().size()));
 
-    EXPECT_CALL(*m_trackEditProject, trackInserted()).Times(0);
-    EXPECT_CALL(*m_trackEditProject, trackRemoved()).Times(0);
+    EXPECT_CALL(*m_trackEditProject, trackListChanged()).Times(0);
     EXPECT_CALL(*m_trackEditProject, trackChanged()).Times(0);
     EXPECT_CALL(*m_trackEditProject, reload()).Times(0);
 
@@ -384,8 +375,7 @@ TEST_F(ChangeDetectionTests, TestClipNotificationRemovingOne)
 
     after.clips.back().pop_back();
 
-    EXPECT_CALL(*m_trackEditProject, trackInserted()).Times(0);
-    EXPECT_CALL(*m_trackEditProject, trackRemoved()).Times(0);
+    EXPECT_CALL(*m_trackEditProject, trackListChanged()).Times(0);
     EXPECT_CALL(*m_trackEditProject, trackChanged()).Times(0);
     EXPECT_CALL(*m_trackEditProject, reload()).Times(0);
 
@@ -408,8 +398,7 @@ TEST_F(ChangeDetectionTests, TestClipNotificationRemovingTwo)
     after.clips.front().pop_back();
     after.clips.back().pop_back();
 
-    EXPECT_CALL(*m_trackEditProject, trackInserted()).Times(0);
-    EXPECT_CALL(*m_trackEditProject, trackRemoved()).Times(0);
+    EXPECT_CALL(*m_trackEditProject, trackListChanged()).Times(0);
     EXPECT_CALL(*m_trackEditProject, trackChanged()).Times(0);
     EXPECT_CALL(*m_trackEditProject, reload()).Times(0);
 
@@ -431,8 +420,7 @@ TEST_F(ChangeDetectionTests, TestClipNotificationChangeStartTime)
 
     after.clips.back().back().startTime += 200;
 
-    EXPECT_CALL(*m_trackEditProject, trackInserted()).Times(0);
-    EXPECT_CALL(*m_trackEditProject, trackRemoved()).Times(0);
+    EXPECT_CALL(*m_trackEditProject, trackListChanged()).Times(0);
     EXPECT_CALL(*m_trackEditProject, trackChanged()).Times(0);
     EXPECT_CALL(*m_trackEditProject, reload()).Times(0);
 
@@ -454,8 +442,7 @@ TEST_F(ChangeDetectionTests, TestClipNotificationChangeEndTime)
 
     after.clips.back().back().endTime += after.clips.back().back().startTime + 200;
 
-    EXPECT_CALL(*m_trackEditProject, trackInserted()).Times(0);
-    EXPECT_CALL(*m_trackEditProject, trackRemoved()).Times(0);
+    EXPECT_CALL(*m_trackEditProject, trackListChanged()).Times(0);
     EXPECT_CALL(*m_trackEditProject, trackChanged()).Times(0);
     EXPECT_CALL(*m_trackEditProject, reload()).Times(0);
 
@@ -488,8 +475,7 @@ TEST_F(ChangeDetectionTests, TestClipNotificationChangeStereo)
     EXPECT_CALL(*m_trackEditProject, trackChanged()).Times(1);
     EXPECT_CALL(*m_trackEditProject, notifyAboutClipChanged(_)).Times(5);
 
-    EXPECT_CALL(*m_trackEditProject, trackInserted()).Times(0);
-    EXPECT_CALL(*m_trackEditProject, trackRemoved()).Times(0);
+    EXPECT_CALL(*m_trackEditProject, trackListChanged()).Times(0);
     EXPECT_CALL(*m_trackEditProject, reload()).Times(0);
 
     EXPECT_CALL(*m_trackEditProject, notifyAboutClipAdded(_)).Times(0);
@@ -509,8 +495,7 @@ TEST_F(ChangeDetectionTests, TestClipNotificationChangePitch)
 
     after.clips.back().back().pitch = 100;
 
-    EXPECT_CALL(*m_trackEditProject, trackInserted()).Times(0);
-    EXPECT_CALL(*m_trackEditProject, trackRemoved()).Times(0);
+    EXPECT_CALL(*m_trackEditProject, trackListChanged()).Times(0);
     EXPECT_CALL(*m_trackEditProject, trackChanged()).Times(0);
     EXPECT_CALL(*m_trackEditProject, reload()).Times(0);
 
@@ -532,8 +517,7 @@ TEST_F(ChangeDetectionTests, TestClipNotificationChangeSpeed)
 
     after.clips.back().back().speed = 10.0;
 
-    EXPECT_CALL(*m_trackEditProject, trackInserted()).Times(0);
-    EXPECT_CALL(*m_trackEditProject, trackRemoved()).Times(0);
+    EXPECT_CALL(*m_trackEditProject, trackListChanged()).Times(0);
     EXPECT_CALL(*m_trackEditProject, trackChanged()).Times(0);
     EXPECT_CALL(*m_trackEditProject, reload()).Times(0);
 
@@ -556,8 +540,7 @@ TEST_F(ChangeDetectionTests, TestClipNotificationChangeGroup)
     after.clips.back().back().groupId = 2;
     after.clips.back().front().groupId = 2;
 
-    EXPECT_CALL(*m_trackEditProject, trackInserted()).Times(0);
-    EXPECT_CALL(*m_trackEditProject, trackRemoved()).Times(0);
+    EXPECT_CALL(*m_trackEditProject, trackListChanged()).Times(0);
     EXPECT_CALL(*m_trackEditProject, trackChanged()).Times(0);
     EXPECT_CALL(*m_trackEditProject, reload()).Times(0);
 
@@ -579,8 +562,7 @@ TEST_F(ChangeDetectionTests, TestClipNotificationChangeVersion)
 
     after.clips.back().back().clipVersion++;
 
-    EXPECT_CALL(*m_trackEditProject, trackInserted()).Times(0);
-    EXPECT_CALL(*m_trackEditProject, trackRemoved()).Times(0);
+    EXPECT_CALL(*m_trackEditProject, trackListChanged()).Times(0);
     EXPECT_CALL(*m_trackEditProject, trackChanged()).Times(0);
     EXPECT_CALL(*m_trackEditProject, reload()).Times(0);
 
@@ -610,8 +592,7 @@ TEST_F(ChangeDetectionTests, TestNotificationsForAddingOneTrackAndOneClip)
 
     EXPECT_NE(before.tracks.size(), after.tracks.size());
 
-    EXPECT_CALL(*m_trackEditProject, trackInserted()).Times(1);
-    EXPECT_CALL(*m_trackEditProject, trackRemoved()).Times(0);
+    EXPECT_CALL(*m_trackEditProject, trackListChanged()).Times(1);
     EXPECT_CALL(*m_trackEditProject, trackChanged()).Times(0);
     EXPECT_CALL(*m_trackEditProject, reload()).Times(0);
 
@@ -639,8 +620,7 @@ TEST_F(ChangeDetectionTests, TestClipNotificationAddingTwoAndRemovingTwo)
     addClipToTrack(after, after.tracks.front().id, newClipIdNumber);
     addClipToTrack(after, after.tracks.back().id, newClipIdNumber + 1);
 
-    EXPECT_CALL(*m_trackEditProject, trackInserted()).Times(0);
-    EXPECT_CALL(*m_trackEditProject, trackRemoved()).Times(0);
+    EXPECT_CALL(*m_trackEditProject, trackListChanged()).Times(0);
     EXPECT_CALL(*m_trackEditProject, trackChanged()).Times(0);
     EXPECT_CALL(*m_trackEditProject, reload()).Times(0);
 
@@ -662,8 +642,7 @@ TEST_F(ChangeDetectionTests, TestClipNotificationChangeTitle)
 
     after.clips.back().back().title = "new clip title";
 
-    EXPECT_CALL(*m_trackEditProject, trackInserted()).Times(0);
-    EXPECT_CALL(*m_trackEditProject, trackRemoved()).Times(0);
+    EXPECT_CALL(*m_trackEditProject, trackListChanged()).Times(0);
     EXPECT_CALL(*m_trackEditProject, trackChanged()).Times(0);
     EXPECT_CALL(*m_trackEditProject, reload()).Times(0);
 
@@ -689,8 +668,7 @@ TEST_F(ChangeDetectionTests, TestLabelNotificationAddingOne)
 
     addLabelToTrack(after, after.tracks.back().id, static_cast<int>(after.labels.back().size()));
 
-    EXPECT_CALL(*m_trackEditProject, trackInserted()).Times(0);
-    EXPECT_CALL(*m_trackEditProject, trackRemoved()).Times(0);
+    EXPECT_CALL(*m_trackEditProject, trackListChanged()).Times(0);
     EXPECT_CALL(*m_trackEditProject, trackChanged()).Times(0);
     EXPECT_CALL(*m_trackEditProject, reload()).Times(0);
 
@@ -713,8 +691,7 @@ TEST_F(ChangeDetectionTests, TestLabelNotificationAddingTwo)
     addLabelToTrack(after, after.tracks.front().id, static_cast<int>(after.labels.front().size()));
     addLabelToTrack(after, after.tracks.back().id, static_cast<int>(after.labels.back().size()));
 
-    EXPECT_CALL(*m_trackEditProject, trackInserted()).Times(0);
-    EXPECT_CALL(*m_trackEditProject, trackRemoved()).Times(0);
+    EXPECT_CALL(*m_trackEditProject, trackListChanged()).Times(0);
     EXPECT_CALL(*m_trackEditProject, trackChanged()).Times(0);
     EXPECT_CALL(*m_trackEditProject, reload()).Times(0);
 
@@ -736,8 +713,7 @@ TEST_F(ChangeDetectionTests, TestLabelNotificationRemovingOne)
 
     after.labels.back().pop_back();
 
-    EXPECT_CALL(*m_trackEditProject, trackInserted()).Times(0);
-    EXPECT_CALL(*m_trackEditProject, trackRemoved()).Times(0);
+    EXPECT_CALL(*m_trackEditProject, trackListChanged()).Times(0);
     EXPECT_CALL(*m_trackEditProject, trackChanged()).Times(0);
     EXPECT_CALL(*m_trackEditProject, reload()).Times(0);
 
@@ -760,8 +736,7 @@ TEST_F(ChangeDetectionTests, TestLabelNotificationRemovingTwo)
     after.labels.front().pop_back();
     after.labels.back().pop_back();
 
-    EXPECT_CALL(*m_trackEditProject, trackInserted()).Times(0);
-    EXPECT_CALL(*m_trackEditProject, trackRemoved()).Times(0);
+    EXPECT_CALL(*m_trackEditProject, trackListChanged()).Times(0);
     EXPECT_CALL(*m_trackEditProject, trackChanged()).Times(0);
     EXPECT_CALL(*m_trackEditProject, reload()).Times(0);
 
@@ -783,8 +758,7 @@ TEST_F(ChangeDetectionTests, TestLabelNotificationChangeStartTime)
 
     after.labels.back().back().startTime += 200;
 
-    EXPECT_CALL(*m_trackEditProject, trackInserted()).Times(0);
-    EXPECT_CALL(*m_trackEditProject, trackRemoved()).Times(0);
+    EXPECT_CALL(*m_trackEditProject, trackListChanged()).Times(0);
     EXPECT_CALL(*m_trackEditProject, trackChanged()).Times(0);
     EXPECT_CALL(*m_trackEditProject, reload()).Times(0);
 
@@ -806,8 +780,7 @@ TEST_F(ChangeDetectionTests, TestLabelNotificationChangeEndTime)
 
     after.labels.back().back().endTime += 200;
 
-    EXPECT_CALL(*m_trackEditProject, trackInserted()).Times(0);
-    EXPECT_CALL(*m_trackEditProject, trackRemoved()).Times(0);
+    EXPECT_CALL(*m_trackEditProject, trackListChanged()).Times(0);
     EXPECT_CALL(*m_trackEditProject, trackChanged()).Times(0);
     EXPECT_CALL(*m_trackEditProject, reload()).Times(0);
 
@@ -829,8 +802,7 @@ TEST_F(ChangeDetectionTests, TestLabelNotificationChangeTitle)
 
     after.labels.back().back().title = "new label title";
 
-    EXPECT_CALL(*m_trackEditProject, trackInserted()).Times(0);
-    EXPECT_CALL(*m_trackEditProject, trackRemoved()).Times(0);
+    EXPECT_CALL(*m_trackEditProject, trackListChanged()).Times(0);
     EXPECT_CALL(*m_trackEditProject, trackChanged()).Times(0);
     EXPECT_CALL(*m_trackEditProject, reload()).Times(0);
 
@@ -858,8 +830,7 @@ TEST_F(ChangeDetectionTests, TestLabelNotificationAddingTwoAndRemovingTwo)
     addLabelToTrack(after, after.tracks.front().id, newLabelIdNumber);
     addLabelToTrack(after, after.tracks.back().id, newLabelIdNumber + 1);
 
-    EXPECT_CALL(*m_trackEditProject, trackInserted()).Times(0);
-    EXPECT_CALL(*m_trackEditProject, trackRemoved()).Times(0);
+    EXPECT_CALL(*m_trackEditProject, trackListChanged()).Times(0);
     EXPECT_CALL(*m_trackEditProject, trackChanged()).Times(0);
     EXPECT_CALL(*m_trackEditProject, reload()).Times(0);
 

--- a/src/trackedit/tests/mocks/trackeditprojectmock.h
+++ b/src/trackedit/tests/mocks/trackeditprojectmock.h
@@ -26,10 +26,8 @@ public:
 
     MOCK_METHOD(void, reload, (), (override));
 
-    MOCK_METHOD(void, notifyAboutTrackAdded, (const Track& track), (override));
     MOCK_METHOD(void, notifyAboutTrackChanged, (const Track& track), (override));
-    MOCK_METHOD(void, notifyAboutTrackRemoved, (const Track& track), (override));
-    MOCK_METHOD(void, notifyAboutTrackInserted, (const Track& track, int pos), (override));
+    MOCK_METHOD(void, notifyAboutTrackListChanged, (const TrackListChange& change), (override));
     MOCK_METHOD(void, notifyAboutTrackMoved, (const Track& track, int pos), (override));
 
     MOCK_METHOD(void, notifyAboutTrackClipListChanged, (const Track& track), (override));
@@ -47,11 +45,9 @@ public:
     MOCK_METHOD(muse::async::Channel<TimeSignature>, timeSignatureChanged, (), (const, override));
 
     MOCK_METHOD(muse::async::Channel<std::vector<au::trackedit::Track> >, tracksChanged, (), (const, override));
-    MOCK_METHOD(muse::async::Channel<trackedit::Track>, trackAdded, (), (const, override));
+    MOCK_METHOD(muse::async::Channel<trackedit::TrackListChange>, trackListChanged, (), (const, override));
     MOCK_METHOD(muse::async::Channel<trackedit::Track>, trackChanged, (), (const, override));
     MOCK_METHOD(muse::async::Channel<trackedit::Track>, trackClipListChanged, (), (const, override));
-    MOCK_METHOD(muse::async::Channel<trackedit::Track>, trackRemoved, (), (const, override));
-    MOCK_METHOD((muse::async::Channel<trackedit::Track, int>), trackInserted, (), (const, override));
     MOCK_METHOD((muse::async::Channel<trackedit::Track, int>), trackMoved, (), (const, override));
 
     MOCK_METHOD(secs_t, totalTime, (), (const, override));

--- a/src/trackedit/tests/tracknavigationmodel_tests.cpp
+++ b/src/trackedit/tests/tracknavigationmodel_tests.cpp
@@ -67,12 +67,8 @@ public:
 
         ON_CALL(*m_trackeditProject, tracksChanged())
         .WillByDefault(Return(m_tracksChanged));
-        ON_CALL(*m_trackeditProject, trackAdded())
-        .WillByDefault(Return(m_trackAdded));
-        ON_CALL(*m_trackeditProject, trackRemoved())
-        .WillByDefault(Return(m_trackRemoved));
-        ON_CALL(*m_trackeditProject, trackInserted())
-        .WillByDefault(Return(m_trackInserted));
+        ON_CALL(*m_trackeditProject, trackListChanged())
+        .WillByDefault(Return(m_trackListChanged));
         ON_CALL(*m_trackeditProject, trackMoved())
         .WillByDefault(Return(m_trackMoved));
 
@@ -237,9 +233,7 @@ public:
     muse::async::Notification m_projectChanged;
     muse::async::Notification m_navigationChanged;
     muse::async::Channel<std::vector<Track> > m_tracksChanged;
-    muse::async::Channel<Track> m_trackAdded;
-    muse::async::Channel<Track> m_trackRemoved;
-    muse::async::Channel<Track, int> m_trackInserted;
+    muse::async::Channel<TrackListChange> m_trackListChanged;
     muse::async::Channel<Track, int> m_trackMoved;
     muse::async::Channel<TrackId, bool> m_focusedTrackChanged;
     muse::async::Channel<TrackItemKey, bool> m_focusedItemChanged;
@@ -293,7 +287,7 @@ TEST_F(TrackNavigationModelTests, TrackAddedAppendsPanels)
     ASSERT_EQ(m_model->trackItemPanels().size(), 1);
 
     //! [WHEN] A second track is added
-    m_trackAdded.send(makeTrack(20));
+    m_trackListChanged.send(TrackListChange({ 10 }, { 10, 20 }));
 
     //! [THEN] Its panels are appended after the first track
     ASSERT_EQ(m_model->trackItemPanels().size(), 2);
@@ -312,7 +306,7 @@ TEST_F(TrackNavigationModelTests, TrackInsertedPlacesPanelsAtPosition)
     loadWithTracks({ makeTrack(10), makeTrack(20) });
 
     //! [WHEN] A track is inserted between them
-    m_trackInserted.send(makeTrack(15), 1);
+    m_trackListChanged.send(TrackListChange({ 10, 20 }, { 10, 15, 20 }));
 
     //! [THEN] The middle position holds the inserted track's panels
     ASSERT_EQ(m_model->trackItemPanels().size(), 3);
@@ -334,7 +328,7 @@ TEST_F(TrackNavigationModelTests, TrackRemovedRemovesTrackPanels)
     loadWithTracks({ makeTrack(10), makeTrack(20), makeTrack(30) });
 
     //! [WHEN] The middle track is removed
-    m_trackRemoved.send(makeTrack(20));
+    m_trackListChanged.send(TrackListChange({ 10, 20, 30 }, { 10, 30 }));
 
     //! [THEN] Only the remaining tracks keep their panels
     ASSERT_EQ(m_model->trackItemPanels().size(), 2);
@@ -547,13 +541,13 @@ TEST_F(TrackNavigationModelTests, DefaultNavigationControlFollowsTracksList)
     trackDefaultNavigationControl();
 
     //! [WHEN] The first track is removed
-    m_trackRemoved.send(makeTrack(10));
+    m_trackListChanged.send(TrackListChange({ 10, 20 }, { 20 }));
 
     //! [THEN] The default control is the control of the track that became first
     EXPECT_EQ(m_defaultNavigationControl, secondTrackControl);
 
     //! [WHEN] The last track is removed
-    m_trackRemoved.send(makeTrack(20));
+    m_trackListChanged.send(TrackListChange({ 20 }, {}));
 
     //! [THEN] The default control is the fallback one again
     EXPECT_EQ(m_defaultNavigationControl, fallbackControl);

--- a/src/trackedit/tracklistchange.h
+++ b/src/trackedit/tracklistchange.h
@@ -1,0 +1,61 @@
+/*
+* Audacity: A Digital Audio Editor
+*/
+#pragma once
+
+#include <algorithm>
+#include <iterator>
+#include <optional>
+
+#include "global/containers.h"
+
+#include "trackedittypes.h"
+
+namespace au::trackedit {
+class TrackListChange
+{
+public:
+    TrackListChange() = default;
+    TrackListChange(TrackIdList before, TrackIdList after)
+        : m_before(std::move(before)), m_after(std::move(after))
+    {
+    }
+
+    const TrackIdList& before() const { return m_before; }
+    const TrackIdList& after() const { return m_after; }
+
+    TrackIdList added() const { return difference(m_after, m_before); }
+    TrackIdList removed() const { return difference(m_before, m_after); }
+
+    bool wasRemoved(const TrackId& trackId) const
+    {
+        return muse::contains(m_before, trackId) && !muse::contains(m_after, trackId);
+    }
+
+    std::optional<size_t> indexAfter(const TrackId& trackId) const
+    {
+        const auto it = std::find(m_after.begin(), m_after.end(), trackId);
+        if (it == m_after.end()) {
+            return std::nullopt;
+        }
+        return static_cast<size_t>(std::distance(m_after.begin(), it));
+    }
+
+    bool hasChanges() const
+    {
+        return !added().empty() || !removed().empty();
+    }
+
+private:
+    static TrackIdList difference(const TrackIdList& lhs, const TrackIdList& rhs)
+    {
+        TrackIdList result;
+        std::copy_if(lhs.begin(), lhs.end(), std::back_inserter(result),
+                     [&rhs](const TrackId& trackId) { return !muse::contains(rhs, trackId); });
+        return result;
+    }
+
+    TrackIdList m_before;
+    TrackIdList m_after;
+};
+}

--- a/src/trackedit/tracklistchangeguard.h
+++ b/src/trackedit/tracklistchangeguard.h
@@ -1,0 +1,36 @@
+/*
+* Audacity: A Digital Audio Editor
+*/
+#pragma once
+
+#include "itrackeditproject.h"
+#include "tracklistchange.h"
+
+namespace au::trackedit {
+class TrackListChangeGuard
+{
+public:
+    explicit TrackListChangeGuard(ITrackeditProjectPtr project)
+        : m_project(std::move(project)), m_before(m_project ? m_project->trackIdList() : TrackIdList {})
+    {
+    }
+
+    ~TrackListChangeGuard()
+    {
+        if (!m_project) {
+            return;
+        }
+
+        m_project->notifyAboutTrackListChanged(TrackListChange(m_before, m_project->trackIdList()));
+    }
+
+    TrackListChangeGuard(const TrackListChangeGuard&) = delete;
+    TrackListChangeGuard& operator=(const TrackListChangeGuard&) = delete;
+    TrackListChangeGuard(TrackListChangeGuard&&) = delete;
+    TrackListChangeGuard& operator=(TrackListChangeGuard&&) = delete;
+
+private:
+    const ITrackeditProjectPtr m_project;
+    const TrackIdList m_before;
+};
+}

--- a/src/trackedit/view/tracknavigationmodel.cpp
+++ b/src/trackedit/view/tracknavigationmodel.cpp
@@ -141,30 +141,23 @@ void TrackNavigationModel::load()
         }
     });
 
-    prj->trackAdded().onReceive(this, [this](const Track& track) {
-        if (m_panels.isEmpty()) {
-            disableDefaultNavigation();
+    prj->trackListChanged().onReceive(this, [this](const TrackListChange& change) {
+        for (const TrackId& trackId : change.removed()) {
+            removePanels(trackId);
         }
-        addPanels(track.id, m_panels.size());
-        resetPanelOrder();
-    });
 
-    prj->trackRemoved().onReceive(this, [this](const Track& track) {
-        removePanels(track.id);
+        disableDefaultNavigation();
+
+        for (const TrackId& trackId : change.added()) {
+            const size_t pos = change.indexAfter(trackId).value_or(m_panels.size());
+            addPanels(trackId, static_cast<int>(pos));
+        }
 
         resetPanelOrder();
 
         if (m_panels.isEmpty()) {
             addDefaultNavigation();
         }
-    });
-
-    prj->trackInserted().onReceive(this, [this](const Track& track, int pos) {
-        if (m_panels.isEmpty()) {
-            disableDefaultNavigation();
-        }
-        addPanels(track.id, pos);
-        resetPanelOrder();
     });
 
     prj->trackMoved().onReceive(this, [this](const Track& track, int pos) {


### PR DESCRIPTION
Resolves: #11865

The issue on #11865 seems to a deadlock on the monitoring layer triggered by a fast change on the focused track.
TrackNavigationController::revalidateFocusedTrack focused in the first track if a focused track is removed.
After #11202 a different approach is done on au3tracksinteraction.cpp where the focus is modified to a nearest track.
In the problem on 11865, the focus changes to the first track and then to a nearby track.
This should be fixed by #11572 on release branch and possibly by #11571 on master.

Apart from that, a problem still remains: au3tracksinteraction.cpp should not be responsible to change focus, this should be part of tracknavigationcontroller code. Also, removing multiple tracks in a row can result the audio stream to start and stop multiple times in a row, without any need.

This PR propose to modify how these track notifications are sent. Instead of per track, the change is done per operation. If we remove multiple tracks in a row, the whole diff is sent on the notification. So each consumer can react accorndly, for example, stoping monitoring and start only when the last track is removed. Something like a db transaction.

I think this should evolve to add clip operations and label operation as well.

The PR adds the concept io a notification guard. The track list is save on construction and the notification with the diff is sent on destruction.

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
