### PR TITLE
Fix clip and label movement

### DIFF
--- a/au3/libraries/au3-realtime-effects/RealtimeEffectList.cpp
+++ b/au3/libraries/au3-realtime-effects/RealtimeEffectList.cpp
@@ -92,6 +92,11 @@ const RealtimeEffectList& RealtimeEffectList::Get(
     return Get(const_cast<ChannelGroup&>(group));
 }
 
+void RealtimeEffectList::ShareStates(ChannelGroup& group, const ChannelGroup& other)
+{
+    group.Attachments::Assign(channelGroupEffects, std::make_unique<RealtimeEffectList>(Get(other)));
+}
+
 bool
 RealtimeEffectList::AddState(std::shared_ptr<RealtimeEffectState> pState)
 {

--- a/au3/libraries/au3-realtime-effects/RealtimeEffectList.h
+++ b/au3/libraries/au3-realtime-effects/RealtimeEffectList.h
@@ -68,6 +68,7 @@ public:
 
     static RealtimeEffectList& Get(ChannelGroup& group);
     static const RealtimeEffectList& Get(const ChannelGroup& group);
+    static void ShareStates(ChannelGroup& group, const ChannelGroup& other);
 
     // Type that state visitor functions would have for out-of-line definition
     // of Visit

--- a/au3/libraries/au3-realtime-effects/RealtimeEffectState.cpp
+++ b/au3/libraries/au3-realtime-effects/RealtimeEffectState.cpp
@@ -381,8 +381,13 @@ RealtimeEffectState::~RealtimeEffectState()
 
 std::shared_ptr<RealtimeEffectState> RealtimeEffectState::Clone() const
 {
-    auto pNewState{ RealtimeEffectState::make_shared(GetID()) };
+    auto pNewState{ RealtimeEffectState::make_shared(PluginID {}) };
+    pNewState->mID = mID;
     pNewState->mPlugin = mPlugin;
+    if (mPlugin) {
+        pNewState->mOutputs = mPlugin->MakeOutputs();
+        pNewState->mMovedOutputs = mPlugin->MakeOutputs();
+    }
     pNewState->mMainSettings.Set(mMainSettings);
     return pNewState;
 }

--- a/au3/libraries/au3-realtime-effects/RealtimeEffectState.cpp
+++ b/au3/libraries/au3-realtime-effects/RealtimeEffectState.cpp
@@ -947,7 +947,6 @@ std::shared_ptr<EffectSettingsAccess> RealtimeEffectState::GetAccess()
     // Only the main thread assigns to the atomic pointer, here and
     // once only in the lifetime of the state
     if (!GetAccessState()) {
-        MakeInstance();
         mpAccessState.emplace(*mPlugin, *this);
     }
 

--- a/au3/libraries/au3-realtime-effects/RealtimeEffectState.h
+++ b/au3/libraries/au3-realtime-effects/RealtimeEffectState.h
@@ -73,6 +73,8 @@ public:
      */
     std::shared_ptr<EffectInstance> GetInstance();
 
+    std::shared_ptr<EffectInstance> PeekInstance() const { return mwInstance.lock(); }
+
     //! Get locations that a GUI can connect meters to
     const EffectOutputs* GetOutputs() const { return mMovedOutputs.get(); }
 

--- a/au3/libraries/au3-track/CMakeLists.txt
+++ b/au3/libraries/au3-track/CMakeLists.txt
@@ -44,6 +44,7 @@ PRIVATE
    au3-exceptions
    au3-project
    au3-project-history
+   au3-realtime-effects
    au3-strings
    wxBase
 )

--- a/au3/libraries/au3-track/UndoTracks.cpp
+++ b/au3/libraries/au3-track/UndoTracks.cpp
@@ -11,6 +11,7 @@
 #include "PendingTracks.h"
 #include "Track.h"
 #include "au3-project-history/UndoManager.h"
