### PR TITLE
fix: don't put control values in accessible names

### DIFF
--- a/src/effects/builtin_collection/noisereduction/NoiseReductionSlider.qml
+++ b/src/effects/builtin_collection/noisereduction/NoiseReductionSlider.qml
@@ -53,7 +53,7 @@ Row {
 
         navigation.panel: root.navigationPanel
         navigation.order: slider.navigation.order + 1
-        navigation.accessible.name: root.accessibleName + " " + currentValue + " " + measureUnitsSymbol
+        navigation.accessible.name: root.accessibleName
 
         decimals: root.isInt ? 0 : 2
         minValue: root.from

--- a/src/effects/builtin_collection/qml/Audacity/BuiltinEffectsCollection/BigParameterKnob.qml
+++ b/src/effects/builtin_collection/qml/Audacity/BuiltinEffectsCollection/BigParameterKnob.qml
@@ -142,7 +142,7 @@ Item {
         IncrementalPropertyControl {
             id: textEdit
 
-            navigation.accessible.name: root.parameter["title"] + " " + currentValue
+            navigation.accessible.name: root.parameter["title"]
 
             anchors.horizontalCenter: parent.horizontalCenter
 

--- a/src/effects/builtin_collection/qml/Audacity/BuiltinEffectsCollection/ParameterKnob.qml
+++ b/src/effects/builtin_collection/qml/Audacity/BuiltinEffectsCollection/ParameterKnob.qml
@@ -87,7 +87,7 @@ Item {
             IncrementalPropertyControl {
                 id: textEdit
 
-                navigation.accessible.name: root.parameter["title"] + " " + currentValue
+                navigation.accessible.name: root.parameter["title"]
 
                 width: 80
 

--- a/src/effects/builtin_collection/qml/Audacity/BuiltinEffectsCollection/SliderWithTextInput.qml
+++ b/src/effects/builtin_collection/qml/Audacity/BuiltinEffectsCollection/SliderWithTextInput.qml
@@ -63,7 +63,7 @@ Column {
 
             navigation.panel: root.navigationPanel
             navigation.order: slider.navigation.order + 1
-            navigation.accessible.name: root.text + " " + currentValue + " " + measureUnitsSymbol
+            navigation.accessible.name: root.text
 
             width: parent.width * .35
 

--- a/src/importexport/export/qml/Export/ExportDialog.qml
+++ b/src/importexport/export/qml/Export/ExportDialog.qml
@@ -768,7 +768,7 @@ StyledDialogView {
 
             navigation.panel: audioSection.navigation
             navigation.order: sampleRateDropdown.navigation.order + 1 + option.index
-            navigation.accessible.name: option.title + " " + currentValue
+            navigation.accessible.name: option.title
 
             onValueEdited: function (newValue) {
                 dynamicOptionsModel.setData(dynamicOptionsModel.index(option.index, 0), newValue, ExportOptionType.ValueRole)

--- a/src/preferences/qml/Audacity/Preferences/internal/IncrementalPropertyControlWithTitle.qml
+++ b/src/preferences/qml/Audacity/Preferences/internal/IncrementalPropertyControlWithTitle.qml
@@ -64,7 +64,7 @@ Column {
         decimals: 0
         step: 1
 
-        navigation.accessible.name: titleLabel.text + " " + currentValue + " " + measureUnitsSymbol
+        navigation.accessible.name: titleLabel.text
 
         onValueEdited: function (newValue) {
             root.valueEdited(newValue)

--- a/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/pitchandspeed/PropertyView.qml
+++ b/src/projectscene/qml/Audacity/ProjectScene/tracksitemsview/pitchandspeed/PropertyView.qml
@@ -50,7 +50,7 @@ Column {
         navigation.name: root.navigationName + " Spinbox"
         navigation.panel: root.navigationPanel
         navigation.row: root.navigationRowStart + 1
-        navigation.accessible.name: root.title + " " + currentValue
+        navigation.accessible.name: root.title
 
         onValueEditingFinished: function (newValue) {
             root.valueChanged(newValue)

--- a/src/uicomponents/qml/Audacity/UiComponents/components/internal/TimeSignaturePopup.qml
+++ b/src/uicomponents/qml/Audacity/UiComponents/components/internal/TimeSignaturePopup.qml
@@ -62,7 +62,7 @@ StyledPopupView {
 
                 navigation.panel: navPanel
                 navigation.order: 1
-                navigation.accessible.name: titleLabel.text + " : " + currentValue
+                navigation.accessible.name: titleLabel.text
 
                 onValueEdited: function (newValue) {
                     root.upperChangeRequested(newValue)


### PR DESCRIPTION
Resolves: https://github.com/audacity/audacity/issues/11600

Please merge after [musescore/muse_framework#269](https://github.com/musescore/muse_framework/issues/269) and the muse submodule bump. On its own this still removes the sibling echo, but spin boxes stop announcing their value when they receive focus (it's still spoken when it changes), because the framework doesn't expose it until [musescore/muse_framework#269](https://github.com/musescore/muse_framework/issues/269).

23 `IncrementalPropertyControl` instances put their current value into `accessible.name`, a workaround for values never being exposed. It costs twice over: the value is announced twice, and because changing the value changes the *name*, the framework's `needsRevoicing()`/`triggerRevoicing()` path bounces focus to a sibling control and back on **every keypress** — so a screen reader reads a neighbouring control between every step.

This changes 9 of them, where the label is a plain property.

**Before**, pressing Up on the Chirp generator's "Start frequency" (NVDA speech viewer):

```
Start frequency 441 Hz  spin button  441 Hz
End frequency 1320 Hz   spin button  1320 Hz
Start frequency 442 Hz  spin button  442 Hz
End frequency 1320 Hz   spin button  1320 Hz
```

**After:**

```
Start frequency  spin button  440 Hz
441 Hz
442 Hz
```

Tested on Windows 10 22H2, NVDA 2026.2, Qt 6.10.3.

Not included yet: 13 more are in the custom FFmpeg options dialog (FLACOptionsSection, GeneralOptionsSection, MPEGOptionsSection). The change is identical and reuses each control's existing visible-label string, so it adds no new translations — but that dialog needs FFmpeg installed and I haven't tested it, so I'll follow up. AutoSaveSection.qml has the same pattern but isn't instantiated anywhere, so I've left it alone.

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior