### PR TITLE
10135 write relative install_manifest.txt for AppImage install/remove

### DIFF
--- a/ci_build.cmake
+++ b/ci_build.cmake
@@ -174,10 +174,19 @@ elseif(BUILD_TYPE STREQUAL "APPIMAGE")
         WORKING_DIRECTORY ${INSTALL_DIR}
     )
 
-    file(COPY
-        ${BUILD_DIR}/install_manifest.txt
-        DESTINATION ${INSTALL_DIR}
-    )
+    # Rewrite install_manifest.txt so that it only lists the desktop
+    # integration resources, with paths relative to the AppDir root.
+    # portable-utils uses this manifest for `install` and `remove`, so it
+    # must not contain absolute build-machine paths (see #10135).
+    # Equivalent to the sed in MuseScore's ninja_build.sh.
+    file(STRINGS ${BUILD_DIR}/install_manifest.txt MANIFEST_LINES)
+    set(PORTABLE_MANIFEST "")
+    foreach(LINE IN LISTS MANIFEST_LINES)
+        if(LINE MATCHES "/(share/(applications|icons|man|metainfo|mime)/.*)$")
+            string(APPEND PORTABLE_MANIFEST "${CMAKE_MATCH_1}\n")
+        endif()
+    endforeach()
+    file(WRITE ${INSTALL_DIR}/install_manifest.txt "${PORTABLE_MANIFEST}")
 
     file(COPY
         ${BUILD_DIR}/org.audacityteam.Audacity${INSTALL_SUFFIX}.desktop
@@ -188,15 +197,6 @@ elseif(BUILD_TYPE STREQUAL "APPIMAGE")
         ${CMAKE_CURRENT_LIST_DIR}/buildscripts/packaging/Linux+BSD/aup4.svg
         DESTINATION ${INSTALL_DIR}
     )
-
-    # audacity="audacity${MUSE_APP_INSTALL_SUFFIX}"
-    # desktop="org.audacityteam.Audacity${MUSE_APP_INSTALL_SUFFIX}.desktop"
-    # icon="${audacity}.png"
-    # mani="install_manifest.txt"
-    # cp "share/applications/${desktop}" "${desktop}"
-    # cp "share/icons/hicolor/128x128/apps/${icon}" "${icon}"
-    # <"$build_dir/${mani}" >"${mani}" sed -rn 's/.*(share\/)(applications|icons|man|metainfo|mime)(.*)/\1\2\3/p'
-    # ;;
 
 
 endif()


### PR DESCRIPTION
Resolves: #10135

The AppImage's `install`, `update` and `remove` commands (portable-utils)
read `install_manifest.txt` from the AppDir and `cp --parents` each entry into
PREFIX. `ci_build.cmake` copied CMake's `install_manifest.txt` verbatim, so it
contained absolute paths from the build machine
(/home/runner/work/audacity/audacity/build.release/...) and every entry in
the build, not just the desktop resources. On a user's machine `cp` fails
with `cannot stat '/home/runner...'` and the install aborts.

MuseScore's `ninja_build.sh` rewrites the manifest with a `sed` that keeps only
`share/{applications,icons,man,metainfo,mime}` entries, relative to the AppDir
root; the equivalent line in `ci_build.cmake` was commented out. This does the
same rewrite in CMake and removes the dead commented-out shell code.

Tested by building the AppDir with the CI workflow locally (act, aarch64):
`install_manifest.txt` now contains only relative `share/...` paths, and
`AppRun install` / `AppRun remove` work.

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior

QA:
- [ ] Testflow test cases have been run