+#include "au3-realtime-effects/RealtimeEffectList.h"
 
 // Undo/redo handling of selection changes
 namespace {
@@ -18,6 +19,11 @@ struct TrackListRestorer final : UndoStateExtension {
     TrackListRestorer(AudacityProject& project)
         : mpTracks{TrackList::Get(project).Duplicate()}
     {
+        // Effect settings are captured separately by RealtimeEffectRestorer.
+        const auto& tracks = TrackList::Get(project);
+        for (auto pTrack : *mpTracks) {
+            RealtimeEffectList::ShareStates(*pTrack, *tracks.FindById(pTrack->GetId()));
+        }
     }
 
     void RestoreUndoRedoState(AudacityProject& project) override
@@ -28,9 +34,9 @@ struct TrackListRestorer final : UndoStateExtension {
         constexpr auto sendEvent = true;
         dstTracks.Clear(sendEvent);
         for (auto pTrack : *mpTracks) {
-            dstTracks.Add(
-                pTrack->Duplicate(Track::DuplicateOptions {}.Backup()),
-                TrackList::DoAssignId::No, synchrony);
+            auto restored = pTrack->Duplicate(Track::DuplicateOptions {}.Backup());
+            RealtimeEffectList::ShareStates(*restored, *pTrack);
+            dstTracks.Add(std::move(restored), TrackList::DoAssignId::No, synchrony);
         }
         dstTracks.EndUndoRedo(synchrony);
     }

--- a/src/effects/effects_base/internal/abstractviewlauncher.cpp
+++ b/src/effects/effects_base/internal/abstractviewlauncher.cpp
@@ -49,9 +49,8 @@ void AbstractViewLauncher::hideRealtimeEffect(const RealtimeEffectStatePtr& stat
     IF_ASSERT_FAILED(state) {
         return;
     }
-    const auto instance = std::dynamic_pointer_cast<effects::EffectInstance>(state->GetInstance());
+    const auto instance = std::dynamic_pointer_cast<effects::EffectInstance>(state->PeekInstance());
     if (!instance) {
-        LOGW() << "Could not get instance for " << state->GetID().ToStdString();
         return;
     }
     const auto instanceId = instance->id();

--- a/src/effects/effects_base/internal/realtimeeffectservice.cpp
+++ b/src/effects/effects_base/internal/realtimeeffectservice.cpp
@@ -150,7 +150,10 @@ void RealtimeEffectService::onTrackListEvent(const TrackListEvent& e)
         IF_ASSERT_FAILED(e.mId.has_value()) {
             return;
         }
-        unregisterRealtimeEffectList(*e.mId);
+        // Track is being replaced, keep the effect list
+        if (e.mExtra != 1) {
+            unregisterRealtimeEffectList(*e.mId);
+        }
     }
     break;
     case TrackListEvent::UNDO_REDO_BEGIN:

--- a/src/project/tests/mocks/dummyeffectinstancefactory.h
+++ b/src/project/tests/mocks/dummyeffectinstancefactory.h
@@ -11,7 +11,7 @@ namespace au::project {
 // needed: serialization only writes the plugin id, and the state is retained on
 // reload regardless. All methods return trivial/empty values; MakeInstance() is
 // never called in this no-playback test.
-class DummyEffectInstanceFactory final : public EffectInstanceFactory
+class DummyEffectInstanceFactory : public EffectInstanceFactory
 {
 public:
     // ComponentInterface

--- a/src/projectscene/CMakeLists.txt
+++ b/src/projectscene/CMakeLists.txt
@@ -134,6 +134,8 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/view/tracksitemsview/viewtrackitem.h
     ${CMAKE_CURRENT_LIST_DIR}/view/tracksitemsview/trackitemslistmodel.cpp
     ${CMAKE_CURRENT_LIST_DIR}/view/tracksitemsview/trackitemslistmodel.h
+    ${CMAKE_CURRENT_LIST_DIR}/view/tracksitemsview/trackitemsmovecontroller.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/view/tracksitemsview/trackitemsmovecontroller.h
     ${CMAKE_CURRENT_LIST_DIR}/view/tracksitemsview/trackclipslistmodel.cpp
     ${CMAKE_CURRENT_LIST_DIR}/view/tracksitemsview/trackclipslistmodel.h
     ${CMAKE_CURRENT_LIST_DIR}/view/tracksitemsview/trackclipitem.cpp

--- a/src/projectscene/internal/projectviewstate.cpp
+++ b/src/projectscene/internal/projectviewstate.cpp
@@ -1069,7 +1069,7 @@ void ProjectViewState::updateItemsBoundaries(bool excludeCurrentSelection, const
     for (const auto& trackId : prj->trackIdList()) {
         // Add clips boundaries
         for (const auto& clip : prj->clipList(trackId)) {
-            if (excludeCurrentSelection && muse::contains(selectedClips, clip.key)) {
+            if ((excludeCurrentSelection || m_moveInitiated) && muse::contains(selectedClips, clip.key)) {
                 continue;
             }
 
@@ -1083,7 +1083,7 @@ void ProjectViewState::updateItemsBoundaries(bool excludeCurrentSelection, const
 
         // Add labels boundaries
         for (const auto& label : prj->labelList(trackId)) {
-            if (excludeCurrentSelection && muse::contains(selectedLabels, label.key)) {
+            if ((excludeCurrentSelection || m_moveInitiated) && muse::contains(selectedLabels, label.key)) {
                 continue;
             }
 

--- a/src/projectscene/projectscenemodule.cpp
+++ b/src/projectscene/projectscenemodule.cpp
@@ -39,6 +39,7 @@
 
 #include "view/tracksitemsview/viewtrackslistmodel.h"
 #include "view/tracksitemsview/trackclipslistmodel.h"
+#include "view/tracksitemsview/trackitemsmovecontroller.h"
 #include "view/tracksitemsview/trackclipitem.h"
 #include "view/tracksitemsview/tracklabelslistmodel.h"
 #include "view/tracksitemsview/tracklabelslayoutmanager.h"
@@ -172,6 +173,7 @@ void ProjectSceneModule::registerUiTypes()
 
     // clips view
     qmlRegisterType<ViewTracksListModel>("Audacity.ProjectScene", 1, 0, "ViewTracksListModel");
+    qmlRegisterType<TrackItemsMoveController>("Audacity.ProjectScene", 1, 0, "TrackItemsMoveController");
     qmlRegisterType<TrackClipsListModel>("Audacity.ProjectScene", 1, 0, "TrackClipsListModel");
     qmlRegisterUncreatableType<TrackClipItem>("Audacity.ProjectScene", 1, 0, "TrackClipItem", "Not creatable from QML");
     qmlRegisterType<MouseHelper>("Audacity.ProjectScene", 1, 0, "MouseHelper");

--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/ClipItem.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/ClipItem.qml
@@ -972,8 +972,10 @@ Rectangle {
 
                     defaultValue: clipGainModel.defaultValue
 
-                    xRangeFrom: waveView.itemStartTime
-                    xRangeTo: waveView.itemEndTime
+                    // Offset the envelope display to follow the drag preview while its point times remain unchanged.
+                    readonly property real timeOffset: waveView.startTime - clipGainModel.clipStartTime
+                    xRangeFrom: waveView.itemStartTime - timeOffset
+                    xRangeTo: waveView.itemEndTime - timeOffset
 
                     yRangeFrom: clipGainModel.minValue
                     yRangeTo: clipGainModel.maxValue

--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TrackClipsContainer.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TrackClipsContainer.qml
@@ -42,6 +42,7 @@ TrackItemsContainer {
 
     TrackClipsListModel {
         id: clipsModel
+        moveController: root.moveController
         trackId: root.trackId
         context: root.context
     }
@@ -307,6 +308,9 @@ TrackItemsContainer {
                         height: parent.height
                         width: Math.max(3, itemData.width)
                         x: itemData.x
+
+                        visible: !itemData.dragged
+                        enabled: !itemData.dragged && !itemData.isDragGhost
 
                         asynchronous: false
 
@@ -740,30 +744,6 @@ TrackItemsContainer {
     Connections {
         target: root.container
 
-        function onItemMoveRequested(itemKey, completed) {
-            // this one notifies every ClipListModel about mouseMoveActive
-            root.updateMouseMoveActive(completed);
-
-            // this one moves the clips
-            let clipMovedToOtherTrack = clipsModel.moveSelectedClips(itemKey, completed);
-
-            // clip might change its' track, we need to update grabbed itemKey
-            if (clipMovedToOtherTrack) {
-                itemKey = clipsModel.updateClipTrack(itemKey)
-                setHoveredItemKey(clipsModel.updateClipTrack(itemKey))
-            }
-
-            handleClipGuideline(itemKey, Direction.Auto, completed)
-        }
-
-        function onItemStartEditRequested(itemKey) {
-            clipsModel.startEditItem(itemKey)
-        }
-
-        function onItemEndEditRequested(itemKey) {
-            clipsModel.endEditItem(itemKey)
-        }
-
         function onItemReleaseRequested(itemKey) {
             clipsModel.handleClipRelease(itemKey)
         }
@@ -784,9 +764,6 @@ TrackItemsContainer {
     }
 
     function handleClipGuideline(clipKey, direction, completed) {
-        // itemMoveRequested is broadcast to every track's container, but the guideline is
-        // shared across all of them. Only the container that owns the dragged clip may touch
-        // it, otherwise non-owners clobber the owning track's guideline.
         if (clipsModel.containsItem(clipKey)) {
             if (completed) {
                 root.clearItemGuideline()

--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TrackItemsContainer.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TrackItemsContainer.qml
@@ -22,6 +22,7 @@ Item {
     property bool isTrackFocused: false
     property bool isMultiSelectionActive: false
     property bool isTrackAudible: true
+    property TrackItemsMoveController moveController: null
     property bool moveActive: false
     property bool altPressed: false
     property bool ctrlPressed: false
@@ -51,8 +52,6 @@ Item {
     signal selectionResetRequested
     signal requestSelectionContextMenu(real x, real y)
     signal selectionResize(var x1, var x2, var completed)
-
-    signal updateMouseMoveActive(bool completed)
 
     signal insureVerticallyVisible
 

--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TrackLabelsContainer.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TrackLabelsContainer.qml
@@ -10,6 +10,7 @@ TrackItemsContainer {
 
     TrackLabelsListModel {
         id: labelsModel
+        moveController: root.moveController
         trackId: root.trackId
         context: root.context
     }
@@ -179,6 +180,9 @@ TrackItemsContainer {
                             z: Boolean(itemData) && itemData.isEditing ? 1000 : itemData.level
 
                             asynchronous: true
+
+                            active: !itemData.dragged
+                            enabled: !itemData.isDragGhost
 
                             visible: y < root.height
 
@@ -410,22 +414,6 @@ TrackItemsContainer {
 
     Connections {
         target: root.container
-
-        function onItemMoveRequested(itemKey, completed) {
-            root.updateMouseMoveActive(completed)
-
-            labelsModel.moveSelectedLabels(itemKey, completed)
-
-            handleLabelGuideline(itemKey, Direction.Auto, completed)
-        }
-
-        function onItemStartEditRequested(itemKey) {
-            labelsModel.startEditItem(itemKey)
-        }
-
-        function onItemEndEditRequested(itemKey) {
-            labelsModel.endEditItem(itemKey)
-        }
 
         function onItemReleaseRequested(itemKey) {
             labelsModel.toggleTracksDataSelectionByLabel(itemKey)

--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TracksItemsView.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TracksItemsView.qml
@@ -57,12 +57,14 @@ Rectangle {
 
     clip: true
 
-    enum State {
-        Idle,
-        DraggingItem
-    }
+    TrackItemsMoveController {
+        id: itemsMoveController
+        context: timeline.context
 
-    property int interactionState: TracksItemsView.State.Idle
+        onGuidelineChanged: function (time) {
+            root.updateGuidelineAtTime(time)
+        }
+    }
 
     MouseHelper {
         id: mouseHelper
@@ -80,6 +82,13 @@ Rectangle {
                 // This will lead to a cancel signal on `mainMouseArea` that will call back into this function,
                 // but this time in released state.
                 mouseHelper.callUngrabMouseOnItem(mainMouseArea)
+                return
+            }
+            if (itemsMoveController.cancel()) {
+                root.hoveredItemKey = null
+                root.itemHeaderHovered = false
+                tracksItemsView.mouseMoveActive = false
+                timeline.context.updateSelectedItemTime()
                 return
             }
             if (root.hoveredItemKey) {
@@ -567,8 +576,7 @@ Rectangle {
 
                 if (e.button === Qt.LeftButton) {
                     if (root.itemHeaderHovered && !(splitToolController.active && splitToolController.hoveredTrackSplittable)) {
-                        tracksItemsView.itemStartEditRequested(hoveredItemKey)
-                        root.interactionState = TracksItemsView.State.DraggingItem
+                        itemsMoveController.start(hoveredItemKey)
                         lastItemClickKey = root.hoveredItemKey
                     } else {
                         content.forceActiveFocus()
@@ -609,7 +617,7 @@ Rectangle {
                 splitToolController.mouseMove(e.x)
                 playCursorController.updateSeekGesture(e.x, e.y)
 
-                if (root.interactionState === TracksItemsView.State.DraggingItem && !itemWasMoved) {
+                if (itemsMoveController.active && !itemWasMoved) {
                     var dx = Math.abs(e.x - pressStartPosition.x)
                     var dy = Math.abs(e.y - pressStartPosition.y)
                     if (dx > moveThreshold || dy > moveThreshold) {
@@ -617,12 +625,12 @@ Rectangle {
                     }
                 }
 
-                if (root.interactionState === TracksItemsView.State.DraggingItem && itemWasMoved) {
-                    tracksItemsView.itemMoveRequested(hoveredItemKey, false)
+                if (itemsMoveController.active && itemWasMoved) {
+                    tracksItemsView.mouseMoveActive = true
+                    itemsMoveController.update()
                     tracksItemsView.startAutoScroll()
                 } else {
                     selectionViewController.onPositionChanged(timeline.context.positionToTime(e.x), e.y)
-                    let trackId = tracksViewState.trackAtPosition(e.x, e.y)
 
                     snapGuidelineToPosition(e.x)
                 }
@@ -635,16 +643,12 @@ Rectangle {
 
                 if (!itemWasMoved) {
                     tracksItemsView.itemReleaseRequested(hoveredItemKey)
-                    itemWasMoved = false
                 }
 
-                if (root.interactionState === TracksItemsView.State.DraggingItem) {
-                    root.interactionState = TracksItemsView.State.Idle
-                    if (itemWasMoved) {
-                        tracksItemsView.itemMoveRequested(hoveredItemKey, true)
-                        tracksItemsView.stopAutoScroll()
-                    }
-                    tracksItemsView.itemEndEditRequested(hoveredItemKey)
+                if (itemsMoveController.active) {
+                    root.hoveredItemKey = itemsMoveController.finish()
+                    tracksItemsView.mouseMoveActive = false
+                    tracksItemsView.stopAutoScroll()
                 } else {
                     splitToolController.mouseUp(e.x)
 
@@ -668,7 +672,6 @@ Rectangle {
             }
 
             onCanceled: e => {
-                root.interactionState = TracksItemsView.State.Idle
                 playCursorController.cancelSeekGesture()
                 prv.cancelItemDragEdit()
             }
@@ -709,7 +712,7 @@ Rectangle {
         HoverHandler {
             id: emptyAreaGuidelineHandler
 
-            enabled: root.interactionState !== TracksItemsView.State.DraggingItem
+            enabled: !itemsMoveController.active
 
             function processHover() {
                 let pos = point.position
@@ -822,9 +825,6 @@ Rectangle {
                     tracksViewState.insureVerticallyVisible(tracksItemsView.contentY + prv.listHeaderHeight, tracksItemsView.height, itemViewY + prv.listHeaderHeight, item.height)
                 }
 
-                signal itemMoveRequested(var itemKey, bool completed)
-                signal itemStartEditRequested(var itemKey)
-                signal itemEndEditRequested(var itemKey)
                 signal itemReleaseRequested(var itemKey)
                 signal cancelItemDragEditRequested(var itemKey)
                 signal startAutoScroll
@@ -853,6 +853,9 @@ Rectangle {
                     } else {
                         tracksViewState.changeTracksVerticalOffset(tracksItemsView.contentY + prv.listHeaderHeight)
                         timeline.context.startVerticalScrollPosition = tracksItemsView.contentY
+                        if (tracksItemsView.mouseMoveActive) {
+                            itemsMoveController.update()
+                        }
                     }
                 }
 
@@ -911,6 +914,7 @@ Rectangle {
 
                             context: timeline.context
 
+                            moveController: itemsMoveController
                             container: tracksItemsView
                             canvas: content
 
@@ -993,13 +997,6 @@ Rectangle {
 
                             onSelectionResetRequested: {
                                 selectionViewController.resetDataSelection()
-                            }
-
-                            onUpdateMouseMoveActive: function (completed) {
-                                if (tracksItemsView.mouseMoveActive !== completed) {
-                                    return
-                                }
-                                tracksItemsView.mouseMoveActive = !completed
                             }
 
                             onRequestSelectionContextMenu: function (x, y) {
@@ -1112,6 +1109,7 @@ Rectangle {
                             width: trackItemLoader.width
 
                             context: timeline.context
+                            moveController: itemsMoveController
                             container: tracksItemsView
                             canvas: content
                             canvasIndentWidth: content.anchors.leftMargin
@@ -1193,13 +1191,6 @@ Rectangle {
 
                             onSelectionResetRequested: {
                                 selectionViewController.resetDataSelection()
-                            }
-
-                            onUpdateMouseMoveActive: function (completed) {
-                                if (tracksItemsView.mouseMoveActive !== completed) {
-                                    return
-                                }
-                                tracksItemsView.mouseMoveActive = !completed
                             }
 
                             onUpdateItemGuideline: function (time) {

--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TracksItemsView.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/TracksItemsView.qml
@@ -64,6 +64,11 @@ Rectangle {
         onGuidelineChanged: function (time) {
             root.updateGuidelineAtTime(time)
         }
+
+        onKeyboardTrackChanged: function (trackId) {
+            const trackY = tracksViewState.trackVerticalPosition(trackId) + tracksViewState.tracksVerticalOffset
+            tracksViewState.insureVerticallyVisible(tracksViewState.tracksVerticalOffset, tracksItemsView.height, trackY, tracksViewState.trackHeight(trackId))
+        }
     }
 
     MouseHelper {
@@ -236,6 +241,7 @@ Rectangle {
         playCursorController.init()
         playPositionActionController.init()
         tracksViewState.init()
+        itemsMoveController.init()
         project.init();
 
         //! NOTE Loading tracks, or rather clips, is the most havy operation.
@@ -570,6 +576,9 @@ Rectangle {
             }
 
             onPressed: function (e) {
+                if (itemsMoveController.keyboardActive) {
+                    itemsMoveController.finish()
+                }
                 if (root.altPressed) {
                     return
                 }
@@ -614,6 +623,9 @@ Rectangle {
 
             onPositionChanged: function (e) {
                 timeline.updateCursorPosition(e.x, e.y)
+                if (itemsMoveController.keyboardActive) {
+                    return
+                }
                 splitToolController.mouseMove(e.x)
                 playCursorController.updateSeekGesture(e.x, e.y)
 
@@ -637,7 +649,7 @@ Rectangle {
             }
 
             onReleased: function (e) {
-                if (e.button !== Qt.LeftButton) {
+                if (e.button !== Qt.LeftButton || itemsMoveController.keyboardActive) {
                     return
                 }
 

--- a/src/projectscene/tests/CMakeLists.txt
+++ b/src/projectscene/tests/CMakeLists.txt
@@ -11,6 +11,7 @@ set(MODULE_TEST_SRC
     ${CMAKE_CURRENT_LIST_DIR}/snaptimeformatter_tests.cpp
     ${CMAKE_CURRENT_LIST_DIR}/tracklabelslayoutmanager_tests.cpp
     ${CMAKE_CURRENT_LIST_DIR}/trackitemsselection_tests.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/trackitemsmovecontroller_tests.cpp
     ${CMAKE_CURRENT_LIST_DIR}/findguideline_tests.cpp
     ${CMAKE_CURRENT_LIST_DIR}/playcursorcontroller_tests.cpp
     ${CMAKE_CURRENT_LIST_DIR}/playpositionactioncontroller_tests.cpp

--- a/src/projectscene/tests/trackitemsmovecontroller_tests.cpp
+++ b/src/projectscene/tests/trackitemsmovecontroller_tests.cpp
@@ -4,10 +4,15 @@
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 
+#include <QCoreApplication>
+
+#include "global/async/async.h"
 #include "projectscene/view/tracksitemsview/trackitemsmovecontroller.h"
 #include "projectscene/view/tracksitemsview/tracklabelslistmodel.h"
 #include "projectscene/internal/projectviewstate.h"
 #include "trackedit/internal/au3/au3tracksinteraction.h"
+#include "trackedit/internal/tracksviewrequestsservice.h"
+#include "trackedit/tests/mocks/tracknavigationcontrollermock.h"
 #include "trackedit/tests/mocks/trackeditprojectmock.h"
 #include "trackedit/tests/mocks/trackeditinteractionmock.h"
 #include "trackedit/tests/mocks/selectioncontrollermock.h"
@@ -78,6 +83,11 @@ protected:
         m_viewState = std::make_shared<DragViewState>(m_tracks);
         m_playback = std::make_shared<NiceMock<playback::PlaybackMock> >();
         m_audioOutput = std::make_shared<NiceMock<playback::AudioOutputMock> >();
+        m_navigation = std::make_shared<NiceMock<trackedit::TrackNavigationControllerMock> >();
+        m_requests = std::make_shared<trackedit::TracksViewRequestsService>(muse::modularity::globalCtx());
+
+        ON_CALL(*m_navigation, focusedItem()).WillByDefault([this] { return m_focusedItem; });
+        ON_CALL(*m_history, historyChanged()).WillByDefault(Return(m_historyChanged));
 
         ON_CALL(*m_globalContext, currentProject()).WillByDefault(Return(m_project));
         ON_CALL(*m_globalContext, currentTrackeditProject()).WillByDefault(Return(m_trackeditProject));
@@ -104,7 +114,7 @@ protected:
             return key == m_clip.key ? m_clip : trackedit::Clip {};
         });
         ON_CALL(*m_trackeditProject, labelList(_)).WillByDefault([this](trackedit::TrackId id) {
-            muse::async::NotifyList<trackedit::Label> labels;
+            muse::async::NotifyList<trackedit::Label> labels(std::make_shared<muse::async::ChangedNotify<trackedit::Label> >());
             if (id == m_label.key.trackId) {
                 labels.push_back(m_label);
             }
@@ -119,7 +129,10 @@ protected:
         m_controller->trackeditInteraction.set(m_interaction);
         m_controller->tracksInteraction.set(m_tracksInteraction);
         m_controller->projectHistory.set(m_history);
+        m_controller->trackNavigationController.set(m_navigation);
+        m_controller->tracksViewRequestsService.set(m_requests);
         m_controller->setTimelineContext(m_context.get());
+        m_controller->init();
     }
 
     void TearDown() override
@@ -157,16 +170,24 @@ protected:
     std::unique_ptr<DragLabelsModel> labelModel(trackedit::TrackId track)
     {
         auto model = std::make_unique<DragLabelsModel>(m_globalContext, m_selection);
-        model->setTrackId(QVariant::fromValue(track));
-        model->setTimelineContext(m_context.get());
-        model->setMoveController(m_controller.get());
-        model->reload();
+        initLabelModel(*model, track);
         return model;
+    }
+
+    void initLabelModel(DragLabelsModel& model, trackedit::TrackId track)
+    {
+        model.tracksViewRequestsService.set(m_requests);
+        model.setTrackId(QVariant::fromValue(track));
+        model.setTimelineContext(m_context.get());
+        model.setMoveController(m_controller.get());
+        model.reload();
     }
 
     void expectFinished()
     {
         EXPECT_FALSE(m_controller->active());
+        EXPECT_FALSE(m_controller->keyboardActive());
+        EXPECT_FALSE(m_viewState->keyboardMoveActive().val);
         EXPECT_FALSE(m_controller->isDragged(m_label.key));
         EXPECT_FALSE(m_viewState->moveInitiated());
         EXPECT_DOUBLE_EQ(m_viewState->itemEditStartTimeOffset(), -1.0);
@@ -178,6 +199,10 @@ protected:
     trackedit::Clip m_clip;
     trackedit::LabelKeyList m_selectedLabels;
     trackedit::ClipKeyList m_selectedClips;
+    trackedit::TrackItemKey m_focusedItem;
+    muse::async::Channel<trackedit::HistoryEvent> m_historyChanged;
+    std::shared_ptr<NiceMock<trackedit::TrackNavigationControllerMock> > m_navigation;
+    std::shared_ptr<trackedit::TracksViewRequestsService> m_requests;
     std::shared_ptr<NiceMock<context::GlobalContextMock> > m_globalContext;
     std::shared_ptr<NiceMock<project::AudacityProjectMock> > m_project;
     std::shared_ptr<NiceMock<trackedit::TrackeditProjectMock> > m_trackeditProject;
@@ -342,6 +367,223 @@ TEST_F(TrackItemsMoveControllerTests, LabelPreviewsClampIndividuallyAtBoundaryTr
         m_controller->finish();
         expectFinished();
     }
+}
+
+TEST_F(TrackItemsMoveControllerTests, KeyboardRepeatsPreviewOriginalItemsUntilModifiersAreReleased)
+{
+    selectClip();
+    m_tracks.push_back({ 3, {}, trackedit::TrackType::Mono });
+    m_focusedItem = m_clip.key;
+    const auto original = m_selectedClips;
+    EXPECT_CALL(*m_history, startUserInteraction()).Times(1);
+    EXPECT_CALL(*m_history, endUserInteraction(false)).Times(1);
+    EXPECT_CALL(*m_navigation, focusedItem()).Times(1);
+
+    m_requests->requestItemMove(0.0, 1);
+    EXPECT_TRUE(m_controller->keyboardActive());
+    EXPECT_TRUE(m_viewState->keyboardMoveActive().val);
+    EXPECT_EQ(m_controller->itemsOnTrack(2), original);
+
+    m_focusedItem = { 2, trackedit::INVALID_TRACK_ITEM };
+    m_selectedClips = { { 2, 20 } };
+    for (int i = 0; i < 20; ++i) {
+        m_requests->requestItemMove(0.0, 1);
+        EXPECT_EQ(m_controller->itemsOnTrack(3), original);
+        m_requests->requestItemMove(0.0, -1);
+        EXPECT_EQ(m_controller->itemsOnTrack(2), original);
+    }
+    m_requests->requestItemMove(0.25, 0);
+    m_requests->requestItemMove(0.25, 0);
+    movePointer(100.0, 50.0);
+    m_controller->update();
+    EXPECT_DOUBLE_EQ(m_controller->timeOffset(), 0.5);
+    EXPECT_EQ(m_controller->itemsOnTrack(2), original);
+
+    const trackedit::ClipKeyList moved { { 2, 20 } };
+    EXPECT_CALL(*m_interaction, moveClips(original, trackedit::secs_t(0.5), 1, true, _))
+    .WillOnce(Return(muse::RetVal<trackedit::ClipKeyList>::make_ok(moved)));
+    EXPECT_CALL(*m_selection, setSelectedClips(original, false));
+    EXPECT_CALL(*m_selection, setSelectedClips(moved, true));
+    EXPECT_CALL(*m_navigation, setFocusedItem(moved.front(), true));
+    m_viewState->modifiersReleased().notify();
+    expectFinished();
+    m_viewState->modifiersReleased().notify();
+}
+
+TEST_F(TrackItemsMoveControllerTests, ReusedTrackModelDoesNotRunOldGhostCleanup)
+{
+    selectLabel();
+    std::optional<DragLabelsModel> destination;
+    destination.emplace(m_globalContext, m_selection);
+    initLabelModel(*destination, 2);
+    m_requests->requestItemMove(0.0, 1);
+    ASSERT_EQ(destination->rowCount({}), 1);
+    QPointer<ViewTrackItem> ghost = destination->data(destination->index(0), Qt::UserRole + 1).value<ViewTrackItem*>();
+    ASSERT_NE(ghost, nullptr);
+
+    m_requests->requestItemMove(0.0, -1);
+    ASSERT_EQ(destination->rowCount({}), 0);
+    EXPECT_FALSE(ghost.isNull());
+    const auto address = &*destination;
+    destination.reset();
+    EXPECT_TRUE(ghost.isNull());
+
+    destination.emplace(m_globalContext, m_selection);
+    ASSERT_EQ(&*destination, address);
+    initLabelModel(*destination, 2);
+    muse::async::Async::call(&*destination, [] {});
+    kors::async::QueuePool::instance()->processMessages();
+    QCoreApplication::sendPostedEvents(nullptr, QEvent::DeferredDelete);
+    EXPECT_EQ(destination->rowCount({}), 0);
+    m_controller->cancel();
+}
+
+TEST_F(TrackItemsMoveControllerTests, RepeatedKeyboardPreviewsDeleteOnlyRetiredGhosts)
+{
+    selectLabel();
+    auto destination = labelModel(2);
+    QList<QPointer<ViewTrackItem> > retired;
+    for (int i = 0; i < 100; ++i) {
+        m_requests->requestItemMove(0.0, 1);
+        ASSERT_EQ(destination->rowCount({}), 1);
+        QPointer<ViewTrackItem> ghost = destination->data(destination->index(0), Qt::UserRole + 1).value<ViewTrackItem*>();
+        ASSERT_NE(ghost, nullptr);
+        retired.append(ghost);
+        m_requests->requestItemMove(0.0, -1);
+        EXPECT_FALSE(ghost.isNull());
+    }
+    m_requests->requestItemMove(0.0, 1);
+    QPointer<ViewTrackItem> current = destination->data(destination->index(0), Qt::UserRole + 1).value<ViewTrackItem*>();
+    ASSERT_NE(current, nullptr);
+
+    kors::async::QueuePool::instance()->processMessages();
+    QCoreApplication::sendPostedEvents(nullptr, QEvent::DeferredDelete);
+    for (const auto& ghost : retired) {
+        EXPECT_TRUE(ghost.isNull());
+    }
+    EXPECT_FALSE(current.isNull());
+    EXPECT_EQ(destination->rowCount({}), 1);
+    m_controller->cancel();
+}
+
+TEST_F(TrackItemsMoveControllerTests, KeyboardMovesUnselectedFocusedItemEvenWithTimeSelection)
+{
+    selectLabel();
+    m_focusedItem = m_label.key;
+    m_selectedLabels.clear();
+    ON_CALL(*m_selection, timeSelectionIsEmpty()).WillByDefault(Return(false));
+    m_requests->requestItemMove(0.5, 1);
+    const trackedit::LabelKeyList original { m_label.key };
+    EXPECT_EQ(m_controller->itemsOnTrack(2), original);
+    EXPECT_TRUE(m_controller->isDragged(m_label.key));
+
+    const trackedit::LabelKeyList moved { { 2, 10 } };
+    EXPECT_CALL(*m_interaction, moveLabels(original, trackedit::secs_t(0.5), 1, true))
+    .WillOnce(Return(muse::RetVal<trackedit::LabelKeyList>::make_ok(moved)));
+    EXPECT_CALL(*m_navigation, setFocusedItem(moved.front(), true));
+    m_viewState->modifiersReleased().notify();
+    expectFinished();
+}
+
+TEST_F(TrackItemsMoveControllerTests, KeyboardIgnoresStaleFocusAndSelectionKeys)
+{
+    selectClip();
+    m_focusedItem = { 2, m_clip.key.itemId };
+    m_selectedClips.push_back(m_focusedItem);
+    m_requests->requestItemMove(0.5, 0);
+
+    const trackedit::ClipKeyList original { m_clip.key };
+    EXPECT_EQ(m_controller->itemsOnTrack(1), original);
+    EXPECT_CALL(*m_interaction, moveClips(original, trackedit::secs_t(0.5), 0, true, _))
+    .WillOnce(Return(muse::RetVal<trackedit::ClipKeyList>::make_ok(original)));
+    m_viewState->modifiersReleased().notify();
+    expectFinished();
+}
+
+TEST_F(TrackItemsMoveControllerTests, KeyboardCreatesPreviewTracksAndCanCancel)
+{
+    selectClip();
+    EXPECT_CALL(*m_tracksInteraction, addWaveTrack(1)).Times(2).WillRepeatedly([this](int) {
+        m_tracks.push_back({ 3, {}, trackedit::TrackType::Mono });
+        return 3;
+    });
+    EXPECT_CALL(*m_tracksInteraction, removeDragAddedTracks(2, true)).Times(2).WillRepeatedly([this](size_t count, bool) {
+        m_tracks.resize(count);
+    });
+
+    m_requests->requestItemMove(0.0, 1);
+    EXPECT_EQ(m_controller->itemsOnTrack(2), m_selectedClips);
+    m_requests->requestItemMove(0.0, 1);
+    EXPECT_EQ(m_controller->itemsOnTrack(3), m_selectedClips);
+    EXPECT_EQ(m_tracks.size(), 3u);
+
+    m_requests->requestItemMove(0.0, -1);
+    EXPECT_EQ(m_controller->itemsOnTrack(2), m_selectedClips);
+    EXPECT_EQ(m_tracks.size(), 2u);
+
+    m_requests->requestItemMove(0.0, 1);
+    EXPECT_EQ(m_controller->itemsOnTrack(3), m_selectedClips);
+    EXPECT_EQ(m_tracks.size(), 3u);
+    EXPECT_TRUE(m_controller->cancel());
+    EXPECT_EQ(m_tracks.size(), 2u);
+    m_viewState->modifiersReleased().notify();
+    expectFinished();
+}
+
+TEST_F(TrackItemsMoveControllerTests, KeyboardCanReverseImmediatelyAtLabelTrackAndTimeBoundaries)
+{
+    selectLabel();
+    m_requests->requestItemMove(-20.0, -1);
+    EXPECT_DOUBLE_EQ(m_controller->timeOffset(), -10.0);
+    EXPECT_EQ(m_controller->itemsOnTrack(1), m_selectedLabels);
+    m_requests->requestItemMove(1.0, 1);
+    EXPECT_DOUBLE_EQ(m_controller->timeOffset(), -9.0);
+    EXPECT_EQ(m_controller->itemsOnTrack(2), m_selectedLabels);
+    m_requests->requestItemMove(0.0, 1);
+    m_requests->requestItemMove(0.0, -1);
+    EXPECT_EQ(m_controller->itemsOnTrack(1), m_selectedLabels);
+    m_controller->cancel();
+}
+
+TEST_F(TrackItemsMoveControllerTests, HistoryChangeCancelsKeyboardPreview)
+{
+    selectClip();
+    m_requests->requestItemMove(0.5, 1);
+    EXPECT_CALL(*m_tracksInteraction, removeDragAddedTracks(_, _)).Times(0);
+    m_historyChanged.send(trackedit::HistoryEvent::RestoredState);
+    m_viewState->modifiersReleased().notify();
+    expectFinished();
+}
+
+TEST_F(TrackItemsMoveControllerTests, KeyboardReturnToStartDoesNotCommit)
+{
+    selectClip();
+    m_requests->requestItemMove(0.5, 1);
+    m_requests->requestItemMove(-0.5, -1);
+    m_viewState->modifiersReleased().notify();
+    expectFinished();
+}
+
+TEST_F(TrackItemsMoveControllerTests, KeyboardDoesNotInterruptMouseDrag)
+{
+    selectClip();
+    m_controller->start(TrackItemKey(m_clip.key));
+    m_requests->requestItemMove(0.5, 1);
+    EXPECT_FALSE(m_controller->keyboardActive());
+    EXPECT_DOUBLE_EQ(m_controller->timeOffset(), 0.0);
+    m_viewState->modifiersReleased().notify();
+    EXPECT_TRUE(m_controller->active());
+    m_controller->cancel();
+}
+
+TEST_F(TrackItemsMoveControllerTests, KeyboardStillReordersFocusedTrack)
+{
+    selectClip();
+    m_focusedItem = { 1, trackedit::INVALID_TRACK_ITEM };
+    EXPECT_CALL(*m_interaction, moveTracks(trackedit::TrackIdList { 1 }, trackedit::TrackMoveDirection::Down));
+    m_requests->requestItemMove(0.0, 1);
+    m_requests->requestItemMove(0.5, 0);
+    expectFinished();
 }
 
 TEST_F(TrackItemsMoveControllerTests, RangeMovesStayIncrementalWithoutGhosts)

--- a/src/projectscene/tests/trackitemsmovecontroller_tests.cpp
+++ b/src/projectscene/tests/trackitemsmovecontroller_tests.cpp
@@ -1,0 +1,373 @@
+/*
+* Audacity: A Digital Audio Editor
+*/
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include "projectscene/view/tracksitemsview/trackitemsmovecontroller.h"
+#include "projectscene/view/tracksitemsview/tracklabelslistmodel.h"
+#include "projectscene/internal/projectviewstate.h"
+#include "trackedit/internal/au3/au3tracksinteraction.h"
+#include "trackedit/tests/mocks/trackeditprojectmock.h"
+#include "trackedit/tests/mocks/trackeditinteractionmock.h"
+#include "trackedit/tests/mocks/selectioncontrollermock.h"
+#include "trackedit/tests/mocks/projecthistorymock.h"
+#include "context/tests/mocks/globalcontextmock.h"
+#include "project/tests/mocks/audacityprojectmock.h"
+#include "playback/tests/mocks/playbackmock.h"
+#include "mocks/audiooutputmock.h"
+#include "snaptestaccess.h"
+
+using namespace ::testing;
+
+namespace au::projectscene {
+namespace {
+class DragViewState : public ProjectViewState
+{
+public:
+    explicit DragViewState(const std::vector<trackedit::Track>& tracks)
+        : ProjectViewState(muse::modularity::globalCtx()), m_tracks(tracks) {}
+
+    trackedit::TrackId trackAtPosition(double y) const override
+    {
+        const int index = static_cast<int>((y + tracksVerticalOffset().val) / 100);
+        return index >= 0 && index < static_cast<int>(m_tracks.size()) ? m_tracks[index].id : trackedit::INVALID_TRACK;
+    }
+
+    muse::ValCh<int> totalTrackHeight() const override { return { static_cast<int>(m_tracks.size()) * 100, {} }; }
+    int trackDefaultHeight() const override { return 100; }
+    void updateItemsBoundaries(bool, const trackedit::TrackItemKey&) override {}
+
+private:
+    const std::vector<trackedit::Track>& m_tracks;
+};
+
+class DragTracksInteraction : public trackedit::Au3TracksInteraction
+{
+public:
+    DragTracksInteraction()
+        : Au3TracksInteraction(muse::modularity::globalCtx()) {}
+    MOCK_METHOD(trackedit::TrackId, addWaveTrack, (int), (override));
+    MOCK_METHOD(void, removeDragAddedTracks, (size_t, bool), (override));
+};
+
+class DragLabelsModel : public TrackLabelsListModel
+{
+public:
+    DragLabelsModel(const std::shared_ptr<context::IGlobalContext>& context,
+                    const std::shared_ptr<trackedit::ISelectionController>& selection)
+    {
+        globalContext.set(context);
+        selectionController.set(selection);
+    }
+};
+}
+
+class TrackItemsMoveControllerTests : public Test
+{
+protected:
+    void SetUp() override
+    {
+        m_globalContext = std::make_shared<NiceMock<context::GlobalContextMock> >();
+        m_project = std::make_shared<NiceMock<project::AudacityProjectMock> >();
+        m_trackeditProject = std::make_shared<NiceMock<trackedit::TrackeditProjectMock> >();
+        m_selection = std::make_shared<NiceMock<trackedit::SelectionControllerMock> >();
+        m_interaction = std::make_shared<StrictMock<trackedit::TrackeditInteractionMock> >();
+        m_history = std::make_shared<NiceMock<trackedit::ProjectHistoryMock> >();
+        m_tracksInteraction = std::make_shared<NiceMock<DragTracksInteraction> >();
+        m_viewState = std::make_shared<DragViewState>(m_tracks);
+        m_playback = std::make_shared<NiceMock<playback::PlaybackMock> >();
+        m_audioOutput = std::make_shared<NiceMock<playback::AudioOutputMock> >();
+
+        ON_CALL(*m_globalContext, currentProject()).WillByDefault(Return(m_project));
+        ON_CALL(*m_globalContext, currentTrackeditProject()).WillByDefault(Return(m_trackeditProject));
+        ON_CALL(*m_project, viewState()).WillByDefault(Return(m_viewState));
+        ON_CALL(*m_playback, audioOutput()).WillByDefault(Return(m_audioOutput));
+        ON_CALL(*m_audioOutput, sampleRate()).WillByDefault(Return(44100));
+        ON_CALL(*m_selection, timeSelectionIsEmpty()).WillByDefault(Return(true));
+        ON_CALL(*m_selection, selectedClipsInTrackOrder()).WillByDefault([this] { return m_selectedClips; });
+        ON_CALL(*m_selection, selectedClips()).WillByDefault([this] { return m_selectedClips; });
+        ON_CALL(*m_selection, selectedLabels()).WillByDefault([this] { return m_selectedLabels; });
+        ON_CALL(*m_trackeditProject, trackList()).WillByDefault([this] { return m_tracks; });
+        ON_CALL(*m_trackeditProject, track(_)).WillByDefault([this](trackedit::TrackId id) -> std::optional<trackedit::Track> {
+            for (const auto& track : m_tracks) {
+                if (track.id == id) {
+                    return track;
+                }
+            }
+            return {};
+        });
+        ON_CALL(*m_trackeditProject, label(_)).WillByDefault([this](const trackedit::LabelKey& key) {
+            return key == m_label.key ? m_label : trackedit::Label {};
+        });
+        ON_CALL(*m_trackeditProject, clip(_)).WillByDefault([this](const trackedit::ClipKey& key) {
+            return key == m_clip.key ? m_clip : trackedit::Clip {};
+        });
+        ON_CALL(*m_trackeditProject, labelList(_)).WillByDefault([this](trackedit::TrackId id) {
+            muse::async::NotifyList<trackedit::Label> labels;
+            if (id == m_label.key.trackId) {
+                labels.push_back(m_label);
+            }
+            return labels;
+        });
+
+        m_context = std::make_unique<TimelineContext>();
+        SnapTestAccess::wireContext(m_context.get(), m_globalContext, m_playback);
+        m_controller = std::make_unique<TrackItemsMoveController>();
+        m_controller->globalContext.set(m_globalContext);
+        m_controller->selectionController.set(m_selection);
+        m_controller->trackeditInteraction.set(m_interaction);
+        m_controller->tracksInteraction.set(m_tracksInteraction);
+        m_controller->projectHistory.set(m_history);
+        m_controller->setTimelineContext(m_context.get());
+    }
+
+    void TearDown() override
+    {
+        m_controller.reset();
+        m_context.reset();
+    }
+
+    void selectLabel()
+    {
+        m_tracks = { { 1, {}, trackedit::TrackType::Label }, { 2, {}, trackedit::TrackType::Label } };
+        m_label.key = { 1, 10 };
+        m_label.startTime = 10.0;
+        m_label.endTime = 15.0;
+        m_selectedLabels = { m_label.key };
+        movePointer(10.0, 50.0);
+    }
+
+    void selectClip()
+    {
+        m_tracks = { { 1, {}, trackedit::TrackType::Mono }, { 2, {}, trackedit::TrackType::Mono } };
+        m_clip.key = { 1, 20 };
+        m_clip.startTime = 10.0;
+        m_clip.endTime = 15.0;
+        m_selectedClips = { m_clip.key };
+        movePointer(10.0, 50.0);
+    }
+
+    void movePointer(double time, double y)
+    {
+        m_context->updateMousePositionTime(time);
+        m_viewState->setMousePositionY(y);
+    }
+
+    std::unique_ptr<DragLabelsModel> labelModel(trackedit::TrackId track)
+    {
+        auto model = std::make_unique<DragLabelsModel>(m_globalContext, m_selection);
+        model->setTrackId(QVariant::fromValue(track));
+        model->setTimelineContext(m_context.get());
+        model->setMoveController(m_controller.get());
+        model->reload();
+        return model;
+    }
+
+    void expectFinished()
+    {
+        EXPECT_FALSE(m_controller->active());
+        EXPECT_FALSE(m_controller->isDragged(m_label.key));
+        EXPECT_FALSE(m_viewState->moveInitiated());
+        EXPECT_DOUBLE_EQ(m_viewState->itemEditStartTimeOffset(), -1.0);
+        EXPECT_TRUE(m_controller->itemsOnTrack(2).empty());
+    }
+
+    std::vector<trackedit::Track> m_tracks;
+    trackedit::Label m_label;
+    trackedit::Clip m_clip;
+    trackedit::LabelKeyList m_selectedLabels;
+    trackedit::ClipKeyList m_selectedClips;
+    std::shared_ptr<NiceMock<context::GlobalContextMock> > m_globalContext;
+    std::shared_ptr<NiceMock<project::AudacityProjectMock> > m_project;
+    std::shared_ptr<NiceMock<trackedit::TrackeditProjectMock> > m_trackeditProject;
+    std::shared_ptr<NiceMock<trackedit::SelectionControllerMock> > m_selection;
+    std::shared_ptr<StrictMock<trackedit::TrackeditInteractionMock> > m_interaction;
+    std::shared_ptr<NiceMock<trackedit::ProjectHistoryMock> > m_history;
+    std::shared_ptr<NiceMock<DragTracksInteraction> > m_tracksInteraction;
+    std::shared_ptr<DragViewState> m_viewState;
+    std::shared_ptr<NiceMock<playback::PlaybackMock> > m_playback;
+    std::shared_ptr<NiceMock<playback::AudioOutputMock> > m_audioOutput;
+    std::unique_ptr<TimelineContext> m_context;
+    std::unique_ptr<TrackItemsMoveController> m_controller;
+};
+
+TEST_F(TrackItemsMoveControllerTests, DropAfterSourceDelegateIsDestroyed)
+{
+    selectLabel();
+    auto source = labelModel(1);
+    m_controller->start(TrackItemKey(m_label.key));
+    movePointer(20.0, 150.0);
+    m_controller->update();
+    source.reset();
+
+    auto destination = labelModel(2);
+    ASSERT_EQ(destination->rowCount({}), 1);
+    const auto ghost = destination->data(destination->index(0), Qt::UserRole + 1).value<ViewTrackItem*>();
+    ASSERT_NE(ghost, nullptr);
+    EXPECT_TRUE(ghost->isDragGhost());
+    EXPECT_DOUBLE_EQ(ghost->time().startTime, 20.0);
+
+    const trackedit::LabelKeyList moved { { 2, 30 } };
+    EXPECT_CALL(*m_interaction, moveLabels(m_selectedLabels, trackedit::secs_t(10.0), 1, true))
+    .WillOnce(Return(muse::RetVal<trackedit::LabelKeyList>::make_ok(moved)));
+    EXPECT_CALL(*m_selection, setSelectedLabels(moved, true));
+    EXPECT_CALL(*m_history, endUserInteraction(false));
+    EXPECT_EQ(m_controller->finish().key, moved.front());
+
+    expectFinished();
+    EXPECT_EQ(destination->rowCount({}), 0);
+}
+
+TEST_F(TrackItemsMoveControllerTests, CancelAfterSourceDelegateIsDestroyed)
+{
+    selectLabel();
+    auto source = labelModel(1);
+    m_controller->start(TrackItemKey(m_label.key));
+    movePointer(20.0, 150.0);
+    m_controller->update();
+    source.reset();
+
+    EXPECT_CALL(*m_tracksInteraction, removeDragAddedTracks(2, true));
+    EXPECT_CALL(*m_history, endUserInteraction(false));
+    EXPECT_TRUE(m_controller->cancel());
+    expectFinished();
+    EXPECT_DOUBLE_EQ(m_label.startTime, 10.0);
+}
+
+TEST_F(TrackItemsMoveControllerTests, HeaderClickEndsWithoutModifyingHistory)
+{
+    for (bool label : { false, true }) {
+        m_selectedClips.clear();
+        m_selectedLabels.clear();
+        if (label) {
+            selectLabel();
+        } else {
+            selectClip();
+        }
+        const TrackItemKey key(label ? m_label.key : m_clip.key);
+        EXPECT_CALL(*m_history, startUserInteraction());
+        EXPECT_CALL(*m_history, endUserInteraction(false));
+        m_controller->start(key);
+        EXPECT_EQ(m_controller->finish().key, key.key);
+        expectFinished();
+    }
+}
+
+TEST_F(TrackItemsMoveControllerTests, ClipsMoveOnlyOnceOnDrop)
+{
+    selectClip();
+    m_controller->start(TrackItemKey(m_clip.key));
+    movePointer(20.0, 150.0);
+    m_controller->update();
+    movePointer(25.0, 150.0);
+    m_controller->update();
+
+    const trackedit::ClipKeyList moved { { 2, 20 } };
+    EXPECT_CALL(*m_interaction, moveClips(m_selectedClips, trackedit::secs_t(15.0), 1, true, _))
+    .WillOnce(Return(muse::RetVal<trackedit::ClipKeyList>::make_ok(moved)));
+    EXPECT_CALL(*m_selection, setSelectedClips(moved, true));
+    m_controller->finish();
+    expectFinished();
+}
+
+TEST_F(TrackItemsMoveControllerTests, CancelRemovesOnlyTracksAddedForPreview)
+{
+    selectClip();
+    EXPECT_CALL(*m_tracksInteraction, addWaveTrack(1)).WillOnce([this](int) {
+        m_tracks.push_back({ 3, {}, trackedit::TrackType::Mono });
+        return 3;
+    });
+    m_controller->start(TrackItemKey(m_clip.key));
+    movePointer(20.0, 250.0);
+    m_controller->update();
+    EXPECT_EQ(m_controller->itemsOnTrack(3), m_selectedClips);
+
+    EXPECT_CALL(*m_tracksInteraction, removeDragAddedTracks(2, true));
+    m_controller->cancel();
+    expectFinished();
+}
+
+TEST_F(TrackItemsMoveControllerTests, MixedSelectionClampsTogetherAtZeroAndTopAudioTrack)
+{
+    selectClip();
+    m_tracks.push_back({ 3, {}, trackedit::TrackType::Label });
+    m_tracks.push_back({ 4, {}, trackedit::TrackType::Label });
+    m_label.key = { 4, 10 };
+    m_label.startTime = 5.0;
+    m_label.endTime = 8.0;
+    m_selectedLabels = { m_label.key };
+    movePointer(5.0, 350.0);
+    m_controller->start(TrackItemKey(m_label.key));
+    movePointer(-10.0, 250.0);
+    m_controller->update();
+
+    EXPECT_DOUBLE_EQ(m_controller->timeOffset(), -5.0);
+    EXPECT_EQ(m_controller->itemsOnTrack(1), m_selectedClips);
+    EXPECT_EQ(m_controller->itemsOnTrack(4), m_selectedLabels);
+    m_controller->cancel();
+}
+
+TEST_F(TrackItemsMoveControllerTests, LabelPreviewsClampIndividuallyAtBoundaryTracks)
+{
+    selectLabel();
+    m_tracks = { { 1, {}, trackedit::TrackType::Label }, { 2, {}, trackedit::TrackType::Mono },
+        { 3, {}, trackedit::TrackType::Label }, { 4, {}, trackedit::TrackType::Mono },
+        { 5, {}, trackedit::TrackType::Label } };
+    m_selectedLabels = { { 1, 10 }, { 3, 30 }, { 5, 50 } };
+    ON_CALL(*m_trackeditProject, label(_)).WillByDefault([this](const trackedit::LabelKey& key) {
+        auto label = m_label;
+        label.key = key;
+        return label;
+    });
+
+    for (int offset : { -1, 1 }) {
+        movePointer(10.0, 250.0);
+        m_controller->start(TrackItemKey(m_selectedLabels[1]));
+        movePointer(10.0, offset < 0 ? 50.0 : 450.0);
+        m_controller->update();
+
+        const trackedit::LabelKeyList firstPair { { 1, 10 }, { 3, 30 } };
+        const trackedit::LabelKeyList lastPair { { 3, 30 }, { 5, 50 } };
+        const trackedit::LabelKeyList firstOnly { { 1, 10 } };
+        const trackedit::LabelKeyList lastOnly { { 5, 50 } };
+        EXPECT_EQ(m_controller->itemsOnTrack(1), offset < 0 ? firstPair : trackedit::LabelKeyList {});
+        EXPECT_EQ(m_controller->itemsOnTrack(3), offset < 0 ? lastOnly : firstOnly);
+        EXPECT_EQ(m_controller->itemsOnTrack(5), offset < 0 ? trackedit::LabelKeyList {} : lastPair);
+        EXPECT_TRUE(m_controller->itemsOnTrack(2).empty());
+        EXPECT_TRUE(m_controller->itemsOnTrack(4).empty());
+
+        EXPECT_CALL(*m_interaction, moveLabels(m_selectedLabels, trackedit::secs_t(0.0), offset, true))
+        .WillOnce(Return(muse::RetVal<trackedit::LabelKeyList>::make_ok(m_selectedLabels)));
+        m_controller->finish();
+        expectFinished();
+    }
+}
+
+TEST_F(TrackItemsMoveControllerTests, RangeMovesStayIncrementalWithoutGhosts)
+{
+    selectLabel();
+    ON_CALL(*m_selection, timeSelectionIsEmpty()).WillByDefault(Return(false));
+    EXPECT_CALL(*m_interaction, moveRangeSelection(trackedit::secs_t(10.0), false)).WillOnce([this](trackedit::secs_t offset, bool) {
+        m_label.startTime += offset;
+        m_label.endTime += offset;
+        return true;
+    });
+    EXPECT_CALL(*m_interaction, moveRangeSelection(trackedit::secs_t(5.0), false)).WillOnce([this](trackedit::secs_t offset, bool) {
+        m_label.startTime += offset;
+        m_label.endTime += offset;
+        return true;
+    });
+    EXPECT_CALL(*m_interaction, moveRangeSelection(trackedit::secs_t(0.0), false)).WillOnce(Return(true));
+    EXPECT_CALL(*m_interaction, moveRangeSelection(trackedit::secs_t(0.0), true)).WillOnce(Return(true));
+    m_controller->start(TrackItemKey(m_label.key));
+    movePointer(20.0, 50.0);
+    m_controller->update();
+    movePointer(25.0, 50.0);
+    m_controller->update();
+    EXPECT_FALSE(m_controller->isDragged(m_label.key));
+    EXPECT_TRUE(m_controller->itemsOnTrack(1).empty());
+    m_controller->finish();
+    expectFinished();
+}
+}

--- a/src/projectscene/tests/trackitemsmovecontroller_tests.cpp
+++ b/src/projectscene/tests/trackitemsmovecontroller_tests.cpp
@@ -234,7 +234,7 @@ TEST_F(TrackItemsMoveControllerTests, DropAfterSourceDelegateIsDestroyed)
     EXPECT_DOUBLE_EQ(ghost->time().startTime, 20.0);
 
     const trackedit::LabelKeyList moved { { 2, 30 } };
-    EXPECT_CALL(*m_interaction, moveLabels(m_selectedLabels, trackedit::secs_t(10.0), ::testing::TypedEq<int>(1)))
+    EXPECT_CALL(*m_interaction, moveLabels(m_selectedLabels, trackedit::secs_t(10.0), 1))
     .WillOnce(Return(muse::RetVal<trackedit::LabelKeyList>::make_ok(moved)));
     EXPECT_CALL(*m_selection, setSelectedLabels(moved, true));
     EXPECT_CALL(*m_history, endUserInteraction(false));
@@ -289,7 +289,7 @@ TEST_F(TrackItemsMoveControllerTests, ClipsMoveOnlyOnceOnDrop)
     m_controller->update();
 
     const trackedit::ClipKeyList moved { { 2, 20 } };
-    EXPECT_CALL(*m_interaction, moveClips(m_selectedClips, trackedit::secs_t(15.0), 1, _))
+    EXPECT_CALL(*m_interaction, moveClips(m_selectedClips, trackedit::secs_t(15.0), 1))
     .WillOnce(Return(muse::RetVal<trackedit::ClipKeyList>::make_ok(moved)));
     EXPECT_CALL(*m_selection, setSelectedClips(moved, true));
     m_controller->finish();
@@ -362,7 +362,7 @@ TEST_F(TrackItemsMoveControllerTests, LabelPreviewsClampIndividuallyAtBoundaryTr
         EXPECT_TRUE(m_controller->itemsOnTrack(2).empty());
         EXPECT_TRUE(m_controller->itemsOnTrack(4).empty());
 
-        EXPECT_CALL(*m_interaction, moveLabels(m_selectedLabels, trackedit::secs_t(0.0), ::testing::TypedEq<int>(offset)))
+        EXPECT_CALL(*m_interaction, moveLabels(m_selectedLabels, trackedit::secs_t(0.0), offset))
         .WillOnce(Return(muse::RetVal<trackedit::LabelKeyList>::make_ok(m_selectedLabels)));
         m_controller->finish();
         expectFinished();
@@ -400,7 +400,7 @@ TEST_F(TrackItemsMoveControllerTests, KeyboardRepeatsPreviewOriginalItemsUntilMo
     EXPECT_EQ(m_controller->itemsOnTrack(2), original);
 
     const trackedit::ClipKeyList moved { { 2, 20 } };
-    EXPECT_CALL(*m_interaction, moveClips(original, trackedit::secs_t(0.5), 1, _))
+    EXPECT_CALL(*m_interaction, moveClips(original, trackedit::secs_t(0.5), 1))
     .WillOnce(Return(muse::RetVal<trackedit::ClipKeyList>::make_ok(moved)));
     EXPECT_CALL(*m_selection, setSelectedClips(original, false));
     EXPECT_CALL(*m_selection, setSelectedClips(moved, true));
@@ -478,7 +478,7 @@ TEST_F(TrackItemsMoveControllerTests, KeyboardMovesUnselectedFocusedItemEvenWith
     EXPECT_TRUE(m_controller->isDragged(m_label.key));
 
     const trackedit::LabelKeyList moved { { 2, 10 } };
-    EXPECT_CALL(*m_interaction, moveLabels(original, trackedit::secs_t(0.5), ::testing::TypedEq<int>(1)))
+    EXPECT_CALL(*m_interaction, moveLabels(original, trackedit::secs_t(0.5), 1))
     .WillOnce(Return(muse::RetVal<trackedit::LabelKeyList>::make_ok(moved)));
     EXPECT_CALL(*m_navigation, setFocusedItem(moved.front(), true));
     m_viewState->modifiersReleased().notify();
@@ -494,7 +494,7 @@ TEST_F(TrackItemsMoveControllerTests, KeyboardIgnoresStaleFocusAndSelectionKeys)
 
     const trackedit::ClipKeyList original { m_clip.key };
     EXPECT_EQ(m_controller->itemsOnTrack(1), original);
-    EXPECT_CALL(*m_interaction, moveClips(original, trackedit::secs_t(0.5), 0, _))
+    EXPECT_CALL(*m_interaction, moveClips(original, trackedit::secs_t(0.5), 0))
     .WillOnce(Return(muse::RetVal<trackedit::ClipKeyList>::make_ok(original)));
     m_viewState->modifiersReleased().notify();
     expectFinished();

--- a/src/projectscene/tests/trackitemsmovecontroller_tests.cpp
+++ b/src/projectscene/tests/trackitemsmovecontroller_tests.cpp
@@ -234,7 +234,7 @@ TEST_F(TrackItemsMoveControllerTests, DropAfterSourceDelegateIsDestroyed)
     EXPECT_DOUBLE_EQ(ghost->time().startTime, 20.0);
 
     const trackedit::LabelKeyList moved { { 2, 30 } };
-    EXPECT_CALL(*m_interaction, moveLabels(m_selectedLabels, trackedit::secs_t(10.0), 1, true))
+    EXPECT_CALL(*m_interaction, moveLabels(m_selectedLabels, trackedit::secs_t(10.0), ::testing::TypedEq<int>(1)))
     .WillOnce(Return(muse::RetVal<trackedit::LabelKeyList>::make_ok(moved)));
     EXPECT_CALL(*m_selection, setSelectedLabels(moved, true));
     EXPECT_CALL(*m_history, endUserInteraction(false));
@@ -289,7 +289,7 @@ TEST_F(TrackItemsMoveControllerTests, ClipsMoveOnlyOnceOnDrop)
     m_controller->update();
 
     const trackedit::ClipKeyList moved { { 2, 20 } };
-    EXPECT_CALL(*m_interaction, moveClips(m_selectedClips, trackedit::secs_t(15.0), 1, true, _))
+    EXPECT_CALL(*m_interaction, moveClips(m_selectedClips, trackedit::secs_t(15.0), 1, _))
     .WillOnce(Return(muse::RetVal<trackedit::ClipKeyList>::make_ok(moved)));
     EXPECT_CALL(*m_selection, setSelectedClips(moved, true));
     m_controller->finish();
@@ -362,7 +362,7 @@ TEST_F(TrackItemsMoveControllerTests, LabelPreviewsClampIndividuallyAtBoundaryTr
         EXPECT_TRUE(m_controller->itemsOnTrack(2).empty());
         EXPECT_TRUE(m_controller->itemsOnTrack(4).empty());
 
-        EXPECT_CALL(*m_interaction, moveLabels(m_selectedLabels, trackedit::secs_t(0.0), offset, true))
+        EXPECT_CALL(*m_interaction, moveLabels(m_selectedLabels, trackedit::secs_t(0.0), ::testing::TypedEq<int>(offset)))
         .WillOnce(Return(muse::RetVal<trackedit::LabelKeyList>::make_ok(m_selectedLabels)));
         m_controller->finish();
         expectFinished();
@@ -400,7 +400,7 @@ TEST_F(TrackItemsMoveControllerTests, KeyboardRepeatsPreviewOriginalItemsUntilMo
     EXPECT_EQ(m_controller->itemsOnTrack(2), original);
 
     const trackedit::ClipKeyList moved { { 2, 20 } };
-    EXPECT_CALL(*m_interaction, moveClips(original, trackedit::secs_t(0.5), 1, true, _))
+    EXPECT_CALL(*m_interaction, moveClips(original, trackedit::secs_t(0.5), 1, _))
     .WillOnce(Return(muse::RetVal<trackedit::ClipKeyList>::make_ok(moved)));
     EXPECT_CALL(*m_selection, setSelectedClips(original, false));
     EXPECT_CALL(*m_selection, setSelectedClips(moved, true));
@@ -478,7 +478,7 @@ TEST_F(TrackItemsMoveControllerTests, KeyboardMovesUnselectedFocusedItemEvenWith
     EXPECT_TRUE(m_controller->isDragged(m_label.key));
 
     const trackedit::LabelKeyList moved { { 2, 10 } };
-    EXPECT_CALL(*m_interaction, moveLabels(original, trackedit::secs_t(0.5), 1, true))
+    EXPECT_CALL(*m_interaction, moveLabels(original, trackedit::secs_t(0.5), ::testing::TypedEq<int>(1)))
     .WillOnce(Return(muse::RetVal<trackedit::LabelKeyList>::make_ok(moved)));
     EXPECT_CALL(*m_navigation, setFocusedItem(moved.front(), true));
     m_viewState->modifiersReleased().notify();
@@ -494,7 +494,7 @@ TEST_F(TrackItemsMoveControllerTests, KeyboardIgnoresStaleFocusAndSelectionKeys)
 
     const trackedit::ClipKeyList original { m_clip.key };
     EXPECT_EQ(m_controller->itemsOnTrack(1), original);
-    EXPECT_CALL(*m_interaction, moveClips(original, trackedit::secs_t(0.5), 0, true, _))
+    EXPECT_CALL(*m_interaction, moveClips(original, trackedit::secs_t(0.5), 0, _))
     .WillOnce(Return(muse::RetVal<trackedit::ClipKeyList>::make_ok(original)));
     m_viewState->modifiersReleased().notify();
     expectFinished();

--- a/src/projectscene/tests/tracklabelslayoutmanager_tests.cpp
+++ b/src/projectscene/tests/tracklabelslayoutmanager_tests.cpp
@@ -438,4 +438,37 @@ TEST_F(TrackLabelsLayoutManagerTests, ChainOfLinkedLabels)
     leftLinkedLabel = leftLinkedLabelKey(key3);
     ASSERT_EQ(leftLinkedLabel, key2) << "Label 3's left link should point to Label 2";
 }
+
+TEST_F(TrackLabelsLayoutManagerTests, DragPreviewsStackWithoutHiddenOriginals)
+{
+    m_layoutManager->setLabelsModel(m_labelsModel);
+    addItem(1, u"Original", 10.0, 20.0);
+    addItem(2, u"Preview one", 10.0, 20.0);
+    addItem(3, u"Preview two", 10.0, 20.0);
+    item(0)->setDragged(true);
+    item(1)->setDragGhost(true);
+    item(2)->setDragGhost(true);
+    m_layoutManager->init();
+
+    EXPECT_EQ(item(1)->level(), 0);
+    EXPECT_EQ(item(2)->level(), 1);
+
+    // Moving a preview away releases its level for the other visible labels.
+    item(1)->setX(40.0);
+    relayout();
+    EXPECT_EQ(item(1)->level(), 0);
+    EXPECT_EQ(item(2)->level(), 0);
+}
+
+TEST_F(TrackLabelsLayoutManagerTests, PreviewsDoNotBecomeEditableLinkedLabels)
+{
+    m_layoutManager->setLabelsModel(m_labelsModel);
+    addItem(1, u"Label", 0.0, 10.0);
+    addItem(2, u"Preview", 10.0, 20.0);
+    item(1)->setDragGhost(true);
+    m_layoutManager->init();
+
+    EXPECT_FALSE(rightLinkedLabelKey(item(0)->key()).isValid());
+    EXPECT_FALSE(leftLinkedLabelKey(item(1)->key()).isValid());
+}
 }

--- a/src/projectscene/view/tracksitemsview/trackclipslistmodel.cpp
+++ b/src/projectscene/view/tracksitemsview/trackclipslistmodel.cpp
@@ -176,7 +176,9 @@ void TrackClipsListModel::update()
     }
 
     QList<TrackClipItem*> newList;
-    bool isStereo = false;
+    const auto prj = globalContext()->currentTrackeditProject();
+    const auto track = prj ? prj->track(m_trackId) : std::nullopt;
+    const bool isStereo = track && track->type == TrackType::Stereo;
 
     // Building a new list, reusing exiting clips
     for (const au::trackedit::Clip& c : m_allClipList) {
@@ -192,7 +194,6 @@ void TrackClipsListModel::update()
 
         item->setClip(c);
         newList.append(item);
-        isStereo |= c.stereo;
     }
 
     // Removing deleted or moved clips

--- a/src/projectscene/view/tracksitemsview/trackclipslistmodel.cpp
+++ b/src/projectscene/view/tracksitemsview/trackclipslistmodel.cpp
@@ -26,6 +26,14 @@ TrackClipsListModel::TrackClipsListModel(QObject* parent)
 
 void TrackClipsListModel::onInit()
 {
+    if (moveController()) {
+        connect(moveController(), &TrackItemsMoveController::activeChanged, this, [this] {
+            if (!moveController()->active()) {
+                m_pendingToggleDeselect.clear();
+            }
+        });
+    }
+
     selectionController()->clipsSelected().onReceive(this, [this](const ClipKeyList& keyList) {
         if (keyList.empty()) {
             resetSelectedClips();
@@ -253,6 +261,11 @@ void TrackClipsListModel::updateItemMetrics(ViewTrackItem* viewItem)
         return;
     }
 
+    if (item->isDragGhost()) {
+        clip.startTime += moveTimeOffset();
+        clip.endTime += moveTimeOffset();
+    }
+
     // Pin the recording clip's visual boundary to the smooth playhead: data is
     // committed in chunks, so following the committed end would make the edge
     // jump. Data ahead of the playhead is revealed as the playhead reaches it.
@@ -286,6 +299,13 @@ void TrackClipsListModel::updateItemMetrics(ViewTrackItem* viewItem)
     item->setWidth((time.itemEndTime - time.itemStartTime) * m_context->zoom());
     item->setLeftVisibleMargin(std::max(m_context->frameStartTime() - time.itemStartTime, 0.0) * m_context->zoom());
     item->setRightVisibleMargin(std::max(time.itemEndTime - m_context->frameEndTime(), 0.0) * m_context->zoom());
+}
+
+ViewTrackItem* TrackClipsListModel::createDragGhost(const trackedit::TrackItemKey& key)
+{
+    TrackClipItem* item = new TrackClipItem(this);
+    item->setClip(globalContext()->currentTrackeditProject()->clip(key));
+    return item;
 }
 
 bool TrackClipsListModel::changeClipTitle(const ClipKey& key, const QString& newTitle)
@@ -365,99 +385,6 @@ bool TrackClipsListModel::asymmetricStereoHeightsPossible() const
 bool TrackClipsListModel::isContrastFocusBorderEnabled() const
 {
     return !uiConfiguration()->isDarkMode();
-}
-
-au::projectscene::ClipKey TrackClipsListModel::updateClipTrack(ClipKey clipKey) const
-{
-    ITrackeditProjectPtr trackeditPrj = globalContext()->currentTrackeditProject();
-    if (!trackeditPrj) {
-        return clipKey;
-    }
-
-    auto allTracks = trackeditPrj->trackIdList();
-
-    for (const auto& trackId : allTracks) {
-        auto clips = trackeditPrj->clipList(trackId);
-
-        for (const auto& clip : clips) {
-            if (clip.key.itemId == clipKey.key.itemId) {
-                ClipKey updatedKey;
-                updatedKey.key.trackId = trackId;
-                updatedKey.key.itemId = clip.key.itemId;
-                return updatedKey;
-            }
-        }
-    }
-
-    return clipKey;
-}
-
-/*!
- * \brief Moves all selected clips
- * \param key - the key from which the offset will be calculated to move all clips
-
-    Calculate offset of clip that's being grabbed
-    and apply it to all selected clips
- */
-bool TrackClipsListModel::moveSelectedClips(const ClipKey& key, bool completed)
-{
-    TrackClipItem* item = clipItemByKey(key.key);
-    if (!item) {
-        return false;
-    }
-
-    m_pendingToggleDeselect.clear();
-
-    auto project = globalContext()->currentProject();
-    IF_ASSERT_FAILED(project) {
-        return false;
-    }
-
-    auto vs = project->viewState();
-    IF_ASSERT_FAILED(vs) {
-        return false;
-    }
-
-    bool clipsMovedToOtherTrack = false;
-    // Clips can only be moved to audio tracks (Mono and Stereo)
-    TrackItemsListModel::MoveOffset moveOffset = calculateMoveOffset(item, key, {
-        trackedit::TrackType::Mono,
-        trackedit::TrackType::Stereo
-    }, completed);
-
-    if (vs->moveInitiated()) {
-        if (!selectionController()->timeSelectionIsEmpty()) {
-            trackeditInteraction()->moveRangeSelection(moveOffset.timeOffset, completed);
-        } else {
-            ClipKeyList selectedClips = selectionController()->selectedClipsInTrackOrder();
-            muse::RetVal<ClipKeyList> result = trackeditInteraction()->moveClips(selectedClips, moveOffset.timeOffset,
-                                                                                 moveOffset.trackOffset,
-                                                                                 completed, clipsMovedToOtherTrack);
-            if (result.ret) {
-                selectionController()->setSelectedClips(result.val, completed);
-            }
-        }
-    }
-
-    // Update key if clip moved to another track
-    ClipKey updatedKey = key;
-    if (clipsMovedToOtherTrack && !completed) {
-        updatedKey = updateClipTrack(key);
-
-        // Reconnect with updated key
-        if (m_autoScrollConnection) {
-            disconnectAutoScroll();
-        }
-        m_autoScrollConnection = connect(m_context, &TimelineContext::frameTimeChanged, [this, updatedKey](){
-            moveSelectedClips(updatedKey, false);
-        });
-    } else if ((completed && m_autoScrollConnection)) {
-        disconnectAutoScroll();
-    } else if (!m_autoScrollConnection && !completed) {
-        m_autoScrollConnection = connect(m_context, &TimelineContext::frameTimeChanged, [this, key](){ moveSelectedClips(key, false); });
-    }
-
-    return clipsMovedToOtherTrack;
 }
 
 ClipKeyList TrackClipsListModel::clipsForInteraction(const ClipKey& key) const

--- a/src/projectscene/view/tracksitemsview/trackclipslistmodel.cpp
+++ b/src/projectscene/view/tracksitemsview/trackclipslistmodel.cpp
@@ -242,9 +242,9 @@ void TrackClipsListModel::update()
         emit isStereoChanged();
     }
 
-    muse::async::Async::call(this, [cleanupList]() {
-        qDeleteAll(cleanupList);
-    });
+    for (TrackClipItem* item : cleanupList) {
+        item->deleteLater();
+    }
 }
 
 void TrackClipsListModel::updateItemMetrics(ViewTrackItem* viewItem)

--- a/src/projectscene/view/tracksitemsview/trackclipslistmodel.h
+++ b/src/projectscene/view/tracksitemsview/trackclipslistmodel.h
@@ -38,8 +38,6 @@ public:
     bool isStereo() const;
     ClipStyles::Style clipStyle() const;
 
-    Q_INVOKABLE bool moveSelectedClips(const ClipKey& key, bool completed);
-
     void endEditItem(const TrackItemKey& key) override;
     Q_INVOKABLE bool trimLeftClip(const ClipKey& key, bool completed, ClipBoundary::Action action = ClipBoundary::Action::Shrink);
     Q_INVOKABLE bool trimRightClip(const ClipKey& key, bool completed, ClipBoundary::Action action = ClipBoundary::Action::Shrink);
@@ -56,9 +54,6 @@ public:
 
     Q_INVOKABLE void openClipSpeedEdit(const ClipKey& key);
     Q_INVOKABLE void resetClipSpeed(const ClipKey& key);
-
-    // update clip after moving to other track
-    Q_INVOKABLE projectscene::ClipKey updateClipTrack(ClipKey clipKey) const;
 
     bool asymmetricStereoHeightsPossible() const;
     bool isContrastFocusBorderEnabled() const;
@@ -80,6 +75,7 @@ private:
 
     void update();
     void updateItemMetrics(ViewTrackItem* item) override;
+    ViewTrackItem* createDragGhost(const trackedit::TrackItemKey& key) override;
     trackedit::TrackItemKeyList getSelectedItemKeys() const override;
     trackedit::ClipKeyList clipsForInteraction(const ClipKey& key) const;
 

--- a/src/projectscene/view/tracksitemsview/trackitemslistmodel.cpp
+++ b/src/projectscene/view/tracksitemsview/trackitemslistmodel.cpp
@@ -5,7 +5,6 @@
 
 #include <algorithm>
 
-#include "framework/global/async/async.h"
 #include "global/realfn.h"
 
 using namespace au::projectscene;
@@ -563,9 +562,9 @@ void TrackItemsListModel::onItemsMoveChanged()
             beginRemoveRows(QModelIndex(), firstGhostRow, firstGhostRow + oldItems.size() - 1);
             m_dragGhostItems.clear();
             endRemoveRows();
-            muse::async::Async::call(this, [oldItems]() {
-                qDeleteAll(oldItems);
-            });
+            for (ViewTrackItem* item : oldItems) {
+                item->deleteLater();
+            }
         }
         if (!ghosts.empty()) {
             beginInsertRows(QModelIndex(), firstGhostRow, firstGhostRow + ghosts.size() - 1);

--- a/src/projectscene/view/tracksitemsview/trackitemslistmodel.cpp
+++ b/src/projectscene/view/tracksitemsview/trackitemslistmodel.cpp
@@ -3,13 +3,15 @@
 */
 #include "trackitemslistmodel.h"
 
+#include <algorithm>
+
+#include "framework/global/async/async.h"
 #include "global/realfn.h"
 
 using namespace au::projectscene;
 using namespace au::trackedit;
 
 constexpr int CACHE_BUFFER_PX = 200;
-constexpr double MOVE_THRESHOLD = 3.0;
 
 TrackItemsListModel::TrackItemsListModel(QObject* parent)
     : QAbstractListModel(parent), muse::Contextable(muse::iocCtxForQmlObject(this))
@@ -71,11 +73,33 @@ void TrackItemsListModel::onTimelineFrameTimeChanged()
     updateItemsMetrics();
 }
 
+TrackItemsMoveController* TrackItemsListModel::moveController() const
+{
+    return m_moveController;
+}
+
+void TrackItemsListModel::setMoveController(TrackItemsMoveController* controller)
+{
+    if (m_moveController == controller) {
+        return;
+    }
+    if (m_moveController) {
+        disconnect(m_moveController, nullptr, this, nullptr);
+    }
+    m_moveController = controller;
+    if (m_moveController) {
+        connect(m_moveController, &TrackItemsMoveController::previewChanged, this, &TrackItemsListModel::onItemsMoveChanged);
+    }
+    emit moveControllerChanged();
+    onItemsMoveChanged();
+}
+
 void TrackItemsListModel::updateItemsMetrics()
 {
     for (int i = 0; i < m_items.size(); ++i) {
         updateItemMetrics(m_items[i]);
     }
+    updateDragGhostsMetrics();
 }
 
 void TrackItemsListModel::setSelectedItems(const QList<ViewTrackItem*>& items)
@@ -236,177 +260,6 @@ QVariant TrackItemsListModel::neighbor(const TrackItemKey& key, int offset) cons
     return QVariant::fromValue(m_items[sortedIndex]);
 }
 
-TrackItemsListModel::MoveOffset TrackItemsListModel::calculateMoveOffset(const ViewTrackItem* item,
-                                                                         const TrackItemKey& key,
-                                                                         const std::vector<trackedit::TrackType>& trackTypesAllowedToMove,
-                                                                         bool completed,
-                                                                         bool applySnap) const
-{
-    project::IAudacityProjectPtr prj = globalContext()->currentProject();
-    if (!prj) {
-        return MoveOffset{};
-    }
-
-    auto vs = prj->viewState();
-
-    MoveOffset moveOffset {
-        calculateTimePositionOffset(item, applySnap),
-        completed ? 0 : calculateTrackPositionOffset(key, trackTypesAllowedToMove)
-    };
-
-    secs_t positionOffsetX = moveOffset.timeOffset * m_context->zoom();
-    if (!vs->moveInitiated() && (muse::RealIsEqualOrMore(std::abs(positionOffsetX), MOVE_THRESHOLD) || moveOffset.trackOffset != 0)) {
-        vs->setMoveInitiated(true);
-    } else if (!vs->moveInitiated()) {
-        moveOffset.timeOffset = 0.0;
-    }
-
-    return moveOffset;
-}
-
-int TrackItemsListModel::calculateTrackPositionOffset(const TrackItemKey& key,
-                                                      const std::vector<trackedit::TrackType>& trackTypesAllowedToMove) const
-{
-    project::IAudacityProjectPtr prj = globalContext()->currentProject();
-    if (!prj) {
-        return 0;
-    }
-
-    IProjectViewStatePtr vs = prj->viewState();
-    double yPos = vs->mousePositionY();
-    int trackVerticalPosition = vs->trackVerticalPosition(key.key.trackId);
-    TrackIdList tracks = vs->tracksInRange(trackVerticalPosition + 2, yPos);
-
-    if (!tracks.size()) {
-        return 0;
-    }
-
-    // Check if mouse is pointing at a track with allowed type
-    if (!trackTypesAllowedToMove.empty()) {
-        trackedit::TrackId targetTrackId = vs->trackAtPosition(yPos);
-        if (targetTrackId != trackedit::INVALID_TRACK) {
-            if (!isAllowedToMoveToTracks(trackTypesAllowedToMove, targetTrackId)) {
-                return 0;
-            }
-        }
-    }
-
-    // Calculate offset based on allowed track types only
-    trackedit::TrackId targetTrackId = vs->trackAtPosition(yPos);
-    bool pointingAtEmptySpace = yPos > vs->totalTrackHeight().val - vs->tracksVerticalOffset().val;
-
-    if (targetTrackId == trackedit::INVALID_TRACK && !pointingAtEmptySpace) {
-        return 0;
-    }
-
-    ITrackeditProjectPtr trackeditPrj = globalContext()->currentTrackeditProject();
-    if (!trackeditPrj) {
-        return 0;
-    }
-
-    TrackIdList allTracks = trackeditPrj->trackIdList();
-
-    int sourceAllowedIndex = -1;
-    int targetAllowedIndex = -1;
-    int allowedCount = 0;
-
-    for (size_t i = 0; i < allTracks.size(); ++i) {
-        auto track = trackeditPrj->track(allTracks[i]);
-        if (!track.has_value()) {
-            continue;
-        }
-
-        if (!muse::contains(trackTypesAllowedToMove, track->type)) {
-            continue;
-        }
-
-        if (allTracks[i] == key.key.trackId) {
-            sourceAllowedIndex = allowedCount;
-        }
-
-        if (allTracks[i] == targetTrackId) {
-            targetAllowedIndex = allowedCount;
-        }
-
-        allowedCount++;
-    }
-
-    int trackPositionOffset = 0;
-    if (pointingAtEmptySpace) {
-        if (sourceAllowedIndex >= 0) {
-            trackPositionOffset = allowedCount - sourceAllowedIndex;
-
-            // Calculate how many tracks fit in the empty space below the last track
-            double lastTrackBottom = vs->totalTrackHeight().val - vs->tracksVerticalOffset().val;
-            double emptyDistance = yPos - lastTrackBottom;
-            if (emptyDistance > 0) {
-                int refTrackHeight = vs->trackDefaultHeight();
-                if (refTrackHeight > 0) {
-                    trackPositionOffset += static_cast<int>(emptyDistance / refTrackHeight);
-                }
-            }
-        }
-    } else if (sourceAllowedIndex >= 0 && targetAllowedIndex >= 0) {
-        trackPositionOffset = targetAllowedIndex - sourceAllowedIndex;
-    }
-
-    return trackPositionOffset;
-}
-
-bool TrackItemsListModel::isAllowedToMoveToTracks(const std::vector<trackedit::TrackType>& allowedTrackTypes,
-                                                  const trackedit::TrackId& movedTrackId) const
-{
-    ITrackeditProjectPtr trackeditPrj = globalContext()->currentTrackeditProject();
-    if (!trackeditPrj) {
-        return true;
-    }
-
-    auto track = trackeditPrj->track(movedTrackId);
-    return track.has_value() ? muse::contains(allowedTrackTypes, track->type) : false;
-}
-
-secs_t TrackItemsListModel::calculateTimePositionOffset(const ViewTrackItem* item, bool applySnap) const
-{
-    auto vs = globalContext()->currentProject()->viewState();
-    if (!vs) {
-        return 0.0;
-    }
-
-    double newStartTime = m_context->mousePositionTime() - vs->itemEditStartTimeOffset();
-
-    if (applySnap) {
-        double duration = item->time().endTime - item->time().startTime;
-        double newEndTime = newStartTime + duration;
-
-        double snappedEndTime = newEndTime;
-        double snappedStartTime = newStartTime;
-        if (vs->isSnapEnabled()) {
-            snappedStartTime = m_context->applySnapToTime(newStartTime);
-        } else {
-            snappedEndTime = m_context->applySnapToItem(newEndTime);
-            snappedStartTime = m_context->applySnapToItem(newStartTime);
-        }
-        if (muse::RealIsEqual(snappedEndTime, newEndTime)) {
-            newStartTime = snappedStartTime;
-        } else if (muse::RealIsEqual(snappedStartTime, newStartTime)) {
-            newStartTime = snappedEndTime - duration;
-        } else {
-            newStartTime
-                = (!muse::RealIsEqualOrMore(std::abs(snappedStartTime - newStartTime), std::abs(snappedEndTime - newEndTime))
-                   ? snappedStartTime : snappedEndTime - duration);
-        }
-    }
-
-    secs_t timePositionOffset = newStartTime - item->time().startTime;
-
-    constexpr auto limit = 1. / 192000.; // 1 sample at 192 kHz
-    if (!muse::RealIsEqualOrMore(std::abs(timePositionOffset), limit)) {
-        timePositionOffset = 0.0;
-    }
-
-    return timePositionOffset;
-}
-
 void TrackItemsListModel::requestItemTitleChange()
 {
     auto selectedItems = getSelectedItemKeys();
@@ -428,7 +281,7 @@ void TrackItemsListModel::requestItemTitleChange()
 
 int TrackItemsListModel::rowCount(const QModelIndex&) const
 {
-    return static_cast<int>(m_items.size());
+    return static_cast<int>(m_items.size() + m_dragGhostItems.size());
 }
 
 QHash<int, QByteArray> TrackItemsListModel::roleNames() const
@@ -448,7 +301,8 @@ QVariant TrackItemsListModel::data(const QModelIndex& index, int role) const
 
     switch (role) {
     case ItemRole: {
-        ViewTrackItem* item = m_items.at(index.row());
+        const int row = index.row();
+        ViewTrackItem* item = row < m_items.size() ? m_items.at(row) : m_dragGhostItems.at(row - m_items.size());
         return QVariant::fromValue(item);
     }
     default:
@@ -603,6 +457,7 @@ void TrackItemsListModel::reload()
     }, muse::async::Asyncable::Mode::SetReplace);
 
     onReload();
+    onItemsMoveChanged();
 }
 
 void TrackItemsListModel::startEditItem(const TrackItemKey& key)
@@ -685,4 +540,60 @@ bool TrackItemsListModel::cancelItemDragEdit(const TrackItemKey& key)
     projectHistory()->endUserInteraction(modifyState);
 
     return true;
+}
+
+void TrackItemsListModel::onItemsMoveChanged()
+{
+    for (ViewTrackItem* item : std::as_const(m_items)) {
+        item->setDragged(m_moveController && m_moveController->isDragged(item->key().key));
+    }
+
+    const trackedit::TrackItemKeyList ghosts = m_moveController
+                                               ? m_moveController->itemsOnTrack(m_trackId) : trackedit::TrackItemKeyList {};
+
+    const bool sameItems = std::equal(ghosts.begin(), ghosts.end(), m_dragGhostItems.cbegin(), m_dragGhostItems.cend(),
+                                      [](const trackedit::TrackItemKey& key, const ViewTrackItem* item) {
+        return key == item->key().key;
+    });
+
+    if (!sameItems) {
+        const int firstGhostRow = static_cast<int>(m_items.size());
+        if (!m_dragGhostItems.isEmpty()) {
+            const QList<ViewTrackItem*> oldItems = m_dragGhostItems;
+            beginRemoveRows(QModelIndex(), firstGhostRow, firstGhostRow + oldItems.size() - 1);
+            m_dragGhostItems.clear();
+            endRemoveRows();
+            muse::async::Async::call(this, [oldItems]() {
+                qDeleteAll(oldItems);
+            });
+        }
+        if (!ghosts.empty()) {
+            beginInsertRows(QModelIndex(), firstGhostRow, firstGhostRow + ghosts.size() - 1);
+            for (const trackedit::TrackItemKey& key : ghosts) {
+                ViewTrackItem* item = createDragGhost(key);
+                item->setDragGhost(true);
+                item->setSelected(true);
+                m_dragGhostItems.append(item);
+            }
+            endInsertRows();
+        }
+    }
+
+    updateDragGhostsMetrics();
+}
+
+double TrackItemsListModel::moveTimeOffset() const
+{
+    return m_moveController ? m_moveController->timeOffset() : 0.0;
+}
+
+void TrackItemsListModel::updateDragGhostsMetrics()
+{
+    if (!m_context) {
+        return;
+    }
+
+    for (ViewTrackItem* item : std::as_const(m_dragGhostItems)) {
+        updateItemMetrics(item);
+    }
 }

--- a/src/projectscene/view/tracksitemsview/trackitemslistmodel.h
+++ b/src/projectscene/view/tracksitemsview/trackitemslistmodel.h
@@ -6,6 +6,7 @@
 #include <functional>
 
 #include <QAbstractListModel>
+#include <QPointer>
 
 #include "framework/global/async/asyncable.h"
 #include "framework/global/iapplication.h"
@@ -26,6 +27,7 @@
 
 #include "projectscene/types/projectscenetypes.h"
 #include "viewtrackitem.h"
+#include "trackitemsmovecontroller.h"
 
 namespace au::projectscene {
 class TrackItemsListModel : public QAbstractListModel, public muse::async::Asyncable, public muse::actions::Actionable,
@@ -35,6 +37,7 @@ class TrackItemsListModel : public QAbstractListModel, public muse::async::Async
 
     Q_PROPERTY(TimelineContext * context READ timelineContext WRITE setTimelineContext NOTIFY timelineContextChanged FINAL)
     Q_PROPERTY(QVariant trackId READ trackId WRITE setTrackId NOTIFY trackIdChanged FINAL)
+    Q_PROPERTY(TrackItemsMoveController * moveController READ moveController WRITE setMoveController NOTIFY moveControllerChanged FINAL)
     Q_PROPERTY(int cacheBufferPx READ cacheBufferPx CONSTANT)
 
 protected:
@@ -56,6 +59,9 @@ public:
     void setTimelineContext(TimelineContext* newContext);
     QVariant trackId() const;
     void setTrackId(const QVariant& newTrackId);
+
+    TrackItemsMoveController* moveController() const;
+    void setMoveController(TrackItemsMoveController* controller);
 
     static int cacheBufferPx();
 
@@ -81,6 +87,7 @@ public:
 
 signals:
     void trackIdChanged();
+    void moveControllerChanged();
     void timelineContextChanged();
     void itemTitleEditRequested(const TrackItemKey& key);
 
@@ -119,17 +126,8 @@ protected:
 
     QVariant neighbor(const TrackItemKey& key, int offset) const;
 
-    struct MoveOffset {
-        muse::secs_t timeOffset = 0.0;
-        int trackOffset = 0;
-    };
-    MoveOffset calculateMoveOffset(const ViewTrackItem* item, const TrackItemKey& key,
-                                   const std::vector<trackedit::TrackType>& trackTypesAllowedToMove, bool completed,
-                                   bool applySnap = true) const;
-    trackedit::secs_t calculateTimePositionOffset(const ViewTrackItem* item, bool applySnap = true) const;
-
-    int calculateTrackPositionOffset(const TrackItemKey& key, const std::vector<trackedit::TrackType>& trackTypesAllowedToMove) const;
-    bool isAllowedToMoveToTracks(const std::vector<trackedit::TrackType>& allowedTrackTypes, const trackedit::TrackId& movedTrackId) const;
+    virtual ViewTrackItem* createDragGhost(const trackedit::TrackItemKey& key) = 0;
+    double moveTimeOffset() const;
 
     trackedit::SelectionMode selectionMode() const;
 
@@ -144,5 +142,12 @@ protected:
     QList<ViewTrackItem*> m_items;
     QList<ViewTrackItem*> m_selectedItems;
     QMetaObject::Connection m_autoScrollConnection;
+
+private:
+    void onItemsMoveChanged();
+    void updateDragGhostsMetrics();
+
+    QList<ViewTrackItem*> m_dragGhostItems;
+    QPointer<TrackItemsMoveController> m_moveController;
 };
 }

--- a/src/projectscene/view/tracksitemsview/trackitemsmovecontroller.cpp
+++ b/src/projectscene/view/tracksitemsview/trackitemsmovecontroller.cpp
@@ -1,0 +1,352 @@
+/*
+* Audacity: A Digital Audio Editor
+*/
+#include "trackitemsmovecontroller.h"
+
+#include <algorithm>
+#include <QScopedValueRollback>
+
+#include "global/realfn.h"
+
+using namespace au::projectscene;
+using namespace au::trackedit;
+
+namespace {
+int indexOf(const TrackIdList& tracks, TrackId id)
+{
+    const auto it = std::find(tracks.begin(), tracks.end(), id);
+    return it == tracks.end() ? -1 : static_cast<int>(std::distance(tracks.begin(), it));
+}
+
+TrackIdList tracksOfKind(const std::vector<Track>& tracks, bool labels)
+{
+    TrackIdList ids;
+    for (const Track& track : tracks) {
+        if (labels ? track.type == TrackType::Label : track.type == TrackType::Mono || track.type == TrackType::Stereo) {
+            ids.push_back(track.id);
+        }
+    }
+    return ids;
+}
+}
+
+TrackItemsMoveController::TrackItemsMoveController(QObject* parent)
+    : QObject(parent), muse::Contextable(muse::iocCtxForQmlObject(this))
+{
+}
+
+TrackItemsMoveController::~TrackItemsMoveController()
+{
+    if (active() && globalContext()->currentTrackeditProject() == m_project) {
+        cancel();
+    }
+}
+
+TimelineContext* TrackItemsMoveController::timelineContext() const
+{
+    return m_context;
+}
+
+void TrackItemsMoveController::setTimelineContext(TimelineContext* context)
+{
+    if (m_context == context) {
+        return;
+    }
+    if (m_context) {
+        disconnect(m_context, nullptr, this, nullptr);
+    }
+    m_context = context;
+    if (m_context) {
+        connect(m_context, &TimelineContext::frameTimeChanged, this, [this] {
+            if (m_moved) {
+                update();
+            }
+        });
+    }
+    emit contextChanged();
+}
+
+void TrackItemsMoveController::start(const TrackItemKey& key)
+{
+    if (active() || !m_context || !key.isValid()) {
+        return;
+    }
+    const auto project = globalContext()->currentProject();
+    const auto trackeditProject = globalContext()->currentTrackeditProject();
+    if (!project || !project->viewState() || !trackeditProject) {
+        return;
+    }
+    const auto track = trackeditProject->track(key.key.trackId);
+    if (!track) {
+        return;
+    }
+    m_sourceIsLabel = track->type == TrackType::Label;
+    if (m_sourceIsLabel) {
+        const Label label = trackeditProject->label(key.key);
+        if (!label.isValid()) {
+            return;
+        }
+        m_startTime = label.startTime;
+        m_endTime = label.endTime;
+    } else {
+        const Clip clip = trackeditProject->clip(key.key);
+        if (!clip.isValid()) {
+            return;
+        }
+        m_startTime = clip.startTime;
+        m_endTime = clip.endTime;
+    }
+
+    m_project = trackeditProject;
+    m_viewState = project->viewState();
+    m_sourceKey = key.key;
+    m_clips = selectionController()->selectedClipsInTrackOrder();
+    m_labels = selectionController()->selectedLabels();
+    m_rangeSelection = !selectionController()->timeSelectionIsEmpty();
+    m_originalTrackCount = m_project->trackList().size();
+
+    projectHistory()->startUserInteraction();
+    m_viewState->setItemEditStartTimeOffset(m_context->mousePositionTime() - m_startTime);
+    m_viewState->setItemEditEndTimeOffset(m_endTime - m_context->mousePositionTime());
+    m_viewState->setEditedItem(m_sourceKey);
+    m_viewState->updateItemsBoundaries(true, m_sourceKey);
+    emit activeChanged();
+}
+
+bool TrackItemsMoveController::active() const
+{
+    return m_sourceKey.isValid();
+}
+
+bool TrackItemsMoveController::isDragged(const trackedit::TrackItemKey& key) const
+{
+    return m_moved && !m_rangeSelection && (muse::contains(m_clips, key) || muse::contains(m_labels, key));
+}
+
+double TrackItemsMoveController::timeOffset() const
+{
+    return m_timeOffset;
+}
+
+double TrackItemsMoveController::pointerTimeOffset(double start, double end) const
+{
+    double newStart = m_context->mousePositionTime() - m_viewState->itemEditStartTimeOffset();
+    const double duration = end - start;
+    const double newEnd = newStart + duration;
+    const double snappedStart = m_viewState->isSnapEnabled()
+                                ? m_context->applySnapToTime(newStart) : m_context->applySnapToItem(newStart);
+    const double snappedEnd = m_viewState->isSnapEnabled() ? newEnd : m_context->applySnapToItem(newEnd);
+    if (muse::RealIsEqual(snappedEnd, newEnd)) {
+        newStart = snappedStart;
+    } else if (muse::RealIsEqual(snappedStart, newStart)) {
+        newStart = snappedEnd - duration;
+    } else {
+        newStart = !muse::RealIsEqualOrMore(std::abs(snappedStart - newStart), std::abs(snappedEnd - newEnd))
+                   ? snappedStart : snappedEnd - duration;
+    }
+    const double offset = newStart - start;
+    return muse::RealIsEqualOrMore(std::abs(offset), 1.0 / 192000.0) ? offset : 0.0;
+}
+
+int TrackItemsMoveController::pointerTrackOffset() const
+{
+    const TrackIdList tracks = tracksOfKind(m_project->trackList(), m_sourceIsLabel);
+    const int source = indexOf(tracks, m_sourceKey.trackId);
+    if (source < 0) {
+        return m_trackOffset;
+    }
+    const double y = m_viewState->mousePositionY();
+    const int target = indexOf(tracks, m_viewState->trackAtPosition(y));
+    if (target >= 0) {
+        return target - source;
+    }
+    const double bottom = m_viewState->totalTrackHeight().val - m_viewState->tracksVerticalOffset().val;
+    if (y > bottom) {
+        return static_cast<int>(tracks.size()) - source
+               + static_cast<int>((y - bottom) / m_viewState->trackDefaultHeight());
+    }
+    // Keep the last destination while the pointer crosses another kind of track.
+    return m_trackOffset;
+}
+
+void TrackItemsMoveController::update()
+{
+    if (!active() || !m_context || m_updating || globalContext()->currentTrackeditProject() != m_project) {
+        return;
+    }
+    QScopedValueRollback<bool> guard(m_updating, true);
+
+    double start = m_startTime;
+    double end = m_endTime;
+    if (m_rangeSelection) {
+        // Range moves still edit incrementally; their source times change after each update.
+        if (m_sourceIsLabel) {
+            const Label label = m_project->label(m_sourceKey);
+            start = label.startTime;
+            end = label.endTime;
+        } else {
+            const Clip clip = m_project->clip(m_sourceKey);
+            start = clip.startTime;
+            end = clip.endTime;
+        }
+    }
+    const double offset = pointerTimeOffset(start, end);
+    const int trackOffset = pointerTrackOffset();
+    if (!m_moved && std::abs(offset * m_context->zoom()) < 3.0 && trackOffset == 0) {
+        return;
+    }
+    m_moved = true;
+    m_viewState->setMoveInitiated(true);
+
+    if (m_rangeSelection) {
+        trackeditInteraction()->moveRangeSelection(offset, false);
+    } else {
+        updatePreview(offset, trackOffset);
+    }
+    const double appliedOffset = m_rangeSelection ? offset : m_timeOffset;
+    double guideline = m_context->findGuideline(start + appliedOffset);
+    if (!m_context->isGuidelineValid(guideline)) {
+        guideline = m_context->findGuideline(end + appliedOffset);
+    }
+    emit guidelineChanged(guideline);
+}
+
+void TrackItemsMoveController::updatePreview(double timeOffset, int trackOffset)
+{
+    for (const trackedit::ClipKey& key : m_clips) {
+        timeOffset = std::max(timeOffset, -m_project->clip(key).startTime);
+    }
+    for (const trackedit::LabelKey& key : m_labels) {
+        timeOffset = std::max(timeOffset, -m_project->label(key).startTime);
+    }
+
+    const auto tracks = m_project->trackList();
+    const TrackIdList audio = tracksOfKind(tracks, false);
+    const int originalAudioCount = static_cast<int>(audio.size()) - static_cast<int>(tracks.size() - m_originalTrackCount);
+    for (const trackedit::ClipKey& key : m_clips) {
+        const int source = indexOf(audio, key.trackId);
+        if (source >= 0) {
+            trackOffset = std::max(trackOffset, -source);
+        }
+    }
+    int extraTracks = 0;
+    for (const trackedit::ClipKey& key : m_clips) {
+        const int source = indexOf(audio, key.trackId);
+        if (source >= 0) {
+            extraTracks = std::max(extraTracks, source + trackOffset - (originalAudioCount - 1));
+        }
+    }
+    const size_t targetCount = m_originalTrackCount + extraTracks;
+    if (tracks.size() > targetCount) {
+        tracksInteraction()->removeDragAddedTracks(targetCount, true /* emptyOnly */);
+    }
+    for (size_t i = tracks.size(); i < targetCount; ++i) {
+        tracksInteraction()->addWaveTrack(1);
+    }
+    m_timeOffset = timeOffset;
+    m_trackOffset = trackOffset;
+    emit previewChanged();
+}
+
+TrackItemKeyList TrackItemsMoveController::itemsOnTrack(TrackId trackId) const
+{
+    TrackItemKeyList keys;
+    if (!m_moved || m_rangeSelection) {
+        return keys;
+    }
+    const auto tracks = m_project->trackList();
+    const bool labels = muse::contains(tracksOfKind(tracks, true), trackId);
+    const TrackIdList destinations = tracksOfKind(tracks, labels);
+    const TrackItemKeyList& items = labels ? m_labels : m_clips;
+    for (const trackedit::TrackItemKey& key : items) {
+        const int source = indexOf(destinations, key.trackId);
+        if (source < 0) {
+            continue;
+        }
+        const int target = labels ? std::clamp(source + m_trackOffset, 0, static_cast<int>(destinations.size()) - 1)
+                           : source + m_trackOffset;
+        if (target >= 0 && target < static_cast<int>(destinations.size()) && destinations[target] == trackId) {
+            keys.push_back(key);
+        }
+    }
+    return keys;
+}
+
+au::projectscene::TrackItemKey TrackItemsMoveController::finish()
+{
+    if (!active() || m_updating) {
+        return {};
+    }
+    TrackItemKey movedKey(m_sourceKey);
+    if (m_moved) {
+        update();
+        QScopedValueRollback<bool> guard(m_updating, true);
+        if (m_rangeSelection) {
+            trackeditInteraction()->moveRangeSelection(0.0, true);
+        } else {
+            m_moved = false;
+            emit previewChanged();
+
+            const TrackItemKeyList& selected = m_sourceIsLabel ? m_labels : m_clips;
+            bool changedTrack = false;
+            const auto result = m_sourceIsLabel
+                                ? trackeditInteraction()->moveLabels(selected, m_timeOffset, m_trackOffset, true)
+                                : trackeditInteraction()->moveClips(selected, m_timeOffset, m_trackOffset, true, changedTrack);
+            if (result.ret) {
+                const auto source = std::find(selected.begin(), selected.end(), m_sourceKey);
+                const auto sourceIndex = std::distance(selected.begin(), source);
+                if (source != selected.end() && sourceIndex < static_cast<int>(result.val.size())) {
+                    movedKey = TrackItemKey(result.val[sourceIndex]);
+                }
+                if (m_sourceIsLabel) {
+                    selectionController()->setSelectedLabels(result.val, true);
+                } else {
+                    selectionController()->setSelectedClips(result.val, true);
+                }
+            }
+        }
+    }
+    endInteraction();
+    return movedKey;
+}
+
+bool TrackItemsMoveController::cancel()
+{
+    if (!active() || m_updating) {
+        return false;
+    }
+    QScopedValueRollback<bool> guard(m_updating, true);
+    if (m_moved) {
+        if (m_rangeSelection) {
+            trackeditInteraction()->cancelItemDragEdit();
+        } else {
+            tracksInteraction()->removeDragAddedTracks(m_originalTrackCount, true /* emptyOnly */);
+        }
+    }
+    endInteraction();
+    return true;
+}
+
+void TrackItemsMoveController::endInteraction()
+{
+    if (m_context) {
+        m_context->stopAutoScroll();
+    }
+    m_moved = false;
+    m_timeOffset = 0.0;
+    m_trackOffset = 0;
+    m_sourceKey = {};
+    m_clips.clear();
+    m_labels.clear();
+    m_viewState->setMoveInitiated(false);
+    m_viewState->setItemEditStartTimeOffset(-1.0);
+    m_viewState->setItemEditEndTimeOffset(-1.0);
+    m_viewState->setEditedItem({});
+    m_viewState->updateItemsBoundaries(false);
+    emit previewChanged();
+    emit guidelineChanged(TimelineContext::INVALID_GUIDELINE_TIME);
+    emit activeChanged();
+    projectHistory()->endUserInteraction();
+    m_viewState.reset();
+    m_project.reset();
+}

--- a/src/projectscene/view/tracksitemsview/trackitemsmovecontroller.cpp
+++ b/src/projectscene/view/tracksitemsview/trackitemsmovecontroller.cpp
@@ -42,6 +42,18 @@ TrackItemsMoveController::~TrackItemsMoveController()
     }
 }
 
+void TrackItemsMoveController::init()
+{
+    tracksViewRequestsService()->itemMoveRequested().onReceive(this, [this](secs_t timeOffset, int trackOffset) {
+        moveByKeyboard(timeOffset, trackOffset);
+    }, muse::async::Asyncable::Mode::SetReplace);
+    projectHistory()->historyChanged().onReceive(this, [this](HistoryEvent) {
+        if (keyboardActive() && !m_updating) {
+            endInteraction();
+        }
+    }, muse::async::Asyncable::Mode::SetReplace);
+}
+
 TimelineContext* TrackItemsMoveController::timelineContext() const
 {
     return m_context;
@@ -67,6 +79,11 @@ void TrackItemsMoveController::setTimelineContext(TimelineContext* context)
 }
 
 void TrackItemsMoveController::start(const TrackItemKey& key)
+{
+    start(key, false);
+}
+
+void TrackItemsMoveController::start(const TrackItemKey& key, bool keyboard)
 {
     if (active() || !m_context || !key.isValid()) {
         return;
@@ -102,7 +119,22 @@ void TrackItemsMoveController::start(const TrackItemKey& key)
     m_sourceKey = key.key;
     m_clips = selectionController()->selectedClipsInTrackOrder();
     m_labels = selectionController()->selectedLabels();
-    m_rangeSelection = !selectionController()->timeSelectionIsEmpty();
+    m_keyboardMove = keyboard;
+    if (keyboard) {
+        muse::remove_if(m_clips, [this](const auto& clipKey) { return !m_project->clip(clipKey).isValid(); });
+        muse::remove_if(m_labels, [this](const auto& labelKey) { return !m_project->label(labelKey).isValid(); });
+        auto& items = m_sourceIsLabel ? m_labels : m_clips;
+        if (!muse::contains(items, m_sourceKey)) {
+            items.push_back(m_sourceKey);
+        }
+        m_viewState->setKeyboardMoveActive(true);
+        m_viewState->modifiersReleased().onNotify(this, [this] {
+            if (keyboardActive()) {
+                finish();
+            }
+        }, muse::async::Asyncable::Mode::SetReplace);
+    }
+    m_rangeSelection = !keyboard && !selectionController()->timeSelectionIsEmpty();
     m_originalTrackCount = m_project->trackList().size();
 
     projectHistory()->startUserInteraction();
@@ -116,6 +148,75 @@ void TrackItemsMoveController::start(const TrackItemKey& key)
 bool TrackItemsMoveController::active() const
 {
     return m_sourceKey.isValid();
+}
+
+bool TrackItemsMoveController::keyboardActive() const
+{
+    return active() && m_keyboardMove;
+}
+
+void TrackItemsMoveController::moveByKeyboard(double timeOffset, int trackOffset)
+{
+    if (m_updating || (active() && !keyboardActive())) {
+        return;
+    }
+    if (!active()) {
+        const auto project = globalContext()->currentTrackeditProject();
+        if (!project) {
+            return;
+        }
+        auto source = trackNavigationController()->focusedItem();
+        if (source.trackId != INVALID_TRACK && source.itemId == INVALID_TRACK_ITEM) {
+            if (trackOffset != 0) {
+                trackeditInteraction()->moveTracks({ source.trackId }, trackOffset < 0 ? TrackMoveDirection::Up : TrackMoveDirection::Down);
+            }
+            return;
+        }
+        const auto exists = [&project](const trackedit::TrackItemKey& key) {
+            const auto track = project->track(key.trackId);
+            return track && (track->type == TrackType::Label ? project->label(key).isValid() : project->clip(key).isValid());
+        };
+        if (!exists(source)) {
+            TrackItemKeyList selected = selectionController()->selectedLabels();
+            const auto clips = selectionController()->selectedClipsInTrackOrder();
+            selected.insert(selected.end(), clips.begin(), clips.end());
+            const auto item = std::find_if(selected.begin(), selected.end(), exists);
+            if (item == selected.end()) {
+                return;
+            }
+            source = *item;
+        }
+        start(TrackItemKey(source), true);
+    }
+    if (!keyboardActive() || globalContext()->currentTrackeditProject() != m_project) {
+        return;
+    }
+    QScopedValueRollback<bool> guard(m_updating, true);
+    m_moved = true;
+    m_viewState->setMoveInitiated(true);
+    int destinationOffset = m_trackOffset + trackOffset;
+    if (m_clips.empty()) {
+        const auto tracks = tracksOfKind(m_project->trackList(), true);
+        int first = static_cast<int>(tracks.size()) - 1;
+        int last = 0;
+        for (const auto& key : m_labels) {
+            const int source = indexOf(tracks, key.trackId);
+            first = std::min(first, source);
+            last = std::max(last, source);
+        }
+        destinationOffset = std::clamp(destinationOffset, -last, static_cast<int>(tracks.size()) - 1 - first);
+    }
+    updatePreview(m_timeOffset + timeOffset, destinationOffset);
+    double guideline = m_context->findGuideline(m_startTime + m_timeOffset);
+    if (!m_context->isGuidelineValid(guideline)) {
+        guideline = m_context->findGuideline(m_endTime + m_timeOffset);
+    }
+    emit guidelineChanged(guideline);
+    if (trackOffset != 0) {
+        const auto tracks = tracksOfKind(m_project->trackList(), m_sourceIsLabel);
+        const int target = std::clamp(indexOf(tracks, m_sourceKey.trackId) + m_trackOffset, 0, static_cast<int>(tracks.size()) - 1);
+        emit keyboardTrackChanged(tracks[target]);
+    }
 }
 
 bool TrackItemsMoveController::isDragged(const trackedit::TrackItemKey& key) const
@@ -171,7 +272,7 @@ int TrackItemsMoveController::pointerTrackOffset() const
 
 void TrackItemsMoveController::update()
 {
-    if (!active() || !m_context || m_updating || globalContext()->currentTrackeditProject() != m_project) {
+    if (!active() || keyboardActive() || !m_context || m_updating || globalContext()->currentTrackeditProject() != m_project) {
         return;
     }
     QScopedValueRollback<bool> guard(m_updating, true);
@@ -278,7 +379,8 @@ au::projectscene::TrackItemKey TrackItemsMoveController::finish()
         return {};
     }
     TrackItemKey movedKey(m_sourceKey);
-    if (m_moved) {
+    const bool keyboard = keyboardActive();
+    if (m_moved && (!keyboard || m_timeOffset != 0.0 || m_trackOffset != 0)) {
         update();
         QScopedValueRollback<bool> guard(m_updating, true);
         if (m_rangeSelection) {
@@ -287,6 +389,10 @@ au::projectscene::TrackItemKey TrackItemsMoveController::finish()
             m_moved = false;
             emit previewChanged();
 
+            if (keyboard) {
+                selectionController()->setSelectedClips(m_clips, false);
+                selectionController()->setSelectedLabels(m_labels, false);
+            }
             const TrackItemKeyList& selected = m_sourceIsLabel ? m_labels : m_clips;
             bool changedTrack = false;
             const auto result = m_sourceIsLabel
@@ -307,6 +413,9 @@ au::projectscene::TrackItemKey TrackItemsMoveController::finish()
         }
     }
     endInteraction();
+    if (keyboard) {
+        trackNavigationController()->setFocusedItem(movedKey.key, true /* highlight */);
+    }
     return movedKey;
 }
 
@@ -338,6 +447,10 @@ void TrackItemsMoveController::endInteraction()
     m_sourceKey = {};
     m_clips.clear();
     m_labels.clear();
+    if (m_keyboardMove) {
+        m_keyboardMove = false;
+        m_viewState->setKeyboardMoveActive(false);
+    }
     m_viewState->setMoveInitiated(false);
     m_viewState->setItemEditStartTimeOffset(-1.0);
     m_viewState->setItemEditEndTimeOffset(-1.0);

--- a/src/projectscene/view/tracksitemsview/trackitemsmovecontroller.cpp
+++ b/src/projectscene/view/tracksitemsview/trackitemsmovecontroller.cpp
@@ -394,10 +394,9 @@ au::projectscene::TrackItemKey TrackItemsMoveController::finish()
                 selectionController()->setSelectedLabels(m_labels, false);
             }
             const TrackItemKeyList& selected = m_sourceIsLabel ? m_labels : m_clips;
-            bool changedTrack = false;
             const auto result = m_sourceIsLabel
                                 ? trackeditInteraction()->moveLabels(selected, m_timeOffset, m_trackOffset)
-                                : trackeditInteraction()->moveClips(selected, m_timeOffset, m_trackOffset, changedTrack);
+                                : trackeditInteraction()->moveClips(selected, m_timeOffset, m_trackOffset);
             if (result.ret) {
                 const auto source = std::find(selected.begin(), selected.end(), m_sourceKey);
                 const auto sourceIndex = std::distance(selected.begin(), source);

--- a/src/projectscene/view/tracksitemsview/trackitemsmovecontroller.cpp
+++ b/src/projectscene/view/tracksitemsview/trackitemsmovecontroller.cpp
@@ -396,8 +396,8 @@ au::projectscene::TrackItemKey TrackItemsMoveController::finish()
             const TrackItemKeyList& selected = m_sourceIsLabel ? m_labels : m_clips;
             bool changedTrack = false;
             const auto result = m_sourceIsLabel
-                                ? trackeditInteraction()->moveLabels(selected, m_timeOffset, m_trackOffset, true)
-                                : trackeditInteraction()->moveClips(selected, m_timeOffset, m_trackOffset, true, changedTrack);
+                                ? trackeditInteraction()->moveLabels(selected, m_timeOffset, m_trackOffset)
+                                : trackeditInteraction()->moveClips(selected, m_timeOffset, m_trackOffset, changedTrack);
             if (result.ret) {
                 const auto source = std::find(selected.begin(), selected.end(), m_sourceKey);
                 const auto sourceIndex = std::distance(selected.begin(), source);

--- a/src/projectscene/view/tracksitemsview/trackitemsmovecontroller.h
+++ b/src/projectscene/view/tracksitemsview/trackitemsmovecontroller.h
@@ -1,0 +1,77 @@
+/*
+* Audacity: A Digital Audio Editor
+*/
+#pragma once
+
+#include <QObject>
+#include <QPointer>
+
+#include "context/iglobalcontext.h"
+#include "trackedit/iprojecthistory.h"
+#include "trackedit/iselectioncontroller.h"
+#include "trackedit/itrackeditinteraction.h"
+#include "trackedit/itracksinteraction.h"
+#include "../timeline/timelinecontext.h"
+
+namespace au::projectscene {
+class TrackItemsMoveController : public QObject, public muse::Contextable
+{
+    Q_OBJECT
+
+    Q_PROPERTY(TimelineContext * context READ timelineContext WRITE setTimelineContext NOTIFY contextChanged FINAL)
+    Q_PROPERTY(bool active READ active NOTIFY activeChanged FINAL)
+
+    muse::ContextInject<context::IGlobalContext> globalContext{ this };
+    muse::ContextInject<trackedit::ISelectionController> selectionController{ this };
+    muse::ContextInject<trackedit::ITrackeditInteraction> trackeditInteraction{ this };
+    muse::ContextInject<trackedit::ITracksInteraction> tracksInteraction{ this };
+    muse::ContextInject<trackedit::IProjectHistory> projectHistory{ this };
+
+public:
+    explicit TrackItemsMoveController(QObject* parent = nullptr);
+    ~TrackItemsMoveController() override;
+
+    TimelineContext* timelineContext() const;
+    void setTimelineContext(TimelineContext* context);
+
+    Q_INVOKABLE void start(const TrackItemKey& key);
+    Q_INVOKABLE void update();
+    Q_INVOKABLE TrackItemKey finish();
+    Q_INVOKABLE bool cancel();
+
+    bool active() const;
+    bool isDragged(const trackedit::TrackItemKey& key) const;
+    double timeOffset() const;
+    trackedit::TrackItemKeyList itemsOnTrack(trackedit::TrackId trackId) const;
+
+signals:
+    void contextChanged();
+    void activeChanged();
+    void previewChanged();
+    void guidelineChanged(double time);
+
+private:
+    friend class TrackItemsMoveControllerTests;
+
+    double pointerTimeOffset(double start, double end) const;
+    int pointerTrackOffset() const;
+    void updatePreview(double timeOffset, int trackOffset);
+    void endInteraction();
+
+    QPointer<TimelineContext> m_context;
+    IProjectViewStatePtr m_viewState;
+    trackedit::ITrackeditProjectPtr m_project;
+    trackedit::TrackItemKey m_sourceKey;
+    trackedit::ClipKeyList m_clips;
+    trackedit::LabelKeyList m_labels;
+    double m_startTime = 0.0;
+    double m_endTime = 0.0;
+    double m_timeOffset = 0.0;
+    int m_trackOffset = 0;
+    size_t m_originalTrackCount = 0;
+    bool m_sourceIsLabel = false;
+    bool m_rangeSelection = false;
+    bool m_moved = false;
+    bool m_updating = false;
+};
+}

--- a/src/projectscene/view/tracksitemsview/trackitemsmovecontroller.h
+++ b/src/projectscene/view/tracksitemsview/trackitemsmovecontroller.h
@@ -6,26 +6,32 @@
 #include <QObject>
 #include <QPointer>
 
+#include "async/asyncable.h"
 #include "context/iglobalcontext.h"
 #include "trackedit/iprojecthistory.h"
 #include "trackedit/iselectioncontroller.h"
 #include "trackedit/itrackeditinteraction.h"
 #include "trackedit/itracksinteraction.h"
+#include "trackedit/itracksviewrequestsservice.h"
+#include "trackedit/internal/itracknavigationcontroller.h"
 #include "../timeline/timelinecontext.h"
 
 namespace au::projectscene {
-class TrackItemsMoveController : public QObject, public muse::Contextable
+class TrackItemsMoveController : public QObject, public muse::async::Asyncable, public muse::Contextable
 {
     Q_OBJECT
 
     Q_PROPERTY(TimelineContext * context READ timelineContext WRITE setTimelineContext NOTIFY contextChanged FINAL)
     Q_PROPERTY(bool active READ active NOTIFY activeChanged FINAL)
+    Q_PROPERTY(bool keyboardActive READ keyboardActive NOTIFY activeChanged FINAL)
 
     muse::ContextInject<context::IGlobalContext> globalContext{ this };
     muse::ContextInject<trackedit::ISelectionController> selectionController{ this };
     muse::ContextInject<trackedit::ITrackeditInteraction> trackeditInteraction{ this };
     muse::ContextInject<trackedit::ITracksInteraction> tracksInteraction{ this };
     muse::ContextInject<trackedit::IProjectHistory> projectHistory{ this };
+    muse::ContextInject<trackedit::ITracksViewRequestsService> tracksViewRequestsService{ this };
+    muse::ContextInject<trackedit::ITrackNavigationController> trackNavigationController{ this };
 
 public:
     explicit TrackItemsMoveController(QObject* parent = nullptr);
@@ -34,12 +40,14 @@ public:
     TimelineContext* timelineContext() const;
     void setTimelineContext(TimelineContext* context);
 
+    Q_INVOKABLE void init();
     Q_INVOKABLE void start(const TrackItemKey& key);
     Q_INVOKABLE void update();
     Q_INVOKABLE TrackItemKey finish();
     Q_INVOKABLE bool cancel();
 
     bool active() const;
+    bool keyboardActive() const;
     bool isDragged(const trackedit::TrackItemKey& key) const;
     double timeOffset() const;
     trackedit::TrackItemKeyList itemsOnTrack(trackedit::TrackId trackId) const;
@@ -49,10 +57,13 @@ signals:
     void activeChanged();
     void previewChanged();
     void guidelineChanged(double time);
+    void keyboardTrackChanged(au::trackedit::TrackId trackId);
 
 private:
     friend class TrackItemsMoveControllerTests;
 
+    void start(const TrackItemKey& key, bool keyboard);
+    void moveByKeyboard(double timeOffset, int trackOffset);
     double pointerTimeOffset(double start, double end) const;
     int pointerTrackOffset() const;
     void updatePreview(double timeOffset, int trackOffset);
@@ -71,6 +82,7 @@ private:
     size_t m_originalTrackCount = 0;
     bool m_sourceIsLabel = false;
     bool m_rangeSelection = false;
+    bool m_keyboardMove = false;
     bool m_moved = false;
     bool m_updating = false;
 };

--- a/src/projectscene/view/tracksitemsview/tracklabelslayoutmanager.cpp
+++ b/src/projectscene/view/tracksitemsview/tracklabelslayoutmanager.cpp
@@ -145,6 +145,7 @@ void TrackLabelsLayoutManager::subscribeToLabelsChanges()
             }
         });
 
+        connect(label.item, &TrackLabelItem::draggedChanged, this, &TrackLabelsLayoutManager::scheduleRelayout);
         connect(label.item, &TrackLabelItem::isEditingChanged, this, &TrackLabelsLayoutManager::relink);
     }
 
@@ -234,6 +235,7 @@ void TrackLabelsLayoutManager::relayout()
     }
 
     QList<LabelInfo> labels = collectLabelsInfo();
+    labels.removeIf([](const LabelInfo& label) { return label.item->dragged(); });
 
     std::sort(labels.begin(), labels.end(), [](const LabelInfo& a, const LabelInfo& b) {
         if (a.x != b.x) {
@@ -336,6 +338,8 @@ void TrackLabelsLayoutManager::relink()
     m_rightLinkedLabels.clear();
 
     QList<LabelInfo> labels = collectLabelsInfo();
+    // Do not link to ghosts
+    labels.removeIf([](const LabelInfo& label) { return label.item->isDragGhost(); });
     for (const LabelInfo& label : labels) {
         label.item->setIsLeftLinked(false);
         label.item->setIsRightLinked(false);

--- a/src/projectscene/view/tracksitemsview/tracklabelslistmodel.cpp
+++ b/src/projectscene/view/tracksitemsview/tracklabelslistmodel.cpp
@@ -185,9 +185,9 @@ void TrackLabelsListModel::update()
 
     updatePendingTitleEdit();
 
-    muse::async::Async::call(this, [cleanupList]() {
-        qDeleteAll(cleanupList);
-    });
+    for (TrackLabelItem* item : cleanupList) {
+        item->deleteLater();
+    }
 }
 
 void TrackLabelsListModel::updatePendingTitleEdit()

--- a/src/projectscene/view/tracksitemsview/tracklabelslistmodel.cpp
+++ b/src/projectscene/view/tracksitemsview/tracklabelslistmodel.cpp
@@ -22,6 +22,14 @@ TrackLabelsListModel::TrackLabelsListModel(QObject* parent)
 
 void TrackLabelsListModel::onInit()
 {
+    if (moveController()) {
+        connect(moveController(), &TrackItemsMoveController::activeChanged, this, [this] {
+            if (!moveController()->active()) {
+                m_pendingToggleDeselect = {};
+            }
+        });
+    }
+
     selectionController()->labelsSelected().onReceive(this, [this](const LabelKeyList& keyList) {
         if (keyList.empty()) {
             resetSelectedLabels();
@@ -223,6 +231,11 @@ void TrackLabelsListModel::updateItemMetrics(ViewTrackItem* viewItem)
         return;
     }
 
+    if (item->isDragGhost()) {
+        label.startTime += moveTimeOffset();
+        label.endTime += moveTimeOffset();
+    }
+
     //! NOTE The first step is to calculate the position and width
     LabelTime time;
     time.startTime = label.startTime;
@@ -240,6 +253,13 @@ void TrackLabelsListModel::updateItemMetrics(ViewTrackItem* viewItem)
     item->setWidth((time.itemEndTime - time.itemStartTime) * m_context->zoom());
     item->setLeftVisibleMargin(std::max(m_context->frameStartTime() - time.itemStartTime, 0.0) * m_context->zoom());
     item->setRightVisibleMargin(std::max(time.itemEndTime - m_context->frameEndTime(), 0.0) * m_context->zoom());
+}
+
+ViewTrackItem* TrackLabelsListModel::createDragGhost(const trackedit::TrackItemKey& key)
+{
+    TrackLabelItem* item = new TrackLabelItem(this);
+    item->setLabel(globalContext()->currentTrackeditProject()->label(key));
+    return item;
 }
 
 TrackItemKeyList TrackLabelsListModel::getSelectedItemKeys() const
@@ -387,52 +407,6 @@ void TrackLabelsListModel::toggleTracksDataSelectionByLabel(const LabelKey& key)
         resetSelectedTracksData();
         selectionController()->setSelectedTracks({ key.key.trackId }, true);
     }
-}
-
-bool TrackLabelsListModel::moveSelectedLabels(const LabelKey& key, bool completed)
-{
-    TrackLabelItem* item = labelItemByKey(key.key);
-    if (!item) {
-        return false;
-    }
-
-    m_pendingToggleDeselect = {};
-
-    auto project = globalContext()->currentProject();
-    IF_ASSERT_FAILED(project) {
-        return false;
-    }
-
-    auto vs = project->viewState();
-    IF_ASSERT_FAILED(vs) {
-        return false;
-    }
-
-    bool ok = false;
-
-    // Labels can only be moved to label tracks.
-    TrackItemsListModel::MoveOffset moveOffset
-        = calculateMoveOffset(item, key, { trackedit::TrackType::Label }, completed);
-    if (vs->moveInitiated()) {
-        if (!selectionController()->timeSelectionIsEmpty()) {
-            ok = trackeditInteraction()->moveRangeSelection(moveOffset.timeOffset, completed);
-        } else {
-            auto selectedLabels = selectionController()->selectedLabels();
-            ok = trackeditInteraction()->moveLabels(selectedLabels, moveOffset.timeOffset, moveOffset.trackOffset, completed).ret;
-        }
-    }
-
-    if (ok && selectionController()->timeSelectionIsEmpty() && isTrackDataSelected()) {
-        doSelectTracksData(key);
-    }
-
-    if ((completed && m_autoScrollConnection)) {
-        disconnectAutoScroll();
-    } else if (!m_autoScrollConnection && !completed) {
-        m_autoScrollConnection = connect(m_context, &TimelineContext::frameTimeChanged, [this, key](){ moveSelectedLabels(key, false); });
-    }
-
-    return ok;
 }
 
 bool TrackLabelsListModel::stretchLabelLeft(const LabelKey& key, const LabelKey& leftLinkedLabel, bool unlink, bool completed)

--- a/src/projectscene/view/tracksitemsview/tracklabelslistmodel.h
+++ b/src/projectscene/view/tracksitemsview/tracklabelslistmodel.h
@@ -26,7 +26,6 @@ public:
 
     Q_INVOKABLE void toggleTracksDataSelectionByLabel(const LabelKey& key);
 
-    Q_INVOKABLE bool moveSelectedLabels(const LabelKey& key, bool completed);
     Q_INVOKABLE bool stretchLabelLeft(const LabelKey& key, const LabelKey& leftLinkedLabel, bool unlink, bool completed);
     Q_INVOKABLE bool stretchLabelRight(const LabelKey& key, const LabelKey& rightLinkedLabel, bool unlink, bool completed);
 
@@ -42,6 +41,7 @@ private:
     void update();
     void updatePendingTitleEdit();
     void updateItemMetrics(ViewTrackItem* item) override;
+    ViewTrackItem* createDragGhost(const trackedit::TrackItemKey& key) override;
     trackedit::TrackItemKeyList getSelectedItemKeys() const override;
 
     TrackLabelItem* labelItemByKey(const trackedit::LabelKey& k) const;

--- a/src/projectscene/view/tracksitemsview/tracklabelslistmodel.h
+++ b/src/projectscene/view/tracksitemsview/tracklabelslistmodel.h
@@ -34,6 +34,7 @@ public:
 
 private:
     friend class TrackLabelsLayoutManagerTests;
+    friend class TrackItemsMoveControllerTests;
 
     void onInit() override;
     void onReload() override;

--- a/src/projectscene/view/tracksitemsview/viewtrackitem.cpp
+++ b/src/projectscene/view/tracksitemsview/viewtrackitem.cpp
@@ -86,6 +86,34 @@ void ViewTrackItem::setSelected(bool newSelected)
     emit selectedChanged();
 }
 
+bool ViewTrackItem::dragged() const
+{
+    return m_dragged;
+}
+
+void ViewTrackItem::setDragged(bool dragged)
+{
+    if (m_dragged == dragged) {
+        return;
+    }
+    m_dragged = dragged;
+    emit draggedChanged();
+}
+
+bool ViewTrackItem::isDragGhost() const
+{
+    return m_dragGhost;
+}
+
+void ViewTrackItem::setDragGhost(bool ghost)
+{
+    if (m_dragGhost == ghost) {
+        return;
+    }
+    m_dragGhost = ghost;
+    emit isDragGhostChanged();
+}
+
 bool ViewTrackItem::intersectsSelection() const
 {
     return m_intersectsSelection;

--- a/src/projectscene/view/tracksitemsview/viewtrackitem.h
+++ b/src/projectscene/view/tracksitemsview/viewtrackitem.h
@@ -28,6 +28,8 @@ class ViewTrackItem : public QObject
     Q_PROPERTY(bool selected READ selected WRITE setSelected NOTIFY selectedChanged FINAL)
     Q_PROPERTY(bool intersectsSelection READ intersectsSelection WRITE setIntersectsSelection NOTIFY intersectsSelectionChanged FINAL)
     Q_PROPERTY(bool focused READ focused WRITE setFocused NOTIFY focusedChanged FINAL)
+    Q_PROPERTY(bool dragged READ dragged WRITE setDragged NOTIFY draggedChanged FINAL)
+    Q_PROPERTY(bool isDragGhost READ isDragGhost NOTIFY isDragGhostChanged FINAL)
 
 public:
     explicit ViewTrackItem(QObject* parent = nullptr);
@@ -55,6 +57,12 @@ public:
     bool focused() const;
     void setFocused(bool focused);
 
+    bool dragged() const;
+    void setDragged(bool dragged);
+
+    bool isDragGhost() const;
+    void setDragGhost(bool ghost);
+
     double leftVisibleMargin() const;
     void setLeftVisibleMargin(double newLeftVisibleMargin);
 
@@ -80,6 +88,8 @@ signals:
     void intersectsSelectionChanged();
 
     void focusedChanged();
+    void draggedChanged();
+    void isDragGhostChanged();
 
 protected:
     TrackItemKey m_key;
@@ -91,6 +101,8 @@ protected:
     bool m_selected = false;
     bool m_intersectsSelection = false;
     bool m_focused = false;
+    bool m_dragged = false;
+    bool m_dragGhost = false;
     double m_leftVisibleMargin = 0.0;
     double m_rightVisibleMargin = 0.0;
     TrackItemTime m_time;

--- a/src/trackedit/iclipsinteraction.h
+++ b/src/trackedit/iclipsinteraction.h
@@ -44,9 +44,7 @@ public:
     virtual ITrackDataPtr copyClip(const ClipKey& clipKey) = 0;
     virtual std::optional<TimeSpan> removeClip(const ClipKey& clipKey) = 0;
     virtual bool removeClips(const ClipKeyList& clipKeyList, bool moveClips) = 0;
-    virtual muse::RetVal<ClipKeyList> moveClips(const ClipKeyList& clipKeyList, secs_t timePositionOffset, int trackPositionOffset,
-                                                bool& clipsMovedToOtherTracks) = 0;
-    virtual void cancelClipDragEdit() = 0;
+    virtual muse::RetVal<ClipKeyList> moveClips(const ClipKeyList& clipKeyList, secs_t timePositionOffset, int trackPositionOffset) = 0;
 
     virtual bool splitClipsAtSilences(const ClipKeyList& clipKeyList) = 0;
     virtual bool splitClipsIntoNewTracks(const ClipKeyList& clipKeyList) = 0;

--- a/src/trackedit/iclipsinteraction.h
+++ b/src/trackedit/iclipsinteraction.h
@@ -45,7 +45,7 @@ public:
     virtual std::optional<TimeSpan> removeClip(const ClipKey& clipKey) = 0;
     virtual bool removeClips(const ClipKeyList& clipKeyList, bool moveClips) = 0;
     virtual muse::RetVal<ClipKeyList> moveClips(const ClipKeyList& clipKeyList, secs_t timePositionOffset, int trackPositionOffset,
-                                                bool completed, bool& clipsMovedToOtherTracks) = 0;
+                                                bool& clipsMovedToOtherTracks) = 0;
     virtual void cancelClipDragEdit() = 0;
 
     virtual bool splitClipsAtSilences(const ClipKeyList& clipKeyList) = 0;

--- a/src/trackedit/internal/au3/au3clipsinteraction.cpp
+++ b/src/trackedit/internal/au3/au3clipsinteraction.cpp
@@ -408,8 +408,7 @@ bool Au3ClipsInteraction::removeClips(const ClipKeyList& clipKeyList, bool moveC
 }
 
 muse::RetVal<ClipKeyList> Au3ClipsInteraction::moveClips(const ClipKeyList& clipKeyList, secs_t timePositionOffset,
-                                                         int trackPositionOffset,
-                                                         bool& clipsMovedToOtherTracks)
+                                                         int trackPositionOffset)
 {
     ClipKeyList newClipKeyList = clipKeyList;
 
@@ -422,10 +421,6 @@ muse::RetVal<ClipKeyList> Au3ClipsInteraction::moveClips(const ClipKeyList& clip
 
     const trackedit::ITrackeditProjectPtr prj = globalContext()->currentTrackeditProject();
 
-    if (!m_tracksWhenDragStarted) {
-        m_tracksWhenDragStarted.emplace(utils::getTrackListInfo(Au3TrackList::Get(projectRef())));
-    }
-
     //! NOTE: check if offset is applicable to every clip and recalculate if needed
     std::optional<secs_t> leftmostStartTime = leftmostClipStartTime(clipKeyList);
 
@@ -437,24 +432,15 @@ muse::RetVal<ClipKeyList> Au3ClipsInteraction::moveClips(const ClipKeyList& clip
 
     changeClipsStartTime(clipKeyList, timePositionOffset, false);
 
-    if (trackPositionOffset != 0) {
-        // Update m_moveClipsNeedsDownmixing only when moving up/down
-        m_moveClipsNeedsDownmixing = moveSelectedClipsUpOrDown(newClipKeyList, trackPositionOffset) == NeedsDownmixing::Yes;
-        clipsMovedToOtherTracks = true;
-    }
-
-    m_tracksWhenDragStarted.reset();
+    const bool needsDownmixing = trackPositionOffset != 0
+                                 && moveSelectedClipsUpOrDown(newClipKeyList, trackPositionOffset) == NeedsDownmixing::Yes;
 
     const muse::Ret makeRoomRet = makeRoomForClips(newClipKeyList);
     if (!makeRoomRet) {
         return muse::RetVal<ClipKeyList>::make_ret(makeRoomRet);
     }
 
-    const muse::Defer defer2([&] {
-        m_moveClipsNeedsDownmixing = false;
-    });
-
-    if (m_moveClipsNeedsDownmixing && !userIsOkWithDownmixing()) {
+    if (needsDownmixing && !userIsOkWithDownmixing()) {
         return muse::RetVal<ClipKeyList>::make_ret(make_ret(Err::DownmixingIsNotAllowed));
     }
 
@@ -505,20 +491,6 @@ muse::RetVal<ClipKeyList> Au3ClipsInteraction::moveClips(const ClipKeyList& clip
     }
 
     return result;
-}
-
-void Au3ClipsInteraction::cancelClipDragEdit()
-{
-    // If false, then the edit wasn't a clip drag (could have been trim or stretch)
-    if (m_tracksWhenDragStarted.has_value()) {
-        if (const auto prj = globalContext()->currentTrackeditProject()) {
-            // Doesn't matter it tracks are now empty or not - we're canceling the action.
-            constexpr auto emptyOnly = false;
-            tracksInteraction()->removeDragAddedTracks(m_tracksWhenDragStarted->size, emptyOnly);
-        }
-        m_tracksWhenDragStarted.reset();
-    }
-    m_moveClipsNeedsDownmixing = false;
 }
 
 bool Au3ClipsInteraction::splitClipsAtSilences(const ClipKeyList& clipKeyList)
@@ -988,21 +960,6 @@ NeedsDownmixing Au3ClipsInteraction::moveSelectedClipsUpOrDown(ClipKeyList& clip
     const NeedsDownmixing needsDownmixing = utils::moveClipsVertically(offset, orig,
                                                                        *copy, clipKeyList);
 
-    // Clean-up after ourselves, preserving original track formats:
-    // Tracks that were empty at the start of the interaction, are empty now and differ in format must be restored.
-    const TrackListInfo copyInfo = utils::getTrackListInfo(*copy);
-    for (const size_t index : copyInfo.emptyTrackIndices) {
-        if (index >= m_tracksWhenDragStarted->size) {
-            continue;
-        }
-        const auto isStereoNow = muse::contains(copyInfo.stereoTrackIndices, index);
-        const auto wasStereoBefore = muse::contains(m_tracksWhenDragStarted->stereoTrackIndices, index);
-        if (isStereoNow != wasStereoBefore) {
-            // Toggle back the way it was.
-            utils::toggleStereo(*copy, index);
-        }
-    }
-
     // Now we can update the original with the modified copy.
     auto& mutOrig = const_cast<au3::Au3TrackList&>(orig);
 
@@ -1075,20 +1032,6 @@ NeedsDownmixing Au3ClipsInteraction::moveSelectedClipsUpOrDown(ClipKeyList& clip
         if (newTrack) {
             clipKey.trackId = newTrack->GetId();
         }
-    }
-
-    if (offset < 0) {
-        // The user dragged up. It's possible that the bottom-most tracks were created during this interaction,
-        // in which case we make it nice to the user and remove them automatically.
-        // Only remove empty temp tracks that are below the dragged clips
-        const auto& origTracks = ::TrackList::Get(projectRef());
-        size_t highestClipIndex = 0;
-        for (const auto& clipKey : clipKeyList) {
-            highestClipIndex = std::max(highestClipIndex, utils::getTrackIndex(origTracks, clipKey.trackId));
-        }
-        const size_t removeFrom = std::max(m_tracksWhenDragStarted->size, highestClipIndex + 1);
-        constexpr auto emptyOnly = true;
-        tracksInteraction()->removeDragAddedTracks(removeFrom, emptyOnly);
     }
 
     return needsDownmixing;

--- a/src/trackedit/internal/au3/au3clipsinteraction.cpp
+++ b/src/trackedit/internal/au3/au3clipsinteraction.cpp
@@ -5,6 +5,7 @@
 #include "au3clipsinteraction.h"
 
 #include <algorithm>
+#include <set>
 
 #include <QCoreApplication>
 
@@ -461,18 +462,35 @@ muse::RetVal<ClipKeyList> Au3ClipsInteraction::moveClips(const ClipKeyList& clip
         return muse::RetVal<ClipKeyList>::make_ret(make_ret(Err::DownmixingIsNotAllowed));
     }
 
+    // Selection can still refer to the source tracks when a preview is committed in one call.
+    std::set<TrackId> destinationTracks;
+    for (const ClipKey& key : newClipKeyList) {
+        destinationTracks.insert(key.trackId);
+    }
+    std::vector<Au3WaveTrack*> tracksToConvert;
+    for (const TrackId trackId : destinationTracks) {
+        Au3WaveTrack* waveTrack = DomAccessor::findWaveTrack(projectRef(), Au3TrackId(trackId));
+        IF_ASSERT_FAILED(waveTrack) {
+            return muse::RetVal<ClipKeyList>::make_ret(make_ret(Err::TrackNotFound));
+        }
+        const auto& clips = waveTrack->Intervals();
+        if (std::any_of(clips.begin(), clips.end(), [waveTrack](const auto& clip) {
+            return clip->NChannels() != waveTrack->NChannels();
+        })) {
+            tracksToConvert.push_back(waveTrack);
+        }
+    }
+    if (tracksToConvert.empty()) {
+        return muse::RetVal<ClipKeyList>::make_ok(newClipKeyList);
+    }
+
     muse::RetVal<ClipKeyList> result;
     //! TODO AU4: later when having keyboard arrow shortcut for moving clips
     //! make use of UndoPush::CONSOLIDATE arg in UndoManager
     result.ret = utils::withProgress(*interactive(), mixingDownToMonoLabel, [&](utils::ProgressCb progressCb, utils::CancelCb cancelCb)
     {
         std::vector<std::pair<WaveTrack*, std::shared_ptr<WaveTrack> > > toReplace;
-        for (const trackedit::TrackId track : selectionController()->selectedTracks()) {
-            Au3WaveTrack* waveTrack = DomAccessor::findWaveTrack(projectRef(), Au3TrackId(track));
-            // If this is not an audio track (i.e. a label track), skip it
-            if (!waveTrack) {
-                continue;
-            }
+        for (Au3WaveTrack* waveTrack : tracksToConvert) {
             const auto copy = std::static_pointer_cast<WaveTrack>(waveTrack->Duplicate(::Track::DuplicateOptions {}.Backup()));
             if (copy->FixClipChannels(progressCb, cancelCb)) {
                 toReplace.emplace_back(waveTrack, copy);

--- a/src/trackedit/internal/au3/au3clipsinteraction.cpp
+++ b/src/trackedit/internal/au3/au3clipsinteraction.cpp
@@ -8,6 +8,7 @@
 
 #include <QCoreApplication>
 
+#include "au3-realtime-effects/RealtimeEffectList.h"
 #include "au3-stretching-sequence/TempoChange.h"
 #include "au3-track/Track.h"
 #include "au3-wave-track/TimeStretching.h"
@@ -1024,6 +1025,7 @@ NeedsDownmixing Au3ClipsInteraction::moveSelectedClipsUpOrDown(ClipKeyList& clip
         const auto wasToggled = origWaveTrack->NChannels() != newWaveTrack->NChannels();
         const auto trackId = origWaveTrack->GetId();
         const auto clipsBefore = prj->clipList(trackId);
+        RealtimeEffectList::ShareStates(*newTrack, *origWaveTrack);
         // Careful, this decreases the `origWaveTrack` ref count.
         mutOrig.ReplaceOne(*origWaveTrack, std::move(*copy));
         if (wasToggled) {

--- a/src/trackedit/internal/au3/au3clipsinteraction.cpp
+++ b/src/trackedit/internal/au3/au3clipsinteraction.cpp
@@ -408,7 +408,7 @@ bool Au3ClipsInteraction::removeClips(const ClipKeyList& clipKeyList, bool moveC
 }
 
 muse::RetVal<ClipKeyList> Au3ClipsInteraction::moveClips(const ClipKeyList& clipKeyList, secs_t timePositionOffset,
-                                                         int trackPositionOffset, bool completed,
+                                                         int trackPositionOffset,
                                                          bool& clipsMovedToOtherTracks)
 {
     ClipKeyList newClipKeyList = clipKeyList;
@@ -441,10 +441,6 @@ muse::RetVal<ClipKeyList> Au3ClipsInteraction::moveClips(const ClipKeyList& clip
         // Update m_moveClipsNeedsDownmixing only when moving up/down
         m_moveClipsNeedsDownmixing = moveSelectedClipsUpOrDown(newClipKeyList, trackPositionOffset) == NeedsDownmixing::Yes;
         clipsMovedToOtherTracks = true;
-    }
-
-    if (!completed) {
-        return muse::RetVal<ClipKeyList>::make_ok(newClipKeyList);
     }
 
     m_tracksWhenDragStarted.reset();
@@ -485,8 +481,6 @@ muse::RetVal<ClipKeyList> Au3ClipsInteraction::moveClips(const ClipKeyList& clip
     }
 
     muse::RetVal<ClipKeyList> result;
-    //! TODO AU4: later when having keyboard arrow shortcut for moving clips
-    //! make use of UndoPush::CONSOLIDATE arg in UndoManager
     result.ret = utils::withProgress(*interactive(), mixingDownToMonoLabel, [&](utils::ProgressCb progressCb, utils::CancelCb cancelCb)
     {
         std::vector<std::pair<WaveTrack*, std::shared_ptr<WaveTrack> > > toReplace;

--- a/src/trackedit/internal/au3/au3clipsinteraction.h
+++ b/src/trackedit/internal/au3/au3clipsinteraction.h
@@ -60,7 +60,7 @@ public:
     ITrackDataPtr copyClip(const trackedit::ClipKey& clipKey) override;
     std::optional<TimeSpan> removeClip(const trackedit::ClipKey& clipKey) override;
     bool removeClips(const trackedit::ClipKeyList& clipKeyList, bool moveClips) override;
-    muse::RetVal<ClipKeyList> moveClips(const ClipKeyList& clipKeyList, secs_t timePositionOffset, int trackPositionOffset, bool completed,
+    muse::RetVal<ClipKeyList> moveClips(const ClipKeyList& clipKeyList, secs_t timePositionOffset, int trackPositionOffset,
                                         bool& clipsMovedToOtherTracks) override;
     void cancelClipDragEdit() override;
 

--- a/src/trackedit/internal/au3/au3clipsinteraction.h
+++ b/src/trackedit/internal/au3/au3clipsinteraction.h
@@ -12,7 +12,6 @@
 #include "trackedit/iselectioncontroller.h"
 #include "trackedit/itrackeditconfiguration.h"
 #include "trackedit/iprojecthistory.h"
-#include "trackedit/itracksinteraction.h"
 #include "automation/iclipgaininteraction.h"
 
 #include "au3wrap/au3types.h"
@@ -33,7 +32,6 @@ class Au3ClipsInteraction : public IClipsInteraction, public muse::Contextable
     muse::ContextInject<au::trackedit::ISelectionController> selectionController{ this };
     muse::ContextInject<au::trackedit::IProjectHistory> projectHistory{ this };
     muse::ContextInject<muse::IInteractive> interactive{ this };
-    muse::ContextInject<ITracksInteraction> tracksInteraction{ this };
     muse::ContextInject<automation::IClipGainInteraction> clipGainInteraction{ this };
 
 public:
@@ -60,9 +58,7 @@ public:
     ITrackDataPtr copyClip(const trackedit::ClipKey& clipKey) override;
     std::optional<TimeSpan> removeClip(const trackedit::ClipKey& clipKey) override;
     bool removeClips(const trackedit::ClipKeyList& clipKeyList, bool moveClips) override;
-    muse::RetVal<ClipKeyList> moveClips(const ClipKeyList& clipKeyList, secs_t timePositionOffset, int trackPositionOffset,
-                                        bool& clipsMovedToOtherTracks) override;
-    void cancelClipDragEdit() override;
+    muse::RetVal<ClipKeyList> moveClips(const ClipKeyList& clipKeyList, secs_t timePositionOffset, int trackPositionOffset) override;
 
     bool splitClipsAtSilences(const ClipKeyList& clipKeyList) override;
     bool splitClipsIntoNewTracks(const ClipKeyList& clipKeyList) override;
@@ -132,8 +128,5 @@ private:
 
     muse::Progress m_progress;
     std::atomic<bool> m_busy = false;
-
-    std::optional<TrackListInfo> m_tracksWhenDragStarted;
-    bool m_moveClipsNeedsDownmixing = false;
 };
 }

--- a/src/trackedit/internal/au3/au3interactiontypes.h
+++ b/src/trackedit/internal/au3/au3interactiontypes.h
@@ -3,23 +3,7 @@
  */
 #pragma once
 
-#include <cstddef>
-#include <vector>
-
 namespace au::trackedit {
-struct TrackListInfo {
-    TrackListInfo(size_t size, std::vector<size_t> stereoTrackIndices, std::vector<size_t> emptyTrackIndices)
-        : size{size}
-        , stereoTrackIndices{std::move(stereoTrackIndices)}
-        , emptyTrackIndices{std::move(emptyTrackIndices)}
-    {
-    }
-
-    const size_t size;
-    const std::vector<size_t> stereoTrackIndices;
-    const std::vector<size_t> emptyTrackIndices;
-};
-
 enum class NeedsDownmixing {
     Yes,
     No,

--- a/src/trackedit/internal/au3/au3interactionutils.cpp
+++ b/src/trackedit/internal/au3/au3interactionutils.cpp
@@ -246,26 +246,6 @@ au::trackedit::NeedsDownmixing au::trackedit::utils::moveClipsVertically(int off
     return needsDownmixing;
 }
 
-au::trackedit::TrackListInfo au::trackedit::utils::getTrackListInfo(const au3::Au3TrackList& tracks)
-{
-    std::vector<size_t> stereoTrackIndices;
-    std::vector<size_t> emptyTrackIndices;
-    auto i = 0;
-    for (const au3::Au3Track* track : tracks) {
-        const au3::Au3WaveTrack* waveTrack = dynamic_cast<const au3::Au3WaveTrack*>(track);
-        if (waveTrack) {
-            if (waveTrack->NChannels() == 2) {
-                stereoTrackIndices.push_back(i);
-            }
-            if (waveTrack->IsEmpty()) {
-                emptyTrackIndices.push_back(i);
-            }
-        }
-        ++i;
-    }
-    return { tracks.Size(), std::move(stereoTrackIndices), std::move(emptyTrackIndices) };
-}
-
 bool au::trackedit::utils::clipIdSetsAreEqual(const au3::Au3WaveTrack& track1, const au3::Au3WaveTrack& track2)
 {
     const auto numClips = track1.GetNumClips();

--- a/src/trackedit/internal/au3/au3interactionutils.cpp
+++ b/src/trackedit/internal/au3/au3interactionutils.cpp
@@ -12,6 +12,7 @@
 #include "au3-wave-track/WaveClip.h"
 #include "au3-project-rate/ProjectRate.h"
 #include "au3-project-rate/QualitySettings.h"
+#include "au3-realtime-effects/RealtimeEffectList.h"
 #include "global/containers.h"
 #include "global/realfn.h"
 #include "log.h"
@@ -96,6 +97,7 @@ size_t au::trackedit::utils::getTrackIndex(const au3::Au3TrackList& tracks, cons
 
 void au::trackedit::utils::exchangeTrack(au3::Au3TrackList& tracks, au3::Au3WaveTrack& oldOne, au3::Au3WaveTrack& newOne)
 {
+    RealtimeEffectList::ShareStates(newOne, oldOne);
     auto tmp = au3::Au3TrackList::Temporary(nullptr, newOne.shared_from_this());
     tracks.ReplaceOne(oldOne, std::move(*tmp));
 }

--- a/src/trackedit/internal/au3/au3interactionutils.h
+++ b/src/trackedit/internal/au3/au3interactionutils.h
@@ -47,8 +47,6 @@ au3::Au3WaveTrack* appendWaveTrack(au3::Au3TrackList& tracks, size_t nChannels, 
 NeedsDownmixing moveClipsVertically(int offset, const au3::Au3TrackList& orig, au3::Au3TrackList& copy,
                                     const trackedit::ClipKeyList& selectedClips);
 
-au::trackedit::TrackListInfo getTrackListInfo(const au3::Au3TrackList& tracks);
-
 bool clipIdSetsAreEqual(const au3::Au3WaveTrack& track1, const au3::Au3WaveTrack& track2);
 
 muse::Ret withProgress(muse::IInteractive& interactive, const std::string& title, const std::function<bool(ProgressCb, CancelCb)>& action);

--- a/src/trackedit/internal/au3/au3labelsinteraction.cpp
+++ b/src/trackedit/internal/au3/au3labelsinteraction.cpp
@@ -317,8 +317,6 @@ muse::RetVal<LabelKeyList> Au3LabelsInteraction::moveLabels(const LabelKeyList& 
     muse::RetVal<LabelKeyList> result;
     result.ret = make_ret(Err::NoError);
 
-    trackPositionOffset = std::clamp(trackPositionOffset, -1, 1);
-
     if (muse::RealIsEqual(timePositionOffset, 0.0) && trackPositionOffset == 0) {
         result.val = labelKeys;
         return result;
@@ -338,25 +336,20 @@ muse::RetVal<LabelKeyList> Au3LabelsInteraction::moveLabels(const LabelKeyList& 
     const trackedit::ITrackeditProjectPtr prj = globalContext()->currentTrackeditProject();
     auto& tracks = Au3TrackList::Get(projectRef());
 
-    auto resolveTrack = [&tracks, &trackPositionOffset](const TrackId& currentTrackId) ->TrackId {
-        size_t index = 0;
-        for (const auto& track : tracks) {
-            if (track->GetId() == currentTrackId) {
-                size_t newIndex = std::clamp(static_cast<int>(index) + trackPositionOffset, 0, static_cast<int>(tracks.Size()) - 1);
-                auto it = std::next(tracks.cbegin(), newIndex);
-                while (*it) {
-                    if (dynamic_cast<const Au3LabelTrack*>(*it)) {
-                        break;
-                    }
-                    newIndex = trackPositionOffset > 0 ? newIndex + 1 : newIndex - 1;
-                    it = std::next(tracks.cbegin(), newIndex);
-                }
-
-                return *it ? (*it)->GetId() : currentTrackId;
-            }
-            ++index;
+    TrackIdList labelTrackIds;
+    for (const auto& track : tracks) {
+        if (dynamic_cast<const Au3LabelTrack*>(track)) {
+            labelTrackIds.push_back(track->GetId());
         }
-        return INVALID_TRACK;
+    }
+    const auto resolveTrack = [&labelTrackIds, trackPositionOffset](TrackId currentTrackId) -> TrackId {
+        const auto it = std::find(labelTrackIds.begin(), labelTrackIds.end(), currentTrackId);
+        if (it == labelTrackIds.end()) {
+            return INVALID_TRACK;
+        }
+        const int index = static_cast<int>(std::distance(labelTrackIds.begin(), it));
+        const int newIndex = std::clamp(index + trackPositionOffset, 0, static_cast<int>(labelTrackIds.size()) - 1);
+        return labelTrackIds[newIndex];
     };
 
     //! NOTE: check if offset is applicable to every label and recalculate if needed

--- a/src/trackedit/internal/trackeditactionscontroller.cpp
+++ b/src/trackedit/internal/trackeditactionscontroller.cpp
@@ -333,7 +333,6 @@ void TrackeditActionsController::init()
         notifyActionEnabledChanged(TRACKEDIT_UNDO);
         notifyActionEnabledChanged(TRACKEDIT_REDO);
         notifyActionEnabledChanged(SILENCE_AUDIO_SELECTION);
-        setFocusedItemMoveInProgress(false);
     });
 
     globalContext()->isRecordingChanged().onNotify(this, [this]() {
@@ -2355,87 +2354,7 @@ void TrackeditActionsController::moveFocusedItemDown()
 
 void TrackeditActionsController::moveFocusedItem(secs_t timePositionOffset, int trackPositionOffset)
 {
-    const TrackItemKey focusedItem = trackNavigationController()->focusedItem();
-    const bool trackFocused = focusedItem.trackId != INVALID_TRACK && focusedItem.itemId == INVALID_TRACK_ITEM;
-    if (trackFocused) {
-        if (trackPositionOffset != 0) {
-            const TrackMoveDirection direction = trackPositionOffset < 0 ? TrackMoveDirection::Up : TrackMoveDirection::Down;
-            trackeditInteraction()->moveTracks({ focusedItem.trackId }, direction);
-        }
-        return;
-    }
-
-    constexpr bool completed = false;
-
-    if (!labelsForInteraction().empty()) {
-        muse::RetVal<LabelKeyList> result = trackeditInteraction()->moveLabels(labelsForInteraction(), timePositionOffset,
-                                                                               trackPositionOffset, completed);
-        if (!result.ret) {
-            return;
-        }
-        selectionController()->setSelectedLabels(result.val, completed);
-        if (trackPositionOffset != 0 && !result.val.empty()) {
-            trackNavigationController()->setFocusedItem(result.val.front(), true /*highlight*/);
-        }
-    } else if (!clipsForInteraction().empty()) {
-        bool itemsMovedToOtherTrack = false;
-        muse::RetVal<ClipKeyList> result = trackeditInteraction()->moveClips(clipsForInteraction(), timePositionOffset,
-                                                                             trackPositionOffset, completed, itemsMovedToOtherTrack);
-        if (!result.ret) {
-            return;
-        }
-        selectionController()->setSelectedClips(result.val, completed);
-        if (trackPositionOffset != 0 && !result.val.empty()) {
-            trackNavigationController()->setFocusedItem(result.val.front(), true /*highlight*/);
-        }
-    } else {
-        return;
-    }
-
-    setFocusedItemMoveInProgress(true);
-}
-
-void TrackeditActionsController::setFocusedItemMoveInProgress(bool inProgress)
-{
-    if (m_focusedItemMoveInProgress == inProgress) {
-        return;
-    }
-    m_focusedItemMoveInProgress = inProgress;
-
-    if (auto project = globalContext()->currentProject()) {
-        if (auto viewState = project->viewState()) {
-            viewState->setKeyboardMoveActive(inProgress);
-            if (inProgress) {
-                viewState->modifiersReleased().onNotify(this, [this]() {
-                    completeFocusedItemMove();
-                }, muse::async::Asyncable::Mode::SetReplace);
-            }
-        }
-    }
-}
-
-void TrackeditActionsController::completeFocusedItemMove()
-{
-    if (!m_focusedItemMoveInProgress) {
-        return;
-    }
-    setFocusedItemMoveInProgress(false);
-
-    constexpr bool completed = true;
-
-    if (!labelsForInteraction().empty()) {
-        muse::RetVal<LabelKeyList> result = trackeditInteraction()->moveLabels(labelsForInteraction(), 0.0, 0, completed);
-        if (result.ret) {
-            selectionController()->setSelectedLabels(result.val, completed);
-        }
-    } else if (!clipsForInteraction().empty()) {
-        bool itemsMovedToOtherTrack = false;
-        muse::RetVal<ClipKeyList> result = trackeditInteraction()->moveClips(clipsForInteraction(), 0.0, 0, completed,
-                                                                             itemsMovedToOtherTrack);
-        if (result.ret) {
-            selectionController()->setSelectedClips(result.val, completed);
-        }
-    }
+    tracksViewRequestsService()->requestItemMove(timePositionOffset, trackPositionOffset);
 }
 
 void TrackeditActionsController::extendFocusedItemBoundaryLeft()

--- a/src/trackedit/internal/trackeditactionscontroller.h
+++ b/src/trackedit/internal/trackeditactionscontroller.h
@@ -210,8 +210,6 @@ private:
     void moveFocusedItemUp();
     void moveFocusedItemDown();
     void moveFocusedItem(secs_t timePositionOffset, int trackPositionOffset);
-    void completeFocusedItemMove();
-    void setFocusedItemMoveInProgress(bool inProgress);
     void extendFocusedItemBoundaryLeft();
     void extendFocusedItemBoundaryRight();
     void reduceFocusedItemBoundaryLeft();
@@ -228,7 +226,5 @@ private:
     muse::async::Channel<muse::actions::ActionCode> m_actionCheckedChanged;
 
     DeleteBehaviorOnboardingScenario m_deleteBehaviorOnboardingScenario;
-
-    bool m_focusedItemMoveInProgress = false;
 };
 }

--- a/src/trackedit/internal/trackeditinteraction.cpp
+++ b/src/trackedit/internal/trackeditinteraction.cpp
@@ -153,14 +153,12 @@ bool TrackeditInteraction::removeTracksData(const TrackIdList& tracksIds, secs_t
 }
 
 muse::RetVal<ClipKeyList> TrackeditInteraction::moveClips(const ClipKeyList& clipKeyList, secs_t timePositionOffset,
-                                                          int trackPositionOffset,
-                                                          bool& clipsMovedToOtherTrack)
+                                                          int trackPositionOffset)
 {
     return withPlaybackStopRetVal(&ITrackeditInteraction::moveClips,
                                   clipKeyList,
                                   timePositionOffset,
-                                  trackPositionOffset,
-                                  clipsMovedToOtherTrack);
+                                  trackPositionOffset);
 }
 
 bool TrackeditInteraction::moveRangeSelection(secs_t timePositionOffset, bool completed)
@@ -480,11 +478,6 @@ bool TrackeditInteraction::cutLabel(const LabelKey& labelKey)
 bool TrackeditInteraction::copyLabel(const LabelKey& labelKey)
 {
     return m_interaction->copyLabel(labelKey);
-}
-
-bool TrackeditInteraction::moveLabels(const LabelKeyList& labelKeys, secs_t timePositionOffset, bool completed)
-{
-    return m_interaction->moveLabels(labelKeys, timePositionOffset, completed);
 }
 
 muse::RetVal<LabelKeyList> TrackeditInteraction::moveLabels(const LabelKeyList& labelKeys, secs_t timePositionOffset,

--- a/src/trackedit/internal/trackeditinteraction.cpp
+++ b/src/trackedit/internal/trackeditinteraction.cpp
@@ -153,14 +153,13 @@ bool TrackeditInteraction::removeTracksData(const TrackIdList& tracksIds, secs_t
 }
 
 muse::RetVal<ClipKeyList> TrackeditInteraction::moveClips(const ClipKeyList& clipKeyList, secs_t timePositionOffset,
-                                                          int trackPositionOffset, bool completed,
+                                                          int trackPositionOffset,
                                                           bool& clipsMovedToOtherTrack)
 {
     return withPlaybackStopRetVal(&ITrackeditInteraction::moveClips,
                                   clipKeyList,
                                   timePositionOffset,
                                   trackPositionOffset,
-                                  completed,
                                   clipsMovedToOtherTrack);
 }
 
@@ -489,9 +488,9 @@ bool TrackeditInteraction::moveLabels(const LabelKeyList& labelKeys, secs_t time
 }
 
 muse::RetVal<LabelKeyList> TrackeditInteraction::moveLabels(const LabelKeyList& labelKeys, secs_t timePositionOffset,
-                                                            int trackPositionOffset, bool completed)
+                                                            int trackPositionOffset)
 {
-    return m_interaction->moveLabels(labelKeys, timePositionOffset, trackPositionOffset, completed);
+    return m_interaction->moveLabels(labelKeys, timePositionOffset, trackPositionOffset);
 }
 
 muse::RetVal<LabelKeyList> TrackeditInteraction::moveLabelsToTrack(const LabelKeyList& labelKeys, const TrackId& toTrackId, bool completed)

--- a/src/trackedit/internal/trackeditinteraction.h
+++ b/src/trackedit/internal/trackeditinteraction.h
@@ -49,7 +49,7 @@ private:
     bool removeClip(const trackedit::ClipKey& clipKey) override;
     bool removeClips(const ClipKeyList& clipKeyList, bool moveClips) override;
     bool removeTracksData(const TrackIdList& tracksIds, secs_t begin, secs_t end, bool moveClips) override;
-    muse::RetVal<ClipKeyList> moveClips(const ClipKeyList& clipKeyList, secs_t timePositionOffset, int trackPositionOffset, bool&) override;
+    muse::RetVal<ClipKeyList> moveClips(const ClipKeyList& clipKeyList, secs_t timePositionOffset, int trackPositionOffset) override;
     bool moveRangeSelection(secs_t timePositionOffset, bool completed) override;
     void cancelItemDragEdit() override;
     bool splitTracksAt(const TrackIdList& tracksIds, std::vector<secs_t> pivots) override;
@@ -127,7 +127,6 @@ private:
     bool cutLabel(const LabelKey& labelKey) override;
     bool copyLabel(const LabelKey& labelKey) override;
 
-    bool moveLabels(const LabelKeyList& labelKeys, secs_t timePositionOffset, bool completed) override;
     muse::RetVal<LabelKeyList> moveLabels(const LabelKeyList& labelKeys, secs_t timePositionOffset, int trackPositionOffset) override;
     muse::RetVal<LabelKeyList> moveLabelsToTrack(const LabelKeyList& labelKeys, const TrackId& toTrackId, bool completed) override;
 

--- a/src/trackedit/internal/trackeditinteraction.h
+++ b/src/trackedit/internal/trackeditinteraction.h
@@ -49,8 +49,7 @@ private:
     bool removeClip(const trackedit::ClipKey& clipKey) override;
     bool removeClips(const ClipKeyList& clipKeyList, bool moveClips) override;
     bool removeTracksData(const TrackIdList& tracksIds, secs_t begin, secs_t end, bool moveClips) override;
-    muse::RetVal<ClipKeyList> moveClips(const ClipKeyList& clipKeyList, secs_t timePositionOffset, int trackPositionOffset, bool completed,
-                                        bool&) override;
+    muse::RetVal<ClipKeyList> moveClips(const ClipKeyList& clipKeyList, secs_t timePositionOffset, int trackPositionOffset, bool&) override;
     bool moveRangeSelection(secs_t timePositionOffset, bool completed) override;
     void cancelItemDragEdit() override;
     bool splitTracksAt(const TrackIdList& tracksIds, std::vector<secs_t> pivots) override;
@@ -129,8 +128,7 @@ private:
     bool copyLabel(const LabelKey& labelKey) override;
 
     bool moveLabels(const LabelKeyList& labelKeys, secs_t timePositionOffset, bool completed) override;
-    muse::RetVal<LabelKeyList> moveLabels(const LabelKeyList& labelKeys, secs_t timePositionOffset, int trackPositionOffset,
-                                          bool completed) override;
+    muse::RetVal<LabelKeyList> moveLabels(const LabelKeyList& labelKeys, secs_t timePositionOffset, int trackPositionOffset) override;
     muse::RetVal<LabelKeyList> moveLabelsToTrack(const LabelKeyList& labelKeys, const TrackId& toTrackId, bool completed) override;
 
     bool stretchLabelLeft(const LabelKey& labelKey, secs_t newStartTime, bool completed) override;

--- a/src/trackedit/internal/trackeditoperationcontroller.cpp
+++ b/src/trackedit/internal/trackeditoperationcontroller.cpp
@@ -326,8 +326,7 @@ bool TrackeditOperationController::removeTracksData(const TrackIdList& tracksIds
 }
 
 muse::RetVal<ClipKeyList> TrackeditOperationController::moveClips(const ClipKeyList& clipKeyList, secs_t timePositionOffset,
-                                                                  int trackPositionOffset,
-                                                                  bool& clipsMovedToOtherTrack)
+                                                                  int trackPositionOffset)
 {
     // Labels to move along with clips
     LabelKeyList selectedLabels = selectionController()->selectedLabels();
@@ -353,11 +352,9 @@ muse::RetVal<ClipKeyList> TrackeditOperationController::moveClips(const ClipKeyL
         timePositionOffset = clampedOffset;
     }
 
-    muse::RetVal<ClipKeyList> result = clipsInteraction()->moveClips(clipKeyList, timePositionOffset, trackPositionOffset,
-                                                                     clipsMovedToOtherTrack);
+    muse::RetVal<ClipKeyList> result = clipsInteraction()->moveClips(clipKeyList, timePositionOffset, trackPositionOffset);
 
     if (!result.ret) {
-        clipsMovedToOtherTrack = false;
         projectHistory()->rollbackState();
         globalContext()->currentTrackeditProject()->reload();
     } else {
@@ -421,7 +418,6 @@ void TrackeditOperationController::cancelItemDragEdit()
     if (!projectHistory()->interactionOngoing()) {
         return;
     }
-    clipsInteraction()->cancelClipDragEdit();
     labelsInteraction()->resetLabelStretchState();
     projectHistory()->rollbackState();
     globalContext()->currentTrackeditProject()->reload();
@@ -980,40 +976,6 @@ bool TrackeditOperationController::removeLabels(const LabelKeyList& labelKeys, b
     return false;
 }
 
-bool TrackeditOperationController::moveLabels(const LabelKeyList& labelKeys, secs_t timePositionOffset, bool completed)
-{
-    ClipKeyList selectedClips = selectionController()->selectedClips();
-    if (!selectedClips.empty()) {
-        secs_t clampedOffset = timePositionOffset;
-
-        for (const auto& clipKey : selectedClips) {
-            secs_t startTime = clipsInteraction()->clipStartTime(clipKey);
-            if (startTime + clampedOffset < 0.0) {
-                clampedOffset = -startTime;
-            }
-        }
-
-        auto prj = globalContext()->currentTrackeditProject();
-        for (const auto& labelKey : labelKeys) {
-            trackedit::Label label = prj->label(labelKey);
-            if (label.isValid() && label.startTime + clampedOffset < 0.0) {
-                clampedOffset = -label.startTime;
-            }
-        }
-
-        clipsInteraction()->changeClipsStartTime(selectedClips, clampedOffset, completed);
-
-        timePositionOffset = clampedOffset;
-    }
-
-    muse::RetVal<LabelKeyList> retVal = labelsInteraction()->moveLabels(labelKeys, timePositionOffset, 0);
-    if (retVal.ret && completed) {
-        const std::string msg = !selectedClips.empty() ? muse::trc("trackedit", "Move items") : muse::trc("trackedit", "Move labels");
-        projectHistory()->pushHistoryState(muse::trc("trackedit", "Move"), msg);
-    }
-    return retVal.ret;
-}
-
 muse::RetVal<LabelKeyList> TrackeditOperationController::moveLabels(const LabelKeyList& labelKeys, secs_t timePositionOffset,
                                                                     int trackPositionOffset)
 {
@@ -1024,8 +986,7 @@ muse::RetVal<LabelKeyList> TrackeditOperationController::moveLabels(const LabelK
 
     bool clipsSelected = isClipsSelected();
     if (isClipsSelected()) {
-        bool clipsMovedToOtherTracks = false;
-        clipsInteraction()->moveClips(selectedClips(), timePositionOffset, trackPositionOffset, clipsMovedToOtherTracks);
+        clipsInteraction()->moveClips(selectedClips(), timePositionOffset, trackPositionOffset);
     }
 
     const std::string msg = clipsSelected ? muse::trc("trackedit", "Move items") : muse::trc("trackedit", "Move labels");

--- a/src/trackedit/internal/trackeditoperationcontroller.cpp
+++ b/src/trackedit/internal/trackeditoperationcontroller.cpp
@@ -327,7 +327,6 @@ bool TrackeditOperationController::removeTracksData(const TrackIdList& tracksIds
 
 muse::RetVal<ClipKeyList> TrackeditOperationController::moveClips(const ClipKeyList& clipKeyList, secs_t timePositionOffset,
                                                                   int trackPositionOffset,
-                                                                  bool completed,
                                                                   bool& clipsMovedToOtherTrack)
 {
     // Labels to move along with clips
@@ -354,16 +353,14 @@ muse::RetVal<ClipKeyList> TrackeditOperationController::moveClips(const ClipKeyL
         timePositionOffset = clampedOffset;
     }
 
-    muse::RetVal<ClipKeyList> result = clipsInteraction()->moveClips(clipKeyList, timePositionOffset, trackPositionOffset, completed,
+    muse::RetVal<ClipKeyList> result = clipsInteraction()->moveClips(clipKeyList, timePositionOffset, trackPositionOffset,
                                                                      clipsMovedToOtherTrack);
 
     if (!result.ret) {
-        if (completed) {
-            clipsMovedToOtherTrack = false;
-            projectHistory()->rollbackState();
-            globalContext()->currentTrackeditProject()->reload();
-        }
-    } else if (completed) {
+        clipsMovedToOtherTrack = false;
+        projectHistory()->rollbackState();
+        globalContext()->currentTrackeditProject()->reload();
+    } else {
         const std::string msg = !selectedLabels.empty() ? muse::trc("trackedit", "Items moved") : muse::trc("trackedit", "Clip moved");
         projectHistory()->pushHistoryState(msg, muse::trc("trackedit", "Move clip"));
     }
@@ -1018,8 +1015,7 @@ bool TrackeditOperationController::moveLabels(const LabelKeyList& labelKeys, sec
 }
 
 muse::RetVal<LabelKeyList> TrackeditOperationController::moveLabels(const LabelKeyList& labelKeys, secs_t timePositionOffset,
-                                                                    int trackPositionOffset,
-                                                                    bool completed)
+                                                                    int trackPositionOffset)
 {
     muse::RetVal<LabelKeyList> retVal = labelsInteraction()->moveLabels(labelKeys, timePositionOffset, trackPositionOffset);
     if (!retVal.ret) {
@@ -1029,13 +1025,11 @@ muse::RetVal<LabelKeyList> TrackeditOperationController::moveLabels(const LabelK
     bool clipsSelected = isClipsSelected();
     if (isClipsSelected()) {
         bool clipsMovedToOtherTracks = false;
-        clipsInteraction()->moveClips(selectedClips(), timePositionOffset, trackPositionOffset, completed, clipsMovedToOtherTracks);
+        clipsInteraction()->moveClips(selectedClips(), timePositionOffset, trackPositionOffset, clipsMovedToOtherTracks);
     }
 
-    if (completed) {
-        const std::string msg = clipsSelected ? muse::trc("trackedit", "Move items") : muse::trc("trackedit", "Move labels");
-        projectHistory()->pushHistoryState(muse::trc("trackedit", "Move"), msg);
-    }
+    const std::string msg = clipsSelected ? muse::trc("trackedit", "Move items") : muse::trc("trackedit", "Move labels");
+    projectHistory()->pushHistoryState(muse::trc("trackedit", "Move"), msg);
 
     return retVal;
 }

--- a/src/trackedit/internal/trackeditoperationcontroller.h
+++ b/src/trackedit/internal/trackeditoperationcontroller.h
@@ -68,7 +68,7 @@ public:
     bool removeClip(const ClipKey& clipKey) override;
     bool removeClips(const ClipKeyList& clipKeyList, bool moveClips) override;
     bool removeTracksData(const TrackIdList& tracksIds, secs_t begin, secs_t end, bool moveClips) override;
-    muse::RetVal<ClipKeyList> moveClips(const ClipKeyList& clipKeyList, secs_t timePositionOffset, int trackPositionOffset, bool completed,
+    muse::RetVal<ClipKeyList> moveClips(const ClipKeyList& clipKeyList, secs_t timePositionOffset, int trackPositionOffset,
                                         bool& clipsMovedToOtherTrack) override;
     bool moveRangeSelection(secs_t timePositionOffset, bool completed) override;
     void cancelItemDragEdit() override;
@@ -150,8 +150,7 @@ public:
     bool copyLabel(const LabelKey& labelKey) override;
 
     bool moveLabels(const LabelKeyList& labelKeys, secs_t timePositionOffset, bool completed) override;
-    muse::RetVal<LabelKeyList> moveLabels(const LabelKeyList& labelKeys, secs_t timePositionOffset, int trackPositionOffset,
-                                          bool completed) override;
+    muse::RetVal<LabelKeyList> moveLabels(const LabelKeyList& labelKeys, secs_t timePositionOffset, int trackPositionOffset) override;
     muse::RetVal<LabelKeyList> moveLabelsToTrack(const LabelKeyList& labelKeys, const TrackId& toTrackId, bool completed) override;
 
     bool stretchLabelLeft(const LabelKey& labelKey, secs_t newStartTime, bool completed) override;

--- a/src/trackedit/internal/trackeditoperationcontroller.h
+++ b/src/trackedit/internal/trackeditoperationcontroller.h
@@ -68,8 +68,7 @@ public:
     bool removeClip(const ClipKey& clipKey) override;
     bool removeClips(const ClipKeyList& clipKeyList, bool moveClips) override;
     bool removeTracksData(const TrackIdList& tracksIds, secs_t begin, secs_t end, bool moveClips) override;
-    muse::RetVal<ClipKeyList> moveClips(const ClipKeyList& clipKeyList, secs_t timePositionOffset, int trackPositionOffset,
-                                        bool& clipsMovedToOtherTrack) override;
+    muse::RetVal<ClipKeyList> moveClips(const ClipKeyList& clipKeyList, secs_t timePositionOffset, int trackPositionOffset) override;
     bool moveRangeSelection(secs_t timePositionOffset, bool completed) override;
     void cancelItemDragEdit() override;
     bool splitTracksAt(const TrackIdList& tracksIds, std::vector<secs_t> pivots) override;
@@ -149,7 +148,6 @@ public:
     bool cutLabel(const LabelKey& labelKey) override;
     bool copyLabel(const LabelKey& labelKey) override;
 
-    bool moveLabels(const LabelKeyList& labelKeys, secs_t timePositionOffset, bool completed) override;
     muse::RetVal<LabelKeyList> moveLabels(const LabelKeyList& labelKeys, secs_t timePositionOffset, int trackPositionOffset) override;
     muse::RetVal<LabelKeyList> moveLabelsToTrack(const LabelKeyList& labelKeys, const TrackId& toTrackId, bool completed) override;
 

--- a/src/trackedit/internal/tracksviewrequestsservice.cpp
+++ b/src/trackedit/internal/tracksviewrequestsservice.cpp
@@ -5,6 +5,16 @@
 
 using namespace au::trackedit;
 
+void TracksViewRequestsService::requestItemMove(secs_t timeOffset, int trackOffset)
+{
+    m_itemMoveRequested.send(timeOffset, trackOffset);
+}
+
+muse::async::Channel<secs_t, int> TracksViewRequestsService::itemMoveRequested() const
+{
+    return m_itemMoveRequested;
+}
+
 void TracksViewRequestsService::requestLabelTitleEdit(const LabelKey& labelKey)
 {
     m_pendingLabelTitleEdit = labelKey;

--- a/src/trackedit/internal/tracksviewrequestsservice.h
+++ b/src/trackedit/internal/tracksviewrequestsservice.h
@@ -15,12 +15,16 @@ public:
     TracksViewRequestsService(const muse::modularity::ContextPtr& ctx)
         : muse::Contextable(ctx) {}
 
+    void requestItemMove(secs_t timeOffset, int trackOffset) override;
+    muse::async::Channel<secs_t, int> itemMoveRequested() const override;
+
     void requestLabelTitleEdit(const LabelKey& labelKey) override;
     std::optional<LabelKey> pendingLabelTitleEdit() const override;
     void labelTitleEditRequestHandled(const LabelKey& labelKey) override;
     muse::async::Channel<LabelKey> labelTitleEditRequested() const override;
 
 private:
+    muse::async::Channel<secs_t, int> m_itemMoveRequested;
     std::optional<LabelKey> m_pendingLabelTitleEdit;
     muse::async::Channel<LabelKey> m_labelTitleEditRequested;
 };

--- a/src/trackedit/itrackeditinteraction.h
+++ b/src/trackedit/itrackeditinteraction.h
@@ -58,7 +58,7 @@ public:
     virtual bool removeClips(const ClipKeyList& clipKeyList, bool moveClips) = 0;
     virtual bool removeTracksData(const TrackIdList& tracksIds, secs_t begin, secs_t end, bool moveClips) = 0;
     virtual muse::RetVal<ClipKeyList> moveClips(const ClipKeyList& clipKeyList, secs_t timePositionOffset, int trackPositionOffset,
-                                                bool completed, bool& clipsMovedToOtherTrack) = 0;
+                                                bool& clipsMovedToOtherTrack) = 0;
     virtual bool moveRangeSelection(secs_t timePositionOffset, bool completed) = 0;
     virtual void cancelItemDragEdit() = 0;
     virtual bool splitTracksAt(const TrackIdList& tracksIds, std::vector<secs_t> pivots) = 0;
@@ -140,8 +140,7 @@ public:
     virtual bool copyLabel(const LabelKey& labelKey) = 0;
 
     virtual bool moveLabels(const LabelKeyList& labelKeys, secs_t timePositionOffset, bool completed) = 0;
-    virtual muse::RetVal<LabelKeyList> moveLabels(const LabelKeyList& labelKeys, secs_t timePositionOffset, int trackPositionOffset,
-                                                  bool completed) = 0;
+    virtual muse::RetVal<LabelKeyList> moveLabels(const LabelKeyList& labelKeys, secs_t timePositionOffset, int trackPositionOffset) = 0;
     virtual muse::RetVal<LabelKeyList> moveLabelsToTrack(const LabelKeyList& labelKeys, const TrackId& toTrackId, bool completed) = 0;
 
     virtual bool stretchLabelLeft(const LabelKey& labelKey, secs_t newStartTime, bool completed) = 0;

--- a/src/trackedit/itrackeditinteraction.h
+++ b/src/trackedit/itrackeditinteraction.h
@@ -57,8 +57,7 @@ public:
     virtual bool removeClip(const ClipKey& clipKey) = 0;
     virtual bool removeClips(const ClipKeyList& clipKeyList, bool moveClips) = 0;
     virtual bool removeTracksData(const TrackIdList& tracksIds, secs_t begin, secs_t end, bool moveClips) = 0;
-    virtual muse::RetVal<ClipKeyList> moveClips(const ClipKeyList& clipKeyList, secs_t timePositionOffset, int trackPositionOffset,
-                                                bool& clipsMovedToOtherTrack) = 0;
+    virtual muse::RetVal<ClipKeyList> moveClips(const ClipKeyList& clipKeyList, secs_t timePositionOffset, int trackPositionOffset) = 0;
     virtual bool moveRangeSelection(secs_t timePositionOffset, bool completed) = 0;
     virtual void cancelItemDragEdit() = 0;
     virtual bool splitTracksAt(const TrackIdList& tracksIds, std::vector<secs_t> pivots) = 0;
@@ -139,7 +138,6 @@ public:
     virtual bool cutLabel(const LabelKey& labelKey) = 0;
     virtual bool copyLabel(const LabelKey& labelKey) = 0;
 
-    virtual bool moveLabels(const LabelKeyList& labelKeys, secs_t timePositionOffset, bool completed) = 0;
     virtual muse::RetVal<LabelKeyList> moveLabels(const LabelKeyList& labelKeys, secs_t timePositionOffset, int trackPositionOffset) = 0;
     virtual muse::RetVal<LabelKeyList> moveLabelsToTrack(const LabelKeyList& labelKeys, const TrackId& toTrackId, bool completed) = 0;
 

--- a/src/trackedit/itracksviewrequestsservice.h
+++ b/src/trackedit/itracksviewrequestsservice.h
@@ -18,6 +18,9 @@ class ITracksViewRequestsService : MODULE_EXPORT_INTERFACE
 public:
     virtual ~ITracksViewRequestsService() = default;
 
+    virtual void requestItemMove(secs_t timeOffset, int trackOffset) = 0;
+    virtual muse::async::Channel<secs_t, int> itemMoveRequested() const = 0;
+
     //! NOTE Set when a label should enter title edit mode; the view consumes
     //! the request once the label item exists, whenever that happens
     virtual void requestLabelTitleEdit(const LabelKey& labelKey) = 0;

--- a/src/trackedit/tests/CMakeLists.txt
+++ b/src/trackedit/tests/CMakeLists.txt
@@ -30,7 +30,11 @@ set(MODULE_TEST_LINK
         trackedit
         spectrogram
         au3wrap
+        effects_base
         au3-label-track
+        au3-project-file-io
+        au3-project-history
+        au3-realtime-effects
         au3-time-frequency-selection
         au3-wave-track
 
@@ -41,5 +45,9 @@ set(MODULE_TEST_LINK
 )
 
 set(MODULE_TEST_DATA_ROOT ${CMAKE_CURRENT_LIST_DIR})
+
+set(MODULE_TEST_INCLUDE
+    ${PROJECT_SOURCE_DIR}/src/effects/effects_base
+)
 
 include(SetupGTest)

--- a/src/trackedit/tests/au3clipsinteraction_tests.cpp
+++ b/src/trackedit/tests/au3clipsinteraction_tests.cpp
@@ -620,8 +620,7 @@ TEST_F(Au3ClipsInteractionTests, MoveClipsRight)
     };
 
     //! [WHEN] Move the clips right
-    auto clipsMovedToOtherTracks = false;
-    m_clipsInteraction->moveClips(selectedClipsKeys, secondsToMove, 0, clipsMovedToOtherTracks);
+    m_clipsInteraction->moveClips(selectedClipsKeys, secondsToMove, 0);
 
     //! [THEN] All clips are moved
     const WaveTrack::IntervalConstHolder modifiedFirstClip = track->GetSortedClipByIndex(0);
@@ -660,8 +659,7 @@ TEST_F(Au3ClipsInteractionTests, MoveClipLeftWhenClipIsAtZero)
     };
 
     //! [WHEN] Move the clips left
-    auto clipsMovedToOtherTracks = false;
-    m_clipsInteraction->moveClips(selectedClipsKeys, -1.0, 0, clipsMovedToOtherTracks);
+    m_clipsInteraction->moveClips(selectedClipsKeys, -1.0, 0);
 
     //! [THEN] No clip is moved
     const WaveTrack::IntervalConstHolder modifiedFirstClip = track->GetSortedClipByIndex(0);
@@ -672,6 +670,49 @@ TEST_F(Au3ClipsInteractionTests, MoveClipLeftWhenClipIsAtZero)
     ValidateClipProperties(modifiedLastClip, lastClipStart, lastClipEnd);
 
     removeTrack(trackId);
+}
+
+TEST_F(Au3ClipsInteractionTests, MoveAcrossTracksPreservesIntermediateAndEmptyTrackFormats)
+{
+    TrackTemplateFactory factory(projectRef(), DEFAULT_SAMPLE_RATE);
+    auto source = factory.createTrackFromTemplate("source", { { 0.0, { { 0.1, TrackTemplateFactory::createNoise } } } });
+    source = source->MonoToStereo();
+    const auto intermediate = factory.createTrackFromTemplate("intermediate", {});
+    const auto destination = factory.createTrackFromTemplate("destination", {});
+    const TrackId sourceId = factory.addTrackToProject(source);
+    const TrackId intermediateId = factory.addTrackToProject(intermediate);
+    const TrackId destinationId = factory.addTrackToProject(destination);
+    const TrackId trailingId = factory.addTrackFromTemplate("trailing", {});
+    const ClipKey sourceKey { sourceId, source->GetSortedClipByIndex(0)->GetId() };
+
+    const auto moved = m_clipsInteraction->moveClips({ sourceKey }, 0.0, 2);
+    ASSERT_TRUE(moved.ret);
+    ASSERT_EQ(moved.val, (ClipKeyList { { destinationId, sourceKey.itemId } }));
+    auto destinationTrack = DomAccessor::findWaveTrack(projectRef(), Au3TrackId(destinationId));
+    ASSERT_NE(destinationTrack, nullptr);
+    EXPECT_EQ(destinationTrack->NChannels(), 2u);
+    EXPECT_EQ(destinationTrack->NIntervals(), 1u);
+    auto sourceTrack = DomAccessor::findWaveTrack(projectRef(), Au3TrackId(sourceId));
+    ASSERT_NE(sourceTrack, nullptr);
+    EXPECT_EQ(sourceTrack->NChannels(), 2u);
+    EXPECT_TRUE(sourceTrack->IsEmpty());
+    EXPECT_EQ(DomAccessor::findWaveTrack(projectRef(), Au3TrackId(intermediateId)), intermediate.get());
+    EXPECT_EQ(intermediate->NChannels(), 1u);
+    EXPECT_TRUE(intermediate->IsEmpty());
+
+    const auto returned = m_clipsInteraction->moveClips(moved.val, 0.0, -2);
+    ASSERT_TRUE(returned.ret);
+    EXPECT_EQ(returned.val, (ClipKeyList { sourceKey }));
+    destinationTrack = DomAccessor::findWaveTrack(projectRef(), Au3TrackId(destinationId));
+    ASSERT_NE(destinationTrack, nullptr);
+    EXPECT_EQ(destinationTrack->NChannels(), 2u);
+    EXPECT_TRUE(destinationTrack->IsEmpty());
+    EXPECT_EQ(DomAccessor::findWaveTrack(projectRef(), Au3TrackId(intermediateId)), intermediate.get());
+    EXPECT_EQ(intermediate->NChannels(), 1u);
+    EXPECT_TRUE(intermediate->IsEmpty());
+    EXPECT_NE(DomAccessor::findWaveTrack(projectRef(), Au3TrackId(trailingId)), nullptr);
+    EXPECT_EQ(Au3TrackList::Get(projectRef()).Size(), 4u);
+    EXPECT_TRUE(ProjectFileIO::Get(projectRef()).AutoSave());
 }
 
 class Au3ClipsDropTests : public Au3ClipsInteractionTests, public testing::WithParamInterface<std::tuple<bool, bool> >
@@ -695,12 +736,10 @@ TEST_P(Au3ClipsDropTests, ConvertsDestinationChannelsBeforeAutosave)
 
     // A preview-only drag keeps the original selection until the completed move returns.
     ON_CALL(*m_selectionController, selectedTracks()).WillByDefault(Return(TrackIdList { sourceId }));
-    bool changedTrack = false;
-    const auto result = m_clipsInteraction->moveClips({ sourceKey }, overlap ? 1.1 : 2.0, 1, changedTrack);
+    const auto result = m_clipsInteraction->moveClips({ sourceKey }, overlap ? 1.1 : 2.0, 1);
 
     ASSERT_TRUE(result.ret);
     ASSERT_EQ(result.val, (ClipKeyList { { destinationId, sourceKey.itemId } }));
-    EXPECT_TRUE(changedTrack);
     const auto movedTrack = DomAccessor::findWaveTrack(projectRef(), Au3TrackId(destinationId));
     ASSERT_NE(movedTrack, nullptr);
     EXPECT_EQ(movedTrack->NChannels(), sourceIsStereo ? 1u : 2u);
@@ -763,8 +802,7 @@ TEST_P(Au3ClipsDropTests, PreservesEffectsThroughUndoRedo)
     history.InitialState();
     history.ModifyState(false);
 
-    bool changedTrack = false;
-    const auto result = m_clipsInteraction->moveClips({ key }, overlap ? 1.1 : 2.0, 1, changedTrack);
+    const auto result = m_clipsInteraction->moveClips({ key }, overlap ? 1.1 : 2.0, 1);
     ASSERT_TRUE(result.ret);
     history.PushState({}, {});
 
@@ -840,12 +878,10 @@ TEST_F(Au3ClipsInteractionTests, CompletedMoveKeepsTrackWhenChannelsAlreadyMatch
     ON_CALL(*m_selectionController, selectedTracks()).WillByDefault(Return(TrackIdList { trackId }));
     EXPECT_CALL(*std::static_pointer_cast<muse::InteractiveMock>(m_interactive), showProgress(_, _)).Times(0);
 
-    bool changedTrack = false;
-    const auto result = m_clipsInteraction->moveClips({ key }, 1.0, 0, changedTrack);
+    const auto result = m_clipsInteraction->moveClips({ key }, 1.0, 0);
 
     ASSERT_TRUE(result.ret);
     EXPECT_EQ(DomAccessor::findWaveTrack(projectRef(), Au3TrackId(trackId)), track);
-    EXPECT_FALSE(changedTrack);
     EXPECT_TRUE(ProjectFileIO::Get(projectRef()).AutoSave());
 }
 

--- a/src/trackedit/tests/au3clipsinteraction_tests.cpp
+++ b/src/trackedit/tests/au3clipsinteraction_tests.cpp
@@ -621,7 +621,7 @@ TEST_F(Au3ClipsInteractionTests, MoveClipsRight)
 
     //! [WHEN] Move the clips right
     auto clipsMovedToOtherTracks = false;
-    m_clipsInteraction->moveClips(selectedClipsKeys, secondsToMove, 0, true, clipsMovedToOtherTracks);
+    m_clipsInteraction->moveClips(selectedClipsKeys, secondsToMove, 0, clipsMovedToOtherTracks);
 
     //! [THEN] All clips are moved
     const WaveTrack::IntervalConstHolder modifiedFirstClip = track->GetSortedClipByIndex(0);
@@ -661,7 +661,7 @@ TEST_F(Au3ClipsInteractionTests, MoveClipLeftWhenClipIsAtZero)
 
     //! [WHEN] Move the clips left
     auto clipsMovedToOtherTracks = false;
-    m_clipsInteraction->moveClips(selectedClipsKeys, -1.0, 0, true, clipsMovedToOtherTracks);
+    m_clipsInteraction->moveClips(selectedClipsKeys, -1.0, 0, clipsMovedToOtherTracks);
 
     //! [THEN] No clip is moved
     const WaveTrack::IntervalConstHolder modifiedFirstClip = track->GetSortedClipByIndex(0);
@@ -696,7 +696,7 @@ TEST_P(Au3ClipsDropTests, ConvertsDestinationChannelsBeforeAutosave)
     // A preview-only drag keeps the original selection until the completed move returns.
     ON_CALL(*m_selectionController, selectedTracks()).WillByDefault(Return(TrackIdList { sourceId }));
     bool changedTrack = false;
-    const auto result = m_clipsInteraction->moveClips({ sourceKey }, overlap ? 1.1 : 2.0, 1, true, changedTrack);
+    const auto result = m_clipsInteraction->moveClips({ sourceKey }, overlap ? 1.1 : 2.0, 1, changedTrack);
 
     ASSERT_TRUE(result.ret);
     ASSERT_EQ(result.val, (ClipKeyList { { destinationId, sourceKey.itemId } }));
@@ -764,7 +764,7 @@ TEST_P(Au3ClipsDropTests, PreservesEffectsThroughUndoRedo)
     history.ModifyState(false);
 
     bool changedTrack = false;
-    const auto result = m_clipsInteraction->moveClips({ key }, overlap ? 1.1 : 2.0, 1, true, changedTrack);
+    const auto result = m_clipsInteraction->moveClips({ key }, overlap ? 1.1 : 2.0, 1, changedTrack);
     ASSERT_TRUE(result.ret);
     history.PushState({}, {});
 
@@ -841,7 +841,7 @@ TEST_F(Au3ClipsInteractionTests, CompletedMoveKeepsTrackWhenChannelsAlreadyMatch
     EXPECT_CALL(*std::static_pointer_cast<muse::InteractiveMock>(m_interactive), showProgress(_, _)).Times(0);
 
     bool changedTrack = false;
-    const auto result = m_clipsInteraction->moveClips({ key }, 1.0, 0, true, changedTrack);
+    const auto result = m_clipsInteraction->moveClips({ key }, 1.0, 0, changedTrack);
 
     ASSERT_TRUE(result.ret);
     EXPECT_EQ(DomAccessor::findWaveTrack(projectRef(), Au3TrackId(trackId)), track);

--- a/src/trackedit/tests/au3clipsinteraction_tests.cpp
+++ b/src/trackedit/tests/au3clipsinteraction_tests.cpp
@@ -2,11 +2,20 @@
  * Audacity: A Digital Audio Editor
  */
 #include <gtest/gtest.h>
+#include "global/defer.h"
 
 #include "../internal/au3/au3clipsinteraction.h"
 #include "../internal/au3/au3trackdata.h"
 
 #include "au3-wave-track/WaveTrackUtilities.h"
+#include "au3-project-file-io/ProjectFileIO.h"
+#include "au3-project-history/UndoManager.h"
+#include "au3-project-history/ProjectHistory.h"
+#include "au3-realtime-effects/RealtimeEffectList.h"
+#include "au3-realtime-effects/RealtimeEffectState.h"
+
+#include "effects/effects_base/internal/realtimeeffectrestorer.h"
+#include "project/tests/mocks/dummyeffectinstancefactory.h"
 
 #include "au3interactiontestbase.h"
 #include "mocks/selectioncontrollermock.h"
@@ -663,6 +672,130 @@ TEST_F(Au3ClipsInteractionTests, MoveClipLeftWhenClipIsAtZero)
     ValidateClipProperties(modifiedLastClip, lastClipStart, lastClipEnd);
 
     removeTrack(trackId);
+}
+
+class Au3ClipsDropTests : public Au3ClipsInteractionTests, public testing::WithParamInterface<std::tuple<bool, bool> >
+{
+};
+
+INSTANTIATE_TEST_SUITE_P(CompletedMove, Au3ClipsDropTests, testing::Combine(testing::Bool(), testing::Bool()));
+
+TEST_P(Au3ClipsDropTests, PreservesEffectsThroughUndoRedo)
+{
+    class CountingEffectFactory final : public project::DummyEffectInstanceFactory
+    {
+    public:
+        std::shared_ptr<EffectInstance> MakeInstance() const override
+        {
+            ++instanceCreations;
+            return nullptr;
+        }
+
+        mutable int instanceCreations = 0;
+    } factory;
+    RealtimeEffectState::EffectFactory::Scope factoryScope {
+        [&](const PluginID&) -> const EffectInstanceFactory* { return &factory; }
+    };
+    const muse::Defer cleanup([&] {
+        Au3TrackList::Get(projectRef()).Clear();
+        ::UndoManager::Get(projectRef()).ClearStates();
+    });
+    // Include the real settings restorer used by the application's undo/redo path.
+    effects::setRealtimeEffectRestorerSignals(projectRef(), {});
+
+    const auto [sourceIsStereo, overlap] = GetParam();
+    TrackTemplateFactory trackFactory(projectRef(), DEFAULT_SAMPLE_RATE);
+    auto source = trackFactory.createTrackFromTemplate("source", { { 0.0, { { 0.1, TrackTemplateFactory::createNoise } } } });
+    auto destination = trackFactory.createTrackFromTemplate("destination", { { 1.0, { { 0.3, TrackTemplateFactory::createNoise } } } });
+    if (sourceIsStereo) {
+        source = source->MonoToStereo();
+    } else {
+        destination = destination->MonoToStereo();
+    }
+    const TrackId sourceId = trackFactory.addTrackToProject(source);
+    const TrackId destinationId = trackFactory.addTrackToProject(destination);
+    const ClipKey key { sourceId, source->GetSortedClipByIndex(0)->GetId() };
+    ON_CALL(*m_selectionController, selectedTracks()).WillByDefault(Return(TrackIdList { destinationId }));
+    const auto sourceEffect = RealtimeEffectState::make_shared("au-test:source");
+    const auto destinationEffect = RealtimeEffectState::make_shared("au-test:destination");
+    ASSERT_TRUE(RealtimeEffectList::Get(*source).AddState(sourceEffect));
+    ASSERT_TRUE(RealtimeEffectList::Get(*destination).AddState(destinationEffect));
+    RealtimeEffectList::Get(*source).SetActive(false);
+    // Loaded effects may never have been played or opened before this edit.
+    ASSERT_EQ(factory.instanceCreations, 0);
+
+    auto& history = ::ProjectHistory::Get(projectRef());
+    auto& undoManager = ::UndoManager::Get(projectRef());
+    const auto restore = [&](const UndoStackElem& elem) { history.PopState(elem.state); };
+    history.InitialState();
+    history.ModifyState(false);
+
+    bool changedTrack = false;
+    const auto result = m_clipsInteraction->moveClips({ key }, overlap ? 1.1 : 2.0, 1, true, changedTrack);
+    ASSERT_TRUE(result.ret);
+    history.PushState({}, {});
+
+    const auto checkEffects = [&] {
+        const auto sourceTrack = DomAccessor::findWaveTrack(projectRef(), Au3TrackId(sourceId));
+        const auto destinationTrack = DomAccessor::findWaveTrack(projectRef(), Au3TrackId(destinationId));
+        ASSERT_NE(sourceTrack, nullptr);
+        ASSERT_NE(destinationTrack, nullptr);
+        EXPECT_EQ(RealtimeEffectList::Get(*sourceTrack).GetStateAt(0), sourceEffect);
+        EXPECT_EQ(RealtimeEffectList::Get(*destinationTrack).GetStateAt(0), destinationEffect);
+        EXPECT_FALSE(RealtimeEffectList::Get(*sourceTrack).IsActive());
+        EXPECT_EQ(factory.instanceCreations, 0);
+        EXPECT_TRUE(ProjectFileIO::Get(projectRef()).AutoSave());
+    };
+    checkEffects();
+
+    for (int i = 0; i < 2; ++i) {
+        ASSERT_TRUE(undoManager.UndoAvailable());
+        undoManager.Undo(restore);
+        EXPECT_NE(DomAccessor::findWaveClip(DomAccessor::findWaveTrack(projectRef(), Au3TrackId(sourceId)), key.itemId), nullptr);
+        checkEffects();
+        ASSERT_TRUE(undoManager.RedoAvailable());
+        undoManager.Redo(restore);
+        EXPECT_NE(DomAccessor::findWaveClip(DomAccessor::findWaveTrack(projectRef(), Au3TrackId(destinationId)), key.itemId), nullptr);
+        checkEffects();
+    }
+
+    destinationEffect->SetActive(false);
+    history.PushState({}, {});
+    undoManager.Undo(restore);
+    EXPECT_TRUE(destinationEffect->IsEnabled());
+    undoManager.Redo(restore);
+    EXPECT_FALSE(destinationEffect->IsEnabled());
+    undoManager.Undo(restore);
+    EXPECT_TRUE(destinationEffect->IsEnabled());
+
+    auto destinationTrack = DomAccessor::findWaveTrack(projectRef(), Au3TrackId(destinationId));
+    RealtimeEffectList::Get(*destinationTrack).RemoveState(destinationEffect);
+    history.PushState({}, {});
+    undoManager.Undo(restore);
+    checkEffects();
+    undoManager.Redo(restore);
+    destinationTrack = DomAccessor::findWaveTrack(projectRef(), Au3TrackId(destinationId));
+    EXPECT_EQ(RealtimeEffectList::Get(*destinationTrack).GetStatesCount(), 0u);
+}
+
+TEST_F(Au3ClipsInteractionTests, TrackCopiesKeepIndependentEffects)
+{
+    RealtimeEffectState::EffectFactory::Scope factoryScope {
+        [](const PluginID&) -> const EffectInstanceFactory* { return &project::dummyFactory(); }
+    };
+    const TrackId trackId = createTrack(TestTrackID::TRACK_THREE_CLIPS);
+    const auto track = DomAccessor::findWaveTrack(projectRef(), Au3TrackId(trackId));
+    const auto effect = RealtimeEffectState::make_shared("au-test:effect");
+    ASSERT_TRUE(RealtimeEffectList::Get(*track).AddState(effect));
+
+    for (const auto& duplicate : { track->Duplicate(), track->Duplicate(::Track::DuplicateOptions {}.Backup()) }) {
+        const auto duplicateEffect = RealtimeEffectList::Get(*duplicate).GetStateAt(0);
+        ASSERT_NE(duplicateEffect, nullptr);
+        EXPECT_NE(duplicateEffect, effect);
+        duplicateEffect->SetActive(false);
+        EXPECT_FALSE(duplicateEffect->IsEnabled());
+        EXPECT_TRUE(effect->IsEnabled());
+    }
 }
 
 TEST_F(Au3ClipsInteractionTests, SplitDeteleByClipId)

--- a/src/trackedit/tests/au3clipsinteraction_tests.cpp
+++ b/src/trackedit/tests/au3clipsinteraction_tests.cpp
@@ -678,6 +678,40 @@ class Au3ClipsDropTests : public Au3ClipsInteractionTests, public testing::WithP
 {
 };
 
+TEST_P(Au3ClipsDropTests, ConvertsDestinationChannelsBeforeAutosave)
+{
+    const auto [sourceIsStereo, overlap] = GetParam();
+    TrackTemplateFactory factory(projectRef(), DEFAULT_SAMPLE_RATE);
+    auto source = factory.createTrackFromTemplate("source", { { 0.0, { { 0.1, TrackTemplateFactory::createNoise } } } });
+    auto destination = factory.createTrackFromTemplate("destination", { { 1.0, { { 0.3, TrackTemplateFactory::createNoise } } } });
+    if (sourceIsStereo) {
+        source = source->MonoToStereo();
+    } else {
+        destination = destination->MonoToStereo();
+    }
+    const TrackId sourceId = factory.addTrackToProject(source);
+    const TrackId destinationId = factory.addTrackToProject(destination);
+    const ClipKey sourceKey { sourceId, source->GetSortedClipByIndex(0)->GetId() };
+
+    // A preview-only drag keeps the original selection until the completed move returns.
+    ON_CALL(*m_selectionController, selectedTracks()).WillByDefault(Return(TrackIdList { sourceId }));
+    bool changedTrack = false;
+    const auto result = m_clipsInteraction->moveClips({ sourceKey }, overlap ? 1.1 : 2.0, 1, true, changedTrack);
+
+    ASSERT_TRUE(result.ret);
+    ASSERT_EQ(result.val, (ClipKeyList { { destinationId, sourceKey.itemId } }));
+    EXPECT_TRUE(changedTrack);
+    const auto movedTrack = DomAccessor::findWaveTrack(projectRef(), Au3TrackId(destinationId));
+    ASSERT_NE(movedTrack, nullptr);
+    EXPECT_EQ(movedTrack->NChannels(), sourceIsStereo ? 1u : 2u);
+    EXPECT_EQ(movedTrack->NIntervals(), overlap ? 3u : 2u);
+    for (const auto& clip : movedTrack->Intervals()) {
+        // A stereo track containing a mono clip crashes while serializing its second channel.
+        ASSERT_EQ(clip->NChannels(), movedTrack->NChannels());
+    }
+    EXPECT_TRUE(ProjectFileIO::Get(projectRef()).AutoSave());
+}
+
 INSTANTIATE_TEST_SUITE_P(CompletedMove, Au3ClipsDropTests, testing::Combine(testing::Bool(), testing::Bool()));
 
 TEST_P(Au3ClipsDropTests, PreservesEffectsThroughUndoRedo)
@@ -715,7 +749,6 @@ TEST_P(Au3ClipsDropTests, PreservesEffectsThroughUndoRedo)
     const TrackId sourceId = trackFactory.addTrackToProject(source);
     const TrackId destinationId = trackFactory.addTrackToProject(destination);
     const ClipKey key { sourceId, source->GetSortedClipByIndex(0)->GetId() };
-    ON_CALL(*m_selectionController, selectedTracks()).WillByDefault(Return(TrackIdList { destinationId }));
     const auto sourceEffect = RealtimeEffectState::make_shared("au-test:source");
     const auto destinationEffect = RealtimeEffectState::make_shared("au-test:destination");
     ASSERT_TRUE(RealtimeEffectList::Get(*source).AddState(sourceEffect));
@@ -796,6 +829,24 @@ TEST_F(Au3ClipsInteractionTests, TrackCopiesKeepIndependentEffects)
         EXPECT_FALSE(duplicateEffect->IsEnabled());
         EXPECT_TRUE(effect->IsEnabled());
     }
+}
+
+TEST_F(Au3ClipsInteractionTests, CompletedMoveKeepsTrackWhenChannelsAlreadyMatch)
+{
+    const TrackId trackId = createTrack(TestTrackID::TRACK_THREE_CLIPS);
+    const auto track = DomAccessor::findWaveTrack(projectRef(), Au3TrackId(trackId));
+    ASSERT_NE(track, nullptr);
+    const ClipKey key { trackId, track->GetSortedClipByIndex(0)->GetId() };
+    ON_CALL(*m_selectionController, selectedTracks()).WillByDefault(Return(TrackIdList { trackId }));
+    EXPECT_CALL(*std::static_pointer_cast<muse::InteractiveMock>(m_interactive), showProgress(_, _)).Times(0);
+
+    bool changedTrack = false;
+    const auto result = m_clipsInteraction->moveClips({ key }, 1.0, 0, true, changedTrack);
+
+    ASSERT_TRUE(result.ret);
+    EXPECT_EQ(DomAccessor::findWaveTrack(projectRef(), Au3TrackId(trackId)), track);
+    EXPECT_FALSE(changedTrack);
+    EXPECT_TRUE(ProjectFileIO::Get(projectRef()).AutoSave());
 }
 
 TEST_F(Au3ClipsInteractionTests, SplitDeteleByClipId)

--- a/src/trackedit/tests/au3labelsinteractions_tests.cpp
+++ b/src/trackedit/tests/au3labelsinteractions_tests.cpp
@@ -1260,6 +1260,45 @@ TEST_F(Au3LabelsInteractionsTests, MoveLabelsWithNoSelection)
     ASSERT_DOUBLE_EQ(label->getT1(), 2.0) << "Label end time should be unchanged";
 }
 
+TEST_F(Au3LabelsInteractionsTests, MoveLabelsClampsIndividuallyAtBoundaryTracks)
+{
+    auto& tracks = Au3TrackList::Get(projectRef());
+    auto* first = ::LabelTrack::Create(tracks);
+    ASSERT_NE(createTrack(TestTrackID::TRACK_SMALL_SILENCE), INVALID_TRACK);
+    auto* middle = ::LabelTrack::Create(tracks);
+    ASSERT_NE(createTrack(TestTrackID::TRACK_SMALL_SILENCE), INVALID_TRACK);
+    auto* last = ::LabelTrack::Create(tracks);
+
+    for (int offset : { -1, 1 }) {
+        LabelKeyList keys;
+        for (auto* track : { first, middle, last }) {
+            keys.push_back({ track->GetId(), track->AddLabel(SelectedRegion(10.0, 15.0), wxString("Label")) });
+        }
+
+        const auto result = m_labelsInteraction->moveLabels(keys, 0.0, offset);
+        ASSERT_TRUE(result.ret);
+        ASSERT_EQ(result.val.size(), 3);
+        EXPECT_EQ(result.val[0].trackId, offset < 0 ? first->GetId() : middle->GetId());
+        EXPECT_EQ(result.val[1].trackId, offset < 0 ? first->GetId() : last->GetId());
+        EXPECT_EQ(result.val[2].trackId, offset < 0 ? middle->GetId() : last->GetId());
+        EXPECT_EQ(first->GetNumLabels(), offset < 0 ? 2 : 0);
+        EXPECT_EQ(middle->GetNumLabels(), 1);
+        EXPECT_EQ(last->GetNumLabels(), offset < 0 ? 0 : 2);
+        for (const auto& key : result.val) {
+            auto* track = DomAccessor::findLabelTrack(projectRef(), Au3TrackId(key.trackId));
+            const auto* label = DomAccessor::findLabel(track, key.itemId);
+            ASSERT_NE(label, nullptr);
+            EXPECT_DOUBLE_EQ(label->getT0(), 10.0);
+            EXPECT_DOUBLE_EQ(label->getT1(), 15.0);
+        }
+        for (auto* track : { first, middle, last }) {
+            while (track->GetNumLabels() > 0) {
+                track->DeleteLabel(0);
+            }
+        }
+    }
+}
+
 TEST_F(Au3LabelsInteractionsTests, MoveLabelsToAnotherTrack)
 {
     //! [GIVEN] There is a project with two label tracks

--- a/src/trackedit/tests/mocks/clipsinteractionmock.h
+++ b/src/trackedit/tests/mocks/clipsinteractionmock.h
@@ -32,7 +32,7 @@ public:
     MOCK_METHOD(ITrackDataPtr, copyClip, (const ClipKey&), (override));
     MOCK_METHOD(std::optional<TimeSpan>, removeClip, (const ClipKey&), (override));
     MOCK_METHOD(bool, removeClips, (const ClipKeyList&, bool), (override));
-    MOCK_METHOD(muse::RetVal<ClipKeyList>, moveClips, (const ClipKeyList&, secs_t, int, bool, bool&), (override));
+    MOCK_METHOD(muse::RetVal<ClipKeyList>, moveClips, (const ClipKeyList&, secs_t, int, bool&), (override));
     MOCK_METHOD(void, cancelClipDragEdit, (), (override));
 
     MOCK_METHOD(bool, splitClipsAtSilences, (const ClipKeyList&), (override));

--- a/src/trackedit/tests/mocks/clipsinteractionmock.h
+++ b/src/trackedit/tests/mocks/clipsinteractionmock.h
@@ -32,8 +32,7 @@ public:
     MOCK_METHOD(ITrackDataPtr, copyClip, (const ClipKey&), (override));
     MOCK_METHOD(std::optional<TimeSpan>, removeClip, (const ClipKey&), (override));
     MOCK_METHOD(bool, removeClips, (const ClipKeyList&, bool), (override));
-    MOCK_METHOD(muse::RetVal<ClipKeyList>, moveClips, (const ClipKeyList&, secs_t, int, bool&), (override));
-    MOCK_METHOD(void, cancelClipDragEdit, (), (override));
+    MOCK_METHOD(muse::RetVal<ClipKeyList>, moveClips, (const ClipKeyList&, secs_t, int), (override));
 
     MOCK_METHOD(bool, splitClipsAtSilences, (const ClipKeyList&), (override));
     MOCK_METHOD(bool, splitClipsIntoNewTracks, (const ClipKeyList&), (override));

--- a/src/trackedit/tests/mocks/trackeditinteractionmock.h
+++ b/src/trackedit/tests/mocks/trackeditinteractionmock.h
@@ -43,7 +43,7 @@ public:
     MOCK_METHOD(bool, removeClip, (const ClipKey&), (override));
     MOCK_METHOD(bool, removeClips, (const ClipKeyList&, bool), (override));
     MOCK_METHOD(bool, removeTracksData, (const TrackIdList&, secs_t, secs_t, bool), (override));
-    MOCK_METHOD(muse::RetVal<ClipKeyList>, moveClips, (const ClipKeyList&, secs_t, int, bool, bool&), (override));
+    MOCK_METHOD(muse::RetVal<ClipKeyList>, moveClips, (const ClipKeyList&, secs_t, int, bool&), (override));
     MOCK_METHOD(bool, moveRangeSelection, (secs_t, bool), (override));
     MOCK_METHOD(void, cancelItemDragEdit, (), (override));
     MOCK_METHOD(bool, splitTracksAt, (const TrackIdList&, std::vector<secs_t>), (override));
@@ -121,7 +121,7 @@ public:
     MOCK_METHOD(bool, copyLabel, (const LabelKey&), (override));
 
     MOCK_METHOD(bool, moveLabels, (const LabelKeyList&, secs_t, bool), (override));
-    MOCK_METHOD(muse::RetVal<LabelKeyList>, moveLabels, (const LabelKeyList&, secs_t, int, bool), (override));
+    MOCK_METHOD(muse::RetVal<LabelKeyList>, moveLabels, (const LabelKeyList&, secs_t, int), (override));
     MOCK_METHOD(muse::RetVal<LabelKeyList>, moveLabelsToTrack, (const LabelKeyList&, const TrackId&, bool), (override));
 
     MOCK_METHOD(bool, stretchLabelLeft, (const LabelKey&, secs_t, bool), (override));

--- a/src/trackedit/tests/mocks/trackeditinteractionmock.h
+++ b/src/trackedit/tests/mocks/trackeditinteractionmock.h
@@ -43,7 +43,7 @@ public:
     MOCK_METHOD(bool, removeClip, (const ClipKey&), (override));
     MOCK_METHOD(bool, removeClips, (const ClipKeyList&, bool), (override));
     MOCK_METHOD(bool, removeTracksData, (const TrackIdList&, secs_t, secs_t, bool), (override));
-    MOCK_METHOD(muse::RetVal<ClipKeyList>, moveClips, (const ClipKeyList&, secs_t, int, bool&), (override));
+    MOCK_METHOD(muse::RetVal<ClipKeyList>, moveClips, (const ClipKeyList&, secs_t, int), (override));
     MOCK_METHOD(bool, moveRangeSelection, (secs_t, bool), (override));
     MOCK_METHOD(void, cancelItemDragEdit, (), (override));
     MOCK_METHOD(bool, splitTracksAt, (const TrackIdList&, std::vector<secs_t>), (override));
@@ -120,7 +120,6 @@ public:
     MOCK_METHOD(bool, cutLabel, (const LabelKey&), (override));
     MOCK_METHOD(bool, copyLabel, (const LabelKey&), (override));
 
-    MOCK_METHOD(bool, moveLabels, (const LabelKeyList&, secs_t, bool), (override));
     MOCK_METHOD(muse::RetVal<LabelKeyList>, moveLabels, (const LabelKeyList&, secs_t, int), (override));
     MOCK_METHOD(muse::RetVal<LabelKeyList>, moveLabelsToTrack, (const LabelKeyList&, const TrackId&, bool), (override));
 

--- a/src/trackedit/tests/trackeditactionscontroller_tests.cpp
+++ b/src/trackedit/tests/trackeditactionscontroller_tests.cpp
@@ -80,8 +80,8 @@ TEST_F(TrackeditActionsControllerTests, KeyboardMoveRequestsPreviewInsteadOfEdit
     m_requests->itemMoveRequested().onReceive(m_controller.get(), [&steps](secs_t timeOffset, int trackOffset) {
         steps.emplace_back(timeOffset, trackOffset);
     });
-    EXPECT_CALL(*m_trackeditInteraction, moveClips(::testing::_, ::testing::_, ::testing::_, ::testing::_)).Times(0);
-    EXPECT_CALL(*m_trackeditInteraction, moveLabels(::testing::_, ::testing::_, ::testing::An<int>())).Times(0);
+    EXPECT_CALL(*m_trackeditInteraction, moveClips(::testing::_, ::testing::_, ::testing::_)).Times(0);
+    EXPECT_CALL(*m_trackeditInteraction, moveLabels(::testing::_, ::testing::_, ::testing::_)).Times(0);
 
     moveItem(0.5, 0);
     moveItem(0.0, 1);

--- a/src/trackedit/tests/trackeditactionscontroller_tests.cpp
+++ b/src/trackedit/tests/trackeditactionscontroller_tests.cpp
@@ -80,8 +80,8 @@ TEST_F(TrackeditActionsControllerTests, KeyboardMoveRequestsPreviewInsteadOfEdit
     m_requests->itemMoveRequested().onReceive(m_controller.get(), [&steps](secs_t timeOffset, int trackOffset) {
         steps.emplace_back(timeOffset, trackOffset);
     });
-    EXPECT_CALL(*m_trackeditInteraction, moveClips(::testing::_, ::testing::_, ::testing::_, ::testing::_, ::testing::_)).Times(0);
-    EXPECT_CALL(*m_trackeditInteraction, moveLabels(::testing::_, ::testing::_, ::testing::_, ::testing::_)).Times(0);
+    EXPECT_CALL(*m_trackeditInteraction, moveClips(::testing::_, ::testing::_, ::testing::_, ::testing::_)).Times(0);
+    EXPECT_CALL(*m_trackeditInteraction, moveLabels(::testing::_, ::testing::_, ::testing::An<int>())).Times(0);
 
     moveItem(0.5, 0);
     moveItem(0.0, 1);

--- a/src/trackedit/tests/trackeditactionscontroller_tests.cpp
+++ b/src/trackedit/tests/trackeditactionscontroller_tests.cpp
@@ -4,6 +4,7 @@
 #include <gtest/gtest.h>
 
 #include "trackedit/internal/trackeditactionscontroller.h"
+#include "trackedit/internal/tracksviewrequestsservice.h"
 
 #include "mocks/selectioncontrollermock.h"
 #include "mocks/tracknavigationcontrollermock.h"
@@ -28,6 +29,8 @@ public:
         m_controller->selectionController.set(m_selectionController);
         m_controller->trackNavigationController.set(m_trackNavigationController);
         m_controller->trackeditInteraction.set(m_trackeditInteraction);
+        m_requests = std::make_shared<TracksViewRequestsService>(m_testCtx);
+        m_controller->tracksViewRequestsService.set(m_requests);
 
         ON_CALL(*m_trackNavigationController, focusedItem())
         .WillByDefault(Return(TrackItemKey { INVALID_TRACK, INVALID_TRACK_ITEM }));
@@ -57,13 +60,34 @@ public:
         m_controller->doGlobalCancel();
     }
 
+    void moveItem(secs_t timeOffset, int trackOffset)
+    {
+        m_controller->moveFocusedItem(timeOffset, trackOffset);
+    }
+
     std::shared_ptr<muse::modularity::Context> m_testCtx;
     std::shared_ptr<TrackeditActionsController> m_controller;
 
     std::shared_ptr<SelectionControllerMock> m_selectionController;
     std::shared_ptr<TrackNavigationControllerMock> m_trackNavigationController;
     std::shared_ptr<TrackeditInteractionMock> m_trackeditInteraction;
+    std::shared_ptr<TracksViewRequestsService> m_requests;
 };
+
+TEST_F(TrackeditActionsControllerTests, KeyboardMoveRequestsPreviewInsteadOfEditingItems)
+{
+    std::vector<std::pair<secs_t, int> > steps;
+    m_requests->itemMoveRequested().onReceive(m_controller.get(), [&steps](secs_t timeOffset, int trackOffset) {
+        steps.emplace_back(timeOffset, trackOffset);
+    });
+    EXPECT_CALL(*m_trackeditInteraction, moveClips(::testing::_, ::testing::_, ::testing::_, ::testing::_, ::testing::_)).Times(0);
+    EXPECT_CALL(*m_trackeditInteraction, moveLabels(::testing::_, ::testing::_, ::testing::_, ::testing::_)).Times(0);
+
+    moveItem(0.5, 0);
+    moveItem(0.0, 1);
+    const std::vector<std::pair<secs_t, int> > expected { { 0.5, 0 }, { 0.0, 1 } };
+    EXPECT_EQ(steps, expected);
+}
 
 /**
  * Cancel always notifies about the in-progress drag edit being cancelled.


### PR DESCRIPTION
Resolves: multiple item drag issues and crashes

Previously, when a clip moved from one track to another, we changed the track content on the fly.

- Move a clip from A to B: a new temporary tracklist is created (with full effect stack)
- In that copy, remove the clip from A and insert it into B
- Replace affected tracks from the temporary tracklist to the project tracklist
- Move the clip from B to C: the process repeats

This made the visualization easier - the view model always rendered the current project state.
But it involved too many moving parts and changing the project data model.

This PR changes the process to this:

- Start dragging - the original clip is hidden, in its place, we create a ghost clip
- The ghost clip is not a real clip, it does not belong to the project, and the QML item for its rendering refers to the original clip key
- When dragging across tracks, we move the ghost clip but never change the project data
- On drag finish, we do the clip movement once as described above


Issues this PR fixes (only ones that I logged during testing)

  

- [x] - Slow clip dragging across tracks when source track contain many realtime effects
- [x]   - Slow undo/redo in projects with many realtime effects
- [x]   - Crashes when moving labels with the keyboard
- [x]   - Labels get stuck when dragging with the mouse
- [x]   - Can't drag a clip if scrolled vertically too much, the clip vanishes 
- [x]   - During keyboard movement focused track changed to the first track contained moving clip, when moving multiple clips on different tracks
- [x]   - Selection was not restored on drag cancel
- [x]   - Unnecessary undo entries after keyboard move, if a clip didnt move, ie move clip up and then back down
- [x]   - When moving clips and lables together, the selection on labels is reset
- [x]   - History item named "Move clip" when moving clip and label, by dragging a clip
- [x]   - When moving a label no history entry is created
- [x]   - When moving clips and labels together, when drag started from the label, the relative time between clips and labels is not maintained. str: label starts at t:4, clip at t:2. Select both, start moving to the left by the label, observe what's happen when clip touches t:0 
- [x]   - When doing clips and labels movement, and mixdown dialog cancelled, labels are still moved, and undo entry is created, and the label selection is reset
- [x]   - Crashes when zooming in or out with offscreen clips caused invalid data offset on unsigned overflow

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [ ] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:

- [ ] Testflow test cases have been run
