### PR TITLE
Fix AUP4 save path and file filter

### DIFF
--- a/src/project/CMakeLists.txt
+++ b/src/project/CMakeLists.txt
@@ -81,6 +81,8 @@ set(MODULE_SRC
     ${CMAKE_CURRENT_LIST_DIR}/internal/iopensaveprojectscenario.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/opensaveprojectscenario.cpp
     ${CMAKE_CURRENT_LIST_DIR}/internal/opensaveprojectscenario.h
+    ${CMAKE_CURRENT_LIST_DIR}/internal/projectpathutils.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/internal/projectpathutils.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/thumbnailcreator.cpp
     ${CMAKE_CURRENT_LIST_DIR}/internal/thumbnailcreator.h
     ${CMAKE_CURRENT_LIST_DIR}/internal/au3/au3metadata.cpp

--- a/src/project/internal/opensaveprojectscenario.cpp
+++ b/src/project/internal/opensaveprojectscenario.cpp
@@ -21,6 +21,7 @@
  */
 
 #include "opensaveprojectscenario.h"
+#include "projectpathutils.h"
 
 #include "cloud/clouderrors.h"
 #include "interactive/iinteractive.h"
@@ -198,20 +199,7 @@ RetVal<muse::io::path_t> OpenSaveProjectScenario::askLocalPath(IAudacityProjectP
         return make_ret(Ret::Code::Cancel);
     }
 
-    // force save to aup4 format
-    std::string suffix = muse::io::suffix(selectedPath);
-    std::string correctedPath = selectedPath.toStdString();
-    if (!suffix.empty()) {
-        correctedPath = correctedPath.substr(0, correctedPath.size() - (suffix.size() + 1));
-    }
-
-    // check if there's a dot at the end; add one if not
-    if (!correctedPath.empty() && correctedPath.back() != '.') {
-        correctedPath += ".";
-    }
-    correctedPath += "aup4";
-
-    selectedPath = correctedPath;
+    selectedPath = forceAup4Extension(selectedPath.toStdString());
 
     configuration()->setLastSavedProjectsPath(io::dirpath(selectedPath));
 

--- a/src/project/internal/opensaveprojectscenario.cpp
+++ b/src/project/internal/opensaveprojectscenario.cpp
@@ -184,13 +184,7 @@ RetVal<muse::io::path_t> OpenSaveProjectScenario::askLocalPath(IAudacityProjectP
     muse::io::path_t defaultPath = configuration()->defaultSavingFilePath(project, filenameAddition);
 
     std::vector<std::string> filter {
-        muse::trc("project", "Audacity 4 files") + " (*.aup4)"
-
-#ifdef Q_OS_MAC
-        + " (*)"
-#else
-        + " (*.)"
-#endif
+        aup4SaveFilter(muse::trc("project", "Audacity 4 files"))
     };
 
     muse::io::path_t selectedPath = interactive()->selectSavingFileSync(dialogTitle, defaultPath, filter);

--- a/src/project/internal/projectpathutils.cpp
+++ b/src/project/internal/projectpathutils.cpp
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// MuseScore-CLA-applies
+
+#include "projectpathutils.h"
+
+#include <algorithm>
+#include <cctype>
+
+namespace {
+std::string suffix(const std::string& path)
+{
+    const size_t separator = path.find_last_of("/\\");
+    const size_t dot = path.find_last_of('.');
+    const size_t filenameStart = separator == std::string::npos ? 0 : separator + 1;
+    if (dot == std::string::npos || dot == filenameStart || dot + 1 == path.size()
+        || dot < filenameStart) {
+        return {};
+    }
+
+    std::string result = path.substr(dot + 1);
+    std::transform(result.begin(), result.end(), result.begin(), [](unsigned char c) { return std::tolower(c); });
+    return result;
+}
+}
+
+std::string au::project::forceAup4Extension(const std::string& path)
+{
+    std::string correctedPath = path;
+    std::string currentSuffix = suffix(correctedPath);
+
+    if (!currentSuffix.empty()) {
+        correctedPath.resize(correctedPath.size() - currentSuffix.size() - 1);
+    }
+
+    // Some save dialogs append the selected extension even when the suggested
+    // filename already has it. Remove any remaining copy before adding the
+    // canonical extension below.
+    while (suffix(correctedPath) == "aup4") {
+        currentSuffix = suffix(correctedPath);
+        correctedPath.resize(correctedPath.size() - currentSuffix.size() - 1);
+    }
+
+    if (!correctedPath.empty() && correctedPath.back() != '.') {
+        correctedPath += ".";
+    }
+    correctedPath += "aup4";
+
+    return correctedPath;
+}

--- a/src/project/internal/projectpathutils.cpp
+++ b/src/project/internal/projectpathutils.cpp
@@ -47,3 +47,8 @@ std::string au::project::forceAup4Extension(const std::string& path)
 
     return correctedPath;
 }
+
+std::string au::project::aup4SaveFilter(const std::string& label)
+{
+    return label + " (*.aup4)";
+}

--- a/src/project/internal/projectpathutils.h
+++ b/src/project/internal/projectpathutils.h
@@ -7,4 +7,5 @@
 
 namespace au::project {
 std::string forceAup4Extension(const std::string& path);
+std::string aup4SaveFilter(const std::string& label);
 }

--- a/src/project/internal/projectpathutils.h
+++ b/src/project/internal/projectpathutils.h
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// MuseScore-CLA-applies
+
+#pragma once
+
+#include <string>
+
+namespace au::project {
+std::string forceAup4Extension(const std::string& path);
+}

--- a/src/project/tests/CMakeLists.txt
+++ b/src/project/tests/CMakeLists.txt
@@ -14,6 +14,7 @@ set(MODULE_TEST_SRC
     ${CMAKE_CURRENT_LIST_DIR}/mocks/dummyeffectinstancefactory.h
     ${CMAKE_CURRENT_LIST_DIR}/audacityproject_tests.cpp
     ${CMAKE_CURRENT_LIST_DIR}/realtimeeffectspersistence_tests.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/projectpathutils_tests.cpp
 )
 
 set(MODULE_TEST_LINK

--- a/src/project/tests/projectpathutils_tests.cpp
+++ b/src/project/tests/projectpathutils_tests.cpp
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// MuseScore-CLA-applies
+
+#include <gtest/gtest.h>
+
+#include "internal/projectpathutils.h"
+
+using au::project::forceAup4Extension;
+
+TEST(ProjectPathUtilsTests, ReplacesMissingOrDifferentExtension)
+{
+    EXPECT_EQ(forceAup4Extension("/projects/session"), "/projects/session.aup4");
+    EXPECT_EQ(forceAup4Extension("/projects/session.wav"), "/projects/session.aup4");
+    EXPECT_EQ(forceAup4Extension("/projects.with.dots/session"), "/projects.with.dots/session.aup4");
+}
+
+TEST(ProjectPathUtilsTests, PreservesOneProjectExtension)
+{
+    EXPECT_EQ(forceAup4Extension("/projects/session.aup4"), "/projects/session.aup4");
+}
+
+TEST(ProjectPathUtilsTests, CollapsesRepeatedProjectExtensions)
+{
+    EXPECT_EQ(forceAup4Extension("/projects/session.aup4.aup4"), "/projects/session.aup4");
+    EXPECT_EQ(forceAup4Extension("/projects/session.AUP4.aup4"), "/projects/session.aup4");
+}

--- a/src/project/tests/projectpathutils_tests.cpp
+++ b/src/project/tests/projectpathutils_tests.cpp
@@ -6,6 +6,12 @@
 #include "internal/projectpathutils.h"
 
 using au::project::forceAup4Extension;
+using au::project::aup4SaveFilter;
+
+TEST(ProjectPathUtilsTests, CreatesAValidProjectFileFilter)
+{
+    EXPECT_EQ(aup4SaveFilter("Audacity 4 files"), "Audacity 4 files (*.aup4)");
+}
 
 TEST(ProjectPathUtilsTests, ReplacesMissingOrDifferentExtension)
 {


### PR DESCRIPTION
Fixes #12117.
Fixes #12105.

This change centralizes AUP4 save-path and file-filter handling:

- collapses duplicate `.aup4` suffixes and replaces unrelated extensions before saving;
- uses a single valid `Audacity 4 files (*.aup4)` filter so AUP4 files remain visible in the Windows Save As dialog;
- adds focused regression coverage for missing, foreign, repeated, and case-insensitive extensions plus the filter grammar.

Validation:

- compiled the extracted production helper with GCC 14 using `-Wall -Wextra -Werror`;
- ran seven focused assertions against the production helper;
- reproduced both bugs against the pinned upstream revision and verified both repairs in Broadcast Control Lab;
- ran all 80 BCL infrastructure tests successfully.

A full Audacity application build was not run locally.
