### PR TITLE
Fixes #12093  Add libOpenGL.so.0 to fallback libraries

### DIFF
--- a/buildscripts/ci/linux/make_appimage.sh
+++ b/buildscripts/ci/linux/make_appimage.sh
@@ -213,6 +213,7 @@ additional_libraries=(
 # Report new additions at https://github.com/linuxdeploy/linuxdeploy/issues
 fallback_libraries=(
   libjack.so.0 # https://github.com/LMMS/lmms/pull/3958
+  libOpenGL.so.0 # https://bugreports.qt.io/browse/QTBUG-89754
 )
 
 # PREVIOUSLY EXTRACTED APPIMAGES


### PR DESCRIPTION
Fix from MuseScore

Resolves: #12093 

 Add libOpenGL.so.0 to fallback libraries

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
